### PR TITLE
Work on set operations and inheritance

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -575,12 +575,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("PendingAmbientTransaction");
 
         /// <summary>
-        ///     Set operations (Union, Concat, Intersect, Except) are only supported over entity types within the same type hierarchy.
-        /// </summary>
-        public static string SetOperationNotWithinEntityTypeHierarchy
-            => GetString("SetOperationNotWithinEntityTypeHierarchy");
-
-        /// <summary>
         ///     FromSqlRaw or FromSqlInterpolated was called with non-composable SQL and with a query composing over it. Consider calling `AsEnumerable` after the FromSqlRaw or FromSqlInterpolated method to perform the composition on the client side.
         /// </summary>
         public static string FromSqlNonComposable

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -491,9 +491,6 @@
   <data name="PendingAmbientTransaction" xml:space="preserve">
     <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>
   </data>
-  <data name="SetOperationNotWithinEntityTypeHierarchy" xml:space="preserve">
-    <value>Set operations (Union, Concat, Intersect, Except) are only supported over entity types within the same type hierarchy.</value>
-  </data>
   <data name="FromSqlNonComposable" xml:space="preserve">
     <value>FromSqlRaw or FromSqlInterpolated was called with non-composable SQL and with a query composing over it. Consider calling `AsEnumerable` after the FromSqlRaw or FromSqlInterpolated method to perform the composition on the client side.</value>
   </data>

--- a/src/EFCore.Relational/Query/EntityProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/EntityProjectionExpression.cs
@@ -111,6 +111,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (!_propertyExpressionsCache.TryGetValue(property, out var expression))
             {
+                if (_innerTable == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not bind property '{property.Name}' on entity type '{EntityType.DisplayName()}': "
+                        + "projection was initialized with an expression cache but the property isn't in it.");
+                }
                 expression = new ColumnExpression(property, _innerTable, _nullable);
                 _propertyExpressionsCache[property] = expression;
             }

--- a/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -434,6 +434,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        #region Set operations
+
         [ConditionalFact]
         public virtual void Union_of_supertype_with_itself_with_properties_mapped_to_same_column()
         {
@@ -483,46 +485,56 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void OfType_Union_subquery()
         {
             using var context = CreateContext();
-            context.Set<Animal>()
+            var kiwis = context.Set<Animal>()
                 .OfType<Kiwi>()
                 .Union(
                     context.Set<Animal>()
                         .OfType<Kiwi>())
-                .Where(o => o.FoundOn == Island.North)
+                .Where(o => o.FoundOn == Island.South)
                 .ToList();
+
+            Assert.Equal("Great spotted kiwi", Assert.Single(kiwis).Name);
         }
 
         [ConditionalFact]
         public virtual void OfType_Union_OfType()
         {
             using var context = CreateContext();
-            context.Set<Bird>()
+            var kiwis = context.Set<Bird>()
                 .OfType<Kiwi>()
                 .Union(context.Set<Bird>())
                 .OfType<Kiwi>()
                 .ToList();
+
+            Assert.Equal("Great spotted kiwi", Assert.Single(kiwis).Name);
         }
 
         [ConditionalFact]
         public virtual void Subquery_OfType()
         {
             using var context = CreateContext();
-            context.Set<Bird>()
+            var kiwis = context.Set<Bird>()
                 .Take(5)
                 .Distinct() // Causes pushdown
                 .OfType<Kiwi>()
                 .ToList();
+
+            Assert.Equal("Great spotted kiwi", Assert.Single(kiwis).Name);
         }
 
         [ConditionalFact]
         public virtual void Union_entity_equality()
         {
             using var context = CreateContext();
-            context.Set<Kiwi>()
+            var kiwis = context.Set<Kiwi>()
                 .Union(context.Set<Eagle>().Cast<Bird>())
                 .Where(b => b == null)
                 .ToList();
+
+            Assert.Empty(kiwis);
         }
+
+        #endregion Set operations
 
         [ConditionalFact]
         public virtual void Setting_foreign_key_to_a_different_type_throws()

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -364,8 +364,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Union(
                         ss.Set<Customer>()
                             .Where(c => c.City == "London")
-                            .Select(c => new { Foo = c.PostalCode, Customer = c })), // Foo is PostalCode
-                entryCount: 7);
+                            .Select(c => new { Foo = c.PostalCode, Customer = c })) // Foo is PostalCode
+                    .OrderBy(c => c.Foo)
+                    .Skip(1)
+                    .Take(10),
+                entryCount: 6);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -364,12 +364,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Union(
                         ss.Set<Customer>()
                             .Where(c => c.City == "London")
-                            .Select(c => new { Foo = c.Region, Customer = c })) // Foo is Region
-                    .OrderBy(x => x.Foo)
-                    .Skip(1)
-                    .Take(10)
-                    .Where(x => x.Foo == "Berlin"),
-                entryCount: 1);
+                            .Select(c => new { Foo = c.PostalCode, Customer = c })), // Foo is PostalCode
+                entryCount: 7);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -423,6 +423,8 @@ FROM [Animal] AS [a]
 WHERE [a].[Discriminator] = N'Kiwi'");
         }
 
