### PR TITLE
[WIP] Fix for #8434 - Add ability to scaffold IEntityTypeConfiguration classes

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -61,6 +61,8 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton<ICandidateNamingService, CandidateNamingService>()
                 .AddSingleton<ICSharpDbContextGenerator, CSharpDbContextGenerator>()
                 .AddSingleton<ICSharpEntityTypeGenerator, CSharpEntityTypeGenerator>()
+                .AddSingleton<ICSharpEntityTypeConfigurationGenerator, CSharpEntityTypeConfigurationGenerator>()
+                .AddSingleton<ICSharpFluentConfigurationCodeGenerator, CSharpFluentConfigurationCodeGenerator>()
                 .AddSingleton<ICSharpHelper, CSharpHelper>()
                 .AddSingleton<ICSharpMigrationOperationGenerator, CSharpMigrationOperationGenerator>()
                 .AddSingleton<ICSharpSnapshotGenerator, CSharpSnapshotGenerator>()

--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -71,7 +71,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool configurationClasses,
+            [CanBeNull] string configurationClassSuffix)
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -105,7 +107,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     ContextNamespace = contextNamespace,
                     Language = _language,
                     ContextDir = MakeDirRelative(outputDir, outputContextDir),
-                    ContextName = dbContextClassName
+                    ContextName = dbContextClassName,
+                    GenerateEntityTypeConfigurationFiles = configurationClasses,
+                    EntityTypeConfigurationClassSuffix = configurationClassSuffix
                 });
 
             return scaffolder.Save(

--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -95,6 +95,12 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var modelNamespace = GetNamespaceFromOutputPath(outputDir);
             var contextNamespace = GetNamespaceFromOutputPath(outputContextDir);
 
+            //default the config class suffix if it's not set and we are using configuration classes
+            if(configurationClasses && string.IsNullOrWhiteSpace(configurationClassSuffix))
+            {
+                configurationClassSuffix = "EntityConfiguration";
+            }
+
             var scaffoldedModel = scaffolder.ScaffoldModel(
                 connectionString,
                 new DatabaseModelFactoryOptions(tables, schemas),

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -179,7 +179,9 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             return new Hashtable
             {
-                ["MigrationFile"] = files.MigrationFile, ["MetadataFile"] = files.MetadataFile, ["SnapshotFile"] = files.SnapshotFile
+                ["MigrationFile"] = files.MigrationFile,
+                ["MetadataFile"] = files.MetadataFile,
+                ["SnapshotFile"] = files.SnapshotFile
             };
         }
 
@@ -335,7 +337,9 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             return new Hashtable
             {
-                ["MigrationFile"] = files.MigrationFile, ["MetadataFile"] = files.MetadataFile, ["SnapshotFile"] = files.SnapshotFile
+                ["MigrationFile"] = files.MigrationFile,
+                ["MetadataFile"] = files.MetadataFile,
+                ["SnapshotFile"] = files.SnapshotFile
             };
         }
 
@@ -463,11 +467,13 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
                 var useDatabaseNames = (bool)args["useDatabaseNames"];
+                var configurationClasses = (bool)args["configurationClasses"];
+                var configurationClassSuffix = (string)args["configurationClassSuffix"];
 
                 Execute(
                     () => executor.ScaffoldContextImpl(
                         provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames));
+                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames, configurationClasses, configurationClassSuffix));
             }
         }
 
@@ -481,7 +487,9 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool configurationClasses,
+            [CanBeNull] string configurationClassSuffix)
         {
             Check.NotNull(provider, nameof(provider));
             Check.NotNull(connectionString, nameof(connectionString));
@@ -490,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = DatabaseOperations.ScaffoldContext(
                 provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames);
+                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames, configurationClasses, configurationClassSuffix);
 
             return new Hashtable { ["ContextFile"] = files.ContextFile, ["EntityTypeFiles"] = files.AdditionalFiles.ToArray() };
         }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeConfigurationGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeConfigurationGenerator.cs
