### PR TITLE
Proxy Change Detection

### DIFF
--- a/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("ProxyServicesMissing");
 
         /// <summary>
-        ///     Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
+        ///     Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
         /// </summary>
         public static string ItsASeal([CanBeNull] object entityType)
             => string.Format(
@@ -33,7 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
+        ///     Property '{property}' on entity type '{entityType}' has no setter. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
+        /// </summary>
+        public static string NoSetterProperty([CanBeNull] object property, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("NoSetterProperty", nameof(property), nameof(entityType)),
+                property, entityType);
+
+        /// <summary>
+        ///     Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
         /// </summary>
         public static string NonVirtualProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -41,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entityType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
+        ///     Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
         /// </summary>
         public static string FieldProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("ProxyServicesMissing");
 
         /// <summary>
-        ///     Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
+        ///     Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
         public static string ItsASeal([CanBeNull] object entityType)
             => string.Format(
@@ -33,15 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' has no setter. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
-        /// </summary>
-        public static string NoSetterProperty([CanBeNull] object property, [CanBeNull] object entityType)
-            => string.Format(
-                GetString("NoSetterProperty", nameof(property), nameof(entityType)),
-                property, entityType);
-
-        /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
+        ///     Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
         public static string NonVirtualProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -49,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entityType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.
+        ///     Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
         public static string FieldProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.Designer.cs
@@ -19,13 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.ProxiesStrings", typeof(ProxiesStrings).Assembly);
 
         /// <summary>
-        ///     UseLazyLoadingProxies requires AddEntityFrameworkProxies to be called on the internal service provider used.
+        ///     UseChangeDetectionProxies and UseLazyLoadingProxies each require AddEntityFrameworkProxies to be called on the internal service provider used.
         /// </summary>
         public static string ProxyServicesMissing
             => GetString("ProxyServicesMissing");
 
         /// <summary>
-        ///     Entity type '{entityType}' is sealed. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.
+        ///     Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
         public static string ItsASeal([CanBeNull] object entityType)
             => string.Format(
@@ -33,23 +33,23 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType);
 
         /// <summary>
-        ///     Navigation property '{navigation}' on entity type '{entityType}' is not virtual. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.
+        ///     Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
-        public static string NonVirtualNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
+        public static string NonVirtualProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
-                GetString("NonVirtualNavigation", nameof(navigation), nameof(entityType)),
-                navigation, entityType);
+                GetString("NonVirtualProperty", nameof(property), nameof(entityType)),
+                property, entityType);
 
         /// <summary>
-        ///     Navigation property '{navigation}' on entity type '{entityType}' is mapped without a CLR property. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.
+        ///     Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.
         /// </summary>
-        public static string FieldNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
+        public static string FieldProperty([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
-                GetString("FieldNavigation", nameof(navigation), nameof(entityType)),
-                navigation, entityType);
+                GetString("FieldProperty", nameof(property), nameof(entityType)),
+                property, entityType);
 
         /// <summary>
-        ///     Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable lazy-loading proxies.
+        ///     Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseChangeDetectionProxies' or 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable proxies.
         /// </summary>
         public static string ProxiesNotEnabled([CanBeNull] object entityType)
             => string.Format(

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.resx
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.resx
@@ -121,18 +121,15 @@
     <value>UseChangeDetectionProxies and UseLazyLoadingProxies each require AddEntityFrameworkProxies to be called on the internal service provider used.</value>
   </data>
   <data name="ItsASeal" xml:space="preserve">
-    <value>Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
+    <value>Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
   <data name="NonVirtualProperty" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
+    <value>Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
   <data name="FieldProperty" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
+    <value>Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
   <data name="ProxiesNotEnabled" xml:space="preserve">
     <value>Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseChangeDetectionProxies' or 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable proxies.</value>
-  </data>
-  <data name="NoSetterProperty" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entityType}' has no setter. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
   </data>
 </root>

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.resx
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.resx
@@ -121,15 +121,18 @@
     <value>UseChangeDetectionProxies and UseLazyLoadingProxies each require AddEntityFrameworkProxies to be called on the internal service provider used.</value>
   </data>
   <data name="ItsASeal" xml:space="preserve">
-    <value>Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
+    <value>Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
   </data>
   <data name="NonVirtualProperty" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
+    <value>Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
   </data>
   <data name="FieldProperty" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
+    <value>Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
   </data>
   <data name="ProxiesNotEnabled" xml:space="preserve">
     <value>Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseChangeDetectionProxies' or 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable proxies.</value>
+  </data>
+  <data name="NoSetterProperty" xml:space="preserve">
+    <value>Property '{property}' on entity type '{entityType}' has no setter. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties with getters and setters, and have a public or protected constructor. UseLazyLoadingProxies requires only getters on the navigation properties be virtual.</value>
   </data>
 </root>

--- a/src/EFCore.Proxies/Properties/ProxiesStrings.resx
+++ b/src/EFCore.Proxies/Properties/ProxiesStrings.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ProxyServicesMissing" xml:space="preserve">
-    <value>UseLazyLoadingProxies requires AddEntityFrameworkProxies to be called on the internal service provider used.</value>
+    <value>UseChangeDetectionProxies and UseLazyLoadingProxies each require AddEntityFrameworkProxies to be called on the internal service provider used.</value>
   </data>
   <data name="ItsASeal" xml:space="preserve">
-    <value>Entity type '{entityType}' is sealed. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.</value>
+    <value>Entity type '{entityType}' is sealed. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
-  <data name="NonVirtualNavigation" xml:space="preserve">
-    <value>Navigation property '{navigation}' on entity type '{entityType}' is not virtual. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.</value>
+  <data name="NonVirtualProperty" xml:space="preserve">
+    <value>Property '{property}' on entity type '{entityType}' is not virtual. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
-  <data name="FieldNavigation" xml:space="preserve">
-    <value>Navigation property '{navigation}' on entity type '{entityType}' is mapped without a CLR property. UseLazyLoadingProxies requires all entity types to be public, unsealed, have virtual navigation properties, and have a public or protected constructor.</value>
+  <data name="FieldProperty" xml:space="preserve">
+    <value>Property '{property}' on entity type '{entityType}' is mapped without a CLR property. UseChangeDetectionProxies requires all entity types to be public, unsealed, have virtual properties, and have a public or protected constructor. UseLazyLoadingProxies requires only the navigation properties be virtual.</value>
   </data>
   <data name="ProxiesNotEnabled" xml:space="preserve">
-    <value>Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable lazy-loading proxies.</value>
+    <value>Unable to create proxy for '{entityType}' because proxies are not enabled. Call 'DbContextOptionsBuilder.UseChangeDetectionProxies' or 'DbContextOptionsBuilder.UseLazyLoadingProxies' to enable proxies.</value>
   </data>
 </root>

