### PR TITLE
Made it possible to use IEnumerable.Empty() in HasDefaultValue.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -334,7 +335,14 @@ namespace Microsoft.EntityFrameworkCore
             {
                 try
                 {
-                    return Convert.ChangeType(value, property.ClrType, CultureInfo.InvariantCulture);
+                    if (typeof(IEnumerable).IsAssignableFrom(property.ClrType) && property.ClrType.IsGenericType)
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        return Convert.ChangeType(value, property.ClrType, CultureInfo.InvariantCulture);
+                    }
                 }
                 catch (Exception)
                 {

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -335,7 +335,9 @@ namespace Microsoft.EntityFrameworkCore
             {
                 try
                 {
-                    if (typeof(IEnumerable).IsAssignableFrom(property.ClrType) && property.ClrType.IsGenericType)
+                    if (typeof(IEnumerable).IsAssignableFrom(property.ClrType)
+                        && property.ClrType.IsGenericType
+                        && property.ClrType.IsAssignableFrom(valueType))
                     {
                         return value;
                     }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -1205,6 +1205,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 .HasConstraintName("Simon");
         }
 
+        [ConditionalFact]
+        public void Can_use_empty_IEnumerable_as_default_value()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+            modelBuilder
+                .Entity<Customer>()
+                .Property(c => c.Orders)
+                .HasDefaultValue(Enumerable.Empty<Order>());
+        }
+
         private void AssertIsGeneric(EntityTypeBuilder<Customer> _)
         {
         }


### PR DESCRIPTION
Made it possible to use IEnumerable.Empty() in HasDefaultValue.
 - Also added a test for it.

Fixes #17780

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/aspnet/AspNetCore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