@@ -81,14 +81,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            _sb.AppendLine($"public partial class {entityType.Name}{classSuffix}: IEntityTypeConfiguration<{entityType.Name}> ");
+            _sb.AppendLine($"public partial class {entityType.Name}{classSuffix} : IEntityTypeConfiguration<{entityType.Name}>");
 
             _sb.AppendLine("{");
 
             using (_sb.Indent())
             {
                 _sb.AppendLine($"public void Configure(EntityTypeBuilder<{entityType.Name}> {BuilderIdentifier})");
-                _sb.AppendLine("{");
+                _sb.Append("{");
 
                 using (_sb.Indent())
                 {
@@ -162,6 +162,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 return;
             }
 
+            //add a blank line at the top
+            _sb.AppendLine();
+
             //append the first line directly to the builder
             _sb.Append($"{BuilderIdentifier}{lines[0]}");
 
@@ -176,9 +179,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             _sb.AppendLine(";");
-
-            //enforce a blank line at the bottom of each fluent block.
-            _sb.AppendLine();
         }
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeConfigurationGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeConfigurationGenerator.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+{        /// <summary>
+         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+         ///     any release. You should only use it directly in your code with extreme caution and knowing that
+         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+         /// </summary>
+    public class CSharpEntityTypeConfigurationGenerator : ICSharpEntityTypeConfigurationGenerator
+    {
+        private const string BuilderIdentifier = "builder";
+
+        private readonly ICSharpHelper _code;
+        private readonly ICSharpFluentConfigurationCodeGenerator _fluentGenerator;
+
+        private IndentedStringBuilder _sb;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public CSharpEntityTypeConfigurationGenerator(
+            [NotNull] ICSharpHelper cSharpHelper, ICSharpFluentConfigurationCodeGenerator cSharpFluentConfigurationGenerator)
+        {
+            Check.NotNull(cSharpHelper, nameof(cSharpHelper));
+
+            _code = cSharpHelper;
+            _fluentGenerator = cSharpFluentConfigurationGenerator;
+        }
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string WriteCode([NotNull] IEntityType entityType, [NotNull] string @namespace, string classSuffix)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(@namespace, nameof(@namespace));
+            Check.NotNull(classSuffix, nameof(classSuffix));
+
+            _sb = new IndentedStringBuilder();
+
+            _sb.AppendLine("using Microsoft.EntityFrameworkCore;");
+            _sb.AppendLine("using Microsoft.EntityFrameworkCore.Metadata.Builders;");
+
+            _sb.AppendLine();
+            _sb.AppendLine($"namespace {@namespace}");
+            _sb.AppendLine("{");
+
+            using (_sb.Indent())
+            {
+                GenerateClass(entityType, classSuffix);
+            }
+
+            _sb.AppendLine("}");
+
+            return _sb.ToString();
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void GenerateClass(IEntityType entityType, string classSuffix)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            _sb.AppendLine($"public partial class {entityType.Name}{classSuffix}: IEntityTypeConfiguration<{entityType.Name}> ");
+
+            _sb.AppendLine("{");
+
+            using (_sb.Indent())
+            {
+                _sb.AppendLine($"public void Configure(EntityTypeBuilder<{entityType.Name}> {BuilderIdentifier})");
+                _sb.AppendLine("{");
+
+                using (_sb.Indent())
+                {
+                    GenerateTableOrView(entityType);
+
+                    GeneratePrimaryKey(entityType);
+
+                    foreach (var property in entityType.GetProperties())
+                    {
+                        GenerateProperty(property);
+                    }
+
+                    foreach (var foreignKey in entityType.GetForeignKeys())
+                    {
+                        GenerateRelationship(foreignKey);
+                    }
+
+                    foreach (var index in entityType.GetIndexes())
+                    {
+                        GenerateIndex(index);
+                    }
+                }
+
+                _sb.AppendLine("}");
+            }
+
+            _sb.AppendLine("}");
+        }
+
+        private void GenerateTableOrView(IEntityType entityType)
+        {
+            var lines = _fluentGenerator.GenerateTableOrView(entityType);
+
+            AppendMultiLineFluentApiToBuilder(lines);
+        }
+
+        private void GeneratePrimaryKey(IEntityType entityType)
+        {
+            var key = entityType.FindPrimaryKey();
+
+            var lines = _fluentGenerator.GenerateKey(key, false, true);
+
+            AppendMultiLineFluentApiToBuilder(lines);
+        }
+
+        private void GenerateProperty(IProperty property)
+        {
+            var lines = _fluentGenerator.GenerateProperty(property, true);
+
+            AppendMultiLineFluentApiToBuilder(lines);
+        }
+
+        private void GenerateRelationship(IForeignKey foreignKey)
+        {
+            var lines = _fluentGenerator.GenerateRelationship(foreignKey, true);
+
+            AppendMultiLineFluentApiToBuilder(lines);
+        }
+
+        private void GenerateIndex(IIndex index)
+        {
+            var lines = _fluentGenerator.GenerateIndex(index);
+
+            AppendMultiLineFluentApiToBuilder(lines);
+        }
+
+        private void AppendMultiLineFluentApiToBuilder(IList<string> lines)
+        {
+            if (lines == null || lines.Count <= 0)
+            {
+                return;
+            }
+
+            //append the first line directly to the builder
+            _sb.Append($"{BuilderIdentifier}{lines[0]}");
+
+            //each subsequent line is added as a fluent api style method call
+            using (_sb.Indent())
+            {
+                foreach (var line in lines.Skip(1))
+                {
+                    _sb.AppendLine();
+                    _sb.Append(line);
+                }
+            }
+
+            _sb.AppendLine(";");
+
+            //enforce a blank line at the bottom of each fluent block.
+            _sb.AppendLine();
+        }
+    }
+}

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpFluentConfigurationCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpFluentConfigurationCodeGenerator.cs
@@ -86,8 +86,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         /// </summary>
         public IList<string> GenerateKey(IKey key, bool generateHasNoKey, bool includeDataAnnotations)
         {
-            Check.NotNull(key, nameof(key));
-
             if (key == null)
             {
                 return generateHasNoKey ? new List<string> { $".{nameof(EntityTypeBuilder.HasNoKey)}()" } : null;
@@ -407,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
 
-            return !includeDataAnnotations || !canUseDataAnnotations ? lines : null;
+            return includeDataAnnotations || !canUseDataAnnotations ? lines : null;
         }
 
         /// <summary>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -124,7 +124,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 resultingFiles.AdditionalFiles.Add(
                     new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
 
-
                 //if the config needs to go into a custom configuration class, then we do that here
                 if(configLocation == EntityConfigurationLocation.IEntityTypeConfiguration)
                 {
@@ -133,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     // output EntityTypeConfiguration .cs file
                     var configFilename = entityType.DisplayName()+ options.EntityTypeConfigurationClassSuffix + FileExtension;
                     resultingFiles.AdditionalFiles.Add(
-                        new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
+                        new ScaffoldedFile { Path = configFilename, Code = generatedCode });
                 }
             }
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -38,17 +38,28 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual ICSharpEntityTypeConfigurationGenerator CSharpEntityTypeConfigurationGenerator { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public CSharpModelGenerator(
             [NotNull] ModelCodeGeneratorDependencies dependencies,
             [NotNull] ICSharpDbContextGenerator cSharpDbContextGenerator,
-            [NotNull] ICSharpEntityTypeGenerator cSharpEntityTypeGenerator)
+            [NotNull] ICSharpEntityTypeGenerator cSharpEntityTypeGenerator,
+            [NotNull] ICSharpEntityTypeConfigurationGenerator cSharpEntityTypeConfigurationGenerator)
             : base(dependencies)
         {
             Check.NotNull(cSharpDbContextGenerator, nameof(cSharpDbContextGenerator));
             Check.NotNull(cSharpEntityTypeGenerator, nameof(cSharpEntityTypeGenerator));
+            Check.NotNull(cSharpEntityTypeConfigurationGenerator, nameof(cSharpEntityTypeConfigurationGenerator));
 
             CSharpDbContextGenerator = cSharpDbContextGenerator;
             CSharpEntityTypeGenerator = cSharpEntityTypeGenerator;
+            CSharpEntityTypeConfigurationGenerator = cSharpEntityTypeConfigurationGenerator;
         }
 
         private const string FileExtension = ".cs";
