### PR TITLE
Add rename primary and foreign key operation

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -1706,6 +1706,50 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         /// <summary>
+        ///     Generates code for a <see cref="RenameCheckConstraintOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="builder"> The builder code is added to. </param>
+        protected virtual void Generate([NotNull] RenameCheckConstraintOperation operation, [NotNull] IndentedStringBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder.AppendLine(".RenameCheckConstraint(");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("name: ")
+                    .Append(Code.Literal(operation.Name));
+
+                if (operation.Schema != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("schema: ")
+                        .Append(Code.Literal(operation.Schema));
+                }
+
+                if (operation.Table != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("table: ")
+                        .Append(Code.Literal(operation.Table));
+                }
+
+                builder
+                    .AppendLine(",")
+                    .Append("newName: ")
+                    .Append(Code.Literal(operation.NewName))
+                    .Append(")");
+
+                Annotations(operation.GetAnnotations(), builder);
+            }
+        }
+
+        /// <summary>
         ///     Generates code for a <see cref="RenameForeignKeyOperation" />.
         /// </summary>
         /// <param name="operation"> The operation. </param>

--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -1706,6 +1706,50 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         /// <summary>
+        ///     Generates code for a <see cref="RenameForeignKeyOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="builder"> The builder code is added to. </param>
+        protected virtual void Generate([NotNull] RenameForeignKeyOperation operation, [NotNull] IndentedStringBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder.AppendLine(".RenameForeignKey(");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("name: ")
+                    .Append(Code.Literal(operation.Name));
+
+                if (operation.Schema != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("schema: ")
+                        .Append(Code.Literal(operation.Schema));
+                }
+
+                if (operation.Table != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("table: ")
+                        .Append(Code.Literal(operation.Table));
+                }
+
+                builder
+                    .AppendLine(",")
+                    .Append("newName: ")
+                    .Append(Code.Literal(operation.NewName))
+                    .Append(")");
+
+                Annotations(operation.GetAnnotations(), builder);
+            }
+        }
+
+        /// <summary>
         ///     Generates code for a <see cref="RenameIndexOperation" />.
         /// </summary>
         /// <param name="operation"> The operation. </param>
@@ -1735,6 +1779,50 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     .AppendLine(",")
                     .Append("table: ")
                     .Append(Code.Literal(operation.Table))
+                    .AppendLine(",")
+                    .Append("newName: ")
+                    .Append(Code.Literal(operation.NewName))
+                    .Append(")");
+
+                Annotations(operation.GetAnnotations(), builder);
+            }
+        }
+
+        /// <summary>
+        ///     Generates code for a <see cref="RenamePrimaryKeyOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="builder"> The builder code is added to. </param>
+        protected virtual void Generate([NotNull] RenamePrimaryKeyOperation operation, [NotNull] IndentedStringBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder.AppendLine(".RenamePrimaryKey(");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("name: ")
+                    .Append(Code.Literal(operation.Name));
+
+                if (operation.Schema != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("schema: ")
+                        .Append(Code.Literal(operation.Schema));
+                }
+
+                if (operation.Table != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("table: ")
+                        .Append(Code.Literal(operation.Table));
+                }
+
+                builder
                     .AppendLine(",")
                     .Append("newName: ")
                     .Append(Code.Literal(operation.NewName))
@@ -1835,6 +1923,50 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 }
 
                 builder.Append(")");
+
+                Annotations(operation.GetAnnotations(), builder);
+            }
+        }
+
+        /// <summary>
+        ///     Generates code for a <see cref="RenameUniqueConstraintOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="builder"> The builder code is added to. </param>
+        protected virtual void Generate([NotNull] RenameUniqueConstraintOperation operation, [NotNull] IndentedStringBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder.AppendLine(".RenameUniqueConstraint(");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("name: ")
+                    .Append(Code.Literal(operation.Name));
+
+                if (operation.Schema != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("schema: ")
+                        .Append(Code.Literal(operation.Schema));
+                }
+
+                if (operation.Table != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("table: ")
+                        .Append(Code.Literal(operation.Table));
+                }
+
+                builder
+                    .AppendLine(",")
+                    .Append("newName: ")
+                    .Append(Code.Literal(operation.NewName))
+                    .Append(")");
 
                 Annotations(operation.GetAnnotations(), builder);
             }

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -65,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             MigrationsNotApplied,
             MigrationsNotFound,
             MigrationAttributeMissingWarning,
+            MigrationOnUpdateReferentialActionResetToDefaultWarning,
 
             // Query events
             QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
@@ -495,6 +496,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId MigrationAttributeMissingWarning = MakeMigrationsId(Id.MigrationAttributeMissingWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         An OnUpdate ReferentialAction is reset to default
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="EventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId MigrationOnUpdateReferentialActionResetToDefaultWarning = MakeMigrationsId(Id.MigrationOnUpdateReferentialActionResetToDefaultWarning);
 
         private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Update;
@@ -3394,6 +3395,41 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             var d = (EventDefinition<string>)definition;
             var p = (MigrationTypeEventData)payload;
             return d.GenerateMessage(p.MigrationType.Name);
+        }
+
+
+        /// <summary>
+        ///     Logs for the <see cref="RelationalEventId.MigrationAttributeMissingWarning" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="renameForeignKeyOperation"> The <see cref="RenameForeignKeyOperation"/> causing the warning. </param>
+        public static void MigrationOnUpdateReferentialActionResetToDefaultWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Migrations> diagnostics,
+            [NotNull] RenameForeignKeyOperation renameForeignKeyOperation)
+        {
+            var definition = RelationalResources.LogMigrationOnUpdateReferentialActionResetToDefaultWarning(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, renameForeignKeyOperation.Name, renameForeignKeyOperation.NewName, renameForeignKeyOperation.Table);
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new RenameForeignKeyEventData(
+                    definition,
+                    MigrationOnUpdateReferentialActionResetToDefaultWarning,
+                    renameForeignKeyOperation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
+
+        private static string MigrationOnUpdateReferentialActionResetToDefaultWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string, string>)definition;
+            var o = ((RenameForeignKeyEventData)payload).RenameForeignKeyOperation;
+            return d.GenerateMessage(o.Name, o.NewName, o.Table);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -366,5 +366,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         [EntityFrameworkInternal]
         public EventDefinitionBase LogValueConversionSqlLiteralWarning;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public EventDefinitionBase LogMigrationOnUpdateReferentialActionResetToDefaultWarning;
     }
 }

