### PR TITLE
Fix to #19295 - Query: optimize CASE blocks

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7518,6 +7518,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Where(g => ss.Set<City>().Where(c => c.Name == g.CityOfBirthName).FirstOrDefault()["Nation"] == null));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Conditional_with_conditions_evaluating_to_false_gets_optimized(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Gear>().Select(g => g.Nickname == null && g.Nickname != null ? g.CityOfBirthName : g.FullName));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Conditional_with_conditions_evaluating_to_true_gets_optimized(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Gear>().Select(g => g.Nickname == null || g.Nickname != null ? g.CityOfBirthName : g.FullName));
+        }
+
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7495,6 +7495,26 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (
     WHERE [c].[Name] = [g].[CityOfBirthName]) IS NULL");
         }
 
+        public override async Task Conditional_with_conditions_evaluating_to_false_gets_optimized(bool isAsync)
+        {
+            await base.Conditional_with_conditions_evaluating_to_false_gets_optimized(isAsync);
+
+            AssertSql(
+                @"SELECT [g].[FullName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
+
+        public override async Task Conditional_with_conditions_evaluating_to_true_gets_optimized(bool isAsync)
+        {
+            await base.Conditional_with_conditions_evaluating_to_true_gets_optimized(isAsync);
+
+            AssertSql(
+                @"SELECT [g].[CityOfBirthName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1181,10 +1181,7 @@ WHERE ([o].[CustomerID] = N'ALFKI') AND ((CHARINDEX(N'1997', CONVERT(nvarchar(ma
             await base.Indexof_with_emptystring(async);
 
             AssertSql(
-                @"SELECT CASE
-    WHEN 1 = 1 THEN 0
-    ELSE CAST(CHARINDEX(N'', [c].[ContactName]) AS int) - 1
-END
+                @"SELECT 0
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1167,10 +1167,7 @@ CROSS APPLY (
             await base.Select_with_complex_expression_that_can_be_funcletized(async);
 
             AssertSql(
-                @"SELECT CASE
-    WHEN 1 = 1 THEN 0
-    ELSE CAST(CHARINDEX(N'', [c].[ContactName]) AS int) - 1
-END
+                @"SELECT 0
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1671,10 +1671,7 @@ WHERE @__p_0 = CAST(1 AS bit)");
             AssertSql(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE CASE
-    WHEN 1 = 1 THEN CAST(0 AS bit)
-    ELSE CAST(1 AS bit)
-END = CAST(1 AS bit)");
+WHERE 0 = 1");
         }
 
         public override async Task Enclosing_class_settable_member_generates_parameter(bool async)


### PR DESCRIPTION
- if one of the conditions in CaseWhen test evaluates to false we can remove it,
- if one of the conditions in CaseWhen test evaluates to true, we can remove all blocks (including else block) that appears after,
- if we only have one CaseWhen block in the end, and test evaluates to true, we can simply return the result,
- if only Else block is left, return it's result,
- if nothing is left, return NULL.

Resolves #19295