### PR TITLE
Query: Unwind nested invocation expressions

### DIFF
--- a/src/EFCore/Query/Internal/InvocationExpressionRemovingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/InvocationExpressionRemovingExpressionVisitor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var invokedExpression = StripTrivialConversions(invocationExpression.Expression);
 
             return invokedExpression is LambdaExpression lambdaExpression
-                ? InlineLambdaExpression(lambdaExpression, invocationExpression.Arguments)
+                ? Visit(InlineLambdaExpression(lambdaExpression, invocationExpression.Arguments))
                 : base.VisitInvocation(invocationExpression);
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1561,6 +1561,16 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        public override async Task Where_expression_invoke_3(bool async)
+        {
+            await base.Where_expression_invoke_3(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_concat_string_int_comparison1(bool async)
         {

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -1530,6 +1530,26 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_expression_invoke_3(bool async)
+        {
+            Expression<Func<Customer, bool>> lambda3 = c => c.CustomerID == "ALFKI";
+            var customerParameter2 = Expression.Parameter(typeof(Customer));
+            var lambda2 = Expression.Lambda<Func<Customer, bool>>(
+                Expression.Invoke(lambda3, customerParameter2),
+                customerParameter2);
+
+            var customerParameter = Expression.Parameter(typeof(Customer));
+            var lambda = Expression.Lambda<Func<Customer, bool>>(
+                Expression.Invoke(lambda2, customerParameter),
+                customerParameter);
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(lambda),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_concat_string_int_comparison1(bool async)
         {
             var i = 10;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1287,6 +1287,16 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }
 
+        public override async Task Where_expression_invoke_3(bool async)
+        {
+            await base.Where_expression_invoke_3(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'");
+        }
+
         public override async Task Where_concat_string_int_comparison1(bool async)
         {
             await base.Where_concat_string_int_comparison1(async);


### PR DESCRIPTION
Resolves #19511
Issue: When we unwound the first level, we did not visit it recursively.