--- a/src/EFCore.Relational/Diagnostics/RenameForeignKeyEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/RenameForeignKeyEventData.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     The <see cref="DiagnosticSource" /> event payload for
+    ///     <see cref="RelationalEventId" /> rename foreign key events.
+    /// </summary>
+    public class RenameForeignKeyEventData : EventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="renameForeignKeyOperation"> The <see cref="RenameForeignKeyOperation"/> causing the event. </param>
+        public RenameForeignKeyEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventData,string> messageGenerator,
+            [NotNull] RenameForeignKeyOperation renameForeignKeyOperation
+            )
+            : base(eventDefinition, messageGenerator)
+        {
+            RenameForeignKeyOperation = renameForeignKeyOperation;
+        }
+
+        /// <summary>
+        ///     The migration type.
+        /// </summary>
+        public virtual RenameForeignKeyOperation RenameForeignKeyOperation { get; }
+
+    }
+}

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1012,6 +1012,35 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
+        ///     Builds an <see cref="RenameForeignKeyOperation" /> to rename an existing primary key.
+        /// </summary>
+        /// <param name="name"> The name of the primary key to be renamed.</param>
+        /// <param name="newName"> The new name for the primary key. </param>
+        /// <param name="table"> The table that the primary key belongs to. </param>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<RenameForeignKeyOperation> RenameForeignKey(
+            [NotNull] string name,
+            [NotNull] string newName,
+            [CanBeNull] string table = null,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotEmpty(newName, nameof(newName));
+
+            var operation = new RenameForeignKeyOperation
+            {
+                Schema = schema,
+                Table = table,
+                Name = name,
+                NewName = newName
+            };
+            Operations.Add(operation);
+
+            return new OperationBuilder<RenameForeignKeyOperation>(operation);
+        }
+
+        /// <summary>
         ///     Builds an <see cref="RenameIndexOperation" /> to rename an existing index.
         /// </summary>
         /// <param name="name"> The name of the index to be renamed.</param>
@@ -1038,6 +1067,35 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Operations.Add(operation);
 
             return new OperationBuilder<RenameIndexOperation>(operation);
+        }
+
+        /// <summary>
+        ///     Builds an <see cref="RenamePrimaryKeyOperation" /> to rename an existing primary key.
+        /// </summary>
+        /// <param name="name"> The name of the primary key to be renamed.</param>
+        /// <param name="newName"> The new name for the primary key. </param>
+        /// <param name="table"> The table that the primary key belongs to. </param>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<RenamePrimaryKeyOperation> RenamePrimaryKey(
+            [NotNull] string name,
+            [NotNull] string newName,
+            [CanBeNull] string table = null,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotEmpty(newName, nameof(newName));
+
+            var operation = new RenamePrimaryKeyOperation
+            {
+                Schema = schema,
+                Table = table,
+                Name = name,
+                NewName = newName
+            };
+            Operations.Add(operation);
+
+            return new OperationBuilder<RenamePrimaryKeyOperation>(operation);
         }
 
         /// <summary>
@@ -1094,6 +1152,35 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Operations.Add(operation);
 
             return new OperationBuilder<RenameTableOperation>(operation);
+        }
+
+        /// <summary>
+        ///     Builds an <see cref="RenameUniqueConstraintOperation" /> to rename an existing unique constraint.
+        /// </summary>
+        /// <param name="name"> The name of the unique constraint to be renamed.</param>
+        /// <param name="newName"> The new name for the unique constraint. </param>
+        /// <param name="table"> The table that the unique constraint belongs to. </param>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<RenameUniqueConstraintOperation> RenameUniqueConstraint(
+            [NotNull] string name,
+            [NotNull] string newName,
+            [CanBeNull] string table = null,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotEmpty(newName, nameof(newName));
+
+            var operation = new RenameUniqueConstraintOperation
+            {
+                Schema = schema,
+                Table = table,
+                Name = name,
+                NewName = newName
+            };
+            Operations.Add(operation);
+
+            return new OperationBuilder<RenameUniqueConstraintOperation>(operation);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1012,6 +1012,35 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
+        ///     Builds an <see cref="RenameCheckConstraintOperation" /> to rename an existing check constraint.
+        /// </summary>
+        /// <param name="name"> The name of the check constraint to be renamed.</param>
+        /// <param name="newName"> The new name for the check constraint. </param>
+        /// <param name="table"> The table that the check constraint belongs to. </param>
+        /// <param name="schema"> The schema that contains the table, or <c>null</c> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<RenameCheckConstraintOperation> RenameCheckConstraint(
+            [NotNull] string name,
+            [NotNull] string newName,
+            [CanBeNull] string table = null,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotEmpty(newName, nameof(newName));
+
+            var operation = new RenameCheckConstraintOperation
+            {
+                Schema = schema,
+                Table = table,
+                Name = name,
+                NewName = newName
+            };
+            Operations.Add(operation);
+
+            return new OperationBuilder<RenameCheckConstraintOperation>(operation);
+        }
+
+        /// <summary>
         ///     Builds an <see cref="RenameForeignKeyOperation" /> to rename an existing primary key.
         /// </summary>
         /// <param name="name"> The name of the primary key to be renamed.</param>

--- a/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     new MigrationCommand(
                         _commandBuilder.Build(),
                         _dependencies.CurrentContext.Context,
-                        _dependencies.Logger,
+                        _dependencies.CommandLogger,
                         suppressTransaction));
 
                 _commandBuilder = _dependencies.CommandBuilderFactory.Create();

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -117,6 +118,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         protected virtual IUpdateSqlGenerator SqlGenerator
             => Dependencies.UpdateSqlGenerator;
+
+        /// <summary>
+        ///     The <see cref="IDiagnosticsLogger{T}" /> of type <see cref="DbLoggerCategory.Migrations" />.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Migrations> Logger
+            => Dependencies.Logger;
 
         /// <summary>
         ///     Gets a comparer that can be used to compare two product versions.
@@ -454,6 +461,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 // Todo: Have a look at his and possibly fix it after https://github.com/dotnet/efcore/issues/4073 has been closed.
                 //OnUpdate = Whatever it was, we've reset it to default now
             };
+            Logger.MigrationOnUpdateReferentialActionResetToDefaultWarning(operation);
+
             addOperation.AddAnnotations(RelationalAnnotations.For(foreignKey));
 
             Generate(dropOperation, model, builder, terminate: false);

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -63,7 +64,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
             [NotNull] ICurrentDbContext currentContext,
             [NotNull] ILoggingOptions loggingOptions,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
+            [NotNull] IRelationalAnnotationProvider relationalAnnotations)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
@@ -72,6 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(currentContext, nameof(currentContext));
             Check.NotNull(loggingOptions, nameof(loggingOptions));
             Check.NotNull(logger, nameof(logger));
+            Check.NotNull(migrationsAnnotations, nameof(migrationsAnnotations));
+            Check.NotNull(relationalAnnotations, nameof(relationalAnnotations));
 
             CommandBuilderFactory = commandBuilderFactory;
             SqlGenerationHelper = sqlGenerationHelper;
@@ -80,6 +85,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             CurrentContext = currentContext;
             LoggingOptions = loggingOptions;
             Logger = logger;
+            MigrationsAnnotations = migrationsAnnotations;
+            RelationalAnnotations = relationalAnnotations;
         }
 
         /// <summary>
@@ -118,6 +125,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
 
         /// <summary>
