### PR TITLE
Fix incorrect summary comment on ReferenceNavigationBuilder.WithOne

### DIFF
--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
         /// <summary>
         ///     <para>
-        ///         Configures this as a one-to-many relationship.
+        ///         Configures this as a one-to-one relationship.
         ///     </para>
         ///     <para>
         ///         Note that calling this method with no parameters will explicitly configure this side


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

`WithOne` on `ReferenceNavigationBuilder` had a comment that said "one-to-many", but it should be "one-to-one". Not much more to say I guess. Let me know if you have any questions.