--- a/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        Type CreateLazyLoadingProxyType([NotNull] IEntityType entityType);
+        Type CreateProxyType([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         object CreateLazyLoadingProxy(
+            [NotNull] IDbContextOptions dbContextOptions,
             [NotNull] IEntityType entityType,
             [NotNull] ILazyLoader loader,
             [NotNull] object[] constructorArguments);
@@ -33,7 +34,20 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        Type CreateProxyType([NotNull] IEntityType entityType);
+        object CreateProxy(
+            [NotNull] IDbContextOptions dbContextOptions,
+            [NotNull] IEntityType entityType,
+            [NotNull] object[] constructorArguments);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        Type CreateProxyType(
+            [NotNull] ProxiesOptionsExtension options,
+            [NotNull] IEntityType entityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using Castle.DynamicProxy;
 using JetBrains.Annotations;
@@ -108,12 +107,10 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
 
                     invocation.Proceed();
 
-                    if (oldValue != newValue)
+                    if (!oldValue.Equals(newValue))
                     {
                         NotifyPropertyChanged(propertyName, invocation.Proxy);
                     }
-
-                    CheckForObservableCollection();
                 }
                 else
                 {
@@ -124,21 +121,6 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             {
                 invocation.Proceed();
                 NotifyPropertyChanged(propertyName, invocation.Proxy);
-                CheckForObservableCollection();
-            }
-
-            void CheckForObservableCollection()
-            {
-                if (newValue is INotifyCollectionChanged observableCollection)
-                {
-                    observableCollection.CollectionChanged += (_, e) =>
-                    {
-                        if (e.Action != NotifyCollectionChangedAction.Move)
-                        {
-                            NotifyPropertyChanged(propertyName, invocation.Proxy);
-                        }
-                    };
-                }
             }
         }
 

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Castle.DynamicProxy;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Proxies.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class PropertyChangedInterceptor : IInterceptor
+    {
+        private static readonly Type _notifyChangedInterface = typeof(INotifyPropertyChanged);
+
+        private readonly IEntityType _entityType;
+        private readonly bool _checkEquality;
+        private PropertyChangedEventHandler _handler;
+        private Type _proxyType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public PropertyChangedInterceptor(
+            [NotNull] IEntityType entityType,
+            bool checkEquality)
+        {
+            _entityType = entityType;
+            _checkEquality = checkEquality;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void Intercept(IInvocation invocation)
+        {
+            if (_proxyType == null)
+            {
+                _proxyType = invocation.Proxy.GetType();
+            }
+
+            var methodName = invocation.Method.Name;
+
+            if (invocation.Method.DeclaringType.Equals(_notifyChangedInterface))
+            {
+                if (methodName == $"add_{nameof(INotifyPropertyChanged.PropertyChanged)}")
+                {
+                    _handler = (PropertyChangedEventHandler)Delegate.Combine(
+                        _handler, (Delegate)invocation.Arguments[0]);
+                }
+                else if (methodName == $"remove_{nameof(INotifyPropertyChanged.PropertyChanged)}")
+                {
+                    _handler = (PropertyChangedEventHandler)Delegate.Remove(
+                        _handler, (Delegate)invocation.Arguments[0]);
+                }
+            }
+            else if (methodName.StartsWith("set_", StringComparison.Ordinal))
+            {
+                var propertyName = methodName.Substring(4);
+
+                var property = _entityType.FindProperty(propertyName);
+                if (property != null)
+                {
+                    HandleChanged(invocation, propertyName);
+                }
+                else
+                {
+                    var navigation = _entityType.FindNavigation(propertyName);
+                    if (navigation != null)
+                    {
+                        HandleChanged(invocation, propertyName);
+                    }
+                    else
+                    {
+                        invocation.Proceed();
+                    }
+                }
+            }
+            else
+            {
+                invocation.Proceed();
+            }
+        }
+
+        private void HandleChanged(IInvocation invocation, string propertyName)
+        {
+            if (_checkEquality)
+            {
+                if (_proxyType == null)
+                {
+                    _proxyType = invocation.Proxy.GetType();
+                }
+
+                var property = _proxyType.GetProperty(propertyName);
+                if (property != null)
+                {
+                    var oldValue = property.GetValue(invocation.Proxy);
+                    var newValue = invocation.Arguments[^1];
+
+                    invocation.Proceed();
+
+                    if (oldValue != newValue)
+                    {
+                        NotifyPropertyChanged(propertyName, invocation.Proxy);
+                    }
+                }
+                else
+                {
+                    invocation.Proceed();
+                }
+            }
+            else
+            {
+                invocation.Proceed();
+                NotifyPropertyChanged(propertyName, invocation.Proxy);
+            } 
+        }
+
+        private void NotifyPropertyChanged(string propertyName, object proxy)
+        {
+            var args = new PropertyChangedEventArgs(propertyName);
+            _handler?.Invoke(proxy, args);
+        }
+    }
+}

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangedInterceptor.cs
@@ -107,7 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
 
                     invocation.Proceed();
 
-                    if (!oldValue.Equals(newValue))
+                    if ((oldValue is null ^ newValue is null)
+                        || oldValue?.Equals(newValue) == false)
                     {
                         NotifyPropertyChanged(propertyName, invocation.Proxy);
                     }

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
@@ -104,7 +104,8 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                     var oldValue = property.GetValue(invocation.Proxy);
                     var newValue = invocation.Arguments[^1];
 
-                    if (!oldValue.Equals(newValue))
+                    if ((oldValue is null ^ newValue is null)
+                        || oldValue?.Equals(newValue) == false)
                     {
                         NotifyPropertyChanging(propertyName, invocation.Proxy);
                     }

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                     var oldValue = property.GetValue(invocation.Proxy);
                     var newValue = invocation.Arguments[^1];
 
-                    if (oldValue != newValue)
+                    if (!oldValue.Equals(newValue))
                     {
                         NotifyPropertyChanging(propertyName, invocation.Proxy);
                     }

--- a/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/PropertyChangingInterceptor.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Castle.DynamicProxy;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Proxies.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class PropertyChangingInterceptor : IInterceptor
+    {
+        private static readonly Type _notifyChangingInterface = typeof(INotifyPropertyChanging);
+
+        private readonly IEntityType _entityType;
+        private readonly bool _checkEquality;
+        private PropertyChangingEventHandler _handler;
+        private Type _proxyType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public PropertyChangingInterceptor(
+            [NotNull] IEntityType entityType,
+            bool checkEquality)
+        {
+            _entityType = entityType;
+            _checkEquality = checkEquality;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void Intercept(IInvocation invocation)
+        {
+            var methodName = invocation.Method.Name;
+
+            if (invocation.Method.DeclaringType.Equals(_notifyChangingInterface))
+            {
+                if (methodName == $"add_{nameof(INotifyPropertyChanging.PropertyChanging)}")
+                {
+                    _handler = (PropertyChangingEventHandler)Delegate.Combine(
+                        _handler, (Delegate)invocation.Arguments[0]);
+                }
+                else if (methodName == $"remove_{nameof(INotifyPropertyChanging.PropertyChanging)}")
+                {
+                    _handler = (PropertyChangingEventHandler)Delegate.Remove(
+                        _handler, (Delegate)invocation.Arguments[0]);
+                }
+            }
+            else if (methodName.StartsWith("set_", StringComparison.Ordinal))
+            {
+                var propertyName = methodName.Substring(4);
+
+                var property = _entityType.FindProperty(propertyName);
+                if (property != null)
+                {
+                    HandleChanging(invocation, propertyName);
+                }
+                else
+                {
+                    var navigation = _entityType.FindNavigation(propertyName);
+                    if (navigation != null)
+                    {
+                        HandleChanging(invocation, propertyName);
+                    }
+                    else
+                    {
+                        invocation.Proceed();
+                    }
+                }
+            }
+            else
+            {
+                invocation.Proceed();
+            }
+        }
+
+        private void HandleChanging(IInvocation invocation, string propertyName)
+        {
+            if (_checkEquality)
+            {
+                if (_proxyType == null)
+                {
+                    _proxyType = invocation.Proxy.GetType();
+                }
+
+                var property = _proxyType.GetProperty(propertyName);
+                if (property != null)
+                {
+                    var oldValue = property.GetValue(invocation.Proxy);
+                    var newValue = invocation.Arguments[^1];
+
+                    if (oldValue != newValue)
+                    {
+                        NotifyPropertyChanging(propertyName, invocation.Proxy);
+                    }
+                }
+            }
+            else
+            {
+                NotifyPropertyChanging(propertyName, invocation.Proxy);
+            }
+
+            invocation.Proceed();
+        }
+
+        private void NotifyPropertyChanging(string propertyName, object proxy)
+        {
+            var args = new PropertyChangingEventArgs(propertyName);
+            _handler?.Invoke(proxy, args);
+        }
+    }
+}

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesConventionSetPlugin.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesConventionSetPlugin.cs
@@ -58,11 +58,18 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         /// </summary>
         public virtual ConventionSet ModifyConventions(ConventionSet conventionSet)
         {
+            var extension = _options.FindExtension<ProxiesOptionsExtension>();
+
+            ConventionSet.AddAfter(
+                conventionSet.ModelInitializedConventions,
+                new ProxyChangeTrackingConvention(extension),
+                typeof(DbSetFindingConvention));
+
             ConventionSet.AddBefore(
                 conventionSet.ModelFinalizedConventions,
                 new ProxyBindingRewriter(
                     _proxyFactory,
-                    _options.FindExtension<ProxiesOptionsExtension>(),
+                    extension,
                     _lazyLoaderParameterBindingFactoryDependencies,
                     _conventionSetBuilderDependencies),
                 typeof(ValidatingConvention));

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             public override bool IsDatabaseProvider => false;
 
             public override string LogFragment
-                => _logFragment ??= Extension.UseProxies
+                => _logFragment ??= Extension.UseLazyLoadingProxies && Extension.UseChangeDetectionProxies
                     ? "using lazy-loading and change detection proxies "
                     : Extension.UseLazyLoadingProxies
                     ? "using lazy-loading proxies "

--- a/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxiesOptionsExtension.cs
@@ -23,6 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
     {
         private DbContextOptionsExtensionInfo _info;
         private bool _useLazyLoadingProxies;
+        private bool _useChangeDetectionProxies;
+        private bool _checkEquality;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,6 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         protected ProxiesOptionsExtension([NotNull] ProxiesOptionsExtension copyFrom)
         {
             _useLazyLoadingProxies = copyFrom._useLazyLoadingProxies;
+            _useChangeDetectionProxies = copyFrom._useChangeDetectionProxies;
+            _checkEquality = copyFrom._checkEquality;
         }
 
         /// <summary>
@@ -76,6 +80,30 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool UseChangeDetectionProxies => _useChangeDetectionProxies;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CheckEquality => _checkEquality;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool UseProxies => UseLazyLoadingProxies || UseChangeDetectionProxies;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual ProxiesOptionsExtension WithLazyLoading(bool useLazyLoadingProxies = true)
         {
             var clone = Clone();
@@ -91,9 +119,25 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual ProxiesOptionsExtension WithChangeDetection(bool useChangeDetectionProxies = true, bool checkEquality = true)
+        {
+            var clone = Clone();
+
+            clone._useChangeDetectionProxies = useChangeDetectionProxies;
+            clone._checkEquality = checkEquality;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual void Validate(IDbContextOptions options)
         {
-            if (_useLazyLoadingProxies)
+            if (UseProxies)
             {
                 var internalServiceProvider = options.FindExtension<CoreOptionsExtension>()?.InternalServiceProvider;
                 if (internalServiceProvider != null)
@@ -132,15 +176,24 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             public override bool IsDatabaseProvider => false;
 
             public override string LogFragment
-                => _logFragment ??= Extension._useLazyLoadingProxies
+                => _logFragment ??= Extension.UseProxies
+                    ? "using lazy-loading and change detection proxies "
+                    : Extension.UseLazyLoadingProxies
                     ? "using lazy-loading proxies "
+                    : Extension.UseChangeDetectionProxies
+                    ? "using change detection proxies "
                     : "";
 
-            public override long GetServiceProviderHashCode() => Extension._useLazyLoadingProxies ? 541 : 0;
+            public override long GetServiceProviderHashCode() => Extension.UseProxies ? 541 : 0;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-                => debugInfo["Proxies:" + nameof(ProxiesExtensions.UseLazyLoadingProxies)]
+            {
+                debugInfo["Proxies:" + nameof(ProxiesExtensions.UseLazyLoadingProxies)]
                     = (Extension._useLazyLoadingProxies ? 541 : 0).ToString(CultureInfo.InvariantCulture);
+
+                debugInfo["Proxies:" + nameof(ProxiesExtensions.UseChangeDetectionProxies)]
+                    = (Extension._useChangeDetectionProxies ? 541 : 0).ToString(CultureInfo.InvariantCulture);
+            }
         }
     }
 }

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         /// <param name="context"> Additional information associated with convention execution. </param>
         public virtual void ProcessModelFinalized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
-            if (_options?.UseLazyLoadingProxies == true)
+            if (_options?.UseProxies == true)
             {
                 foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
                 {
@@ -71,67 +71,100 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                             throw new InvalidOperationException(ProxiesStrings.ItsASeal(entityType.DisplayName()));
                         }
 
-                        var proxyType = _proxyFactory.CreateLazyLoadingProxyType(entityType);
+                        var proxyType = _proxyFactory.CreateProxyType(entityType);
 
-                        foreach (var conflictingProperty in entityType.GetDerivedTypes()
-                            .SelectMany(e => e.GetDeclaredServiceProperties().Where(p => p.ClrType == typeof(ILazyLoader)))
-                            .ToList())
+                        if (_options.UseLazyLoadingProxies == true)
                         {
-                            conflictingProperty.DeclaringEntityType.RemoveServiceProperty(conflictingProperty.Name);
-                        }
+                            foreach (var conflictingProperty in entityType.GetDerivedTypes()
+                                .SelectMany(e => e.GetDeclaredServiceProperties().Where(p => p.ClrType == typeof(ILazyLoader)))
+                                .ToList())
+                            {
+                                conflictingProperty.DeclaringEntityType.RemoveServiceProperty(conflictingProperty.Name);
+                            }
 
-                        var serviceProperty = entityType.GetServiceProperties().FirstOrDefault(e => e.ClrType == typeof(ILazyLoader));
-                        if (serviceProperty == null)
-                        {
-                            serviceProperty = entityType.AddServiceProperty(_lazyLoaderProperty);
-                            serviceProperty.SetParameterBinding(
-                                (ServiceParameterBinding)new LazyLoaderParameterBindingFactory(
-                                        _lazyLoaderParameterBindingFactoryDependencies)
-                                    .Bind(
-                                        entityType,
-                                        typeof(ILazyLoader),
-                                        nameof(IProxyLazyLoader.LazyLoader)));
-                        }
+                            var serviceProperty = entityType.GetServiceProperties().FirstOrDefault(e => e.ClrType == typeof(ILazyLoader));
+                            if (serviceProperty == null)
+                            {
+                                serviceProperty = entityType.AddServiceProperty(_lazyLoaderProperty);
+                                serviceProperty.SetParameterBinding(
+                                    (ServiceParameterBinding)new LazyLoaderParameterBindingFactory(
+                                            _lazyLoaderParameterBindingFactoryDependencies)
+                                        .Bind(
+                                            entityType,
+                                            typeof(ILazyLoader),
+                                            nameof(IProxyLazyLoader.LazyLoader)));
+                            }
 
-                        // WARNING: This code is EF internal; it should not be copied. See #10789 #14554
-                        var binding = (InstantiationBinding)entityType[CoreAnnotationNames.ConstructorBinding];
-                        if (binding == null)
-                        {
-                            _directBindingConvention.ProcessModelFinalized(modelBuilder, context);
-                        }
-
-                        // WARNING: This code is EF internal; it should not be copied. See #10789 #14554
-                        binding = (InstantiationBinding)entityType[CoreAnnotationNames.ConstructorBinding];
-
-                        entityType.SetAnnotation(
                             // WARNING: This code is EF internal; it should not be copied. See #10789 #14554
-                            CoreAnnotationNames.ConstructorBinding,
-                            new FactoryMethodBinding(
-                                _proxyFactory,
-                                _createLazyLoadingProxyMethod,
-                                new List<ParameterBinding>
+                            var binding = (InstantiationBinding)entityType[CoreAnnotationNames.ConstructorBinding];
+                            if (binding == null)
+                            {
+                                _directBindingConvention.ProcessModelFinalized(modelBuilder, context);
+                            }
+
+                            // WARNING: This code is EF internal; it should not be copied. See #10789 #14554
+                            binding = (InstantiationBinding)entityType[CoreAnnotationNames.ConstructorBinding];
+
+                            entityType.SetAnnotation(
+                                // WARNING: This code is EF internal; it should not be copied. See #10789 #14554
+                                CoreAnnotationNames.ConstructorBinding,
+                                new FactoryMethodBinding(
+                                    _proxyFactory,
+                                    _createLazyLoadingProxyMethod,
+                                    new List<ParameterBinding>
+                                    {
+                                        new EntityTypeParameterBinding(),
+                                        new DependencyInjectionParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader), serviceProperty),
+                                        new ObjectArrayParameterBinding(binding.ParameterBindings)
+                                    },
+                                    proxyType));
+                        }
+
+                        if (_options.UseChangeDetectionProxies)
+                        {
+                            foreach (var prop in entityType.GetProperties())
+                            {
+                                if (prop.PropertyInfo == null)
                                 {
-                                    new EntityTypeParameterBinding(),
-                                    new DependencyInjectionParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader), serviceProperty),
-                                    new ObjectArrayParameterBinding(binding.ParameterBindings)
-                                },
-                                proxyType));
+                                    throw new InvalidOperationException(
+                                        ProxiesStrings.FieldProperty(prop.Name, entityType.DisplayName()));
+                                }
+
+                                if (!prop.PropertyInfo.GetMethod.IsVirtual
+                                    || !prop.PropertyInfo.SetMethod.IsVirtual)
+                                {
+                                    throw new InvalidOperationException(
+                                        ProxiesStrings.NonVirtualProperty(prop.Name, entityType.DisplayName()));
+                                }
+                            }
+                        }
 
                         foreach (var navigation in entityType.GetNavigations())
                         {
                             if (navigation.PropertyInfo == null)
                             {
                                 throw new InvalidOperationException(
-                                    ProxiesStrings.FieldNavigation(navigation.Name, entityType.DisplayName()));
+                                    ProxiesStrings.FieldProperty(navigation.Name, entityType.DisplayName()));
                             }
 