+        ///     The migrations annotations to use.
+        /// </summary>
+        public IMigrationsAnnotationProvider MigrationsAnnotations { get; }
+
+        /// <summary>
+        ///     The relational annotations to use.
+        /// </summary>
+        public IRelationalAnnotationProvider RelationalAnnotations { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="commandBuilderFactory"> A replacement for the current dependency of this type. </param>
@@ -130,7 +147,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 CurrentContext,
                 LoggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -145,7 +164,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 CurrentContext,
                 LoggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -160,7 +181,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 CurrentContext,
                 LoggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -175,7 +198,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 typeMappingSource,
                 CurrentContext,
                 LoggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -190,7 +215,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 currentContext,
                 LoggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -205,7 +232,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 CurrentContext,
                 loggingOptions,
-                Logger);
+                Logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -220,6 +249,42 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 TypeMappingSource,
                 CurrentContext,
                 LoggingOptions,
-                logger);
+                logger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="migrationsAnnotations"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsSqlGeneratorDependencies With([NotNull] IMigrationsAnnotationProvider migrationsAnnotations)
+            => new MigrationsSqlGeneratorDependencies(
+                CommandBuilderFactory,
+                UpdateSqlGenerator,
+                SqlGenerationHelper,
+                TypeMappingSource,
+                CurrentContext,
+                LoggingOptions,
+                Logger,
+                migrationsAnnotations,
+                RelationalAnnotations);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="relationalAnnotations"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsSqlGeneratorDependencies With([NotNull] IRelationalAnnotationProvider relationalAnnotations)
+            => new MigrationsSqlGeneratorDependencies(
+                CommandBuilderFactory,
+                UpdateSqlGenerator,
+                SqlGenerationHelper,
+                TypeMappingSource,
+                CurrentContext,
+                LoggingOptions,
+                Logger,
+                MigrationsAnnotations,
+                relationalAnnotations);
     }
 }

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
@@ -64,7 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
             [NotNull] ICurrentDbContext currentContext,
             [NotNull] ILoggingOptions loggingOptions,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
             [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
             [NotNull] IRelationalAnnotationProvider relationalAnnotations)
         {
@@ -75,6 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(currentContext, nameof(currentContext));
             Check.NotNull(loggingOptions, nameof(loggingOptions));
             Check.NotNull(logger, nameof(logger));
+            Check.NotNull(commandLogger, nameof(commandLogger));
             Check.NotNull(migrationsAnnotations, nameof(migrationsAnnotations));
             Check.NotNull(relationalAnnotations, nameof(relationalAnnotations));
 
@@ -85,6 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             CurrentContext = currentContext;
             LoggingOptions = loggingOptions;
             Logger = logger;
+            CommandLogger = commandLogger;
             MigrationsAnnotations = migrationsAnnotations;
             RelationalAnnotations = relationalAnnotations;
         }
@@ -121,8 +124,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
         /// <summary>
         ///     The database command logger.
+        ///     A logger for commands.
         /// </summary>
-        public IDiagnosticsLogger<DbLoggerCategory.Database.Command> Logger { get; }
+        public IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandLogger { get; }
+
+        /// <summary>
+        ///     A logger for migrations.
+        /// </summary>
+        public IDiagnosticsLogger<DbLoggerCategory.Migrations> Logger { get; }
 
         /// <summary>
         ///     The migrations annotations to use.
@@ -148,6 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -165,6 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -182,6 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -199,6 +211,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -216,6 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 currentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -233,6 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 loggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -241,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public MigrationsSqlGeneratorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
+        public MigrationsSqlGeneratorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Migrations> logger)
             => new MigrationsSqlGeneratorDependencies(
                 CommandBuilderFactory,
                 UpdateSqlGenerator,
@@ -250,6 +265,25 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 logger,
+                CommandLogger,
+                MigrationsAnnotations,
+                RelationalAnnotations);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="commandLogger"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsSqlGeneratorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
+            => new MigrationsSqlGeneratorDependencies(
+                CommandBuilderFactory,
+                UpdateSqlGenerator,
+                SqlGenerationHelper,
+                TypeMappingSource,
+                CurrentContext,
+                LoggingOptions,
+                Logger,
+                commandLogger,
                 MigrationsAnnotations,
                 RelationalAnnotations);
 
@@ -267,6 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 migrationsAnnotations,
                 RelationalAnnotations);
 
@@ -284,6 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 CurrentContext,
                 LoggingOptions,
                 Logger,
+                CommandLogger,
                 MigrationsAnnotations,
                 relationalAnnotations);
     }

