### PR TITLE
Added support for query filter factories to "lazy load" query filter expressions

### DIFF
--- a/src/EFCore/Infrastructure/Annotation.cs
+++ b/src/EFCore/Infrastructure/Annotation.cs
@@ -38,6 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Gets the value assigned to this annotation.
         /// </summary>
-        public virtual object Value { get; }
+        public virtual object Value { get; internal set; }
     }
 }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -241,6 +241,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="filter"> The factory for the LINQ predicate expression. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder HasQueryFilter([CanBeNull] Func<LambdaExpression> filter)
+        {
+            Builder.HasQueryFilter(filter, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
         ///     Configures an index on the specified properties. If there is an existing index on the given
         ///     set of properties, then the existing index will be returned for configuration.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -165,6 +165,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(filter);
 
         /// <summary>
+        ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="filter"> The factory for the LINQ predicate expression. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder<TEntity> HasQueryFilter([CanBeNull] Func<Expression<Func<TEntity, bool>>> filter)
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(filter);
+
+        /// <summary>
         ///     Configures a query used to provide data for a keyless entity type.
         /// </summary>
         /// <param name="query"> The query that will provide the underlying data for the keyless entity type. </param>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2680,6 +2680,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual void SetQueryFilter([CanBeNull] Func<LambdaExpression> queryFilter, ConfigurationSource configurationSource)
+        {
+            this.SetOrRemoveAnnotation(CoreAnnotationNames.QueryFilter, queryFilter, configurationSource);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual string CheckQueryFilter([CanBeNull] LambdaExpression queryFilter)
         {
             if (queryFilter != null

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1110,9 +1110,38 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual InternalEntityTypeBuilder HasQueryFilter(
+            [CanBeNull] Func<LambdaExpression> filter, ConfigurationSource configurationSource)
+        {
+            if (CanSetQueryFilter(configurationSource))
+            {
+                Metadata.SetQueryFilter(filter, configurationSource);
+
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual bool CanSetQueryFilter([CanBeNull] LambdaExpression filter, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetQueryFilterConfigurationSource())
                 || Metadata.GetQueryFilter() == filter;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetQueryFilter(ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetQueryFilterConfigurationSource())
+                && Metadata.GetQueryFilter() == null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1157,7 +1157,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var sequenceType = navigationExpansionExpression.Type.GetSequenceType();
                 var entityType = _queryCompilationContext.Model.FindEntityType(sequenceType);
                 var rootEntityType = entityType.GetRootType();
-                var queryFilter = rootEntityType.GetQueryFilter();
+                var queryFilter = rootEntityType.GetOrBuildQueryFilter();
                 if (queryFilter != null)
                 {
                     if (!_parameterizedQueryFilterPredicateCache.TryGetValue(rootEntityType, out var filterPredicate))

--- a/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             // Parametrize
             // Filters defined in OnModelCreating
             modelBuilder.Entity<FieldFilter>().HasQueryFilter(e => e.IsEnabled == Field);
-            modelBuilder.Entity<PropertyFilter>().HasQueryFilter(e => e.IsEnabled == Property);
+            modelBuilder.Entity<PropertyFilter>().HasQueryFilter(() => e => e.IsEnabled == Property);
             modelBuilder.Entity<MethodCallFilter>().HasQueryFilter(e => e.Tenant == GetId());
             modelBuilder.Entity<ListFilter>().HasQueryFilter(e => TenantIds.Contains(e.Tenant));
             modelBuilder.Entity<PropertyChainFilter>().HasQueryFilter(e => e.IsEnabled == IndirectionFlag.Enabled);


### PR DESCRIPTION
Query filters are a powerful tool in Entity Framework, but limited as they are restricted to being defined ahead of being used.

**Suppose the following scenario**

A business application with 200 tables. Extreme performance is not imperative as this does not need to scale to millions of users, but correct business security, per user, is paramount.

Currently, as the data context is generated, the logic behind query filters for each of those tables must be created before any of those tables are even queried. Additionally, the logic is static, sealed in a single `LambdaExpression`.

If we needed different logic per tenants we can either use a new derivative of our `DbContext` or we can use a new `IModelCacheKeyFactory` implementation (or perhaps some usage of `ICompiledQueryCacheKeyGenerator`), and configure the query filters depending on the current user/request.

*But again, the current set-up forces us to determine the query filters for all 200 tables ahead of time.*

A better set-up would be to **only construct the query filters if a request requires it**, essentially lazy load them.

EF Core has a strong opinion about sealing the model once it's built - it becomes read-only. I have attempted to adhere to this opinion in this PR, albeit with the singular exception of internally swapping a query filter factory in the entity type annotations for the actual `LambdaExpression` once the factory has been invoked for the first time. This maintains the idea of defining what tables have query filters ahead of time, and keeps the factory invoked only once per model-cache.

The result is the ability to do this (when combined with a per-request `IModelCacheKeyFactory`):

    modelBuilder.Entity<ApplicationUser>().HasQueryFilter(() =>
    {
        if (this.CheckSomethingAboutCurrentUser())
        {
            return user => user.FullName.Contains("hello");
        }
        return user => user.FullName.Contains("goodbye");
    });

Given we can inject anything we like into the `DbContext`, we can check details about the request, perhaps some user information stored elsewhere, anything we like to construct our query filter, but at no expense if the filter is not used in that request.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/aspnet/AspNetCore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