-                            if (!navigation.PropertyInfo.GetMethod.IsVirtual)
+                            if (_options.UseLazyLoadingProxies
+                                && !navigation.PropertyInfo.GetMethod.IsVirtual)
                             {
                                 throw new InvalidOperationException(
-                                    ProxiesStrings.NonVirtualNavigation(navigation.Name, entityType.DisplayName()));
+                                    ProxiesStrings.NonVirtualProperty(navigation.Name, entityType.DisplayName()));
                             }
 
-                            navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
+                            if (_options.UseChangeDetectionProxies
+                                && !navigation.PropertyInfo.SetMethod.IsVirtual)
+                            {
+                                throw new InvalidOperationException(
+                                    ProxiesStrings.NonVirtualProperty(navigation.Name, entityType.DisplayName()));
+                            }
+
+                            if (_options.UseLazyLoadingProxies)
+                            {
+                                navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
+                            }
                         }
                     }
                 }

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -65,12 +66,6 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         {
             if (_options?.UseProxies == true)
             {
-                if (_options.UseChangeDetectionProxies)
-                {
-                    modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
-                    modelBuilder.HasAnnotation(ModelValidator.SkipChangeTrackingStrategyValidationAnnotation, "true");
-                }
-
                 foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
                 {
                     if (entityType.ClrType?.IsAbstract == false)
@@ -144,10 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                                         new ObjectArrayParameterBinding(binding.ParameterBindings)
                                     },
                                     proxyType));
-                        }
 
-                        if (_options.UseChangeDetectionProxies)
-                        {
                             foreach (var prop in entityType.GetProperties().Where(p => !p.IsShadowProperty()))
                             {
                                 if (prop.PropertyInfo == null)

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -130,8 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                                         ProxiesStrings.FieldProperty(prop.Name, entityType.DisplayName()));
                                 }
 
-                                if (!prop.PropertyInfo.GetMethod.IsVirtual
-                                    || !prop.PropertyInfo.SetMethod.IsVirtual)
+                                if (!prop.PropertyInfo.SetMethod.IsVirtual)
                                 {
                                     throw new InvalidOperationException(
                                         ProxiesStrings.NonVirtualProperty(prop.Name, entityType.DisplayName()));
@@ -147,13 +146,6 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                                     ProxiesStrings.FieldProperty(navigation.Name, entityType.DisplayName()));
                             }
 
-                            if (_options.UseLazyLoadingProxies
-                                && !navigation.PropertyInfo.GetMethod.IsVirtual)
-                            {
-                                throw new InvalidOperationException(
-                                    ProxiesStrings.NonVirtualProperty(navigation.Name, entityType.DisplayName()));
-                            }
-
                             if (_options.UseChangeDetectionProxies
                                 && !navigation.PropertyInfo.SetMethod.IsVirtual)
                             {
@@ -163,6 +155,12 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
 
                             if (_options.UseLazyLoadingProxies)
                             {
+                                if (!navigation.PropertyInfo.GetMethod.IsVirtual)
+                                {
+                                    throw new InvalidOperationException(
+                                    ProxiesStrings.NonVirtualProperty(navigation.Name, entityType.DisplayName()));
+                                }
+
                                 navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
                             }
                         }

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Microsoft.EntityFrameworkCore.Proxies.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class ProxyChangeTrackingConvention : IModelInitializedConvention
+    {
+        private readonly ProxiesOptionsExtension _options;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public ProxyChangeTrackingConvention(
+                [CanBeNull] ProxiesOptionsExtension options)
+        {
+            _options = options;
+        }
+
+        public void ProcessModelInitialized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+        {
+            if (_options?.UseChangeDetectionProxies == true)
+            {
+                modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+                modelBuilder.HasAnnotation(ModelValidator.SkipChangeTrackingStrategyValidationAnnotation, "true");
+            }
+        }
+    }
+}

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
@@ -30,7 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             _options = options;
         }
 