--- a/src/EFCore.Relational/Migrations/Operations/RenameCheckConstraintOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/RenameCheckConstraintOperation.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations
+{
+    /// <summary>
+    ///     A <see cref="MigrationOperation" /> for renaming an existing check constraint.
+    /// </summary>
+    public class RenameCheckConstraintOperation : MigrationOperation
+    {
+        /// <summary>
+        ///     The old name of the check constraint.
+        /// </summary>
+        public virtual string Name { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The new name for the check constraint.
+        /// </summary>
+        public virtual string NewName { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     The name of the table that the check constraint belongs to.
+        /// </summary>
+        public virtual string Table { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.Relational/Migrations/Operations/RenameForeignKeyOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/RenameForeignKeyOperation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations
+{
+    /// <summary>
+    ///     A <see cref="MigrationOperation" /> for renaming an existing foreign key.
+    /// </summary>
+    public class RenameForeignKeyOperation : MigrationOperation
+    {
+        /// <summary>
+        ///     The old name of the foreign key.
+        /// </summary>
+        public virtual string Name { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The new name for the foreign key.
+        /// </summary>
+        public virtual string NewName { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     The name of the table that the foreign key belongs to.
+        /// </summary>
+        public virtual string Table { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.Relational/Migrations/Operations/RenamePrimaryKeyOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/RenamePrimaryKeyOperation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations
+{
+    /// <summary>
+    ///     A <see cref="MigrationOperation" /> for renaming an existing primary key.
+    /// </summary>
+    public class RenamePrimaryKeyOperation : MigrationOperation
+    {
+        /// <summary>
+        ///     The old name of the primary key.
+        /// </summary>
+        public virtual string Name { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The new name for the primary key.
+        /// </summary>
+        public virtual string NewName { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     The name of the table that the primary key belongs to.
+        /// </summary>
+        public virtual string Table { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.Relational/Migrations/Operations/RenameUniqueConstraintOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/RenameUniqueConstraintOperation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Migrations.Operations
+{
+    /// <summary>
+    ///     A <see cref="MigrationOperation" /> for renaming an existing unique constraint.
+    /// </summary>
+    public class RenameUniqueConstraintOperation : MigrationOperation
+    {
+        /// <summary>
+        ///     The old name of the unique constraint.
+        /// </summary>
+        public virtual string Name { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The new name for the unique constraint.
+        /// </summary>
+        public virtual string NewName { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The schema that contains the table, or <c>null</c> if the default schema should be used.
+        /// </summary>
+        public virtual string Schema { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     The name of the table that the unique constraint belongs to.
+        /// </summary>
+        public virtual string Table { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -808,6 +808,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("DbFunctionAggregateCustomTranslation", nameof(function)),
                 function);
 
+        /// <summary>
+        ///     The foreign key '{foreignKeyName}' was not found.
+        /// </summary>
+        public static string ForeignKeyNotFound([CanBeNull] object foreignKeyName)
+            => string.Format(
+                GetString("ForeignKeyNotFound", nameof(foreignKeyName)),
+                foreignKeyName);
+
+        /// <summary>
+        ///     The primary key '{primaryKeyName}' was not found.
+        /// </summary>
+        public static string PrimaryKeyNotFound([CanBeNull] object primaryKeyName)
+            => string.Format(
+                GetString("PrimaryKeyNotFound", nameof(primaryKeyName)),
+                primaryKeyName);
+
+        /// <summary>
+        ///     The unique constraint '{uniqueConstraintName}' was not found.
+        /// </summary>
+        public static string UniqueConstraintNotFound([CanBeNull] object uniqueConstraintName)
+            => string.Format(
+                GetString("UniqueConstraintNotFound", nameof(uniqueConstraintName)),
+                uniqueConstraintName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1769,5 +1769,29 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
 
             return (EventDefinition<string>)definition;
         }
+
+        /// <summary>
+        ///     The OnUpdate ReferentialAction will be reset to the default value after renaming the foreign key '{name}' to '{newName}' in table '{tableName}'
+        /// </summary>
+        public static EventDefinition<string, string, string> LogMigrationOnUpdateReferentialActionResetToDefaultWarning([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationOnUpdateReferentialActionResetToDefaultWarning;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationOnUpdateReferentialActionResetToDefaultWarning,
+                    () => new EventDefinition<string, string, string>(
+                        logger.Options,
+                        RelationalEventId.MigrationOnUpdateReferentialActionResetToDefaultWarning,
+                        LogLevel.Warning,
+                        "RelationalEventId.MigrationOnUpdateReferentialActionResetToDefaultWarning",
+                        level => LoggerMessage.Define<string, string, string>(
+                            level,
+                            RelationalEventId.MigrationOnUpdateReferentialActionResetToDefaultWarning,
+                            _resourceManager.GetString("LogMigrationOnUpdateReferentialActionResetToDefaultWarning"))));
+            }
+
+            return (EventDefinition<string, string, string>)definition;
+        }
     }
 }

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -584,4 +584,13 @@
   <data name="DbFunctionAggregateCustomTranslation" xml:space="preserve">
     <value>Cannot set custom translation on the DbFunction '{function}' since it is an aggregate function.</value>
   </data>
+  <data name="ForeignKeyNotFound" xml:space="preserve">
+    <value>The foreign key '{foreignKeyName}' was not found.</value>
+  </data>
+  <data name="PrimaryKeyNotFound" xml:space="preserve">
+    <value>The primary key '{primaryKeyName}' was not found.</value>
+  </data>
+  <data name="UniqueConstraintNotFound" xml:space="preserve">
+    <value>The unique constraint '{uniqueConstraintName}' was not found.</value>
+  </data>
 </root>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -593,4 +593,8 @@
   <data name="UniqueConstraintNotFound" xml:space="preserve">
     <value>The unique constraint '{uniqueConstraintName}' was not found.</value>
   </data>
+  <data name="LogMigrationOnUpdateReferentialActionResetToDefaultWarning" xml:space="preserve">
+    <value>The OnUpdate ReferentialAction will be reset to the default value after renaming the foreign key '{name}' to '{newName}' in table '{tableName}'</value>
+    <comment>Warning RelationalEventId.MigrationOnUpdateReferentialActionResetToDefaultWarning string string string</comment>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public SqlServerMigrationsSqlGenerator(
             [NotNull] MigrationsSqlGeneratorDependencies dependencies,
             [NotNull] IRelationalAnnotationProvider migrationsAnnotations)
-            : base(dependencies)
+            : base(dependencies.With(migrationsAnnotations))
         {
         }
 
@@ -378,6 +378,28 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
+        ///     Builds commands for the given <see cref="RenameForeignKeyOperation" />
+        ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(
+            RenameForeignKeyOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            Rename(
+                Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema),
+                operation.NewName,
+                builder);
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
+        }
+
+        /// <summary>
         ///     Builds commands for the given <see cref="RenameIndexOperation" />
         ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
         /// </summary>
@@ -403,6 +425,28 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 + Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name),
                 operation.NewName,
                 "INDEX",
+                builder);
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
+        }
+
+        /// <summary>
+        ///     Builds commands for the given <see cref="RenamePrimaryKeyOperation" />
+        ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(
+            RenamePrimaryKeyOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            Rename(
+                Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema),
+                operation.NewName,
                 builder);
             builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
@@ -439,6 +483,28 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
 
             builder.EndCommand();
+        }
+
+        /// <summary>
+        ///     Builds commands for the given <see cref="RenameUniqueConstraintOperation" />
+        ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(
+            RenameUniqueConstraintOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            Rename(
+                Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema),
+                operation.NewName,
+                builder);
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -385,6 +385,28 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
         /// <param name="builder"> The command builder to use to build the commands. </param>
         protected override void Generate(
+            RenameCheckConstraintOperation operation,
+            IModel model,
+            MigrationCommandListBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            Rename(
+                Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema),
+                operation.NewName,
+                builder);
+            builder.EndCommand(suppressTransaction: IsMemoryOptimized(operation, model, operation.Schema, operation.Table));
+        }
+
+        /// <summary>
+        ///     Builds commands for the given <see cref="RenameForeignKeyOperation" />
+        ///     by making calls on the given <see cref="MigrationCommandListBuilder" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(
             RenameForeignKeyOperation operation,
             IModel model,
             MigrationCommandListBuilder builder)

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -597,6 +597,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="operation"> The operation. </param>
         /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
         /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(RenameCheckConstraintOperation operation, IModel model, MigrationCommandListBuilder builder)
+            => throw new NotSupportedException(
+                SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+        /// <summary>
+        ///     Throws <see cref="NotSupportedException" /> since this operation requires table rebuilds, which
+        ///     are not yet supported.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
         protected override void Generate(RenameForeignKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
             => throw new NotSupportedException(
                 SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public SqliteMigrationsSqlGenerator(
             [NotNull] MigrationsSqlGeneratorDependencies dependencies,
             [NotNull] IRelationalAnnotationProvider migrationsAnnotations)
-            : base(dependencies)
+            : base(dependencies.With(migrationsAnnotations))
         {
         }
 
@@ -587,6 +587,39 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
         /// <param name="builder"> The command builder to use to build the commands. </param>
         protected override void Generate(AlterColumnOperation operation, IModel model, MigrationCommandListBuilder builder)
+            => throw new NotSupportedException(
+                SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+        /// <summary>
+        ///     Throws <see cref="NotSupportedException" /> since this operation requires table rebuilds, which
+        ///     are not yet supported.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(RenameForeignKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
+            => throw new NotSupportedException(
+                SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+        /// <summary>
+        ///     Throws <see cref="NotSupportedException" /> since this operation requires table rebuilds, which
+        ///     are not yet supported.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(RenamePrimaryKeyOperation operation, IModel model, MigrationCommandListBuilder builder)
+            => throw new NotSupportedException(
+                SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+        /// <summary>
+        ///     Throws <see cref="NotSupportedException" /> since this operation requires table rebuilds, which
+        ///     are not yet supported.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to build the commands. </param>
+        protected override void Generate(RenameUniqueConstraintOperation operation, IModel model, MigrationCommandListBuilder builder)
             => throw new NotSupportedException(
                 SqliteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
 

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -65,6 +65,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
                 GetString("DuplicateColumnNameSridMismatch", nameof(entityType1), nameof(property1), nameof(entityType2), nameof(property2), nameof(columnName), nameof(table)),
                 entityType1, property1, entityType2, property2, columnName, table);
 
+        /// <summary>
+        ///     The index '{indexName}' was not found.
+        /// </summary>
+        public static string IndexNotFound([CanBeNull] object indexName)
+            => string.Format(
+                GetString("IndexNotFound", nameof(indexName)),
+                indexName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -187,4 +187,7 @@
   <data name="DuplicateColumnNameSridMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured with different SRIDs.</value>
   </data>
+  <data name="IndexNotFound" xml:space="preserve">
+    <value>The index '{indexName}' was not found.</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -2350,6 +2350,52 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         [ConditionalFact]
+        public void RenameForeignKeyOperation_required_args()
+        {
+            Test(
+                new RenameForeignKeyOperation
+                {
+                    Name = "FK_Post_Title_Titles_Name",
+                    NewName = "FK_Post_PostTitle_Titles_Name"
+                },
+                "mb.RenameForeignKey(" + _eol +
+                "    name: \"FK_Post_Title_Titles_Name\"," + _eol +
+                "    newName: \"FK_Post_PostTitle_Titles_Name\");",
+                o =>
+                {
+                    Assert.Equal("FK_Post_Title_Titles_Name", o.Name);
+                    Assert.Equal("FK_Post_PostTitle_Titles_Name", o.NewName);
+                    Assert.Null(o.Table);
+                    Assert.Null(o.Schema);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenameForeignKeyOperation_all_args()
+        {
+            Test(
+                new RenameForeignKeyOperation
+                {
+                    Name = "FK_Post_Title_Titles_Name",
+                    Schema = "dbo",
+                    Table = "Post",
+                    NewName = "FK_Post_PostTitle_Titles_Name"
+                },
+                "mb.RenameForeignKey(" + _eol +
+                "    name: \"FK_Post_Title_Titles_Name\"," + _eol +
+                "    schema: \"dbo\"," + _eol +
+                "    table: \"Post\"," + _eol +
+                "    newName: \"FK_Post_PostTitle_Titles_Name\");",
+                o =>
+                {
+                    Assert.Equal("FK_Post_Title_Titles_Name", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("Post", o.Table);
+                    Assert.Equal("FK_Post_PostTitle_Titles_Name", o.NewName);
+                });
+        }
+
+        [ConditionalFact]
         public void RenameIndexOperation_required_args()
         {
             Test(
@@ -2400,6 +2446,52 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Assert.Equal("dbo", o.Schema);
                     Assert.Equal("Post", o.Table);
                     Assert.Equal("IX_dbo.Post_PostTitle", o.NewName);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenamePrimaryKeyOperation_required_args()
+        {
+            Test(
+                new RenamePrimaryKeyOperation
+                {
+                    Name = "PK_Post_Title",
+                    NewName = "PK_Post_PostTitle"
+                },
+                "mb.RenamePrimaryKey(" + _eol +
+                "    name: \"PK_Post_Title\"," + _eol +
+                "    newName: \"PK_Post_PostTitle\");",
+                o =>
+                {
+                    Assert.Equal("PK_Post_Title", o.Name);
+                    Assert.Equal("PK_Post_PostTitle", o.NewName);
+                    Assert.Null(o.Table);
+                    Assert.Null(o.Schema);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenamePrimaryKeyOperation_all_args()
+        {
+            Test(
+                new RenamePrimaryKeyOperation
+                {
+                    Name = "PK_dbo.Post_Title",
+                    Schema = "dbo",
+                    Table = "Post",
+                    NewName = "PK_dbo.Post_PostTitle"
+                },
+                "mb.RenamePrimaryKey(" + _eol +
+                "    name: \"PK_dbo.Post_Title\"," + _eol +
+                "    schema: \"dbo\"," + _eol +
+                "    table: \"Post\"," + _eol +
+                "    newName: \"PK_dbo.Post_PostTitle\");",
+                o =>
+                {
+                    Assert.Equal("PK_dbo.Post_Title", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("Post", o.Table);
+                    Assert.Equal("PK_dbo.Post_PostTitle", o.NewName);
                 });
         }
 
@@ -2476,6 +2568,52 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Assert.Equal("dbo", o.Schema);
                     Assert.Equal("Posts", o.NewName);
                     Assert.Equal("my", o.NewSchema);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenameUniqueConstraintOperation_required_args()
+        {
+            Test(
+                new RenameUniqueConstraintOperation
+                {
+                    Name = "UN_Post_Title",
+                    NewName = "UN_Post_PostTitle"
+                },
+                "mb.RenameUniqueConstraint(" + _eol +
+                "    name: \"UN_Post_Title\"," + _eol +
+                "    newName: \"UN_Post_PostTitle\");",
+                o =>
+                {
+                    Assert.Equal("UN_Post_Title", o.Name);
+                    Assert.Equal("UN_Post_PostTitle", o.NewName);
+                    Assert.Null(o.Table);
+                    Assert.Null(o.Schema);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenameUniqueConstraintOperation_all_args()
+        {
+            Test(
+                new RenameUniqueConstraintOperation
+                {
+                    Name = "UN_dbo.Post_Title",
+                    Schema = "dbo",
+                    Table = "Post",
+                    NewName = "UN_dbo.Post_PostTitle"
+                },
+                "mb.RenameUniqueConstraint(" + _eol +
+                "    name: \"UN_dbo.Post_Title\"," + _eol +
+                "    schema: \"dbo\"," + _eol +
+                "    table: \"Post\"," + _eol +
+                "    newName: \"UN_dbo.Post_PostTitle\");",
+                o =>
+                {
+                    Assert.Equal("UN_dbo.Post_Title", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("Post", o.Table);
+                    Assert.Equal("UN_dbo.Post_PostTitle", o.NewName);
                 });
         }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -2350,6 +2350,52 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         [ConditionalFact]
+        public void RenameCheckConstraintOperation_required_args()
+        {
+            Test(
+                new RenameCheckConstraintOperation
+                {
+                    Name = "CK_Post_Title_IsTiCase",
+                    NewName = "CK_Post_Title_IsTitleCase"
+                },
+                "mb.RenameCheckConstraint(" + _eol +
+                "    name: \"CK_Post_Title_IsTiCase\"," + _eol +
+                "    newName: \"CK_Post_Title_IsTitleCase\");",
+                o =>
+                {
+                    Assert.Equal("CK_Post_Title_IsTiCase", o.Name);
+                    Assert.Equal("CK_Post_Title_IsTitleCase", o.NewName);
+                    Assert.Null(o.Table);
+                    Assert.Null(o.Schema);
+                });
+        }
+
+        [ConditionalFact]
+        public void RenameCheckConstraintOperation_all_args()
+        {
+            Test(
+                new RenameForeignKeyOperation
+                {
+                    Name = "CK_Post_Title_IsTiCase",
+                    Schema = "dbo",
+                    Table = "Post",
+                    NewName = "CK_Post_Title_IsTitleCase"
+                },
+                "mb.RenameForeignKey(" + _eol +
+                "    name: \"CK_Post_Title_IsTiCase\"," + _eol +
+                "    schema: \"dbo\"," + _eol +
+                "    table: \"Post\"," + _eol +
+                "    newName: \"CK_Post_Title_IsTitleCase\");",
+                o =>
+                {
+                    Assert.Equal("CK_Post_Title_IsTiCase", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("Post", o.Table);
+                    Assert.Equal("CK_Post_Title_IsTitleCase", o.NewName);
+                });
+        }
+
+        [ConditionalFact]
         public void RenameForeignKeyOperation_required_args()
         {
             Test(

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -93,8 +93,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         new TestRelationalTypeMappingSource(
                             TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                             TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
-                    new MigrationsAnnotationProvider(
-                        new MigrationsAnnotationProviderDependencies()),
+                        new RelationalAnnotationProvider(
+                            new RelationalAnnotationProviderDependencies()),
+                        new MigrationsAnnotationProvider(
+                            new MigrationsAnnotationProviderDependencies()),
                         services.GetRequiredService<IChangeDetector>(),
                         services.GetRequiredService<IUpdateAdapterFactory>(),
                         services.GetRequiredService<CommandBatchPreparerDependencies>()),

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -1223,6 +1223,22 @@ namespace Microsoft.EntityFrameworkCore
                 });
 
         [ConditionalFact]
+        public virtual Task Rename_check_constraint()
+            => Test(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("DriverLicense");
+                    }),
+                builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_Bar", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                model =>
+                {
+                    // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+                });
+
+        [ConditionalFact]
         public virtual Task Create_sequence()
             => Test(
                 builder => { },

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -2577,18 +2577,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(1, operations.Count);
 
-                    var dropOperation = Assert.IsType<DropCheckConstraintOperation>(operations[0]);
-                    Assert.Equal("dbo", dropOperation.Schema);
-                    Assert.Equal("Pelican", dropOperation.Table);
-                    Assert.Equal("CK_Flamingo_AlternateId", dropOperation.Name);
-
-                    var createOperation = Assert.IsType<CreateCheckConstraintOperation>(operations[1]);
-                    Assert.Equal("dbo", createOperation.Schema);
-                    Assert.Equal("Pelican", createOperation.Table);
-                    Assert.Equal("CK_Flamingo", createOperation.Name);
-                    Assert.Equal("AlternateId > Id", createOperation.Sql);
+                    var renameOperation = Assert.IsType<RenameCheckConstraintOperation>(operations[0]);
+                    Assert.Equal("dbo", renameOperation.Schema);
+                    Assert.Equal("Pelican", renameOperation.Table);
+                    Assert.Equal("CK_Flamingo_AlternateId", renameOperation.Name);
+                    Assert.Equal("CK_Flamingo", renameOperation.NewName);
                 });
         }
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -2437,18 +2437,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(1, operations.Count);
 
-                    var dropOperation = Assert.IsType<DropUniqueConstraintOperation>(operations[0]);
-                    Assert.Equal("dbo", dropOperation.Schema);
-                    Assert.Equal("Pelican", dropOperation.Table);
-                    Assert.Equal("AK_Pelican_AlternateId", dropOperation.Name);
-
-                    var addOperation = Assert.IsType<AddUniqueConstraintOperation>(operations[1]);
-                    Assert.Equal("dbo", addOperation.Schema);
-                    Assert.Equal("Pelican", addOperation.Table);
-                    Assert.Equal("AK_dbo.Pelican_AlternateId", addOperation.Name);
-                    Assert.Equal(new[] { "AlternateId" }, addOperation.Columns);
+                    var renameOperation = Assert.IsType<RenameUniqueConstraintOperation>(operations[0]);
+                    Assert.Equal("dbo", renameOperation.Schema);
+                    Assert.Equal("Pelican", renameOperation.Table);
+                    Assert.Equal("AK_Pelican_AlternateId", renameOperation.Name);
+                    Assert.Equal("AK_dbo.Pelican_AlternateId", renameOperation.NewName);
                 });
         }
 
@@ -2680,18 +2675,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(1, operations.Count);
 
-                    var dropOperation = Assert.IsType<DropPrimaryKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", dropOperation.Schema);
-                    Assert.Equal("Puffin", dropOperation.Table);
-                    Assert.Equal("PK_Puffin", dropOperation.Name);
-
-                    var addOperation = Assert.IsType<AddPrimaryKeyOperation>(operations[1]);
-                    Assert.Equal("dbo", addOperation.Schema);
-                    Assert.Equal("Puffin", addOperation.Table);
-                    Assert.Equal("PK_dbo.Puffin", addOperation.Name);
-                    Assert.Equal(new[] { "Id" }, addOperation.Columns);
+                    var operation = Assert.IsType<RenamePrimaryKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", operation.Schema);
+                    Assert.Equal("Puffin", operation.Table);
+                    Assert.Equal("PK_Puffin", operation.Name);
+                    Assert.Equal("PK_dbo.Puffin", operation.NewName);
                 });
         }
 
@@ -3138,21 +3128,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(1, operations.Count);
 
-                    var dropOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", dropOperation.Schema);
-                    Assert.Equal("Nematode", dropOperation.Table);
-                    Assert.Equal("FK_Nematode_Nematode_ParentId", dropOperation.Name);
-
-                    var addOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
-                    Assert.Equal("dbo", addOperation.Schema);
-                    Assert.Equal("Nematode", addOperation.Table);
-                    Assert.Equal("FK_Nematode_NematodeParent", addOperation.Name);
-                    Assert.Equal(new[] { "ParentId" }, addOperation.Columns);
-                    Assert.Equal("dbo", addOperation.PrincipalSchema);
-                    Assert.Equal("Nematode", addOperation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, addOperation.PrincipalColumns);
+                    var renameOperation = Assert.IsType<RenameForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", renameOperation.Schema);
+                    Assert.Equal("Nematode", renameOperation.Table);
+                    Assert.Equal("FK_Nematode_Nematode_ParentId", renameOperation.Name);
+                    Assert.Equal("FK_Nematode_NematodeParent", renameOperation.NewName);
                 });
         }
 
@@ -4267,11 +4249,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(3, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    Assert.IsType<DropUniqueConstraintOperation>(operations[0]);
-                    Assert.IsType<RenameColumnOperation>(operations[1]);
-                    Assert.IsType<AddUniqueConstraintOperation>(operations[2]);
+                    Assert.IsType<RenameColumnOperation>(operations[0]);
+                    Assert.IsType<RenameUniqueConstraintOperation>(operations[1]);
                 });
         }
 
@@ -4444,12 +4425,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(4, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
-                    Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                    Assert.IsType<RenameColumnOperation>(operations[1]);
-                    Assert.IsType<RenameIndexOperation>(operations[2]);
-                    Assert.IsType<AddForeignKeyOperation>(operations[3]);
+                    Assert.IsType<RenameColumnOperation>(operations[0]);
+                    Assert.IsType<RenameIndexOperation>(operations[1]);
+                    Assert.IsType<RenameForeignKeyOperation>(operations[2]);
                 });
         }
 
@@ -5770,21 +5750,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 target => target.Entity("Table").ToTable("RenamedTable", "new").Property<int>("Id"),
                 operations =>
                 {
-                    Assert.Equal(4, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
-                    var dropPrimaryKeyOperation = Assert.IsType<DropPrimaryKeyOperation>(operations[0]);
-                    Assert.Equal("old", dropPrimaryKeyOperation.Schema);
-                    Assert.Equal("Table", dropPrimaryKeyOperation.Table);
-                    Assert.Equal("PK_Table", dropPrimaryKeyOperation.Name);
+                    Assert.IsType<EnsureSchemaOperation>(operations[0]);
 
-                    Assert.IsType<EnsureSchemaOperation>(operations[1]);
+                    Assert.IsType<RenameTableOperation>(operations[1]);
 
-                    Assert.IsType<RenameTableOperation>(operations[2]);
-
-                    var addPrimaryKeyOperation = Assert.IsType<AddPrimaryKeyOperation>(operations[3]);
-                    Assert.Equal("new", addPrimaryKeyOperation.Schema);
-                    Assert.Equal("RenamedTable", addPrimaryKeyOperation.Table);
-                    Assert.Equal("PK_RenamedTable", addPrimaryKeyOperation.Name);
+                    var renamePrimaryKeyOperation = Assert.IsType<RenamePrimaryKeyOperation>(operations[2]);
+                    Assert.Equal("PK_Table", renamePrimaryKeyOperation.Name);
+                    Assert.Equal("PK_RenamedTable", renamePrimaryKeyOperation.NewName);
+                    Assert.Equal("RenamedTable", renamePrimaryKeyOperation.Table);
+                    Assert.Equal("new", renamePrimaryKeyOperation.Schema);
                 });
         }
 
@@ -5802,15 +5778,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(3, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    Assert.IsType<DropPrimaryKeyOperation>(operations[0]);
+                    Assert.IsType<RenameColumnOperation>(operations[0]);
 
-                    Assert.IsType<RenameColumnOperation>(operations[1]);
-
-                    var addPrimaryKeyOperation = Assert.IsType<AddPrimaryKeyOperation>(operations[2]);
-                    Assert.Equal(new[] { "RenamedId" }, addPrimaryKeyOperation.Columns);
-                    Assert.Equal("PK_Table_Renamed", addPrimaryKeyOperation.Name);
+                    var renamePrimaryKeyOperation = Assert.IsType<RenamePrimaryKeyOperation>(operations[1]);
+                    Assert.Equal("PK_Table", renamePrimaryKeyOperation.Name);
+                    Assert.Equal("PK_Table_Renamed", renamePrimaryKeyOperation.NewName);
+                    Assert.Equal("Table", renamePrimaryKeyOperation.Table);
+                    Assert.Null(renamePrimaryKeyOperation.Schema);
                 });
         }
 

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -163,6 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 new TestRelationalTypeMappingSource(
                     TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                     TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()),
+                new RelationalAnnotationProvider(
+                    new RelationalAnnotationProviderDependencies()),
                 new MigrationsAnnotationProvider(
                     new MigrationsAnnotationProviderDependencies()),
                 ctx.GetService<IChangeDetector>(),

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
@@ -125,6 +126,8 @@ Statement3
 
             var logger = new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>();
             var generationHelper = new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
+            var migrationsAnnotations = new MigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies());
+            var relationalAnnotations = new RelationalAnnotationProvider(new RelationalAnnotationProviderDependencies());
 
             return new MigrationCommandListBuilder(
                 new MigrationsSqlGeneratorDependencies(
@@ -139,7 +142,9 @@ Statement3
                     typeMappingSource,
                     new CurrentDbContext(new FakeDbContext()),
                     new LoggingOptions(),
-                    logger));
+                    logger,
+                    migrationsAnnotations,
+                    relationalAnnotations));
         }
 
         private class FakeDbContext : DbContext

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -124,7 +124,8 @@ Statement3
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
-            var logger = new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>();
+            var logger = new FakeDiagnosticsLogger<DbLoggerCategory.Migrations>();
+            var commandLogger = new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>();
             var generationHelper = new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
             var migrationsAnnotations = new MigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies());
             var relationalAnnotations = new RelationalAnnotationProvider(new RelationalAnnotationProviderDependencies());
@@ -143,6 +144,7 @@ Statement3
                     new CurrentDbContext(new FakeDbContext()),
                     new LoggingOptions(),
                     logger,
+                    commandLogger,
                     migrationsAnnotations,
                     relationalAnnotations));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -1605,6 +1605,14 @@ ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
                 @"ALTER TABLE [People] DROP CONSTRAINT [CK_Foo];");
         }
 
+        public override async Task Rename_check_constraint()
+        {
+            await base.Rename_check_constraint();
+
+            AssertSql(
+                @"EXEC sp_rename N'[CK_Foo]', N'CK_Bar';");
+        }
+
         public override async Task Create_sequence()
         {
             await base.Create_sequence();

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -179,11 +179,9 @@ EXEC sp_dropextendedproperty 'MS_Description', 'SCHEMA', @defaultSchema, 'TABLE'
             await base.Rename_table_with_primary_key();
 
             AssertSql(
-                @"ALTER TABLE [People] DROP CONSTRAINT [PK_People];",
-                //
                 @"EXEC sp_rename N'[People]', N'people';",
                 //
-                @"ALTER TABLE [people] ADD CONSTRAINT [PK_people] PRIMARY KEY ([Id]);");
+                @"EXEC sp_rename N'[PK_People]', N'PK_people';");
         }
 
         public override async Task Move_table()
@@ -1509,6 +1507,14 @@ ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
                 @"ALTER TABLE [People] DROP CONSTRAINT [PK_People];");
         }
 
+        public override async Task Rename_primary_key()
+        {
+            await base.Rename_primary_key();
+
+            AssertSql(
+                @"EXEC sp_rename N'[PK_People]', N'MyShinyNewPrimaryKeyName';");
+        }
+
         public override async Task Add_foreign_key()
         {
             await base.Add_foreign_key();
@@ -1533,6 +1539,14 @@ ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
                 @"ALTER TABLE [Orders] DROP CONSTRAINT [FK_Orders_Customers_CustomerId];");
         }
 
+        public override async Task Rename_foreign_key()
+        {
+            await base.Rename_foreign_key();
+
+            AssertSql(
+                @"EXEC sp_rename N'[FK_Orders_Customers_CustomerId]', N'MyShinyNewForeignKeyConstraintName';");
+        }
+
         public override async Task Add_unique_constraint()
         {
             await base.Add_unique_constraint();
@@ -1555,6 +1569,14 @@ ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
 
             AssertSql(
                 @"ALTER TABLE [People] DROP CONSTRAINT [AK_People_AlternateKeyColumn];");
+        }
+
+        public override async Task Rename_unique_constraint()
+        {
+            await base.Rename_unique_constraint();
+
+            AssertSql(
+                @"EXEC sp_rename N'[AK_People_AlternateKeyColumn]', N'MyShinyNewUniqueConstraintName';");
         }
 
         public override async Task Add_check_constraint_with_name()

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -519,6 +519,20 @@ DROP DATABASE [Northwind];
         }
 
         [ConditionalFact]
