### PR TITLE
Cosmos: translate string Contains, StartsWith, and EndsWith

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 new IMethodCallTranslator[]
                 {
                     new EqualsTranslator(sqlExpressionFactory),
-                    //new StringMethodTranslator(sqlExpressionFactory),
+                    new StringMethodTranslator(sqlExpressionFactory),
                     new ContainsTranslator(sqlExpressionFactory)
                     //new LikeTranslator(sqlExpressionFactory),
                     //new EnumHasFlagTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -85,6 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 case SqlParameterExpression sqlParameterExpression:
                     return sqlParameterExpression.ApplyTypeMapping(typeMapping);
 
+                case SqlFunctionExpression sqlFunctionExpression:
+                    return sqlFunctionExpression.ApplyTypeMapping(typeMapping);
+
                 default:
                     return sqlExpression;
             }

--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class StringMethodTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _containsMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) });
+
+        private static readonly MethodInfo _startsWithMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) });
+
+        private static readonly MethodInfo _endsWithMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public StringMethodTranslator([NotNull] ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            Check.NotNull(method, nameof(method));
+            Check.NotNull(arguments, nameof(arguments));
+
+            if (_containsMethodInfo.Equals(method))
+            {
+                return TranslateSystemFunction("CONTAINS", instance, arguments[0], typeof(bool));
+            }
+
+            if (_startsWithMethodInfo.Equals(method))
+            {
+                return TranslateSystemFunction("STARTSWITH", instance, arguments[0], typeof(bool));
+            }
+
+            if (_endsWithMethodInfo.Equals(method))
+            {
+                return TranslateSystemFunction("ENDSWITH", instance, arguments[0], typeof(bool));
+            }
+
+            return null;
+        }
+
+        private SqlExpression TranslateSystemFunction(string function, SqlExpression instance, SqlExpression pattern, Type returnType)
+        {
+            Check.NotNull(instance, nameof(instance));
+            return _sqlExpressionFactory.Function(
+                function,
+                new[] { instance, pattern },
+                returnType,
+                ExpressionExtensions.InferTypeMapping(instance, pattern));
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -71,10 +71,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         private SqlExpression TranslateSystemFunction(string function, SqlExpression instance, SqlExpression pattern, Type returnType)
         {
             Check.NotNull(instance, nameof(instance));
-            return _sqlExpressionFactory.Function(
+            return _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                _sqlExpressionFactory.Function(
                 function,
                 new[] { instance, pattern },
-                returnType);
+                returnType));
         }
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -74,8 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             return _sqlExpressionFactory.Function(
                 function,
                 new[] { instance, pattern },
-                returnType,
-                ExpressionExtensions.InferTypeMapping(instance, pattern));
+                returnType);
         }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -19,184 +19,123 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory]
         public override async Task String_StartsWith_Literal(bool async)
         {
             await base.String_StartsWith_Literal(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""M""";
-            string function = "STARTSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] != null) AND ((""M"" != null) AND STARTSWITH(c[""ContactName""], ""M""))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_StartsWith_Identity(bool async)
         {
             await base.String_StartsWith_Identity(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "STARTSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] = """") OR ((c[""ContactName""] != null) AND ((c[""ContactName""] != null) AND STARTSWITH(c[""ContactName""], c[""ContactName""])))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_StartsWith_Column(bool async)
         {
             await base.String_StartsWith_Column(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "STARTSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] = """") OR ((c[""ContactName""] != null) AND ((c[""ContactName""] != null) AND STARTSWITH(c[""ContactName""], c[""ContactName""])))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_StartsWith_MethodCall(bool async)
         {
             await base.String_StartsWith_MethodCall(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""M""";
-            string function = "STARTSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] != null) AND ((""M"" != null) AND STARTSWITH(c[""ContactName""], ""M""))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_EndsWith_Literal(bool async)
         {
             await base.String_EndsWith_Literal(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""b""";
-            string function = "ENDSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] != null) AND ((""b"" != null) AND ENDSWITH(c[""ContactName""], ""b""))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_EndsWith_Identity(bool async)
         {
             await base.String_EndsWith_Identity(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "ENDSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] = """") OR ((c[""ContactName""] != null) AND ((c[""ContactName""] != null) AND ENDSWITH(c[""ContactName""], c[""ContactName""])))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_EndsWith_Column(bool async)
         {
             await base.String_EndsWith_Column(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "ENDSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] = """") OR ((c[""ContactName""] != null) AND ((c[""ContactName""] != null) AND ENDSWITH(c[""ContactName""], c[""ContactName""])))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_EndsWith_MethodCall(bool async)
         {
             await base.String_EndsWith_MethodCall(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""m""";
-            string function = "ENDSWITH";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""ContactName""] != null) AND ((""m"" != null) AND ENDSWITH(c[""ContactName""], ""m""))))");
         }
 
-        [ConditionalTheory]
         public override async Task String_Contains_Literal(bool async)
         {
             await base.String_Contains_Literal(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""M""";
-            string function = "CONTAINS";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""M""))");
         }
 
-        [ConditionalTheory]
         public override async Task String_Contains_Identity(bool async)
         {
             await base.String_Contains_Identity(async);
-
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "CONTAINS";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], c[""ContactName""]))");
         }
 
-        [ConditionalTheory]
         public override async Task String_Contains_Column(bool async)
         {
             await base.String_Contains_Column(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = instance;
-            string function = "CONTAINS";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], c[""ContactName""]))");
         }
 
-        [ConditionalTheory]
         public override async Task String_Contains_MethodCall(bool async)
         {
             await base.String_Contains_MethodCall(async);
 
-            string instance = @"c[""ContactName""]";
-            string argument = @"""M""";
-            string function = "CONTAINS";
-
             AssertSql(
-                @$"SELECT c
+                @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""M""))");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -19,136 +19,184 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_StartsWith_Literal(bool async)
         {
             await base.String_StartsWith_Literal(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""M""";
+            string function = "STARTSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_StartsWith_Identity(bool async)
         {
             await base.String_StartsWith_Identity(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "STARTSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_StartsWith_Column(bool async)
         {
             await base.String_StartsWith_Column(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "STARTSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_StartsWith_MethodCall(bool async)
         {
             await base.String_StartsWith_MethodCall(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""M""";
+            string function = "STARTSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_EndsWith_Literal(bool async)
         {
             await base.String_EndsWith_Literal(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""b""";
+            string function = "ENDSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_EndsWith_Identity(bool async)
         {
             await base.String_EndsWith_Identity(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "ENDSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_EndsWith_Column(bool async)
         {
             await base.String_EndsWith_Column(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "ENDSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} = """") OR (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument})))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_EndsWith_MethodCall(bool async)
         {
             await base.String_EndsWith_MethodCall(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""m""";
+            string function = "ENDSWITH";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (({instance} != null) AND (({argument} != null) AND {function}({instance}, {argument}))))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_Contains_Literal(bool async)
         {
             await base.String_Contains_Literal(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""M""";
+            string function = "CONTAINS";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_Contains_Identity(bool async)
         {
             await base.String_Contains_Identity(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "CONTAINS";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_Contains_Column(bool async)
         {
             await base.String_Contains_Column(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = instance;
+            string function = "CONTAINS";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
+        [ConditionalTheory]
         public override async Task String_Contains_MethodCall(bool async)
         {
             await base.String_Contains_MethodCall(async);
 
+            string instance = @"c[""ContactName""]";
+            string argument = @"""M""";
+            string function = "CONTAINS";
+
             AssertSql(
-                @"SELECT c
+                @$"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND {function}({instance}, {argument}))");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]


### PR DESCRIPTION
Addresses part of #16143

This PR introduces translation for `string.StartsWith`, `string.EndsWith`, and `string.Contains` in cosmos queries. They are converted to the built-in cosmos functions `STARTSWITH`, `ENDSWITH`, and `CONTAINS` respectively.

Not sure if this contribution is wanted, but I had added this extension to my code as I was playing around with efcore cosmos and figured I would offer to contribute it back. If it is wanted, I will add tests and make changes as requested.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