+        #region Set operations
+
         public override void Union_of_supertype_with_itself_with_properties_mapped_to_same_column()
         {
             base.Union_of_supertype_with_itself_with_properties_mapped_to_same_column();
@@ -483,7 +485,7 @@ FROM (
     FROM [Animal] AS [a0]
     WHERE [a0].[Discriminator] IN (N'Eagle', N'Kiwi') AND ([a0].[Discriminator] = N'Kiwi')
 ) AS [t]
-WHERE [t].[FoundOn] = CAST(0 AS tinyint)");
+WHERE [t].[FoundOn] = CAST(1 AS tinyint)");
         }
 
         public override void OfType_Union_OfType()
@@ -491,7 +493,7 @@ WHERE [t].[FoundOn] = CAST(0 AS tinyint)");
             base.OfType_Union_OfType();
 
             AssertSql(
-                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[Group], [t].[FoundOn]
+                @"SELECT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name], [t].[EagleId], [t].[IsFlightless], [t].[FoundOn]
 FROM (
     SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn], NULL AS [Group]
     FROM [Animal] AS [a]
@@ -500,7 +502,8 @@ FROM (
     SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[FoundOn], [a0].[Group]
     FROM [Animal] AS [a0]
     WHERE [a0].[Discriminator] IN (N'Eagle', N'Kiwi')
-) AS [t]");
+) AS [t]
+WHERE [t].[Discriminator] = N'Kiwi'");
         }
 
         public override void Subquery_OfType()
@@ -536,6 +539,8 @@ FROM (
 ) AS [t]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
+
+        #endregion Set operations
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -298,26 +298,13 @@ ORDER BY [t].[ContactName]");
             await base.Select_Union_different_fields_in_anonymous_with_subquery(async);
 
             AssertSql(
-                @"@__p_0='1'
-@__p_1='10'
-
-SELECT [t0].[Foo], [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
-FROM (
-    SELECT [t].[Foo], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
-    FROM (
-        SELECT [c].[City] AS [Foo], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-        FROM [Customers] AS [c]
-        WHERE [c].[City] = N'Berlin'
-        UNION
-        SELECT [c0].[Region] AS [Foo], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-        FROM [Customers] AS [c0]
-        WHERE [c0].[City] = N'London'
-    ) AS [t]
-    ORDER BY [t].[Foo]
-    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
-) AS [t0]
-WHERE [t0].[Foo] = N'Berlin'
-ORDER BY [t0].[Foo]");
+                @"SELECT [c].[City] AS [Foo], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = N'Berlin'
+UNION
+SELECT [c0].[PostalCode] AS [Foo], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+WHERE [c0].[City] = N'London'");
         }
 
         public override async Task Union_Include(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -298,13 +298,21 @@ ORDER BY [t].[ContactName]");
             await base.Select_Union_different_fields_in_anonymous_with_subquery(async);
 
             AssertSql(
-                @"SELECT [c].[City] AS [Foo], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE [c].[City] = N'Berlin'
-UNION
-SELECT [c0].[PostalCode] AS [Foo], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM [Customers] AS [c0]
-WHERE [c0].[City] = N'London'");
+                @"@__p_0='1'
+@__p_1='10'
+
+SELECT [t].[Foo], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT [c].[City] AS [Foo], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    WHERE [c].[City] = N'Berlin'
+    UNION
+    SELECT [c0].[PostalCode] AS [Foo], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[City] = N'London'
+) AS [t]
+ORDER BY [t].[Foo]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
         }
 
         public override async Task Union_Include(bool async)


### PR DESCRIPTION
*Weekend/Jetlag Project*

Added support for set operations over different entity types.

When performing a set operation, if two properties in the entity inheritance hierarchy were mapped to the same database column, that column was projected twice.

Closes #16298
Fixes #18832