-        public void ProcessModelInitialized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+        /// <summary>
+        ///     Called after a model is finalized.
+        /// </summary>
+        /// <param name="modelBuilder"> The builder for the model. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessModelInitialized(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
         {
             if (_options?.UseChangeDetectionProxies == true)
             {

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using Castle.DynamicProxy;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore.Proxies.Internal
@@ -17,8 +21,39 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
     /// </summary>
     public class ProxyFactory : IProxyFactory
     {
+        private static readonly Type _proxyLazyLoaderInterface = typeof(IProxyLazyLoader);
+        private static readonly Type _notifyPropertyChangedInterface = typeof(INotifyPropertyChanged);
+        private static readonly Type _notifyPropertyChangingInterface = typeof(INotifyPropertyChanging);
+
+        private readonly IDbContextOptions _dbContextOptions;
+        private readonly Lazy<ProxiesOptionsExtension> _options;
         private readonly ProxyGenerator _generator = new ProxyGenerator();
-        private static readonly Type[] _additionalInterfacesToProxy = { typeof(IProxyLazyLoader) };
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual ProxiesOptionsExtension Options => _options.Value;
+
+        public ProxyFactory(
+            [NotNull] IDbContextOptions dbContextOptions)
+        {
+            _dbContextOptions = dbContextOptions;
+            _options = new Lazy<ProxiesOptionsExtension>(
+                () =>
+                {
+                    var extension = _dbContextOptions.FindExtension<ProxiesOptionsExtension>();
+
+                    if (extension == null)
+                    {
+                        throw new InvalidOperationException(ProxiesStrings.ProxyServicesMissing);
+                    }
+
+                    return extension;
+                });
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -37,7 +72,12 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                 throw new InvalidOperationException(CoreStrings.EntityTypeNotFound(entityClrType.ShortDisplayName()));
             }
 
-            return CreateLazyLoadingProxy(entityType, context.GetService<ILazyLoader>(), constructorArguments);
+            if (Options.UseLazyLoadingProxies)
+            {
+                return CreateLazyLoadingProxy(entityType, context.GetService<ILazyLoader>(), constructorArguments);
+            } 
+
+            return CreateProxy(entityType, constructorArguments);
         }
 
         /// <summary>
@@ -46,10 +86,10 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Type CreateLazyLoadingProxyType(IEntityType entityType)
+        public virtual Type CreateProxyType(IEntityType entityType)
             => _generator.ProxyBuilder.CreateClassProxyType(
                 entityType.ClrType,
-                _additionalInterfacesToProxy,
+                GetInterfacesToProxy(entityType),
                 ProxyGenerationOptions.Default);
 
         /// <summary>
@@ -64,9 +104,82 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             object[] constructorArguments)
             => _generator.CreateClassProxy(
                 entityType.ClrType,
-                _additionalInterfacesToProxy,
+                GetInterfacesToProxy(entityType),
                 ProxyGenerationOptions.Default,
                 constructorArguments,
-                new LazyLoadingInterceptor(entityType, loader));
+                GetNotifyChangeInterceptors(entityType, new LazyLoadingInterceptor(entityType, loader)));
+
+        private object CreateProxy(
+            IEntityType entityType,
+            object[] constructorArguments)
+            => _generator.CreateClassProxy(
+                entityType.ClrType,
+                GetInterfacesToProxy(entityType),
+                ProxyGenerationOptions.Default,
+                constructorArguments,
+                GetNotifyChangeInterceptors(entityType));
+
+        private Type[] GetInterfacesToProxy(
+            IEntityType entityType)
+        {
+            var interfacesToProxy = new List<Type>();
+
+            if (Options.UseLazyLoadingProxies)
+            {
+                interfacesToProxy.Add(_proxyLazyLoaderInterface);
+            }
+
+            if (Options.UseChangeDetectionProxies)
+            {
+                var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
+                switch (changeTrackingStrategy)
+                {
+                    case ChangeTrackingStrategy.ChangedNotifications:
+                        interfacesToProxy.Add(_notifyPropertyChangedInterface);
+                        break;
+                    case ChangeTrackingStrategy.ChangingAndChangedNotifications:
+                    case ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues:
+                        interfacesToProxy.Add(_notifyPropertyChangedInterface);
+                        interfacesToProxy.Add(_notifyPropertyChangingInterface);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return interfacesToProxy.ToArray();
+        }
+
+        private Castle.DynamicProxy.IInterceptor[] GetNotifyChangeInterceptors(
+            IEntityType entityType,
+            LazyLoadingInterceptor lazyLoadingInterceptor = null)
+        {
+            var interceptors = new List<Castle.DynamicProxy.IInterceptor>();
+
+            if (lazyLoadingInterceptor != null)
+            {
+                interceptors.Add(lazyLoadingInterceptor);
+            }
+
+            if (Options.UseChangeDetectionProxies)
+            {
+                var changeTrackingStrategy = entityType.GetChangeTrackingStrategy();
+                switch (changeTrackingStrategy)
+                {
+                    case ChangeTrackingStrategy.ChangedNotifications:
+                        interceptors.Add(new PropertyChangedInterceptor(entityType, Options.CheckEquality));
+                        break;
+                    case ChangeTrackingStrategy.ChangingAndChangedNotifications:
+                    case ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues:
+                        interceptors.Add(new PropertyChangedInterceptor(entityType, Options.CheckEquality));
+                        interceptors.Add(new PropertyChangingInterceptor(entityType, Options.CheckEquality));
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return interceptors.ToArray();
+        }
     }
 }

--- a/src/EFCore.Proxies/ProxiesExtensions.cs
+++ b/src/EFCore.Proxies/ProxiesExtensions.cs
@@ -18,6 +18,65 @@ namespace Microsoft.EntityFrameworkCore
     {
         /// <summary>
         ///     <para>
+        ///         Turns on the creation of change detection proxies.
+        ///     </para>
+        ///     <para>
+        ///         Note that this requires appropriate services to be available in the EF internal service provider. Normally this
+        ///         will happen automatically, but if the application is controlling the service provider, then a call to
+        ///         <see cref="ProxiesServiceCollectionExtensions.AddEntityFrameworkProxies" /> may be needed.
+        ///     </para>
+        /// </summary>
+        /// <param name="optionsBuilder">
+        ///     The options builder, as passed to <see cref="DbContext.OnConfiguring" />
+        ///     or exposed AddDbContext.
+        /// </param>
+        /// <param name="useChangeDetectionProxies"> <c>True</c> to use change detection proxies; false to prevent their use. </param>
+        /// <param name="checkEquality"> <c>True</c> if proxy change detection should check if the incoming value is equal to the current value before notifying. Defaults to <c>True</c>. </param>
+        /// <returns> The same builder to allow method calls to be chained. </returns>
+        public static DbContextOptionsBuilder UseChangeDetectionProxies(
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            bool useChangeDetectionProxies = true,
+            bool checkEquality = true)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+
+            var extension = optionsBuilder.Options.FindExtension<ProxiesOptionsExtension>()
+                ?? new ProxiesOptionsExtension();
+
+            extension = extension.WithChangeDetection(useChangeDetectionProxies, checkEquality);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            return optionsBuilder;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Turns on the creation of change detection proxies.
+        ///     </para>
+        ///     <para>
+        ///         Note that this requires appropriate services to be available in the EF internal service provider. Normally this
+        ///         will happen automatically, but if the application is controlling the service provider, then a call to
+        ///         <see cref="ProxiesServiceCollectionExtensions.AddEntityFrameworkProxies" /> may be needed.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The <see cref="DbContext" /> type. </typeparam>
+        /// <param name="optionsBuilder">
+        ///     The options builder, as passed to <see cref="DbContext.OnConfiguring" />
+        ///     or exposed AddDbContext.
+        /// </param>
+        /// <param name="useChangeDetectionProxies"> <c>True</c> to use change detection proxies; false to prevent their use. </param>
+        /// <param name="checkEquality"> <c>True</c> if proxy change detection should check if the incoming value is equal to the current value before notifying. Defaults to <c>True</c>. </param>
+        /// <returns> The same builder to allow method calls to be chained. </returns>
+        public static DbContextOptionsBuilder<TContext> UseChangeDetectionProxies<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            bool useChangeDetectionProxies = true,
+            bool checkEquality = true)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseChangeDetectionProxies((DbContextOptionsBuilder)optionsBuilder, useChangeDetectionProxies, checkEquality);
+
+        /// <summary>
+        ///     <para>
         ///         Turns on the creation of lazy-loading proxies.
         ///     </para>
         ///     <para>
@@ -127,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var options = serviceProvider.GetService<IDbContextOptions>().FindExtension<ProxiesOptionsExtension>();
 
-            if (options?.UseLazyLoadingProxies != true)
+            if (options?.UseProxies != true)
             {
                 throw new InvalidOperationException(ProxiesStrings.ProxiesNotEnabled(entityType.ShortDisplayName()));
             }

--- a/src/EFCore.Proxies/ProxiesServiceCollectionExtensions.cs
+++ b/src/EFCore.Proxies/ProxiesServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
             new EntityFrameworkServicesBuilder(serviceCollection)
                 .TryAdd<IConventionSetPlugin, ProxiesConventionSetPlugin>()
                 .TryAddProviderSpecificServices(
-                    b => b.TryAddSingleton<IProxyFactory, ProxyFactory>());
+                    b => b.TryAddScoped<IProxyFactory, ProxyFactory>());
 
             return serviceCollection;
         }