+        public virtual void RenameForeignKeyOperation_uses_default_schema_when_no_schema()
+        {
+            Generate(new RenameForeignKeyOperation{
+                Table = "People",
+                Name = "FK_People_Name_Names_Name",
+                NewName = "FK_People_FullName_Names_Name"
+            });
+
+            Assert.Equal(
+                "EXEC sp_rename N'[FK_People_Name_Names_Name]', N'FK_People_FullName_Names_Name';" + EOL,
+                Sql);
+        }
+
+        [ConditionalFact]
         public virtual void RenameIndexOperations_throws_when_no_table()
         {
             var migrationBuilder = new MigrationBuilder("SqlServer");
@@ -531,6 +545,20 @@ DROP DATABASE [Northwind];
                 () => Generate(migrationBuilder.Operations.ToArray()));
 
             Assert.Equal(SqlServerStrings.IndexTableRequired, ex.Message);
+        }
+
+        [ConditionalFact]
+        public virtual void RenamePrimaryKeyOperation_uses_default_schema_when_no_schema()
+        {
+            Generate(new RenamePrimaryKeyOperation{
+                Table = "People",
+                Name = "PK_People_Name",
+                NewName = "PK_People_FullName"
+            });
+
+            Assert.Equal(
+                "EXEC sp_rename N'[PK_People_Name]', N'PK_People_FullName';" + EOL,
+                Sql);
         }
 
         [ConditionalFact]