@@ -76,13 +87,23 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var resultingFiles = new ScaffoldedModel();
 
+            var configLocation = EntityConfigurationLocation.OnModelCreating;
+            if (options.UseDataAnnotations)
+            {
+                configLocation = EntityConfigurationLocation.DataAnnotations;
+            }
+            else if (options.GenerateEntityTypeConfigurationFiles)
+            {
+                configLocation = EntityConfigurationLocation.IEntityTypeConfiguration;
+            }
+
             var generatedCode = CSharpDbContextGenerator.WriteCode(
                 model,
                 options.ContextNamespace ?? options.ModelNamespace,
                 options.ContextName,
                 options.ConnectionString,
-                options.UseDataAnnotations,
-                options.SuppressConnectionStringWarning);
+                options.SuppressConnectionStringWarning,
+                configLocation);
 
             // output DbContext .cs file
             var dbContextFileName = options.ContextName + FileExtension;
@@ -96,12 +117,24 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                generatedCode = CSharpEntityTypeGenerator.WriteCode(entityType, options.ModelNamespace, options.UseDataAnnotations);
+                generatedCode = CSharpEntityTypeGenerator.WriteCode(entityType, options.ModelNamespace, configLocation == EntityConfigurationLocation.DataAnnotations);
 
                 // output EntityType poco .cs file
                 var entityTypeFileName = entityType.DisplayName() + FileExtension;
                 resultingFiles.AdditionalFiles.Add(
                     new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
+
+
+                //if the config needs to go into a custom configuration class, then we do that here
+                if(configLocation == EntityConfigurationLocation.IEntityTypeConfiguration)
+                {
+                    generatedCode = CSharpEntityTypeConfigurationGenerator.WriteCode(entityType, options.ModelNamespace, options.EntityTypeConfigurationClassSuffix);
+
+                    // output EntityTypeConfiguration .cs file
+                    var configFilename = entityType.DisplayName()+ options.EntityTypeConfigurationClassSuffix + FileExtension;
+                    resultingFiles.AdditionalFiles.Add(
+                        new ScaffoldedFile { Path = entityTypeFileName, Code = generatedCode });
+                }
             }
 
             return resultingFiles;