--- a/src/EFCore.Proxies/ProxiesServiceCollectionExtensions.cs
+++ b/src/EFCore.Proxies/ProxiesServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
             new EntityFrameworkServicesBuilder(serviceCollection)
                 .TryAdd<IConventionSetPlugin, ProxiesConventionSetPlugin>()
                 .TryAddProviderSpecificServices(
-                    b => b.TryAddScoped<IProxyFactory, ProxyFactory>());
+                    b => b.TryAddSingleton<IProxyFactory, ProxyFactory>());
 
             return serviceCollection;
         }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -30,6 +30,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     public class ModelValidator : IModelValidator
     {
         /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public const string SkipChangeTrackingStrategyValidationAnnotation = "ModelValidator.SkipChangeTrackingStrategyValidation";
+
+        /// <summary>
         ///     Creates a new instance of <see cref="ModelValidator" />.
         /// </summary>
         /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
@@ -585,12 +593,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             Check.NotNull(model, nameof(model));
 
-            foreach (var entityType in model.GetEntityTypes())
+            if ((string)model[SkipChangeTrackingStrategyValidationAnnotation] != "true")
             {
-                var errorMessage = entityType.AsEntityType().CheckChangeTrackingStrategy(entityType.GetChangeTrackingStrategy());
-                if (errorMessage != null)
+                foreach (var entityType in model.GetEntityTypes())
                 {
-                    throw new InvalidOperationException(errorMessage);
+                    var errorMessage = entityType.AsEntityType().CheckChangeTrackingStrategy(entityType.GetChangeTrackingStrategy());
+                    if (errorMessage != null)
+                    {
+                        throw new InvalidOperationException(errorMessage);
+                    }
                 }
             }
         }

--- a/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class ChangeDetectionProxyTests
+    {
+        [ConditionalFact]
+        public void Throws_if_sealed_class()
+        {
+            using var context = new ChangeContext<ChangeSealedEntity>();
+            Assert.Equal(
+                ProxiesStrings.ItsASeal(nameof(ChangeSealedEntity)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Model).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_if_non_virtual_property()
+        {
+            using var context = new ChangeContext<ChangeNonVirtualPropEntity>();
+            Assert.Equal(
+                ProxiesStrings.NonVirtualProperty(nameof(ChangeNonVirtualPropEntity.Id), nameof(ChangeNonVirtualPropEntity)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Model).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_if_non_virtual_navigation()
+        {
+            using var context = new ChangeContext<ChangeNonVirtualNavEntity>();
+            Assert.Equal(
+                ProxiesStrings.NonVirtualProperty(nameof(ChangeNonVirtualNavEntity.SelfRef), nameof(ChangeNonVirtualNavEntity)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.Model).Message);
+        }
+
+        [ConditionalFact]
+        public void Sets_default_change_tracking_strategy()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>();
+            Assert.Equal(
+                ChangeTrackingStrategy.ChangingAndChangedNotifications,
+                context.Model.GetChangeTrackingStrategy());
+        }
+
+        private static readonly Type changeInterface = typeof(INotifyPropertyChanged);
+        private static readonly Type changingInterface = typeof(INotifyPropertyChanging);
+
+        [ConditionalFact]
+        public void Proxies_correct_interfaces_for_Snapshot()
+        {
+            using var context = new ProxyGenerationContext(ChangeTrackingStrategy.Snapshot);
+            var proxy = context.CreateProxy<ChangeValueEntity>();
+            var proxyType = proxy.GetType();
+
+            Assert.False(changeInterface.IsAssignableFrom(proxyType));
+            Assert.False(changingInterface.IsAssignableFrom(proxyType));
+        }
+
+        [ConditionalFact]
+        public void Proxies_correct_interfaces_for_ChangedNotifications()
+        {
+            using var context = new ProxyGenerationContext(ChangeTrackingStrategy.ChangedNotifications);
+            var proxy = context.CreateProxy<ChangeValueEntity>();
+            var proxyType = proxy.GetType();
+
+            Assert.True(changeInterface.IsAssignableFrom(proxyType));
+            Assert.False(changingInterface.IsAssignableFrom(proxyType));
+        }
+
+        [ConditionalFact]
+        public void Proxies_correct_interfaces_for_ChangingAndChangedNotifications()
+        {
+            using var context = new ProxyGenerationContext(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+            var proxy = context.CreateProxy<ChangeValueEntity>();
+            var proxyType = proxy.GetType();
+
+            Assert.True(changeInterface.IsAssignableFrom(proxyType));
+            Assert.True(changingInterface.IsAssignableFrom(proxyType));
+        }
+
+        [ConditionalFact]
+        public void Proxies_correct_interfaces_for_ChangingAndChangedNotificationsWithOriginalValues()
+        {
+            using var context = new ProxyGenerationContext(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
+            var proxy = context.CreateProxy<ChangeValueEntity>();
+            var proxyType = proxy.GetType();
+
+            Assert.True(changeInterface.IsAssignableFrom(proxyType));
+            Assert.True(changingInterface.IsAssignableFrom(proxyType));
+        }
+
+        [ConditionalFact]
+        public void Raises_changed_event_when_changed()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>();
+            context.Add(new ChangeValueEntity());
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanged)entity).PropertyChanged += (s, e) =>
+            {
+                eventRaised = true;
+
+                Assert.Equal(entity, s);
+
+                Assert.Equal(
+                    nameof(ChangeValueEntity.Value),
+                    e.PropertyName);
+
+                Assert.Equal(
+                    10,
+                    ((ChangeValueEntity)s).Value);
+            };
+
+            entity.Value = 10;
+            Assert.True(eventRaised);
+        }
+
+        [ConditionalFact]
+        public void Raises_changing_event_before_change()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>();
+            context.Add(new ChangeValueEntity { Value = 5 });
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanging)entity).PropertyChanging += (s, e) =>
+            {
+                eventRaised = true;
+
+                Assert.Equal(entity, s);
+
+                Assert.Equal(
+                    nameof(ChangeValueEntity.Value),
+                    e.PropertyName);
+
+                Assert.Equal(
+                    5,
+                    ((ChangeValueEntity)s).Value);
+            };
+
+            entity.Value = 10;
+            Assert.True(eventRaised);
+        }
+
+        [ConditionalFact]
+        public void Doesnt_raise_change_event_when_equal_and_check_equality_true()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>(checkEquality: true);
+            context.Add(new ChangeValueEntity { Value = 10 });
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanged)entity).PropertyChanged += (s, e) =>
+            {
+                eventRaised = true;
+            };
+
+            entity.Value = 10;
+            Assert.False(eventRaised);
+        }
+
+        [ConditionalFact]
+        public void Doesnt_raise_changing_event_when_equal_and_check_equality_true()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>(checkEquality: true);
+            context.Add(new ChangeValueEntity { Value = 10 });
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanging)entity).PropertyChanging += (s, e) =>
+            {
+                eventRaised = true;
+            };
+
+            entity.Value = 10;
+            Assert.False(eventRaised);
+        }
+
+        [ConditionalFact]
+        public void Raises_change_event_when_equal_and_check_equality_false()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>(checkEquality: false);
+            context.Add(new ChangeValueEntity { Value = 10 });
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanged)entity).PropertyChanged += (s, e) =>
+            {
+                eventRaised = true;
+            };
+
+            entity.Value = 10;
+            Assert.True(eventRaised);
+        }
+
+        [ConditionalFact]
+        public void Raises_changing_event_when_equal_and_check_equality_false()
+        {
+            using var context = new ChangeContext<ChangeValueEntity>(checkEquality: false);
+            context.Add(new ChangeValueEntity { Value = 10 });
+            context.SaveChanges();
+
+            var eventRaised = false;
+
+            var entity = context.Set<ChangeValueEntity>().Single();
+            ((INotifyPropertyChanging)entity).PropertyChanging += (s, e) =>
+            {
+                eventRaised = true;
+            };
+
+            entity.Value = 10;
+            Assert.True(eventRaised);
+        }
+
+        private class ChangeContext<TEntity> : TestContext<TEntity>
+            where TEntity : class
+        {
+            public ChangeContext(bool checkEquality = true)
+                : base(dbName: "ChangeDetectionContext", useLazyLoading: false, useChangeDetection: true, checkEquality: checkEquality)
+            {
+            }
+        }
+
+        public sealed class ChangeSealedEntity
+        {
+            public int Id { get; set; }
+        }
+
+        public class ChangeNonVirtualPropEntity
+        {
+            public int Id { get; set; }
+
+            public virtual ChangeNonVirtualPropEntity SelfRef { get; set; }
+        }
+
+        public class ChangeNonVirtualNavEntity
+        {
+            public virtual int Id { get; set; }
+
+            public ChangeNonVirtualNavEntity SelfRef { get; set; }
+        }
+
+        public class ChangeValueEntity
+        {
+            public virtual int Id { get; set; }
+
+            public virtual int Value { get; set; }
+        }
+
+        private class ProxyGenerationContext : TestContext<ChangeValueEntity>
+        {
+            public ProxyGenerationContext(
+                ChangeTrackingStrategy changeTrackingStrategy)
+                : base("ProxyGenerationContext", false, true, true, changeTrackingStrategy)
+            {
+            }
+        }
+    }
+}

--- a/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
@@ -265,40 +265,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(eventRaised);
         }
 