@@ -566,6 +594,20 @@ DROP DATABASE [Northwind];
             AssertSql(
                 @"EXEC sp_rename N'[dbo].[People]', N'Person';
 ");
+        }
+
+        [ConditionalFact]
+        public virtual void RenameUniqueConstraintOperation_uses_default_schema_when_no_schema()
+        {
+            Generate(new RenameUniqueConstraintOperation{
+                Table = "People",
+                Name = "UN_People_Name",
+                NewName = "UN_People_FullName"
+            });
+
+            Assert.Equal(
+                "EXEC sp_rename N'[UN_People_Name]', N'UN_People_FullName';" + EOL,
+                Sql);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -204,7 +204,7 @@ be found in the docs.";
 
         public override Task Rename_table_with_primary_key()
             => AssertNotSupportedAsync(
-                base.Rename_table_with_primary_key, SqliteStrings.InvalidMigrationOperation("DropPrimaryKeyOperation"));
+                base.Rename_table_with_primary_key, SqliteStrings.InvalidMigrationOperation("RenamePrimaryKeyOperation"));
 
         // SQLite does not support schemas.
         public override Task Move_table()
@@ -430,6 +430,9 @@ CREATE INDEX ""foo"" ON ""People"" (""FirstName"");");
         public override Task Drop_primary_key()
             => AssertNotSupportedAsync(base.Drop_primary_key, SqliteStrings.InvalidMigrationOperation("DropPrimaryKeyOperation"));
 
