### PR TITLE
Fix scaffolding NRT issues

### DIFF
--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabasePrimaryKey.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabasePrimaryKey.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
     /// </summary>
     public class DatabasePrimaryKey : Annotatable
     {
-        public DatabasePrimaryKey([NotNull] DatabaseTable table, [NotNull] string name)
+        public DatabasePrimaryKey([NotNull] DatabaseTable table, [CanBeNull] string? name)
         {
             Table = table;
             Name = name;
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         /// <summary>
         ///     The name of the primary key.
         /// </summary>
-        public virtual string Name { get; [param: NotNull] set; }
+        public virtual string? Name { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     The ordered list of columns that make up the primary key.

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlDataReaderExtension.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlDataReaderExtension.cs
@@ -5,6 +5,8 @@ using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using JB = JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
 {
     /// <summary>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -606,7 +606,7 @@ ORDER BY [table_schema], [table_name], [c].[column_id]";
             var tableColumnGroups = reader.Cast<DbDataRecord>()
                 .GroupBy(
                     ddr => (tableSchema: ddr.GetValueOrDefault<string>("table_schema"),
-                        tableName: ddr.GetValueOrDefault<string>("table_name")));
+                        tableName: ddr.GetFieldValue<string>("table_name")));
 
             foreach (var tableColumnGroup in tableColumnGroups)
             {
@@ -830,7 +830,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
             var tableIndexGroups = reader.Cast<DbDataRecord>()
                 .GroupBy(
                     ddr => (tableSchema: ddr.GetValueOrDefault<string>("table_schema"),
-                        tableName: ddr.GetValueOrDefault<string>("table_name")));
+                        tableName: ddr.GetFieldValue<string>("table_name")));
 
             foreach (var tableIndexGroup in tableIndexGroups)
             {
@@ -976,7 +976,7 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id]";
             var tableForeignKeyGroups = reader.Cast<DbDataRecord>()
                 .GroupBy(
                     ddr => (tableSchema: ddr.GetValueOrDefault<string>("table_schema"),
-                        tableName: ddr.GetValueOrDefault<string>("table_name")));
+                        tableName: ddr.GetFieldValue<string>("table_name")));
 
             foreach (var tableForeignKeyGroup in tableForeignKeyGroups)
             {
@@ -989,7 +989,7 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id]";
                     .GroupBy(
                         c => (Name: c.GetValueOrDefault<string>("name"),
                             PrincipalTableSchema: c.GetValueOrDefault<string>("principal_table_schema"),
-                            PrincipalTableName: c.GetValueOrDefault<string>("principal_table_name"),
+                            PrincipalTableName: c.GetFieldValue<string>("principal_table_name"),
                             OnDeleteAction: c.GetValueOrDefault<string>("delete_referential_action_desc")));
 
                 foreach (var foreignKeyGroup in foreignKeyGroups)
@@ -1108,7 +1108,7 @@ WHERE name = '{connection.Database}';";
             return result != null ? Convert.ToByte(result) : (byte)0;
         }
 
-        private static string DisplayName(string? schema, string? name)
+        private static string DisplayName(string? schema, string name)
             => (!string.IsNullOrEmpty(schema) ? schema + "." : "") + name;
 
         private static ReferentialAction? ConvertToReferentialAction(string? onDeleteAction)


### PR DESCRIPTION
That only surface in preview versions of VS.

I've fixed this by using GetFieldValue instead of GetValueOrDefault when reading the relevant database values. I've taken a look (e.g. [here](https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-foreign-keys-transact-sql)) and to my understanding, the affected columns (table/index/key/constraint name, delete referential action) can never be null in the database. In at least some of the cases, our own code would anyway throw immediately afterwards if null was ever returned (@bricelam can you please confirm this looks OK?).

Fixes #19496