-        [ConditionalFact]
-        public void Navigational_property_marked_modified_without_being_loaded()
-        {
-            var id = 0;
-
-            using (var context = new ChangeContext<ChangeSelfRefEntity>(checkEquality: false))
-            {
-                var parent = context.CreateProxy<ChangeSelfRefEntity>();
-                parent.SelfRef = context.CreateProxy<ChangeSelfRefEntity>();
-                context.Add(parent);
-                context.SaveChanges();
-                id = parent.Id;
-            }
-
-            using (var context = new ChangeContext<ChangeSelfRefEntity>(checkEquality: false))
-            {
-                var parent = context.Set<ChangeSelfRefEntity>().Find(id);
-
-                Assert.Null(parent.SelfRef);
-
-                parent.SelfRef = null;
-
-                var entry = context.Entry(parent);
-
-                Assert.Equal(
-                    EntityState.Modified,
-                    entry.State);
-
-                var fKey = entry.Property($"{nameof(ChangeSelfRefEntity.SelfRef)}Id");
-
-                Assert.True(fKey.IsModified);
-            }
-        }
-
         private class ChangeContext<TEntity> : TestContext<TEntity>
             where TEntity : class
         {

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -19,147 +19,11 @@ namespace Microsoft.EntityFrameworkCore
     public class LazyLoadingProxyTests
     {
         [ConditionalFact]
-        public void Materialization_uses_parameterless_constructor()
-        {
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterless_constructor)))
-            {
-                context.Add(new March82GGtp());
-                context.SaveChanges();
-            }
-
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterless_constructor)))
-            {
-                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
-            }
-        }
-
-        [ConditionalFact]
-        public void Materialization_uses_parameterized_constructor()
-        {
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor)))
-            {
-                context.Add(new March881(77, "Leyton House"));
-                context.SaveChanges();
-            }
-
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor)))
-            {
-                var proxy = context.Set<March881>().Single();
-
-                Assert.Same(typeof(March881), proxy.GetType().BaseType);
-                Assert.Equal(77, proxy.Id);
-                Assert.Equal("Leyton House", proxy.Sponsor);
-            }
-        }
-
-        [ConditionalFact]
-        public void Materialization_uses_parameterized_constructor_taking_context()
-        {
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor_taking_context)))
-            {
-                context.Add(new WilliamsFw14(context, 6, "Canon"));
-                context.SaveChanges();
-            }
-
-            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor_taking_context)))
-            {
-                var proxy = context.Set<WilliamsFw14>().Single();
-
-                Assert.Same(typeof(WilliamsFw14), proxy.GetType().BaseType);
-                Assert.Same(context, proxy.Context);
-                Assert.Equal(6, proxy.Id);
-                Assert.Equal("Canon", proxy.Sponsor);
-            }
-        }
-
-        [ConditionalFact]
-        public void CreateProxy_uses_parameterless_constructor()
-        {
-            using var context = new NeweyContext();
-            Assert.Same(typeof(March82GGtp), context.CreateProxy<March82GGtp>().GetType().BaseType);
-        }
-
-        [ConditionalFact]
-        public void CreateProxy_uses_parameterized_constructor()
-        {
-            using var context = new NeweyContext();
-            var proxy = context.CreateProxy<March881>(77, "Leyton House");
-
-            Assert.Same(typeof(March881), proxy.GetType().BaseType);
-            Assert.Equal(77, proxy.Id);
-            Assert.Equal("Leyton House", proxy.Sponsor);
-        }
-
-        [ConditionalFact]
-        public void CreateProxy_uses_parameterized_constructor_taking_context()
-        {
-            using var context = new NeweyContext();
-            var proxy = context.CreateProxy<WilliamsFw14>(context, 6, "Canon");
-
-            Assert.Same(typeof(WilliamsFw14), proxy.GetType().BaseType);
-            Assert.Same(context, proxy.Context);
-            Assert.Equal(6, proxy.Id);
-            Assert.Equal("Canon", proxy.Sponsor);
-        }
-
-        [ConditionalFact]
-        public void Proxies_only_created_if_Use_called()
-        {
-            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), false))
-            {
-                context.Add(new March82GGtp());
-                context.SaveChanges();
-            }
-
-            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), false))
-            {
-                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType());
-            }
-
-            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called)))
-            {
-                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
-            }
-        }
-
-        [ConditionalFact]
-        public void Proxy_services_must_be_available()
-        {
-            var withoutProxies = new ServiceCollection()
-                .AddEntityFrameworkInMemoryDatabase()
-                .BuildServiceProvider();
-
-            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available), false))
-            {
-                context.Add(new March82GGtp());
-                context.SaveChanges();
-            }
-
-            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available), false))
-            {
-                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType());
-            }
-
-            using (var context = new NeweyContext(nameof(Proxy_services_must_be_available)))
-            {
-                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
-            }
-
-            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available)))
-            {
-                Assert.Equal(
-                    ProxiesStrings.ProxyServicesMissing,
-                    Assert.Throws<InvalidOperationException>(
-                        () => context.Model).Message);
-            }
-        }
-
-        [ConditionalFact]
         public void Throws_if_sealed_class()
         {
-            using var context = new NeweyContextN1();
+            using var context = new LazyContext<LazySealedEntity>();
             Assert.Equal(
-                ProxiesStrings.ItsASeal(nameof(McLarenMp418)),
+                ProxiesStrings.ItsASeal(nameof(LazySealedEntity)),
                 Assert.Throws<InvalidOperationException>(
                     () => context.Model).Message);
         }
@@ -167,9 +31,9 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public void Throws_if_non_virtual_navigation()
         {
-            using var context = new NeweyContextN2();
+            using var context = new LazyContext<LazyNonVirtualNavEntity>();
             Assert.Equal(
-                ProxiesStrings.NonVirtualNavigation(nameof(McLarenMp419.SelfRef), nameof(McLarenMp419)),
+                ProxiesStrings.NonVirtualProperty(nameof(LazyNonVirtualNavEntity.SelfRef), nameof(LazyNonVirtualNavEntity)),
                 Assert.Throws<InvalidOperationException>(
                     () => context.Model).Message);
         }
@@ -177,69 +41,11 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public void Throws_if_no_field_found()
         {
-            using var context = new NeweyContextN3();
+            using var context = new LazyContext<LazyHiddenFieldEntity>();
             Assert.Equal(
-                CoreStrings.NoBackingFieldLazyLoading(nameof(MarchCg901.SelfRef), nameof(MarchCg901)),
+                CoreStrings.NoBackingFieldLazyLoading(nameof(LazyHiddenFieldEntity.SelfRef), nameof(LazyHiddenFieldEntity)),
                 Assert.Throws<InvalidOperationException>(
                     () => context.Model).Message);
-        }
-
-        [ConditionalFact]
-        public void Throws_if_type_not_available_to_Castle()
-        {
-            using var context = new NeweyContextN4();
-            Assert.Throws<GeneratorException>(() => context.CreateProxy<McLarenMp421>());
-        }
-
-        [ConditionalFact]
-        public void Throws_if_constructor_not_available_to_Castle()
-        {
-            using var context = new NeweyContextN5();
-            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<RedBullRb3>());
-        }
-
-        [ConditionalFact]
-        public void CreateProxy_throws_if_constructor_args_do_not_match()
-        {
-            using var context = new NeweyContext();
-            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<March881>(77, 88));
-        }
-
-        [ConditionalFact]
-        public void CreateProxy_throws_if_wrong_number_of_constructor_args()
-        {
-            using var context = new NeweyContext();
-            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<March881>(77, 88, 99));
-        }
-
-        [ConditionalFact]
-        public void Throws_if_create_proxy_for_non_mapped_type()
-        {
-            using var context = new NeweyContextN();
-            Assert.Equal(
-                CoreStrings.EntityTypeNotFound(nameof(March82GGtp)),
-                Assert.Throws<InvalidOperationException>(
-                    () => context.CreateProxy<March82GGtp>()).Message);
-        }
-
-        [ConditionalFact]
-        public void Throws_if_create_proxy_when_proxies_not_used()
-        {
-            using var context = new NeweyContextN6();
-            Assert.Equal(
-                ProxiesStrings.ProxiesNotEnabled(nameof(RedBullRb3)),
-                Assert.Throws<InvalidOperationException>(
-                    () => context.CreateProxy<RedBullRb3>()).Message);
-        }
-
-        [ConditionalFact]
-        public void Throws_if_create_proxy_when_proxies_not_enabled()
-        {
-            using var context = new NeweyContextN7();
-            Assert.Equal(
-                ProxiesStrings.ProxiesNotEnabled(nameof(RedBullRb3)),
-                Assert.Throws<InvalidOperationException>(
-                    () => context.CreateProxy<RedBullRb3>()).Message);
         }
 
         [ConditionalFact]
@@ -279,6 +85,41 @@ namespace Microsoft.EntityFrameworkCore
                     () => phone.Texts).Message);
         }
 