+        public override Task Rename_primary_key()
+            => AssertNotSupportedAsync(base.Rename_primary_key, SqliteStrings.InvalidMigrationOperation("RenamePrimaryKeyOperation"));
+
         public override Task Add_foreign_key()
             => AssertNotSupportedAsync(base.Add_foreign_key, SqliteStrings.InvalidMigrationOperation("AddForeignKeyOperation"));
 
@@ -438,6 +441,9 @@ CREATE INDEX ""foo"" ON ""People"" (""FirstName"");");
 
         public override Task Drop_foreign_key()
             => AssertNotSupportedAsync(base.Drop_foreign_key, SqliteStrings.InvalidMigrationOperation("DropForeignKeyOperation"));
+
+        public override Task Rename_foreign_key()
+            => AssertNotSupportedAsync(base.Rename_foreign_key, SqliteStrings.InvalidMigrationOperation("RenameForeignKeyOperation"));
 
         public override Task Add_unique_constraint()
             => AssertNotSupportedAsync(base.Add_unique_constraint, SqliteStrings.InvalidMigrationOperation("AddUniqueConstraintOperation"));
@@ -449,6 +455,10 @@ CREATE INDEX ""foo"" ON ""People"" (""FirstName"");");
         public override Task Drop_unique_constraint()
             => AssertNotSupportedAsync(
                 base.Drop_unique_constraint, SqliteStrings.InvalidMigrationOperation("DropUniqueConstraintOperation"));