--- a/src/EFCore.Design/Scaffolding/Internal/EntityConfigurationLocation.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/EntityConfigurationLocation.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+{    /// <summary>
+     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+     ///     any release. You should only use it directly in your code with extreme caution and knowing that
+     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+     /// </summary>
+    public enum EntityConfigurationLocation
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        OnModelCreating,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        DataAnnotations,
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IEntityTypeConfiguration
+    }
+}

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpEntityTypeConfigurationGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpEntityTypeConfigurationGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface ICSharpDbContextGenerator
+    public interface ICSharpEntityTypeConfigurationGenerator
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,12 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        string WriteCode(
-            [NotNull] IModel model,
-            [NotNull] string @namespace,
-            [NotNull] string contextName,
-            [NotNull] string connectionString,
-            bool suppressConnectionStringWarning,
-            EntityConfigurationLocation entityConfigurationLocation);
+        string WriteCode([NotNull] IEntityType entityType, [NotNull] string @namespace, string classSuffix);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpFluentConfigurationCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpFluentConfigurationCodeGenerator.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public interface ICSharpFluentConfigurationCodeGenerator
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IList<string> GenerateIndex(IIndex index);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IList<string> GenerateKey(IKey key, bool generateHasNoKey, bool includeDataAnnotations);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IList<string> GenerateProperty(IProperty property, bool includeDataAnnotations);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IList<string> GenerateRelationship(IForeignKey foreignKey, bool includeDataAnnotations);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IList<string> GenerateTableOrView(IEntityType entityType);
+    }
+}