+        private class LazyContext<TEntity> : TestContext<TEntity>
+            where TEntity : class
+        {
+            public LazyContext()
+                : base(dbName: "LazyLoadingContext", useLazyLoading: true, useChangeDetection: false)
+            {
+            }
+        }
+
+        public sealed class LazySealedEntity
+        {
+            public int Id { get; set; }
+        }
+
+        public class LazyNonVirtualNavEntity
+        {
+            public int Id { get; set; }
+
+            public LazyNonVirtualNavEntity SelfRef { get; set; }
+        }
+
+        public class LazyHiddenFieldEntity
+        {
+            private LazyHiddenFieldEntity _hiddenBackingField;
+
+            public int Id { get; set; }
+
+            // ReSharper disable once ConvertToAutoProperty
+            public virtual LazyHiddenFieldEntity SelfRef
+            {
+                get => _hiddenBackingField;
+                set => _hiddenBackingField = value;
+            }
+        }
+
         private class JammieDodgerContext : DbContext
         {
             public JammieDodgerContext(DbContextOptions options)
@@ -299,211 +140,6 @@ namespace Microsoft.EntityFrameworkCore
         public class Text
         {
             public int Id { get; set; }
-        }
-
-        public class March82GGtp
-        {
-            public int Id { get; set; }
-        }
-
-        public class March881
-        {
-            public March881(int id, string sponsor)
-            {
-                Id = id;
-                Sponsor = sponsor;
-            }
-
-            public int Id { get; }
-            public string Sponsor { get; }
-        }
-
-        public class WilliamsFw14
-        {
-            public WilliamsFw14(DbContext context, int id, string sponsor)
-            {
-                Context = context;
-                Id = id;
-                Sponsor = sponsor;
-            }
-
-            public DbContext Context { get; }
-            public int Id { get; }
-            public string Sponsor { get; }
-        }
-
-        private class NeweyContext : DbContext
-        {
-            private readonly IServiceProvider _internalServiceProvider;
-            private static readonly InMemoryDatabaseRoot _dbRoot = new InMemoryDatabaseRoot();
-            private readonly bool _useProxies;
-            private readonly string _dbName;
-
-            public NeweyContext(string dbName = null, bool useProxies = true)
-            {
-                _internalServiceProvider
-                    = new ServiceCollection()
-                        .AddEntityFrameworkInMemoryDatabase()
-                        .AddEntityFrameworkProxies()
-                        .BuildServiceProvider();
-
-                _dbName = dbName;
-                _useProxies = useProxies;
-            }
-
-            public NeweyContext(IServiceProvider internalServiceProvider, string dbName = null, bool useProxies = true)
-                : this(dbName, useProxies)
-            {
-                _internalServiceProvider = internalServiceProvider;
-            }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                if (_useProxies)
-                {
-                    optionsBuilder.UseLazyLoadingProxies();
-                }
-
-                if (_internalServiceProvider != null)
-                {
-                    optionsBuilder.UseInternalServiceProvider(_internalServiceProvider);
-                }
-
-                optionsBuilder.UseInMemoryDatabase(_dbName ?? nameof(NeweyContext), _dbRoot);
-            }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder.Entity<March82GGtp>();
-
-                modelBuilder.Entity<March881>(
-                    b =>
-                    {
-                        b.Property(e => e.Id);
-                        b.Property(e => e.Sponsor);
-                    });
-
-                modelBuilder.Entity<WilliamsFw14>(
-                    b =>
-                    {
-                        b.Property(e => e.Id);
-                        b.Property(e => e.Sponsor);
-                    });
-            }
-        }
-
-        public sealed class McLarenMp418
-        {
-            public int Id { get; set; }
-        }
-
-        private class NeweyContextN : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLazyLoadingProxies()
-                    .UseInternalServiceProvider(
-                        new ServiceCollection()
-                            .AddEntityFrameworkInMemoryDatabase()
-                            .AddEntityFrameworkProxies()
-                            .BuildServiceProvider())
-                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
-        }
-
-        private class NeweyContextN1 : NeweyContextN
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<McLarenMp418>();
-        }
-
-        public class McLarenMp419
-        {
-            public int Id { get; set; }
-
-            public McLarenMp419 SelfRef { get; set; }
-        }
-
-        private class NeweyContextN2 : NeweyContextN
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<McLarenMp419>();
-        }
-
-        public class MarchCg901
-        {
-            private MarchCg901 _hiddenBackingField;
-
-            public int Id { get; set; }
-
-            // ReSharper disable once ConvertToAutoProperty
-            public virtual MarchCg901 SelfRef
-            {
-                get => _hiddenBackingField;
-                set => _hiddenBackingField = value;
-            }
-        }
-
-        private class NeweyContextN3 : NeweyContextN
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<MarchCg901>();
-        }
-
-        internal class McLarenMp421
-        {
-            public int Id { get; set; }
-        }
-
-        private class NeweyContextN4 : NeweyContextN
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<McLarenMp421>();
-        }
-
-        public class RedBullRb3
-        {
-            internal RedBullRb3()
-            {
-            }
-
-            public int Id { get; set; }
-        }
-
-        private class NeweyContextN5 : NeweyContextN
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<RedBullRb3>();
-        }
-
-        private class NeweyContextN6 : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseInternalServiceProvider(
-                        new ServiceCollection()
-                            .AddEntityFrameworkInMemoryDatabase()
-                            .AddEntityFrameworkProxies()
-                            .BuildServiceProvider())
-                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<March82GGtp>();
-        }
-
-        private class NeweyContextN7 : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-                => optionsBuilder
-                    .UseLazyLoadingProxies(false)
-                    .UseInternalServiceProvider(
-                        new ServiceCollection()
-                            .AddEntityFrameworkInMemoryDatabase()
-                            .AddEntityFrameworkProxies()
-                            .BuildServiceProvider())
-                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-                => modelBuilder.Entity<March82GGtp>();
         }
     }
 }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Castle.DynamicProxy;
-using Castle.DynamicProxy.Generators;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/test/EFCore.Proxies.Tests/ProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ProxyTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public class March82GGtp
         {
-            public int Id { get; set; }
+            public virtual int Id { get; set; }
         }
 
         public class March881
@@ -232,8 +232,9 @@ namespace Microsoft.EntityFrameworkCore
                 Sponsor = sponsor;
             }
 
-            public int Id { get; }
-            public string Sponsor { get; }
+            public virtual int Id { get; set; }
+
+            public virtual string Sponsor { get; set; }
         }
 
         public class WilliamsFw14
@@ -245,9 +246,11 @@ namespace Microsoft.EntityFrameworkCore
                 Sponsor = sponsor;
             }
 
-            public DbContext Context { get; }
-            public int Id { get; }
-            public string Sponsor { get; }
+            public DbContext Context { get; set; }
+
+            public virtual int Id { get; set; }
+
+            public virtual string Sponsor { get; set; }
         }
 
         private class NeweyContext : DbContext
@@ -332,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore
 
         internal class McLarenMp421
         {
-            public int Id { get; set; }
+            public virtual int Id { get; set; }
         }
 
         private class NeweyContextN4 : NeweyContextN
@@ -347,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            public int Id { get; set; }
+            public virtual int Id { get; set; }
         }
 
         private class NeweyContextN5 : NeweyContextN