+
+        public override Task Rename_unique_constraint()
+            => AssertNotSupportedAsync(
+                base.Rename_unique_constraint, SqliteStrings.InvalidMigrationOperation("RenameUniqueConstraintOperation"));
 
         public override Task Add_check_constraint_with_name()
             => AssertNotSupportedAsync(

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -471,6 +471,9 @@ CREATE INDEX ""foo"" ON ""People"" (""FirstName"");");
         public override Task Drop_check_constraint()
             => AssertNotSupportedAsync(base.Drop_check_constraint, SqliteStrings.InvalidMigrationOperation("DropCheckConstraintOperation"));
 
+        public override Task Rename_check_constraint()
+            => AssertNotSupportedAsync(base.Rename_check_constraint, SqliteStrings.InvalidMigrationOperation("RenameCheckConstraintOperation"));
+
         public override Task Create_sequence()
             => AssertNotSupportedAsync(base.Create_sequence, SqliteStrings.SequencesNotSupported);
 


### PR DESCRIPTION
Addresses #5662 

~~I've kept separate commits for the three different constraint types but will squash them upon request.~~

- [X] The code builds
- [X] All but 2 tests pass (verified by running `.\build.cmd -test` on my system). The 2 failing tests seem to be completely unrelated to my changes as they also fail on a clean master checkout on my system:
  - `Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDatabaseModelFactoryTest.Default_value_matching_clr_default_is_not_stored` fails for `IgnoredDefault24 float NOT NULL DEFAULT 0.0E0` where `null` is expected and the actual value is `0.000000000000000e+000`
  - `Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDatabaseModelFactoryTest.Hidden_columns_are_not_created` throws an `SqlException` : `Incorrect syntax near 'GENERATED'.\r\nIncorrect syntax near 'HIDDEN'.\r\nIncorrect syntax near the keyword 'with'. If this statement is a common table expression, an xmlnamespaces clause or a change tracking context clause, the previous statement must be terminated with a semicolon.`
- [ ] Commit messages currently don't follow this format as they aren't finalized yet
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.