--- a/src/EFCore.Design/Scaffolding/ModelCodeGenerationOptions.cs
+++ b/src/EFCore.Design/Scaffolding/ModelCodeGenerationOptions.cs
@@ -17,6 +17,18 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         public virtual bool UseDataAnnotations { get; set; }
 
         /// <summary>
+        ///     Gets or sets a value indicated whether to generate entity configuration in IEntityTypeConfiguration files.
+        /// </summary>
+        /// <value>A value indicating whether to generate entity configuration in IEntityTypeConfiguration files.</value>
+        public virtual bool GenerateEntityTypeConfigurationFiles { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the suffix for EntityTypeConfiguration classes.
+        /// </summary>
+        /// <value>Gets or sets the suffix for EntityTypeConfiguration classes.</value>
+        public virtual string EntityTypeConfigurationClassSuffix { get; [param: CanBeNull] set; }
+
+        /// <summary>
         ///     Gets or sets a value indicating whether to suppress the connection string sensitive information warning.
         /// </summary>
         /// <value> A value indicating whether to suppress the connection string sensitive information warning. </value>

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -412,6 +412,18 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string BuildSucceeded
             => GetString("BuildSucceeded");
 
+        /// <summary>
+        ///     Use IEntityTypeConfiguration classes to configure the model (where possible).
+        /// </summary>
+        public static string ConfigurationClassesDescription
+            => GetString("ConfigurationClassesDescription");
+
+        /// <summary>
+        ///     A suffix to add to IEntityTypeConfiguration class names. Defaults to "EntityConfiguration".
+        /// </summary>
+        public static string ConfigurationClassSuffixDescription
+            => GetString("ConfigurationClassSuffixDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -306,4 +306,10 @@
   <data name="BuildSucceeded" xml:space="preserve">
     <value>Build succeeded.</value>
   </data>
+  <data name="ConfigurationClassesDescription" xml:space="preserve">
+    <value>Use IEntityTypeConfiguration classes to configure the model (where possible).</value>
+  </data>
+  <data name="ConfigurationClassSuffixDescription" xml:space="preserve">
+    <value>A suffix to add to IEntityTypeConfiguration class names. Defaults to "EntityConfiguration".</value>
+  </data>
 </root>

--- a/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
@@ -11,6 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandArgument _connection;
         private CommandArgument _provider;
         private CommandOption _dataAnnotations;
+        private CommandOption _configurationClasses;
+        private CommandOption _configurationClassSuffix;
         private CommandOption _context;
         private CommandOption _contextDir;
         private CommandOption _force;
@@ -28,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             _provider = command.Argument("<PROVIDER>", Resources.ProviderDescription);
 
             _dataAnnotations = command.Option("-d|--data-annotations", Resources.DataAnnotationsDescription);
+            _configurationClasses = command.Option("--configuration-classes", Resources.ConfigurationClassesDescription);
+            _configurationClassSuffix = command.Option("--configuration-class-suffix <SUFFIX>", Resources.ConfigurationClassSuffixDescription);
             _context = command.Option("-c|--context <NAME>", Resources.ContextNameDescription);
             _contextDir = command.Option("--context-dir <PATH>", Resources.ContextDirDescription);
             _force = command.Option("-f|--force", Resources.DbContextScaffoldForceDescription);

--- a/src/ef/Commands/DbContextScaffoldCommand.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.cs
@@ -37,7 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 _tables.Values,
                 _dataAnnotations.HasValue(),
                 _force.HasValue(),
-                _useDatabaseNames.HasValue());
+                _useDatabaseNames.HasValue(),
+                _configurationClasses.HasValue(),
+                _configurationClassSuffix.Value());
             if (_json.HasValue())
             {
                 ReportJsonResults(result);

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -27,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames);
+            bool useDatabaseNames,
+            bool useConfigurationClasses,
+            string configurationClassSuffix);
 
         string ScriptMigration(string fromMigration, string toMigration, bool idempotent, string contextType);
 

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -125,7 +125,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool useConfigurationClasses,
+            string configurationClassSuffix)
             => InvokeOperation<IDictionary>(
                 "ScaffoldContext",
                 new Dictionary<string, object>
@@ -139,7 +141,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["tableFilters"] = tableFilters,
                     ["useDataAnnotations"] = useDataAnnotations,
                     ["overwriteFiles"] = overwriteFiles,
-                    ["useDatabaseNames"] = useDatabaseNames
+                    ["useDatabaseNames"] = useDatabaseNames,
+                    ["configurationClasses"] = useConfigurationClasses,
+                    ["configurationClassSuffix"] = configurationClassSuffix
                 });
 
         public string ScriptMigration(

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -456,6 +456,24 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string DbContextScriptDescription
             => GetString("DbContextScriptDescription");
 
+        /// <summary>
+        ///     Use IEntityTypeConfiguration classes to configure the model (where possible).
+        /// </summary>
+        public static string ConfigurationClassesDescription
+            => GetString("ConfigurationClassesDescription");
+
+        /// <summary>
+        ///     A suffix to add to IEntityTypeConfiguration class names. Defaults to "EntityConfiguration".
+        /// </summary>
+        public static string ConfigurationClassSuffixDescription
+            => GetString("ConfigurationClassSuffixDescription");
+
+        /// <summary>
+        ///     Testing
+        /// </summary>
+        public static string Test
+            => GetString("Test");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -321,7 +321,10 @@
   <data name="ConfigurationClassesDescription" xml:space="preserve">
     <value>Use IEntityTypeConfiguration classes to configure the model (where possible).</value>
   </data>
-  <data name="ConfigurationClassSuffix" xml:space="preserve">
-    <value>A suffix to add to IEntityTypeConfiguration classes. Defaults to "EntityConfiguration".</value>
+  <data name="ConfigurationClassSuffixDescription" xml:space="preserve">
+    <value>A suffix to add to IEntityTypeConfiguration class names. Defaults to "EntityConfiguration".</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Testing</value>
   </data>
 </root>

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -318,4 +318,10 @@
   <data name="DbContextScriptDescription" xml:space="preserve">
     <value>Generate a script to create all tables for the DbContext.</value>
   </data>
+  <data name="ConfigurationClassesDescription" xml:space="preserve">
+    <value>Use IEntityTypeConfiguration classes to configure the model (where possible).</value>
+  </data>
+  <data name="ConfigurationClassSuffix" xml:space="preserve">
+    <value>A suffix to add to IEntityTypeConfiguration classes. Defaults to "EntityConfiguration".</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityConfigurationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityConfigurationGeneratorTest.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+{
+    public class CSharpEntityConfigurationGeneratorTest : ModelCodeGeneratorTestBase
+    {
+        [ConditionalFact]
+        public void Composite_key()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "Post",
+                        x =>
+                        {
+                            x.Property<int>("Key");
+                            x.Property<int>("Serial");
+                            x.HasKey("Key", "Serial");
+                        }),
+                new ModelCodeGenerationOptions { GenerateEntityTypeConfigurationFiles = true, EntityTypeConfigurationClassSuffix = "EntityConfiguration" },
+                code =>
+                {
+                    var postFile = code.AdditionalFiles.First(f => f.Path == "PostEntityConfiguration.cs");
+                    Assert.Equal(
+                        @"using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace TestNamespace
+{
+    public partial class PostEntityConfiguration : IEntityTypeConfiguration<Post>
+    {
+        public void Configure(EntityTypeBuilder<Post> builder)
+        {
+            builder.HasKey(e => new { e.Key, e.Serial });
+        }
+    }
+}
+",
+                        postFile.Code);
+                },
+                model =>
+                {
+                    var postType = model.FindEntityType("TestNamespace.Post");
+                    Assert.NotNull(postType.FindPrimaryKey());
+                });
+        }
+
+        [ConditionalFact]
+        public void Views_generate_ToView_method()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").ToView("Vistas", "test"),
+                new ModelCodeGenerationOptions { GenerateEntityTypeConfigurationFiles = true, EntityTypeConfigurationClassSuffix = "EntityConfiguration" },
+                code => Assert.Contains(
+                    "ToView(\"Vistas\", \"test\");",
+                    code.AdditionalFiles.First(f => f.Path == "VistaEntityConfiguration.cs").Code),
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Equal("Vistas", entityType.GetTableName());
+                    Assert.Equal("dbo", entityType.GetSchema());
+                });
+        }
+
+        [ConditionalFact]
+        public void Navigation_property_with_same_type_and_property_name()
+        {
+            Test(
+                modelBuilder =>modelBuilder
+                   .Entity(
+                       "Blog",
+                       x => x.Property<int>("Id"))
+                   .Entity(
+                       "Post",
+                       x =>
+                       {
+                           x.Property<int>("Id");
+                           x.Property<int>("BlogId");
+                           x.HasOne("Blog", "Blog").WithMany("Posts").HasForeignKey("BlogId");
+                       }),
+                new ModelCodeGenerationOptions { GenerateEntityTypeConfigurationFiles = true, EntityTypeConfigurationClassSuffix = "EntityConfiguration" },
+                code =>
+                {
+                    var postFile = code.AdditionalFiles.First(f => f.Path == "PostEntityConfiguration.cs");
+
+                    Assert.Equal(@"using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace TestNamespace
+{
+    public partial class PostEntityConfiguration : IEntityTypeConfiguration<Post>
+    {
+        public void Configure(EntityTypeBuilder<Post> builder)
+        {
+            builder.Property(e => e.Id);
+
+            builder.Property(e => e.BlogId);
+
+            builder.HasOne(d => d.Blog)
+                .WithMany(p => p.Posts)
+                .WithForeignKey(d => d.BlogId);
+
+            builder.HasIndex(e => e.BlogId);
+        }
+    }
+}
+",
+                        postFile.Code);
+                },
+                model =>
+                {
+                    var postType = model.FindEntityType("TestNamespace.Post");
+                    var blogNavigation = postType.FindNavigation("Blog");
+
+                    var foreignKeyProperty = Assert.Single(blogNavigation.ForeignKey.Properties);
+                    Assert.Equal("BlogId", foreignKeyProperty.Name);
+
+                    var inverseNavigation = blogNavigation.FindInverse();
+                    Assert.Equal("TestNamespace.Blog", inverseNavigation.DeclaringEntityType.Name);
+                    Assert.Equal("Posts", inverseNavigation.Name);
+                });
+        }
+    }
+}