--- a/test/EFCore.Proxies.Tests/ProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ProxyTests.cs
@@ -1,0 +1,390 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Castle.DynamicProxy;
+using Castle.DynamicProxy.Generators;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class ProxyTests
+    {
+        [ConditionalFact]
+        public void Materialization_uses_parameterless_constructor()
+        {
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterless_constructor)))
+            {
+                context.Add(new March82GGtp());
+                context.SaveChanges();
+            }
+
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterless_constructor)))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
+            }
+        }
+
+        [ConditionalFact]
+        public void Materialization_uses_parameterized_constructor()
+        {
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor)))
+            {
+                context.Add(new March881(77, "Leyton House"));
+                context.SaveChanges();
+            }
+
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor)))
+            {
+                var proxy = context.Set<March881>().Single();
+
+                Assert.Same(typeof(March881), proxy.GetType().BaseType);
+                Assert.Equal(77, proxy.Id);
+                Assert.Equal("Leyton House", proxy.Sponsor);
+            }
+        }
+
+        [ConditionalFact]
+        public void Materialization_uses_parameterized_constructor_taking_context()
+        {
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor_taking_context)))
+            {
+                context.Add(new WilliamsFw14(context, 6, "Canon"));
+                context.SaveChanges();
+            }
+
+            using (var context = new NeweyContext(nameof(Materialization_uses_parameterized_constructor_taking_context)))
+            {
+                var proxy = context.Set<WilliamsFw14>().Single();
+
+                Assert.Same(typeof(WilliamsFw14), proxy.GetType().BaseType);
+                Assert.Same(context, proxy.Context);
+                Assert.Equal(6, proxy.Id);
+                Assert.Equal("Canon", proxy.Sponsor);
+            }
+        }
+
+        [ConditionalFact]
+        public void CreateProxy_uses_parameterless_constructor()
+        {
+            using var context = new NeweyContext();
+            Assert.Same(typeof(March82GGtp), context.CreateProxy<March82GGtp>().GetType().BaseType);
+        }
+
+        [ConditionalFact]
+        public void CreateProxy_uses_parameterized_constructor()
+        {
+            using var context = new NeweyContext();
+            var proxy = context.CreateProxy<March881>(77, "Leyton House");
+
+            Assert.Same(typeof(March881), proxy.GetType().BaseType);
+            Assert.Equal(77, proxy.Id);
+            Assert.Equal("Leyton House", proxy.Sponsor);
+        }
+
+        [ConditionalFact]
+        public void CreateProxy_uses_parameterized_constructor_taking_context()
+        {
+            using var context = new NeweyContext();
+            var proxy = context.CreateProxy<WilliamsFw14>(context, 6, "Canon");
+
+            Assert.Same(typeof(WilliamsFw14), proxy.GetType().BaseType);
+            Assert.Same(context, proxy.Context);
+            Assert.Equal(6, proxy.Id);
+            Assert.Equal("Canon", proxy.Sponsor);
+        }
+
+        [ConditionalFact]
+        public void Proxies_only_created_if_Use_called()
+        {
+            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), false, false))
+            {
+                context.Add(new March82GGtp());
+                context.SaveChanges();
+            }
+
+            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), false, false))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType());
+            }
+
+            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), true, false))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
+            }
+
+            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), false, true))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
+            }
+
+            using (var context = new NeweyContext(nameof(Proxies_only_created_if_Use_called), true, true))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
+            }
+        }
+
+        [ConditionalFact]
+        public void Proxy_services_must_be_available()
+        {
+            var withoutProxies = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .BuildServiceProvider();
+
+            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available), false))
+            {
+                context.Add(new March82GGtp());
+                context.SaveChanges();
+            }
+
+            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available), false))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType());
+            }
+
+            using (var context = new NeweyContext(nameof(Proxy_services_must_be_available)))
+            {
+                Assert.Same(typeof(March82GGtp), context.Set<March82GGtp>().Single().GetType().BaseType);
+            }
+
+            using (var context = new NeweyContext(withoutProxies, nameof(Proxy_services_must_be_available)))
+            {
+                Assert.Equal(
+                    ProxiesStrings.ProxyServicesMissing,
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Model).Message);
+            }
+        }
+
+        [ConditionalFact]
+        public void Throws_if_type_not_available_to_Castle()
+        {
+            using var context = new NeweyContextN4();
+            Assert.Throws<GeneratorException>(() => context.CreateProxy<McLarenMp421>());
+        }
+
+        [ConditionalFact]
+        public void Throws_if_constructor_not_available_to_Castle()
+        {
+            using var context = new NeweyContextN5();
+            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<RedBullRb3>());
+        }
+
+        [ConditionalFact]
+        public void CreateProxy_throws_if_constructor_args_do_not_match()
+        {
+            using var context = new NeweyContext();
+            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<March881>(77, 88));
+        }
+
+        [ConditionalFact]
+        public void CreateProxy_throws_if_wrong_number_of_constructor_args()
+        {
+            using var context = new NeweyContext();
+            Assert.Throws<InvalidProxyConstructorArgumentsException>(() => context.CreateProxy<March881>(77, 88, 99));
+        }
+
+        [ConditionalFact]
+        public void Throws_if_create_proxy_for_non_mapped_type()
+        {
+            using var context = new NeweyContextN();
+            Assert.Equal(
+                CoreStrings.EntityTypeNotFound(nameof(RedBullRb3)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.CreateProxy<RedBullRb3>()).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_if_create_proxy_when_proxies_not_used()
+        {
+            using var context = new NeweyContextN6();
+            Assert.Equal(
+                ProxiesStrings.ProxiesNotEnabled(nameof(RedBullRb3)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.CreateProxy<RedBullRb3>()).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_if_create_proxy_when_proxies_not_enabled()
+        {
+            using var context = new NeweyContextN7();
+            Assert.Equal(
+                ProxiesStrings.ProxiesNotEnabled(nameof(RedBullRb3)),
+                Assert.Throws<InvalidOperationException>(
+                    () => context.CreateProxy<RedBullRb3>()).Message);
+        }
+
+        public class March82GGtp
+        {
+            public int Id { get; set; }
+        }
+
+        public class March881
+        {
+            public March881(int id, string sponsor)
+            {
+                Id = id;
+                Sponsor = sponsor;
+            }
+
+            public int Id { get; }
+            public string Sponsor { get; }
+        }
+
+        public class WilliamsFw14
+        {
+            public WilliamsFw14(DbContext context, int id, string sponsor)
+            {
+                Context = context;
+                Id = id;
+                Sponsor = sponsor;
+            }
+
+            public DbContext Context { get; }
+            public int Id { get; }
+            public string Sponsor { get; }
+        }
+
+        private class NeweyContext : DbContext
+        {
+            private readonly IServiceProvider _internalServiceProvider;
+            private static readonly InMemoryDatabaseRoot _dbRoot = new InMemoryDatabaseRoot();
+            private readonly bool _useLazyLoadingProxies;
+            private readonly bool _useChangeDetectionProxies;
+            private readonly string _dbName;
+
+            public NeweyContext(string dbName = null, bool useLazyLoading = true, bool useChangeDetection = false)
+            {
+                _internalServiceProvider
+                    = new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .AddEntityFrameworkProxies()
+                        .BuildServiceProvider();
+
+                _dbName = dbName;
+                _useLazyLoadingProxies = useLazyLoading;
+                _useChangeDetectionProxies = useChangeDetection;
+            }
+
+            public NeweyContext(IServiceProvider internalServiceProvider, string dbName = null, bool useLazyLoading = true, bool useChangeDetection = false)
+                : this(dbName, useLazyLoading, useChangeDetection)
+            {
+                _internalServiceProvider = internalServiceProvider;
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                if (_useLazyLoadingProxies)
+                {
+                    optionsBuilder.UseLazyLoadingProxies();
+                }
+
+                if (_useChangeDetectionProxies)
+                {
+                    optionsBuilder.UseChangeDetectionProxies();
+                }
+
+                if (_internalServiceProvider != null)
+                {
+                    optionsBuilder.UseInternalServiceProvider(_internalServiceProvider);
+                }
+
+                optionsBuilder.UseInMemoryDatabase(_dbName ?? nameof(NeweyContext), _dbRoot);
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<March82GGtp>();
+
+                modelBuilder.Entity<March881>(
+                    b =>
+                    {
+                        b.Property(e => e.Id);
+                        b.Property(e => e.Sponsor);
+                    });
+
+                modelBuilder.Entity<WilliamsFw14>(
+                    b =>
+                    {
+                        b.Property(e => e.Id);
+                        b.Property(e => e.Sponsor);
+                    });
+            }
+        }
+
+        private class NeweyContextN : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseLazyLoadingProxies()
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkInMemoryDatabase()
+                            .AddEntityFrameworkProxies()
+                            .BuildServiceProvider())
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
+        }
+
+        internal class McLarenMp421
+        {
+            public int Id { get; set; }
+        }
+
+        private class NeweyContextN4 : NeweyContextN
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<McLarenMp421>();
+        }
+
+        public class RedBullRb3
+        {
+            internal RedBullRb3()
+            {
+            }
+
+            public int Id { get; set; }
+        }
+
+        private class NeweyContextN5 : NeweyContextN
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<RedBullRb3>();
+        }
+
+        private class NeweyContextN6 : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkInMemoryDatabase()
+                            .AddEntityFrameworkProxies()
+                            .BuildServiceProvider())
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<March82GGtp>();
+        }
+
+        private class NeweyContextN7 : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseLazyLoadingProxies(false)
+                    .UseInternalServiceProvider(
+                        new ServiceCollection()
+                            .AddEntityFrameworkInMemoryDatabase()
+                            .AddEntityFrameworkProxies()
+                            .BuildServiceProvider())
+                    .UseInMemoryDatabase(Guid.NewGuid().ToString());
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<March82GGtp>();
+        }
+    }
+}

--- a/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
+++ b/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    internal abstract class TestContext<TEntity> : DbContext
+            where TEntity : class
+    {
+        private readonly IServiceProvider _internalServiceProvider;
+        private static readonly InMemoryDatabaseRoot _dbRoot = new InMemoryDatabaseRoot();
+        private readonly bool _useLazyLoadingProxies;
+        private readonly bool _useChangeDetectionProxies;
+        private readonly string _dbName;
+
+        protected TestContext(string dbName = null, bool useLazyLoading = false, bool useChangeDetection = false)
+        {
+            _internalServiceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddEntityFrameworkProxies()
+                    .BuildServiceProvider();
+
+            _dbName = dbName;
+            _useLazyLoadingProxies = useLazyLoading;
+            _useChangeDetectionProxies = useChangeDetection;
+        }
+
+        protected TestContext(IServiceProvider internalServiceProvider, string dbName = null, bool useLazyLoading = false, bool useChangeDetection = false)
+            : this(dbName, useLazyLoading, useChangeDetection)
+        {
+            _internalServiceProvider = internalServiceProvider;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (_useLazyLoadingProxies)
+            {
+                optionsBuilder.UseLazyLoadingProxies();
+            }
+
+            if (_useChangeDetectionProxies)
+            {
+                optionsBuilder.UseChangeDetectionProxies();
+            }
+
+            if (_internalServiceProvider != null)
+            {
+                optionsBuilder.UseInternalServiceProvider(_internalServiceProvider);
+            }
+
+            optionsBuilder.UseInMemoryDatabase(_dbName ?? "TestContext", _dbRoot);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TEntity>();
+        }
+    }
+}


### PR DESCRIPTION
Addresses #10949 

This was getting a bit bigger than I originally anticipated so making a draft pull request for any early feedback.

Note that the tests are currently all in `LazyLoadingProxyTests` and as part of this PR I have split them out into 3 files (change detection, lazy loading, proxy) since they don't all fall under "Lazy-Loading" anymore. All the tests still exist in their current form. Hopefully that's not an issue.

Things that still need to be done:

- [x] Tests that ensure proxy change detection convention is enforced.
- [x] Tests that ensure that the correct combination of interfaces/interceptors are proxied given whether lazy loading and/or change detection is enabled, and the entity's change tracking strategy.
- [x] Tests that ensure events are raised by interceptors when necessary.

Some questions copied from #10949, which still stand:

1. If the entity already implements one of the notify interfaces, should we just not proxy that interface and leave it up to the consumer to raise those events? Edit: alternatively we could just continue to proxy and potentially raise 2 events if the consumer is already raising 1. **Currently I am not even checking for this. At the moment I don't think this will be an issue, but could and probably will make tests against entities that are already implementing these interfaces in order to verify.**

2. In a similar vein, for collection navigations we can bubble a collection change up to the parent entity if the underlying collection is one of the observable collection types. But it will be up to the consumer to instantiate that collection as one of the observable types in their entity's constructor, is that ok?

3. With what I've currently written out, if a consumer enables `UseChangeDetectionProxies` the default `ChangeDetectionStrategy` will still be `Snapshot` so none of the entities will receive the INPC proxies. Should we also be updating the `ChangeDetectionStrategy` to some other default value when change detection proxies are first enabled?

**Current issue that I wouldn't mind insight on:**


~~IProxyFactory now relies on ProxiesOptionsExtension in order to determine how to proxy entities. Since IProxyFactory is registered as a "provider-specific service" it is apparently not able to resolve IDbContextOptions to retrieve the extension. Is there some existing mechanism for a "provider-specific service" to get access to an extension? I couldn't seem to find one.~~

~~Edit: looking at it again and the IProxyFactory.Create takes in DbContext - so I'm just realizing that IProxyFactory is not tied to a DbContext (whoops). Will either need to change that or have other methods provide DbContext when necessary...~~