### PR DESCRIPTION
As per #8434, it would be nice to have the ability to scaffold `IEntityTypeConfiguration` classes as an option to either `OnModelCreating` or data attributes.

This is still WIP as I'm working on adding tests and looking for feedback on the approach I've taken

In the process of understanding how the scaffolding code works, I realised that the `OnModelCreating`/`DbContext` configuration generation output is very similar (if not identical) to the output required for `IEntityTypeConfiguration`.

I extracted the appropriate parts of that code into a new `ICSharpFluentConfigurationGenerator` (and appropriate implementation) that provides a single location for resolving the model and generating the code required for fluent config. These methods broadly return a list of lines to be written, allowing the consumer class to generate the correct code.

I added a new `ICSharpEntityTypeConfigurationGenerator` which is the class that actually generates an `IEntityTypeCOnfiguration` class for each entity.

I also put in new parameters into the `ef scaffold` command, which allow you to
- Specify to scaffold `IEntityTypeConfiguration` classes
- Specify a default suffix to add to these generated classes. (e.g. `MyEntity[Suffix].cs`)

I'm still working on adding appropriate tests to make sure it's generating correctly, but it seems to be working at least in the basic cases.

Some things I'm not 100% sure about and would love some feedback on:
- I'm not sure if we need a new way to specify what configuration style to run (in the `ef` command). How do we handle if someone specifies `-d|--data-attributes` as well as the new command I added?
- I added a `EntityConfigurationLocation` enum to "track" the "location" of the configuration, as if we have specified `IEntityConfiguration` classes, then we need to write a line into the `OnModelCreating` to search the assembly for these classes. Is this an acceptable approach?
- The `ef` command parameter names are super long (imo) and probably could be more concise. Happy for some feedback on them.

