### PR TITLE
Fix to #18555 - Query: when rewriting null semantics for comparisons with functions use function specific metadata to get better SQL

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -131,6 +131,54 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] Type returnType,
             [CanBeNull] RelationalTypeMapping typeMapping = null);
 
+        SqlFunctionExpression Function(
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
+        SqlFunctionExpression Function(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
+        SqlFunctionExpression Function(
+            [CanBeNull] SqlExpression instance,
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            bool instancePropagatesNullability,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
+        SqlFunctionExpression Function(
+            [NotNull] string name,
+            bool nullResultAllowed,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
+        SqlFunctionExpression Function(
+            [NotNull] string schema,
+            [NotNull] string name,
+            bool nullResultAllowed,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
+        SqlFunctionExpression Function(
+            [CanBeNull] SqlExpression instance,
+            [NotNull] string name,
+            bool nullResultAllowed,
+            bool instancePropagatesNullability,
+            [NotNull] Type returnType,
+            [CanBeNull] RelationalTypeMapping typeMapping = null);
+
         ExistsExpression Exists([NotNull] SelectExpression subquery, bool negated);
         InExpression In([NotNull] SqlExpression item, [NotNull] SqlExpression values, bool negated);
         InExpression In([NotNull] SqlExpression item, [NotNull] SelectExpression subquery, bool negated);

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -56,6 +56,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         dbFunction.Schema,
                         dbFunction.Name,
                         arguments,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: arguments.Select(a => true).ToList(),
                         method.ReturnType);
             }
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -99,11 +99,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             return inputType == typeof(float)
                 ? SqlExpressionFactory.Convert(
                     SqlExpressionFactory.Function(
-                        "AVG", new[] { sqlExpression }, typeof(double)),
+                        "AVG",
+                        new[] { sqlExpression },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { false },
+                        typeof(double)),
                     sqlExpression.Type,
                     sqlExpression.TypeMapping)
                 : (SqlExpression)SqlExpressionFactory.Function(
-                    "AVG", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping);
+                    "AVG",
+                    new[] { sqlExpression },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false },
+                    sqlExpression.Type,
+                    sqlExpression.TypeMapping);
         }
 
         public virtual SqlExpression TranslateCount([CanBeNull] Expression expression = null)
@@ -115,7 +124,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return SqlExpressionFactory.ApplyDefaultTypeMapping(
-                SqlExpressionFactory.Function("COUNT", new[] { SqlExpressionFactory.Fragment("*") }, typeof(int)));
+                SqlExpressionFactory.Function(
+                    "COUNT",
+                    new[] { SqlExpressionFactory.Fragment("*") },
+                    nullResultAllowed: false,
+                    argumentsPropagateNullability: new[] { false },
+                    typeof(int)));
         }
 
         public virtual SqlExpression TranslateLongCount([CanBeNull] Expression expression = null)
@@ -127,7 +141,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return SqlExpressionFactory.ApplyDefaultTypeMapping(
-                SqlExpressionFactory.Function("COUNT", new[] { SqlExpressionFactory.Fragment("*") }, typeof(long)));
+                SqlExpressionFactory.Function(
+                    "COUNT",
+                    new[] { SqlExpressionFactory.Fragment("*") },
+                    nullResultAllowed: false,
+                    argumentsPropagateNullability: new[] { false },
+                    typeof(long)));
         }
 
         public virtual SqlExpression TranslateMax([NotNull] Expression expression)
@@ -140,7 +159,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return sqlExpression != null
-                ? SqlExpressionFactory.Function("MAX", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                ? SqlExpressionFactory.Function(
+                    "MAX",
+                    new[] { sqlExpression },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false },
+                    sqlExpression.Type,
+                    sqlExpression.TypeMapping)
                 : null;
         }
 
@@ -154,7 +179,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return sqlExpression != null
-                ? SqlExpressionFactory.Function("MIN", new[] { sqlExpression }, sqlExpression.Type, sqlExpression.TypeMapping)
+                ? SqlExpressionFactory.Function(
+                    "MIN",
+                    new[] { sqlExpression },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false },
+                    sqlExpression.Type,
+                    sqlExpression.TypeMapping)
                 : null;
         }
 
@@ -176,11 +207,21 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return inputType == typeof(float)
                 ? SqlExpressionFactory.Convert(
-                    SqlExpressionFactory.Function("SUM", new[] { sqlExpression }, typeof(double)),
+                    SqlExpressionFactory.Function(
+                        "SUM",
+                        new[] { sqlExpression },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { false },
+                        typeof(double)),
                     inputType,
                     sqlExpression.TypeMapping)
                 : (SqlExpression)SqlExpressionFactory.Function(
-                    "SUM", new[] { sqlExpression }, inputType, sqlExpression.TypeMapping);
+                    "SUM",
+                    new[] { sqlExpression },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false },
+                    inputType,
+                    sqlExpression.TypeMapping);
         }
 
         private sealed class SqlTypeMappingVerifyingExpressionVisitor : ExpressionVisitor

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -17,17 +17,80 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             [NotNull] string name,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
+            => CreateNiladic(name, nullResultAllowed: true, type, typeMapping);
+
+        public static SqlFunctionExpression CreateNiladic(
+            [NotNull] string schema,
+            [NotNull] string name,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            => CreateNiladic(schema, name, nullResultAllowed: true, type, typeMapping);
+
+        public static SqlFunctionExpression CreateNiladic(
+            [NotNull] SqlExpression instance,
+            [NotNull] string name,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            => CreateNiladic(instance, name, nullResultAllowed: true, instancPropagatesNullability: false, type, typeMapping);
+
+        public static SqlFunctionExpression Create(
+            [NotNull] SqlExpression instance,
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            => Create(
+                instance,
+                name,
+                arguments,
+                nullResultAllowed: true,
+                instancPropagatesNullability: false,
+                argumentsPropagateNullability: arguments.Select(a => false),
+                type,
+                typeMapping);
+
+        public static SqlFunctionExpression Create(
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            => Create(name, arguments, nullResultAllowed: true, argumentsPropagateNullability: arguments.Select(a => false), type, typeMapping);
+
+        public static SqlFunctionExpression Create(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] IEnumerable<SqlExpression> arguments,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
+            => Create(schema, name, arguments, nullResultAllowed: true, argumentsPropagateNullability: arguments.Select(a => false), type, typeMapping);
+
+        public static SqlFunctionExpression CreateNiladic(
+            [NotNull] string name,
+            bool nullResultAllowed,
+            [NotNull] Type type,
+            [CanBeNull] RelationalTypeMapping typeMapping)
         {
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(type, nameof(type));
 
             return new SqlFunctionExpression(
-                instance: null, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
+                instance: null,
+                schema: null,
+                name,
+                niladic: true,
+                arguments: null,
+                nullResultAllowed,
+                instancPropagatesNullability: null,
+                argumentsPropagateNullability: null,
+                builtIn: true,
+                type,
+                typeMapping);
         }
 
         public static SqlFunctionExpression CreateNiladic(
             [NotNull] string schema,
             [NotNull] string name,
+            bool nullResultAllowed,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
         {
@@ -36,12 +99,24 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(type, nameof(type));
 
             return new SqlFunctionExpression(
-                instance: null, schema, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
+                instance: null,
+                schema,
+                name,
+                niladic: true,
+                arguments: null,
+                nullResultAllowed,
+                instancPropagatesNullability: null,
+                argumentsPropagateNullability: null,
+                builtIn: true,
+                type,
+                typeMapping);
         }
 
         public static SqlFunctionExpression CreateNiladic(
             [NotNull] SqlExpression instance,
             [NotNull] string name,
+            bool nullResultAllowed,
+            bool instancPropagatesNullability,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
         {
@@ -50,27 +125,54 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(type, nameof(type));
 
             return new SqlFunctionExpression(
-                instance, schema: null, name, niladic: true, arguments: null, builtIn: true, type, typeMapping);
+                instance,
+                schema: null,
+                name,
+                niladic: true,
+                arguments: null,
+                nullResultAllowed,
+                instancPropagatesNullability,
+                argumentsPropagateNullability: null,
+                builtIn: true,
+                type,
+                typeMapping);
         }
 
         public static SqlFunctionExpression Create(
             [NotNull] SqlExpression instance,
             [NotNull] string name,
             [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            bool instancPropagatesNullability,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
         {
             Check.NotNull(instance, nameof(instance));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(arguments, nameof(arguments));
+            Check.NotNull(argumentsPropagateNullability, nameof(argumentsPropagateNullability));
             Check.NotNull(type, nameof(type));
 
-            return new SqlFunctionExpression(instance, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
+            return new SqlFunctionExpression(
+                instance,
+                schema: null,
+                name,
+                niladic: false,
+                arguments,
+                nullResultAllowed,
+                instancPropagatesNullability,
+                argumentsPropagateNullability,
+                builtIn: true,
+                type,
+                typeMapping);
         }
 
         public static SqlFunctionExpression Create(
             [NotNull] string name,
             [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
         {
@@ -79,13 +181,25 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(type, nameof(type));
 
             return new SqlFunctionExpression(
-                instance: null, schema: null, name, niladic: false, arguments, builtIn: true, type, typeMapping);
+                instance: null,
+                schema: null,
+                name,
+                niladic: false,
+                arguments,
+                nullResultAllowed,
+                instancPropagatesNullability: null,
+                argumentsPropagateNullability,
+                builtIn: true,
+                type,
+                typeMapping);
         }
 
         public static SqlFunctionExpression Create(
             [CanBeNull] string schema,
             [NotNull] string name,
             [NotNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            [NotNull] IEnumerable<bool> argumentsPropagateNullability,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
         {
@@ -93,7 +207,18 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(arguments, nameof(arguments));
             Check.NotNull(type, nameof(type));
 
-            return new SqlFunctionExpression(instance: null, schema, name, niladic: false, arguments, builtIn: false, type, typeMapping);
+            return new SqlFunctionExpression(
+                instance: null,
+                schema,
+                name,
+                niladic: false,
+                arguments,
+                nullResultAllowed,
+                instancPropagatesNullability: null,
+                argumentsPropagateNullability,
+                builtIn: false,
+                type,
+                typeMapping);
         }
 
         public SqlFunctionExpression(
@@ -102,6 +227,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             [NotNull] string name,
             bool niladic,
             [CanBeNull] IEnumerable<SqlExpression> arguments,
+            bool nullResultAllowed,
+            bool? instancPropagatesNullability,
+            [CanBeNull] IEnumerable<bool> argumentsPropagateNullability,
             bool builtIn,
             [NotNull] Type type,
             [CanBeNull] RelationalTypeMapping typeMapping)
@@ -116,6 +244,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             IsNiladic = niladic;
             IsBuiltIn = builtIn;
             Arguments = (arguments ?? Array.Empty<SqlExpression>()).ToList();
+            NullResultAllowed = nullResultAllowed;
+            InstancPropagatesNullability = instancPropagatesNullability;
+            ArgumentsPropagateNullability = (argumentsPropagateNullability ?? Array.Empty<bool>()).ToList();
         }
 
         public virtual string Name { get; }
@@ -124,6 +255,30 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public virtual bool IsBuiltIn { get; }
         public virtual IReadOnlyList<SqlExpression> Arguments { get; }
         public virtual SqlExpression Instance { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool NullResultAllowed { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool? InstancPropagatesNullability { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IReadOnlyList<bool> ArgumentsPropagateNullability { get; private set; }
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
@@ -146,6 +301,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                     Name,
                     IsNiladic,
                     arguments,
+                    NullResultAllowed,
+                    InstancPropagatesNullability,
+                    ArgumentsPropagateNullability,
                     IsBuiltIn,
                     Type,
                     TypeMapping)
@@ -159,6 +317,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 Name,
                 IsNiladic,
                 Arguments,
+                NullResultAllowed,
+                InstancPropagatesNullability,
+                ArgumentsPropagateNullability,
                 IsBuiltIn,
                 Type,
                 typeMapping ?? TypeMapping);
@@ -166,7 +327,18 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public virtual SqlFunctionExpression Update([CanBeNull] SqlExpression instance, [CanBeNull] IReadOnlyList<SqlExpression> arguments)
         {
             return instance != Instance || !arguments.SequenceEqual(Arguments)
-                ? new SqlFunctionExpression(instance, Schema, Name, IsNiladic, arguments, IsBuiltIn, Type, TypeMapping)
+                ? new SqlFunctionExpression(
+                    instance,
+                    Schema,
+                    Name,
+                    IsNiladic,
+                    arguments,
+                    NullResultAllowed,
+                    InstancPropagatesNullability,
+                    ArgumentsPropagateNullability,
+                    IsBuiltIn,
+                    Type,
+                    TypeMapping)
                 : this;
         }
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMemberTranslator.cs
@@ -32,6 +32,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     instance,
                     "STNumGeometries",
                     Array.Empty<SqlExpression>(),
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: Array.Empty<bool>(),
                     returnType);
             }
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryCollectionMethodTranslator.cs
@@ -42,6 +42,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: new[] { false },
                     method.ReturnType,
                     _typeMappingSource.FindMapping(typeof(Geometry), instance.TypeMapping.StoreType));
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
@@ -73,6 +73,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         instance,
                         functionName,
                         Array.Empty<SqlExpression>(),
+                        nullResultAllowed: true,
+                        instancePropagatesNullability: true,
+                        argumentsPropagateNullability: Array.Empty<bool>(),
                         returnType,
                         resultTypeMapping);
                 }
@@ -121,6 +124,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             instance,
                             "STGeometryType",
                             Array.Empty<SqlExpression>(),
+                            nullResultAllowed: true,
+                            instancePropagatesNullability: true,
+                            argumentsPropagateNullability: Array.Empty<bool>(),
                             typeof(string)),
                         whenClauses.ToArray());
                 }
@@ -130,6 +136,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     return _sqlExpressionFactory.Function(
                         instance,
                         "STSrid",
+                        nullResultAllowed: true,
+                        instancePropagatesNullability: true,
                         returnType);
                 }
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMemberTranslator.cs
@@ -60,6 +60,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     instance,
                     functionName,
                     Enumerable.Empty<SqlExpression>(),
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: Enumerable.Empty<bool>(),
                     returnType,
                     resultTypeMapping);
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerLineStringMethodTranslator.cs
@@ -44,6 +44,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: new[] { true },
                     method.ReturnType,
                     _typeMappingSource.FindMapping(method.ReturnType, instance.TypeMapping.StoreType));
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerMultiLineStringMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerMultiLineStringMemberTranslator.cs
@@ -32,6 +32,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     instance,
                     "STIsClosed",
                     Array.Empty<SqlExpression>(),
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: Array.Empty<bool>(),
                     returnType);
             }
 

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
@@ -51,6 +51,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     return _sqlExpressionFactory.Function(
                         instance,
                         propertyName,
+                        nullResultAllowed: true,
+                        instancePropagatesNullability: true,
                         returnType);
                 }
             }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMemberTranslator.cs
@@ -53,6 +53,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             instance,
                             "RingN",
                             new[] { _sqlExpressionFactory.Constant(1) },
+                            nullResultAllowed: true,
+                            instancePropagatesNullability: true,
+                            argumentsPropagateNullability: new[] { false },
                             returnType,
                             _typeMappingSource.FindMapping(returnType, storeType));
                     }
@@ -64,6 +67,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                                 instance,
                                 "NumRings",
                                 Array.Empty<SqlExpression>(),
+                                nullResultAllowed: true,
+                                instancePropagatesNullability: true,
+                                argumentsPropagateNullability: Array.Empty<bool>(),
                                 returnType),
                             _sqlExpressionFactory.Constant(1));
                     }
@@ -79,6 +85,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         instance,
                         functionName,
                         Array.Empty<SqlExpression>(),
+                        nullResultAllowed: true,
+                        instancePropagatesNullability: true,
+                        argumentsPropagateNullability: Array.Empty<bool>(),
                         returnType,
                         resultTypeMapping);
                 }

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPolygonMethodTranslator.cs
@@ -50,6 +50,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                                 arguments[0],
                                 _sqlExpressionFactory.Constant(2))
                         },
+                        nullResultAllowed: true,
+                        instancePropagatesNullability: true,
+                        argumentsPropagateNullability: new[] { true },
                         method.ReturnType,
                         _typeMappingSource.FindMapping(method.ReturnType, storeType));
                 }
@@ -63,6 +66,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
+                    nullResultAllowed: true,
+                    instancePropagatesNullability: true,
+                    argumentsPropagateNullability: new[] { true },
                     method.ReturnType,
                     _typeMappingSource.FindMapping(method.ReturnType, storeType));
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerByteArrayMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerByteArrayMethodTranslator.cs
@@ -36,7 +36,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     : _sqlExpressionFactory.Convert(arguments[1], typeof(byte[]), sourceTypeMapping);
 
                 return _sqlExpressionFactory.GreaterThan(
-                    _sqlExpressionFactory.Function("CHARINDEX", new[] { value, source }, typeof(int)),
+                    _sqlExpressionFactory.Function(
+                        "CHARINDEX",
+                        new[] { value, source },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
+                        typeof(int)),
                     _sqlExpressionFactory.Constant(0));
             }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerConvertTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerConvertTranslator.cs
@@ -62,6 +62,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 ? _sqlExpressionFactory.Function(
                     "CONVERT",
                     new[] { _sqlExpressionFactory.Fragment(_typeMapping[method.Name]), arguments[0] },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false, true },
                     method.ReturnType)
                 : null;
         }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateDiffFunctionsTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateDiffFunctionsTranslator.cs
@@ -355,6 +355,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "DATEDIFF",
                     new[] { _sqlExpressionFactory.Fragment(datePart), startDate, endDate },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false, true, true },
                     typeof(int));
             }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -50,6 +50,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     return _sqlExpressionFactory.Function(
                         "DATEPART",
                         new[] { _sqlExpressionFactory.Fragment(datePart), instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { false, true },
                         returnType);
                 }
 
@@ -59,6 +61,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         return _sqlExpressionFactory.Function(
                             "CONVERT",
                             new[] { _sqlExpressionFactory.Fragment("date"), instance },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { false, true },
                             returnType,
                             declaringType == typeof(DateTime)
                                 ? instance.TypeMapping
@@ -71,12 +75,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         return _sqlExpressionFactory.Function(
                             declaringType == typeof(DateTime) ? "GETDATE" : "SYSDATETIMEOFFSET",
                             Array.Empty<SqlExpression>(),
+                            nullResultAllowed: false,
+                            argumentsPropagateNullability: Array.Empty<bool>(),
                             returnType);
 
                     case nameof(DateTime.UtcNow):
                         var serverTranslation = _sqlExpressionFactory.Function(
                             declaringType == typeof(DateTime) ? "GETUTCDATE" : "SYSUTCDATETIME",
                             Array.Empty<SqlExpression>(),
+                            nullResultAllowed: false,
+                            argumentsPropagateNullability: Array.Empty<bool>(),
                             returnType);
 
                         return declaringType == typeof(DateTime)
@@ -92,8 +100,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                                 _sqlExpressionFactory.Function(
                                     "GETDATE",
                                     Array.Empty<SqlExpression>(),
+                                    nullResultAllowed: false,
+                                    argumentsPropagateNullability: Array.Empty<bool>(),
                                     typeof(DateTime))
                             },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { false, true },
                             returnType);
                 }
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMethodTranslator.cs
@@ -61,6 +61,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                                 _sqlExpressionFactory.Convert(arguments[0], typeof(int)),
                                 instance
                             },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { false, true, true },
                             instance.Type,
                             instance.TypeMapping);
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerFromPartsFunctionTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerFromPartsFunctionTranslator.cs
@@ -50,6 +50,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "DATEFROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _dateFromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(DateTime), "date"));
             }
@@ -59,6 +61,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "DATETIMEFROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _dateTimeFromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(DateTime), "datetime"));
             }
@@ -68,6 +72,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "DATETIME2FROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _dateTime2FromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(DateTime), "datetime2"));
             }
@@ -77,6 +83,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "DATETIMEOFFSETFROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _dateTimeOffsetFromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(DateTimeOffset), "datetimeoffset"));
             }
@@ -86,6 +94,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "SMALLDATETIMEFROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _smallDateTimeFromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(DateTime), "smalldatetime"));
             }
@@ -95,6 +105,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "TIMEFROMPARTS",
                     arguments.Skip(1),
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: arguments.Skip(1).Select(a => true),
                     _timeFromPartsMethodInfo.ReturnType,
                     _typeMappingSource.FindMapping(typeof(TimeSpan), "time"));
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerFullTextSearchFunctionsTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerFullTextSearchFunctionsTranslator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -80,6 +81,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     functionName,
                     functionArguments,
+                    nullResultAllowed: true,
+                    // TODO: don't propagate for now
+                    argumentsPropagateNullability: functionArguments.Select(a => false).ToList(),
                     typeof(bool));
             }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerIsDateFunctionTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerIsDateFunctionTranslator.cs
@@ -30,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     _sqlExpressionFactory.Function(
                         "ISDATE",
                         new[] { arguments[1] },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
                         _methodInfo.ReturnType),
                     _methodInfo.ReturnType)
                 : null;

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMathTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMathTranslator.cs
@@ -92,6 +92,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     sqlFunctionName,
                     newArguments,
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: newArguments.Select(a => true).ToArray(),
                     method.ReturnType,
                     sqlFunctionName == "SIGN" ? null : typeMapping);
             }
@@ -103,6 +105,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "ROUND",
                     new[] { argument, _sqlExpressionFactory.Constant(0), _sqlExpressionFactory.Constant(1) },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, false, false },
                     method.ReturnType,
                     argument.TypeMapping);
             }
@@ -115,6 +119,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "ROUND",
                     new[] { argument, digits },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true },
                     method.ReturnType,
                     argument.TypeMapping);
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerNewGuidTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerNewGuidTranslator.cs
@@ -30,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 ? _sqlExpressionFactory.Function(
                     "NEWID",
                     Array.Empty<SqlExpression>(),
+                    nullResultAllowed: false,
+                    argumentsPropagateNullability: Array.Empty<bool>(),
                     method.ReturnType)
                 : null;
         }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
@@ -58,6 +58,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     ? _sqlExpressionFactory.Function(
                         "CONVERT",
                         new[] { _sqlExpressionFactory.Fragment(storeType), instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new bool[] { false, true },
                         typeof(string))
                     : null;
         }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQuerySqlGenerator.cs
@@ -67,6 +67,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     schema: "dbo",
                     sqlFunctionExpression.Name,
                     sqlFunctionExpression.Arguments,
+                    sqlFunctionExpression.NullResultAllowed,
+                    sqlFunctionExpression.ArgumentsPropagateNullability,
                     sqlFunctionExpression.Type,
                     sqlFunctionExpression.TypeMapping);
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -74,7 +74,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
                 var isBinaryMaxDataType = GetProviderType(sqlExpression) == "varbinary(max)" || sqlExpression is SqlParameterExpression;
                 var dataLengthSqlFunction = SqlExpressionFactory.Function(
-                    "DATALENGTH", new[] { sqlExpression }, isBinaryMaxDataType ? typeof(long) : typeof(int));
+                    "DATALENGTH",
+                    new[] { sqlExpression },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new bool[] { true },
+                    isBinaryMaxDataType ? typeof(long) : typeof(int));
 
                 return isBinaryMaxDataType
                     ? (Expression)SqlExpressionFactory.Convert(dataLengthSqlFunction, typeof(int))
@@ -93,7 +97,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             }
 
             return SqlExpressionFactory.ApplyDefaultTypeMapping(
-                SqlExpressionFactory.Function("COUNT_BIG", new[] { SqlExpressionFactory.Fragment("*") }, typeof(long)));
+                SqlExpressionFactory.Function(
+                    "COUNT_BIG",
+                    new[] { SqlExpressionFactory.Fragment("*") },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { false },
+                    typeof(long)));
         }
 
         private static string GetProviderType(SqlExpression expression)

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringMemberTranslator.cs
@@ -28,7 +28,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 && instance?.Type == typeof(string))
             {
                 return _sqlExpressionFactory.Convert(
-                    _sqlExpressionFactory.Function("LEN", new[] { instance }, typeof(long)),
+                    _sqlExpressionFactory.Function(
+                        "LEN",
+                        new[] { instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(long)),
                     returnType);
             }
 

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
@@ -90,6 +90,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     charIndexExpression = _sqlExpressionFactory.Function(
                         "CHARINDEX",
                         new[] { argument, _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping) },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new [] { true, true },
                         typeof(long));
 
                     charIndexExpression = _sqlExpressionFactory.Convert(charIndexExpression, typeof(int));
@@ -99,6 +101,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     charIndexExpression = _sqlExpressionFactory.Function(
                         "CHARINDEX",
                         new[] { argument, _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping) },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
                         method.ReturnType);
                 }
 
@@ -129,6 +133,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "REPLACE",
                     new[] { instance, firstArgument, secondArgument },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
                     method.ReturnType,
                     stringTypeMapping);
             }
@@ -139,6 +145,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     _toLowerMethodInfo.Equals(method) ? "LOWER" : "UPPER",
                     new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
                     method.ReturnType,
                     instance.TypeMapping);
             }
@@ -155,6 +163,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             _sqlExpressionFactory.Constant(1)),
                         arguments[1]
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
                     method.ReturnType,
                     instance.TypeMapping);
             }
@@ -173,9 +183,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                                 _sqlExpressionFactory.Function(
                                     "RTRIM",
                                     new[] { argument },
+                                    nullResultAllowed: true,
+                                    argumentsPropagateNullability: new[] { true },
                                     argument.Type,
                                     argument.TypeMapping)
                             },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true },
                             argument.Type,
                             argument.TypeMapping),
                         _sqlExpressionFactory.Constant(string.Empty, argument.TypeMapping)));
@@ -189,6 +203,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "LTRIM",
                     new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
                     instance.Type,
                     instance.TypeMapping);
             }
@@ -201,6 +217,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "RTRIM",
                     new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
                     instance.Type,
                     instance.TypeMapping);
             }
@@ -217,9 +235,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         _sqlExpressionFactory.Function(
                             "RTRIM",
                             new[] { instance },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true },
                             instance.Type,
                             instance.TypeMapping)
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
                     instance.Type,
                     instance.TypeMapping);
             }
@@ -245,6 +267,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         _sqlExpressionFactory.Function(
                             "CHARINDEX",
                             new[] { pattern, instance },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true, true },
                             typeof(int)),
                         _sqlExpressionFactory.Constant(0));
                 }
@@ -257,6 +281,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         _sqlExpressionFactory.Function(
                             "CHARINDEX",
                             new[] { pattern, instance },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true, true },
                             typeof(int)),
                         _sqlExpressionFactory.Constant(0)));
             }
@@ -312,7 +338,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.Equal(
                     _sqlExpressionFactory.Function(
                         "LEFT",
-                        new[] { instance, _sqlExpressionFactory.Function("LEN", new[] { pattern }, typeof(int)) },
+                        new[]
+                        {
+                            instance,
+                            _sqlExpressionFactory.Function(
+                                "LEN",
+                                new[] { pattern },
+                                nullResultAllowed: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(int))
+                        },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
                         typeof(string),
                         stringTypeMapping),
                     pattern);
@@ -321,7 +358,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             return _sqlExpressionFactory.Equal(
                 _sqlExpressionFactory.Function(
                     "RIGHT",
-                    new[] { instance, _sqlExpressionFactory.Function("LEN", new[] { pattern }, typeof(int)) },
+                    new[]
+                    {
+                        instance,
+                        _sqlExpressionFactory.Function(
+                            "LEN",
+                            new[] { pattern },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true },
+                            typeof(int))
+                    },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true },
                     typeof(string),
                     stringTypeMapping),
                 pattern);

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteByteArrayMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteByteArrayMethodTranslator.cs
@@ -28,10 +28,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
                 var value = arguments[1] is SqlConstantExpression constantValue
                     ? (SqlExpression)_sqlExpressionFactory.Constant(new[] { (byte)constantValue.Value }, source.TypeMapping)
-                    : _sqlExpressionFactory.Function("char", new[] { arguments[1] }, typeof(string));
+                    : _sqlExpressionFactory.Function(
+                        "char",
+                        new[] { arguments[1] },
+                        nullResultAllowed: false,
+                        argumentsPropagateNullability: new[] { false },
+                        typeof(string));
 
                 return _sqlExpressionFactory.GreaterThan(
-                    _sqlExpressionFactory.Function("instr", new[] { source, value }, typeof(int)),
+                    _sqlExpressionFactory.Function(
+                        "instr",
+                        new[] { source, value },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
+                        typeof(int)),
                     _sqlExpressionFactory.Constant(0));
             }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
@@ -87,9 +87,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                                     new[] { modifier }),
                                 _sqlExpressionFactory.Constant("0")
                             },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true, false },
                             method.ReturnType),
                         _sqlExpressionFactory.Constant(".")
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, false },
                     method.ReturnType);
             }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
@@ -61,6 +61,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                                 _sqlExpressionFactory.Function(
                                     "julianday",
                                     new[] { instance },
+                                    nullResultAllowed: true,
+                                    argumentsPropagateNullability: new[] { true },
                                     typeof(double)),
                                 _sqlExpressionFactory.Constant(1721425.5)), // NB: Result of julianday('0001-01-01 00:00:00')
                             _sqlExpressionFactory.Constant(TimeSpan.TicksPerDay)),
@@ -135,9 +137,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                                     modifiers),
                                 _sqlExpressionFactory.Constant("0")
                             },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true, false },
                             returnType),
                         _sqlExpressionFactory.Constant(".")
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, false },
                     returnType);
             }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteExpression.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteExpression.cs
@@ -53,9 +53,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                 modifiers = strftimeFunction.Arguments.Skip(2).Concat(modifiers);
             }
 
+            var finalArguments = new[] { sqlExpressionFactory.Constant(format), timestring }.Concat(modifiers);
+
             return sqlExpressionFactory.Function(
                 "strftime",
-                new[] { sqlExpressionFactory.Constant(format), timestring }.Concat(modifiers),
+                finalArguments,
+                nullResultAllowed: true,
+                argumentsPropagateNullability: finalArguments.Select(a => true),
                 returnType,
                 typeMapping);
         }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMathTranslator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
@@ -75,9 +76,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                     typeMapping = arguments[0].TypeMapping;
                 }
 
+                var finalArguments = newArguments ?? arguments;
+
                 return _sqlExpressionFactory.Function(
                     sqlFunctionName,
-                    newArguments ?? arguments,
+                    finalArguments,
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: finalArguments.Select(a => true).ToList(),
                     method.ReturnType,
                     typeMapping);
             }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -91,7 +91,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                  && unaryExpression.Operand.Type == typeof(byte[]))
             {
                 return base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression
-                    ? SqlExpressionFactory.Function("length", new[] { sqlExpression }, typeof(int))
+                    ? SqlExpressionFactory.Function(
+                        "length",
+                        new[] { sqlExpression },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(int))
                     : null;
             }
 

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringLengthTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringLengthTranslator.cs
@@ -26,7 +26,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
             return instance?.Type == typeof(string)
                 && member.Name == nameof(string.Length)
-                    ? _sqlExpressionFactory.Function("length", new[] { instance }, returnType)
+                    ? _sqlExpressionFactory.Function(
+                        "length",
+                        new[] { instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
+                        returnType)
                     : null;
         }
     }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteStringMethodTranslator.cs
@@ -97,6 +97,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping),
                             _sqlExpressionFactory.ApplyTypeMapping(argument, stringTypeMapping)
                         },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
                         method.ReturnType),
                     _sqlExpressionFactory.Constant(1));
             }
@@ -115,6 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                         _sqlExpressionFactory.ApplyTypeMapping(firstArgument, stringTypeMapping),
                         _sqlExpressionFactory.ApplyTypeMapping(secondArgument, stringTypeMapping)
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
                     method.ReturnType,
                     stringTypeMapping);
             }
@@ -125,6 +129,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                 return _sqlExpressionFactory.Function(
                     _toLowerMethodInfo.Equals(method) ? "lower" : "upper",
                     new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
                     method.ReturnType,
                     instance.TypeMapping);
             }
@@ -134,6 +140,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "substr",
                     new[] { instance, _sqlExpressionFactory.Add(arguments[0], _sqlExpressionFactory.Constant(1)), arguments[1] },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
                     method.ReturnType,
                     instance.TypeMapping);
             }
@@ -146,7 +154,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                     _sqlExpressionFactory.IsNull(argument),
                     _sqlExpressionFactory.Equal(
                         _sqlExpressionFactory.Function(
-                            "trim", new[] { argument }, argument.Type, argument.TypeMapping),
+                            "trim",
+                            new[] { argument },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true },
+                            argument.Type,
+                            argument.TypeMapping),
                         _sqlExpressionFactory.Constant(string.Empty)));
             }
 
@@ -187,6 +200,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                         _sqlExpressionFactory.Function(
                             "instr",
                             new[] { instance, pattern },
+                            nullResultAllowed: true,
+                            argumentsPropagateNullability: new[] { true, true },
                             typeof(int)),
                         _sqlExpressionFactory.Constant(0)));
             }
@@ -258,8 +273,15 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                                 {
                                     instance,
                                     _sqlExpressionFactory.Constant(1),
-                                    _sqlExpressionFactory.Function("length", new[] { pattern }, typeof(int))
+                                    _sqlExpressionFactory.Function(
+                                        "length",
+                                        new[] { pattern },
+                                        nullResultAllowed: true,
+                                        argumentsPropagateNullability: new[] { true },
+                                        typeof(int))
                                 },
+                                nullResultAllowed: true,
+                                argumentsPropagateNullability: new[] { true, false, true },
                                 typeof(string),
                                 stringTypeMapping),
                             pattern)),
@@ -276,8 +298,15 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                         {
                             instance,
                             _sqlExpressionFactory.Negate(
-                                _sqlExpressionFactory.Function("length", new[] { pattern }, typeof(int)))
+                                _sqlExpressionFactory.Function(
+                                    "length",
+                                    new[] { pattern },
+                                    nullResultAllowed: true,
+                                    argumentsPropagateNullability: new[] { true },
+                                    typeof(int)))
                         },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true, true },
                         typeof(string),
                         stringTypeMapping),
                     pattern),
@@ -343,6 +372,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             return _sqlExpressionFactory.Function(
                 functionName,
                 sqlArguments,
+
+                nullResultAllowed: true,
+                argumentsPropagateNullability: sqlArguments.Select(a => true).ToList(),
                 typeof(string),
                 typeMapping);
         }

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryCollectionMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryCollectionMemberTranslator.cs
@@ -27,7 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             Check.NotNull(returnType, nameof(returnType));
 
             return Equals(member, _count)
-                ? _sqlExpressionFactory.Function("NumGeometries", new[] { instance }, returnType)
+                ? _sqlExpressionFactory.Function(
+                    "NumGeometries",
+                    new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
+                    returnType)
                 : null;
         }
     }

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryCollectionMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryCollectionMethodTranslator.cs
@@ -37,6 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true },
                     method.ReturnType);
             }
 

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteGeometryMemberTranslator.cs
@@ -48,21 +48,26 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
             if (_memberToFunctionName.TryGetValue(member, out var functionName))
             {
-                SqlExpression translation = _sqlExpressionFactory.Function(functionName, new[] { instance }, returnType);
-
-                if (returnType == typeof(bool))
-                {
-                    translation = _sqlExpressionFactory.Case(
+                return returnType == typeof(bool)
+                    ? _sqlExpressionFactory.Case(
                         new[]
                         {
                             new CaseWhenClause(
                                 _sqlExpressionFactory.IsNotNull(instance),
-                                translation)
+                                _sqlExpressionFactory.Function(
+                                    functionName,
+                                    new[] { instance },
+                                    nullResultAllowed: false,
+                                    argumentsPropagateNullability: new[] { false },
+                                    returnType))
                         },
-                        null);
-                }
-
-                return translation;
+                        null)
+                    : (SqlExpression)_sqlExpressionFactory.Function(
+                        functionName,
+                        new[] { instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
+                        returnType);
             }
 
             if (Equals(member, _geometryType))
@@ -75,9 +80,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             _sqlExpressionFactory.Function(
                                 "GeometryType",
                                 new[] { instance },
+                                nullResultAllowed: true,
+                                argumentsPropagateNullability: new[] { true },
                                 returnType),
                             _sqlExpressionFactory.Constant(" ZM")
                         },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
                         returnType),
                     new CaseWhenClause(_sqlExpressionFactory.Constant("POINT"), _sqlExpressionFactory.Constant("Point")),
                     new CaseWhenClause(_sqlExpressionFactory.Constant("LINESTRING"), _sqlExpressionFactory.Constant("LineString")),
@@ -100,9 +109,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             _sqlExpressionFactory.Function(
                                 "GeometryType",
                                 new[] { instance },
+                                nullResultAllowed: true,
+                                argumentsPropagateNullability: new[] { true },
                                 typeof(string)),
                             _sqlExpressionFactory.Constant(" ZM")
                         },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
                         typeof(string)),
                     new CaseWhenClause(_sqlExpressionFactory.Constant("POINT"), _sqlExpressionFactory.Constant(OgcGeometryType.Point)),
                     new CaseWhenClause(

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteLineStringMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteLineStringMemberTranslator.cs
@@ -38,22 +38,26 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
             if (_memberToFunctionName.TryGetValue(member, out var functionName))
             {
-                SqlExpression translation = _sqlExpressionFactory.Function(
-                    functionName, new[] { instance }, returnType);
-
-                if (returnType == typeof(bool))
-                {
-                    translation = _sqlExpressionFactory.Case(
+                return returnType == typeof(bool)
+                    ? _sqlExpressionFactory.Case(
                         new[]
                         {
                             new CaseWhenClause(
                                 _sqlExpressionFactory.IsNotNull(instance),
-                                translation)
+                                _sqlExpressionFactory.Function(
+                                    functionName,
+                                    new[] { instance },
+                                    nullResultAllowed: false,
+                                    argumentsPropagateNullability: new[] { false },
+                                    returnType))
                         },
-                        null);
-                }
-
-                return translation;
+                        null)
+                    : (SqlExpression)_sqlExpressionFactory.Function(
+                        functionName,
+                        new[] { instance },
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: new[] { true },
+                        returnType);
             }
 
             return null;

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteLineStringMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteLineStringMethodTranslator.cs
@@ -39,6 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             arguments[0],
                             _sqlExpressionFactory.Constant(1))
                     },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true, true },
                     method.ReturnType);
             }
 

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqliteMultiLineStringMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqliteMultiLineStringMemberTranslator.cs
@@ -36,6 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                             _sqlExpressionFactory.Function(
                                 "IsClosed",
                                 new[] { instance },
+                                nullResultAllowed: false,
+                                argumentsPropagateNullability: new[] { false },
                                 returnType))
                     },
                     null);

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePointMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePointMemberTranslator.cs
@@ -35,7 +35,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             Check.NotNull(returnType, nameof(returnType));
 
             return _memberToFunctionName.TryGetValue(member, out var functionName)
-                ? _sqlExpressionFactory.Function(functionName, new[] { instance }, returnType)
+                ? _sqlExpressionFactory.Function(
+                    functionName,
+                    new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
+                    returnType)
                 : null;
         }
     }

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePolygonMemberTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePolygonMemberTranslator.cs
@@ -34,7 +34,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             Check.NotNull(returnType, nameof(returnType));
 
             return _memberToFunctionName.TryGetValue(member, out var functionName)
-                ? _sqlExpressionFactory.Function(functionName, new[] { instance }, returnType)
+                ? _sqlExpressionFactory.Function(
+                    functionName,
+                    new[] { instance },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new[] { true },
+                    returnType)
                 : null;
         }
     }

--- a/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePolygonMethodTranslator.cs
+++ b/src/EFCore.Sqlite.NTS/Query/Internal/SqlitePolygonMethodTranslator.cs
@@ -33,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "InteriorRingN",
                     new[] { instance, _sqlExpressionFactory.Add(arguments[0], _sqlExpressionFactory.Constant(1)) },
+                    nullResultAllowed: true,
+                    argumentsPropagateNullability: new [] { true, true },
                     method.ReturnType);
             }
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/SpatialQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SpatialQueryInMemoryTest.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Xunit;
+
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class SpatialQueryInMemoryTest : SpatialQueryTestBase<SpatialQueryInMemoryFixture>
@@ -8,6 +11,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         public SpatialQueryInMemoryTest(SpatialQueryInMemoryFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalTheory(Skip = "issue #19661")]
+        public override Task Distance_constant_lhs(bool async)
+        {
+            return base.Distance_constant_lhs(async);
+        }
+
+        [ConditionalTheory(Skip = "issue #19664")]
+        public override Task Intersects_equal_to_null(bool async)
+        {
+            return base.Intersects_equal_to_null(async);
+        }
+
+        [ConditionalTheory(Skip = "issue #19664")]
+        public override Task Intersects_not_equal_to_null(bool async)
+        {
+            return base.Intersects_not_equal_to_null(async);
+        }
+
+        public override Task GetGeometryN_with_null_argument(bool async)
+        {
+            // Sequence contains no elements
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -126,12 +126,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .HasTranslation(args => new SqlFragmentExpression("'Two'"));
                 var isDateMethodInfo = typeof(UDFSqlContext).GetMethod(nameof(IsDateStatic));
                 modelBuilder.HasDbFunction(isDateMethodInfo)
-                    .HasTranslation(args => SqlFunctionExpression.Create("IsDate", args, isDateMethodInfo.ReturnType, null));
+                    .HasTranslation(args => SqlFunctionExpression.Create(
+                        "IsDate",
+                        args,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: args.Select(a => true).ToList(),
+                        isDateMethodInfo.ReturnType,
+                        null));
 
                 var methodInfo = typeof(UDFSqlContext).GetMethod(nameof(MyCustomLengthStatic));
 
                 modelBuilder.HasDbFunction(methodInfo)
-                    .HasTranslation(args => SqlFunctionExpression.Create("len", args, methodInfo.ReturnType, null));
+                    .HasTranslation(args => SqlFunctionExpression.Create(
+                        "len",
+                        args,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: args.Select(a => true).ToList(),
+                        methodInfo.ReturnType,
+                        null));
 
                 //Instance
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(CustomerOrderCountInstance)))
@@ -146,14 +158,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .HasName("GetReportingPeriodStartDate");
                 var isDateMethodInfo2 = typeof(UDFSqlContext).GetMethod(nameof(IsDateInstance));
                 modelBuilder.HasDbFunction(isDateMethodInfo2)
-                    .HasTranslation(args => SqlFunctionExpression.Create("IsDate", args, isDateMethodInfo2.ReturnType, null));
+                    .HasTranslation(args => SqlFunctionExpression.Create(
+                        "IsDate",
+                        args,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: args.Select(a => true).ToList(),
+                        isDateMethodInfo2.ReturnType,
+                        null));
 
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(DollarValueInstance))).HasName("DollarValue");
 
                 var methodInfo2 = typeof(UDFSqlContext).GetMethod(nameof(MyCustomLengthInstance));
 
                 modelBuilder.HasDbFunction(methodInfo2)
-                    .HasTranslation(args => SqlFunctionExpression.Create("len", args, methodInfo2.ReturnType, null));
+                    .HasTranslation(args => SqlFunctionExpression.Create(
+                        "len",
+                        args,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: args.Select(a => true).ToList(),
+                        methodInfo2.ReturnType,
+                        null));
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -315,7 +315,7 @@ WHERE [l0].[Name] = N'L2 01'");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
-WHERE UPPER([l0].[Name]) IS NOT NULL AND (UPPER([l0].[Name]) LIKE N'L%')");
+WHERE [l0].[Name] IS NOT NULL AND (UPPER([l0].[Name]) LIKE N'L%')");
         }
 
         public override async Task Method_call_on_optional_navigation_translates_to_null_conditional_properly_for_arguments(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -202,13 +202,13 @@ WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR LEFT([f].[FirstName], LEN(@__prm6_0)) IS NULL))",
+WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR LEFT([f].[FirstName], LEN(@__prm7_0)) IS NULL))",
+WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (LEFT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -274,7 +274,7 @@ WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastNam
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND ((LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]) OR LEFT([f].[FirstName], LEN([f0].[LastName])) IS NULL)))");
+WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (LEFT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
         }
 
         public override async Task String_ends_with_on_argument_with_wildcard_constant(bool async)
@@ -351,13 +351,13 @@ WHERE (@__prm5_0 = N'') OR ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstNam
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0) OR RIGHT([f].[FirstName], LEN(@__prm6_0)) IS NULL))",
+WHERE (@__prm6_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm6_0)) <> @__prm6_0))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0) OR RIGHT([f].[FirstName], LEN(@__prm7_0)) IS NULL))",
+WHERE (@__prm7_0 <> N'') AND ([f].[FirstName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN(@__prm7_0)) <> @__prm7_0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -383,7 +383,7 @@ WHERE ([f0].[LastName] = N'') OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastNam
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]) OR RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NULL)))");
+WHERE (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName])))");
         }
 
         public override async Task String_ends_with_inside_conditional(bool async)
@@ -409,7 +409,7 @@ END = CAST(1 AS bit)");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]) OR RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NULL))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] <> N'') OR [f0].[LastName] IS NULL) AND ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) <> [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = CAST(1 AS bit)");
         }
@@ -423,7 +423,7 @@ END = CAST(1 AS bit)");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE CASE
-    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) AND RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NOT NULL))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END = [f].[NullableBool]");
         }
@@ -437,7 +437,7 @@ END = [f].[NullableBool]");
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
 WHERE (CASE
-    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND ((RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]) AND RIGHT([f].[FirstName], LEN([f0].[LastName])) IS NOT NULL))) THEN CAST(1 AS bit)
+    WHEN (([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR ([f].[FirstName] IS NOT NULL AND ([f0].[LastName] IS NOT NULL AND (RIGHT([f].[FirstName], LEN([f0].[LastName])) = [f0].[LastName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END <> [f].[NullableBool]) OR [f].[NullableBool] IS NULL");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -959,7 +959,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             AssertSql(
                 @"SELECT CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN (CAST(LEN([g].[Nickname]) AS int) = 5) AND LEN([g].[Nickname]) IS NOT NULL THEN CAST(1 AS bit)
+        WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1053,7 +1053,7 @@ ORDER BY [t].[Nickname]");
             AssertSql(
                 @"SELECT CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN ((CAST(LEN([g].[LeaderNickname]) AS int) <> CAST(LEN([g].[LeaderNickname]) AS int)) OR LEN([g].[LeaderNickname]) IS NULL) AND LEN([g].[LeaderNickname]) IS NOT NULL THEN CAST(1 AS bit)
+        WHEN CAST(LEN([g].[LeaderNickname]) AS int) <> CAST(LEN([g].[LeaderNickname]) AS int) THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -1101,7 +1101,7 @@ LEFT JOIN [Cities] AS [c] ON [t0].[AssignedCityName] = [c].[Name]");
             AssertSql(
                 @"SELECT CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN COALESCE(CASE
-        WHEN (CAST(LEN([g].[Nickname]) AS int) = 5) AND LEN([g].[Nickname]) IS NOT NULL THEN CAST(1 AS bit)
+        WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END, CAST(0 AS bit))
     ELSE NULL
@@ -2628,7 +2628,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
             AssertSql(
                 @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE ([m].[Timeline] <> SYSDATETIMEOFFSET()) OR SYSDATETIMEOFFSET() IS NULL");
+WHERE [m].[Timeline] <> SYSDATETIMEOFFSET()");
         }
 
         public override async Task Where_datetimeoffset_utcnow(bool async)
@@ -2638,7 +2638,7 @@ WHERE ([m].[Timeline] <> SYSDATETIMEOFFSET()) OR SYSDATETIMEOFFSET() IS NULL");
             AssertSql(
                 @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE ([m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)) OR SYSUTCDATETIME() IS NULL");
+WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)");
         }
 
         public override async Task Where_datetimeoffset_date_component(bool async)
@@ -6224,7 +6224,7 @@ ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId], [t].[Id]");
             AssertSql(
                 @"SELECT CASE
     WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-        WHEN (CAST(LEN([g].[Nickname]) AS int) = 5) AND LEN([g].[Nickname]) IS NOT NULL THEN CAST(1 AS bit)
+        WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
         ELSE CAST(0 AS bit)
     END
     ELSE NULL
@@ -6234,7 +6234,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ORDER BY CASE
     WHEN CASE
         WHEN [g].[LeaderNickname] IS NOT NULL THEN CASE
-            WHEN (CAST(LEN([g].[Nickname]) AS int) = 5) AND LEN([g].[Nickname]) IS NOT NULL THEN CAST(1 AS bit)
+            WHEN CAST(LEN([g].[Nickname]) AS int) = 5 THEN CAST(1 AS bit)
             ELSE CAST(0 AS bit)
         END
         ELSE NULL
@@ -6355,7 +6355,7 @@ LEFT JOIN (
     WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
 LEFT JOIN [Squads] AS [s] ON [t0].[SquadId] = [s].[Id]
-WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) IS NULL AND [t].[GearNickName] IS NULL)");
+WHERE (SUBSTRING([t].[Note], 0 + 1, CAST(LEN([s].[Name]) AS int)) = [t].[GearNickName]) OR (([t].[Note] IS NULL OR [s].[Name] IS NULL) AND [t].[GearNickName] IS NULL)");
         }
 
         public override async Task Filter_with_new_Guid(bool async)
@@ -7316,7 +7316,7 @@ WHERE CAST(DATALENGTH([s].[Banner]) AS int) = @__p_0");
 
 SELECT COUNT(*)
 FROM [Squads] AS [s]
-WHERE (CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)) OR (DATALENGTH([s].[Banner]) IS NULL AND DATALENGTH(@__byteArrayParam) IS NULL)");
+WHERE CAST(DATALENGTH([s].[Banner]) AS int) = CAST(DATALENGTH(@__byteArrayParam) AS int)");
         }
 
         public override async Task Byte_array_contains_parameter(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -873,7 +873,7 @@ WHERE ([o].[OrderID] = 11077) AND (SIGN([o].[Discount]) > 0)");
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
-WHERE (NEWID() <> '00000000-0000-0000-0000-000000000000') OR NEWID() IS NULL");
+WHERE NEWID() <> '00000000-0000-0000-0000-000000000000'");
         }
 
         public override async Task Where_string_to_upper(bool async)
@@ -1141,35 +1141,35 @@ WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(bigint, CONVERT(nvarchar(max), 
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(tinyint, [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(tinyint, [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(tinyint, [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(decimal(18, 2), [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(decimal(18, 2), [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(decimal(18, 2), [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(float, [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(float, [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(float, [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CAST(CONVERT(float, [o].[OrderID] % 1) AS real)) <> N'10') OR CONVERT(nvarchar(max), CAST(CONVERT(float, [o].[OrderID] % 1) AS real)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CAST(CONVERT(float, [o].[OrderID] % 1) AS real)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(smallint, [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(smallint, [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(smallint, [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(int, [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(int, [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(int, [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(bigint, [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(bigint, [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(bigint, [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), CONVERT(nvarchar(max), [o].[OrderID] % 1)) <> N'10') OR CONVERT(nvarchar(max), CONVERT(nvarchar(max), [o].[OrderID] % 1)) IS NULL)",
+WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(nvarchar(max), [o].[OrderID] % 1)) <> N'10')",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1460,7 +1460,7 @@ END");
     WHEN NOT EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL) AND ([c].[ContactName] IS NULL OR ((LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName]) OR LEFT([c].[ContactName], LEN([c].[ContactName])) IS NULL))) THEN CAST(1 AS bit)
+        WHERE (([c].[ContactName] <> N'') OR [c].[ContactName] IS NULL) AND ([c].[ContactName] IS NULL OR (LEFT([c].[ContactName], LEN([c].[ContactName])) <> [c].[ContactName]))) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -407,7 +407,7 @@ WHERE [c].[CustomerID] LIKE N'A%'");
     SELECT TOP(1) (
         SELECT TOP(1) [o].[ProductID]
         FROM [Order Details] AS [o]
-        WHERE ([o0].[OrderID] = [o].[OrderID]) AND (([o].[OrderID] <> CAST(LEN([c].[CustomerID]) AS int)) OR LEN([c].[CustomerID]) IS NULL))
+        WHERE ([o0].[OrderID] = [o].[OrderID]) AND ([o].[OrderID] <> CAST(LEN([c].[CustomerID]) AS int)))
     FROM [Orders] AS [o0]
     WHERE ([c].[CustomerID] = [o0].[CustomerID]) AND ([o0].[OrderID] < 10500)) AS [Order]
 FROM [Customers] AS [c]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -715,7 +715,7 @@ WHERE SUBSTRING([c].[City], 1 + 1, 2) = N'ea'");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (GETDATE() <> @__myDatetime_0) OR GETDATE() IS NULL");
+WHERE GETDATE() <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_utcnow(bool async)
@@ -727,7 +727,7 @@ WHERE (GETDATE() <> @__myDatetime_0) OR GETDATE() IS NULL");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (GETUTCDATE() <> @__myDatetime_0) OR GETUTCDATE() IS NULL");
+WHERE GETUTCDATE() <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_today(bool async)
@@ -737,7 +737,7 @@ WHERE (GETUTCDATE() <> @__myDatetime_0) OR GETUTCDATE() IS NULL");
             AssertSql(
                 @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE (CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())) OR CONVERT(date, GETDATE()) IS NULL");
+WHERE CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())");
         }
 
         public override async Task Where_datetime_date_component(bool async)
@@ -849,7 +849,7 @@ WHERE DATEPART(millisecond, [o].[OrderDate]) = 88");
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE (CAST([o].[OrderDate] AS datetimeoffset) = SYSDATETIMEOFFSET()) OR ([o].[OrderDate] IS NULL AND SYSDATETIMEOFFSET() IS NULL)");
+WHERE CAST([o].[OrderDate] AS datetimeoffset) = SYSDATETIMEOFFSET()");
         }
 
         public override async Task Where_datetimeoffset_utcnow_component(bool async)
@@ -859,7 +859,7 @@ WHERE (CAST([o].[OrderDate] AS datetimeoffset) = SYSDATETIMEOFFSET()) OR ([o].[O
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE (CAST([o].[OrderDate] AS datetimeoffset) = CAST(SYSUTCDATETIME() AS datetimeoffset)) OR ([o].[OrderDate] IS NULL AND SYSUTCDATETIME() IS NULL)");
+WHERE CAST([o].[OrderDate] AS datetimeoffset) = CAST(SYSUTCDATETIME() AS datetimeoffset)");
         }
 
         public override async Task Where_simple_reversed(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1370,11 +1370,11 @@ END IS NOT NULL)");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) = [e].[NullableStringA]) OR (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) IS NULL AND [e].[NullableStringA] IS NULL)",
+WHERE (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) = [e].[NullableStringA]) OR ((([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL) AND [e].[NullableStringA] IS NULL)",
                 //
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) <> [e].[NullableStringA]) OR (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) IS NULL OR [e].[NullableStringA] IS NULL)) AND (REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) IS NOT NULL OR [e].[NullableStringA] IS NOT NULL)");
+WHERE ((REPLACE([e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC]) <> [e].[NullableStringA]) OR ((([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR [e].[NullableStringC] IS NULL) OR [e].[NullableStringA] IS NULL)) AND ((([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL) AND [e].[NullableStringC] IS NOT NULL) OR [e].[NullableStringA] IS NOT NULL)");
         }
 
         public override async Task Null_semantics_coalesce(bool async)
@@ -1442,7 +1442,7 @@ END = CAST(1 AS bit)");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStringB]) OR (SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) IS NULL OR [e].[NullableStringB] IS NULL)) AND (SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
+WHERE ((SUBSTRING([e].[NullableStringA], 0 + 1, [e].[IntA]) <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
         }
 
         public override async Task Null_semantics_join_with_composite_key(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -100,7 +100,7 @@ WHERE ((([d].[DateTime2_2] = GETDATE()) OR ([d].[DateTime2_7] = GETDATE())) OR (
                 AssertSql(
                     @"SELECT [d].[Id], [d].[DateTime], [d].[DateTime2], [d].[DateTime2_0], [d].[DateTime2_1], [d].[DateTime2_2], [d].[DateTime2_3], [d].[DateTime2_4], [d].[DateTime2_5], [d].[DateTime2_6], [d].[DateTime2_7], [d].[SmallDateTime]
 FROM [Dates] AS [d]
-WHERE (((([d].[DateTime2_2] <> GETDATE()) OR GETDATE() IS NULL) AND (([d].[DateTime2_7] <> GETDATE()) OR GETDATE() IS NULL)) AND (([d].[DateTime] <> GETDATE()) OR GETDATE() IS NULL)) AND (([d].[SmallDateTime] <> GETDATE()) OR GETDATE() IS NULL)");
+WHERE ((([d].[DateTime2_2] <> GETDATE()) AND ([d].[DateTime2_7] <> GETDATE())) AND ([d].[DateTime] <> GETDATE())) AND ([d].[SmallDateTime] <> GETDATE())");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerFixture.cs
@@ -37,9 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 typeof(GeoExtensions).GetMethod(nameof(GeoExtensions.Distance)),
                 b => b.HasTranslation(
                     e => SqlFunctionExpression.Create(
-                        e.First(),
+                        instance: e.First(),
                         "STDistance",
-                        e.Skip(1),
+                        arguments: e.Skip(1),
+                        nullResultAllowed: true,
+                        instancPropagatesNullability: true,
+                        argumentsPropagateNullability: e.Skip(1).Select(a => true),
                         typeof(double),
                         null)));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -50,20 +50,30 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.AsBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task AsBinary_with_null_check(bool async)
+        {
+            await base.AsBinary_with_null_check(async);
+
+            AssertSql(
+                @"SELECT [p].[Id], CASE
+    WHEN [p].[Point] IS NULL THEN NULL
+    ELSE [p].[Point].STAsBinary()
+END AS [Binary]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task AsText(bool async)
         {
             await base.AsText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].AsTextZM() AS [Text]
+FROM [PointEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -76,10 +86,9 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Buffer(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Polygon].STBuffer(1.0E0) AS [Buffer]
-//FROM [PolygonEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Polygon].STBuffer(1.0E0) AS [Buffer]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -98,22 +107,20 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Contains(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0xE6100000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Binary)
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STContains(@__point_0) AS [Contains]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STContains(@__point_0) AS [Contains]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task ConvexHull(bool async)
         {
             await base.ConvexHull(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Polygon].STConvexHull() AS [ConvexHull]
-//FROM [PolygonEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Polygon].STConvexHull() AS [ConvexHull]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task IGeometryCollection_Count(bool async)
@@ -156,12 +163,11 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.Difference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Binary)
+            AssertSql(
+                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STDifference(@__polygon_0) AS [Difference]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDifference(@__polygon_0) AS [Difference]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task Dimension(bool async)
@@ -173,40 +179,84 @@ FROM [LineStringEntity] AS [l]");
 FROM [PointEntity] AS [p]");
         }
 
-        public override async Task Disjoint(bool async)
+        public override async Task Disjoint_with_cast_to_nullable(bool async)
         {
-            await base.Disjoint(async);
+            await base.Disjoint_with_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Binary)
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
         }
 
-        public override async Task Distance(bool async)
+        public override async Task Disjoint_without_cast_to_nullable(bool async)
         {
-            await base.Distance(async);
+            await base.Disjoint_without_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Binary)
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STDistance(@__point_0) AS [Distance]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
+        }
+
+        public override async Task Disjoint_with_null_check(bool async)
+        {
+            await base.Disjoint_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], CASE
+    WHEN [p].[Polygon] IS NULL THEN NULL
+    ELSE [p].[Polygon].STDisjoint(@__point_0)
+END AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
+        }
+
+        public override async Task Distance_without_null_check(bool async)
+        {
+            await base.Distance_without_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task Distance_with_null_check(bool async)
+        {
+            await base.Distance_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task Distance_with_cast_to_nullable(bool async)
+        {
+            await base.Distance_with_cast_to_nullable(async);
+
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Distance_geometry(bool async)
         {
             await base.Distance_geometry(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Binary)
+            AssertSql(
+                @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Geometry].STDistance(@__point_0) AS [Distance]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Geometry].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         // Mixing SRIDs not supported
@@ -219,10 +269,9 @@ FROM [PointEntity] AS [p]");
         {
             await base.Distance_constant_srid_4326(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STDistance('POINT (1 1)') AS [Distance]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STDistance('POINT (1 1)') AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         // Mixing SRIDs not supported
@@ -284,12 +333,11 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.EqualsTopologically(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Point].STEquals(@__point_0) AS [EqualsTopologically]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task ExteriorRing(bool async)
@@ -314,10 +362,15 @@ FROM [PointEntity] AS [p]");
         {
             await base.GetGeometryN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[MultiLineString].STGeometryN(0 + 1) AS [Geometry0]
-//FROM [MultiLineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [m].[Id], [m].[MultiLineString].STGeometryN(0 + 1) AS [Geometry0]
+FROM [MultiLineStringEntity] AS [m]");
+        }
+
+        public override Task GetGeometryN_with_null_argument(bool async)
+        {
+            // 'geometry::STGeometryN' failed because parameter 1 is not allowed to be null.
+            return Task.CompletedTask;
         }
 
         public override async Task GetInteriorRingN(bool async)
@@ -326,7 +379,7 @@ FROM [PointEntity] AS [p]");
 
             AssertSql(
                 @"SELECT [p].[Id], CASE
-    WHEN [p].[Polygon] IS NULL OR (([p].[Polygon].NumRings() - 1) = 0) THEN NULL
+    WHEN ([p].[Polygon].NumRings() - 1) = 0 THEN NULL
     ELSE [p].[Polygon].RingN(0 + 2)
 END AS [InteriorRing0]
 FROM [PolygonEntity] AS [p]");
@@ -336,10 +389,9 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.GetPointN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[LineString].STPointN(0 + 1) AS [Point0]
-//FROM [LineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [l].[Id], [l].[LineString].STPointN(0 + 1) AS [Point0]
+FROM [LineStringEntity] AS [l]");
         }
 
         // No SqlServer Translation
@@ -352,24 +404,22 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Intersection(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task Intersects(bool async)
         {
             await base.Intersects(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__lineString_0='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Object)
+            AssertSql(
+                @"@__lineString_0='0xE61000000114000000000000E0BF000000000000E03F000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-//SELECT [e].[Id], [e].[LineString].STIntersects(@__lineString_0) AS [Intersects]
-//FROM [LineStringEntity] AS [e]");
+SELECT [l].[Id], [l].[LineString].STIntersects(@__lineString_0) AS [Intersects]
+FROM [LineStringEntity] AS [l]");
         }
 
         public override async Task ICurve_IsClosed(bool async)
@@ -428,11 +478,8 @@ FROM [PointEntity] AS [p]");
                 @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Object)
 
 SELECT [p].[Id], CASE
-    WHEN [p].[Point] IS NULL THEN NULL
-    ELSE CASE
-        WHEN [p].[Point].STDistance(@__point_0) <= 1.0E0 THEN CAST(1 AS bit)
-        ELSE CAST(0 AS bit)
-    END
+    WHEN [p].[Point].STDistance(@__point_0) <= 1.0E0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
 END AS [IsWithinDistance]
 FROM [PointEntity] AS [p]");
         }
@@ -441,10 +488,9 @@ FROM [PointEntity] AS [p]");
         {
             await base.Item(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[MultiLineString].STGeometryN(0 + 1) AS [Item0]
-//FROM [MultiLineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [m].[Id], [m].[MultiLineString].STGeometryN(0 + 1) AS [Item0]
+FROM [MultiLineStringEntity] AS [m]");
         }
 
         public override async Task Length(bool async)
@@ -517,12 +563,11 @@ FROM [PointEntity] AS [p]");
         {
             await base.Overlaps(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -574,32 +619,29 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.SymmetricDifference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task ToBinary(bool async)
         {
             await base.ToBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task ToText(bool async)
         {
             await base.ToText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].AsTextZM() AS [Text]
+FROM [PointEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -612,12 +654,11 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.Union(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0xE610000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STUnion(@__polygon_0) AS [Union]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STUnion(@__polygon_0) AS [Union]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -630,12 +671,11 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.Within(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Point].STWithin(@__polygon_0) AS [Within]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task X(bool async)
@@ -663,6 +703,54 @@ FROM [PointEntity] AS [p]");
             AssertSql(
                 @"SELECT [p].[Id], [p].[Point].Z AS [Z]
 FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task IsEmpty_equal_to_null(bool async)
+        {
+            await base.IsEmpty_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [p].[Id]
+FROM [PointEntity] AS [p]
+WHERE [p].[Point] IS NULL");
+        }
+
+        public override async Task IsEmpty_not_equal_to_null(bool async)
+        {
+            await base.IsEmpty_not_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [p].[Id]
+FROM [PointEntity] AS [p]
+WHERE [p].[Point] IS NOT NULL");
+        }
+
+        public override async Task Intersects_equal_to_null(bool async)
+        {
+            await base.Intersects_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NULL",
+                //
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NULL");
+        }
+
+        public override async Task Intersects_not_equal_to_null(bool async)
+        {
+            await base.Intersects_not_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NOT NULL",
+                //
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NOT NULL");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -50,20 +50,30 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.AsBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task AsBinary_with_null_check(bool async)
+        {
+            await base.AsBinary_with_null_check(async);
+
+            AssertSql(
+                @"SELECT [p].[Id], CASE
+    WHEN [p].[Point] IS NULL THEN NULL
+    ELSE [p].[Point].STAsBinary()
+END AS [Binary]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task AsText(bool async)
         {
             await base.AsText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].AsTextZM() AS [Text]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Boundary(bool async)
@@ -79,10 +89,9 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Buffer(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Polygon].STBuffer(1.0E0) AS [Buffer]
-//FROM [PolygonEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Polygon].STBuffer(1.0E0) AS [Buffer]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -104,22 +113,20 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Contains(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000D03F000000000000D03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STContains(@__point_0) AS [Contains]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STContains(@__point_0) AS [Contains]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task ConvexHull(bool async)
         {
             await base.ConvexHull(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Polygon].STConvexHull() AS [ConvexHull]
-//FROM [PolygonEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Polygon].STConvexHull() AS [ConvexHull]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task IGeometryCollection_Count(bool async)
@@ -143,7 +150,7 @@ FROM [LineStringEntity] AS [l]");
         // No SqlServer Translation
         public override Task CoveredBy(bool async)
         {
-            return base.CoveredBy(async);
+            return Task.CompletedTask;
         }
 
         // No SqlServer Translation
@@ -156,48 +163,44 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.Crosses(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
+            AssertSql(
+                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-//SELECT [e].[Id], [e].[LineString].STCrosses(@__lineString_0) AS [Crosses]
-//FROM [LineStringEntity] AS [e]");
+SELECT [l].[Id], [l].[LineString].STCrosses(@__lineString_0) AS [Crosses]
+FROM [LineStringEntity] AS [l]");
         }
 
         public override async Task Difference(bool async)
         {
             await base.Difference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STDifference(@__polygon_0) AS [Difference]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDifference(@__polygon_0) AS [Difference]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task Distance_on_converted_geometry_type(bool async)
         {
             await base.Distance_on_converted_geometry_type(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Location].STDistance(@__point_0) AS [Distance]
-//FROM [GeoPointEntity] AS [e]");
+SELECT [g].[Id], [g].[Location].STDistance(@__point_0) AS [Distance]
+FROM [GeoPointEntity] AS [g]");
         }
 
         public override async Task Distance_on_converted_geometry_type_lhs(bool async)
         {
             await base.Distance_on_converted_geometry_type_lhs(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000F03F0000000000000000' (Nullable = false) (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], @__point_0.STDistance([e].[Location]) AS [Distance]
-//FROM [GeoPointEntity] AS [e]");
+SELECT [g].[Id], @__point_0.STDistance([g].[Location]) AS [Distance]
+FROM [GeoPointEntity] AS [g]");
         }
 
         public override async Task Distance_on_converted_geometry_type_constant(bool async)
@@ -222,18 +225,17 @@ FROM [GeoPointEntity] AS [g]");
         {
             await base.Distance_constant(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STDistance('POINT (0 1)') AS [Distance]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STDistance('POINT (0 1)') AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Distance_constant_srid_4326(bool async)
         {
             await AssertQuery(
                 async,
-                ss => ss.Set<PointEntity>().Select(
-                    e => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(new Point(1, 1) { SRID = 4326 }) }),
+                ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point.Distance(new Point(1, 1) { SRID = 4326 }) }),
+                ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(new Point(1, 1) { SRID = 4326 }) }),
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
@@ -241,20 +243,18 @@ FROM [GeoPointEntity] AS [g]");
                     Assert.Null(a.Distance);
                 });
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STDistance(geometry::STGeomFromText('POINT (1 1)', 4326)) AS [Distance]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STDistance(geometry::STGeomFromText('POINT (1 1)', 4326)) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Distance_constant_lhs(bool async)
         {
             await base.Distance_constant_lhs(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], geometry::Parse('POINT (0 1)').STDistance([e].[Point]) AS [Distance]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], geometry::Parse('POINT (0 1)').STDistance([p].[Point]) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Dimension(bool async)
@@ -266,40 +266,84 @@ FROM [GeoPointEntity] AS [g]");
 FROM [PointEntity] AS [p]");
         }
 
-        public override async Task Disjoint(bool async)
+        public override async Task Disjoint_with_cast_to_nullable(bool async)
         {
-            await base.Disjoint(async);
+            await base.Disjoint_with_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
         }
 
-        public override async Task Distance(bool async)
+        public override async Task Disjoint_without_cast_to_nullable(bool async)
         {
-            await base.Distance(async);
+            await base.Disjoint_without_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STDistance(@__point_0) AS [Distance]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
+        }
+
+        public override async Task Disjoint_with_null_check(bool async)
+        {
+            await base.Disjoint_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x00000000010C000000000000F03F000000000000F03F' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], CASE
+    WHEN [p].[Polygon] IS NULL THEN NULL
+    ELSE [p].[Polygon].STDisjoint(@__point_0)
+END AS [Disjoint]
+FROM [PolygonEntity] AS [p]");
+        }
+
+        public override async Task Distance_without_null_check(bool async)
+        {
+            await base.Distance_without_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task Distance_with_null_check(bool async)
+        {
+            await base.Distance_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task Distance_with_cast_to_nullable(bool async)
+        {
+            await base.Distance_with_cast_to_nullable(async);
+
+            AssertSql(
+                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+
+SELECT [p].[Id], [p].[Point].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Distance_geometry(bool async)
         {
             await base.Distance_geometry(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Geometry].STDistance(@__point_0) AS [Distance]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Geometry].STDistance(@__point_0) AS [Distance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task EndPoint(bool async)
@@ -324,12 +368,11 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.EqualsTopologically(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Point].STEquals(@__point_0) AS [EqualsTopologically]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task ExteriorRing(bool async)
@@ -354,10 +397,15 @@ FROM [PointEntity] AS [p]");
         {
             await base.GetGeometryN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[MultiLineString].STGeometryN(0 + 1) AS [Geometry0]
-//FROM [MultiLineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [m].[Id], [m].[MultiLineString].STGeometryN(0 + 1) AS [Geometry0]
+FROM [MultiLineStringEntity] AS [m]");
+        }
+
+        public override Task GetGeometryN_with_null_argument(bool async)
+        {
+            // 'geometry::STGeometryN' failed because parameter 1 is not allowed to be null.
+            return Task.CompletedTask;
         }
 
         public override async Task GetInteriorRingN(bool async)
@@ -366,7 +414,7 @@ FROM [PointEntity] AS [p]");
 
             AssertSql(
                 @"SELECT [p].[Id], CASE
-    WHEN [p].[Polygon] IS NULL OR ([p].[Polygon].STNumInteriorRing() = 0) THEN NULL
+    WHEN [p].[Polygon].STNumInteriorRing() = 0 THEN NULL
     ELSE [p].[Polygon].STInteriorRingN(0 + 1)
 END AS [InteriorRing0]
 FROM [PolygonEntity] AS [p]");
@@ -376,10 +424,9 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.GetPointN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[LineString].STPointN(0 + 1) AS [Point0]
-//FROM [LineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [l].[Id], [l].[LineString].STPointN(0 + 1) AS [Point0]
+FROM [LineStringEntity] AS [l]");
         }
 
         public override async Task InteriorPoint(bool async)
@@ -395,24 +442,22 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Intersection(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task Intersects(bool async)
         {
             await base.Intersects(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
+            AssertSql(
+                @"@__lineString_0='0x000000000114000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 38) (DbType = Object)
 
-//SELECT [e].[Id], [e].[LineString].STIntersects(@__lineString_0) AS [Intersects]
-//FROM [LineStringEntity] AS [e]");
+SELECT [l].[Id], [l].[LineString].STIntersects(@__lineString_0) AS [Intersects]
+FROM [LineStringEntity] AS [l]");
         }
 
         public override async Task ICurve_IsClosed(bool async)
@@ -473,25 +518,23 @@ FROM [PointEntity] AS [p]");
         {
             await base.IsWithinDistance(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
+            AssertSql(
+                @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Object)
 
-//SELECT [e].[Id], CASE
-//    WHEN [e].[Point].STDistance(@__point_0) <= 1.0E0
-//    THEN CAST(1 AS bit) ELSE CAST(0 AS bit)
-//END AS [IsWithinDistance]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], CASE
+    WHEN [p].[Point].STDistance(@__point_0) <= 1.0E0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [IsWithinDistance]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Item(bool async)
         {
             await base.Item(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[MultiLineString].STGeometryN(0 + 1) AS [Item0]
-//FROM [MultiLineStringEntity] AS [e]");
+            AssertSql(
+                @"SELECT [m].[Id], [m].[MultiLineString].STGeometryN(0 + 1) AS [Item0]
+FROM [MultiLineStringEntity] AS [m]");
         }
 
         public override async Task Length(bool async)
@@ -563,12 +606,11 @@ FROM [PointEntity] AS [p]");
         {
             await base.Overlaps(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STOverlaps(@__polygon_0) AS [Overlaps]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task PointOnSurface(bool async)
@@ -584,18 +626,17 @@ FROM [PolygonEntity] AS [p]");
         {
             await base.Relate(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STRelate(@__polygon_0, N'212111212') AS [Relate]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STRelate(@__polygon_0, N'212111212') AS [Relate]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
         public override Task Reverse(bool async)
         {
-            return base.Reverse(async);
+            return Task.CompletedTask;
         }
 
         public override async Task SRID(bool async)
@@ -629,56 +670,51 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.SymmetricDifference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STSymDifference(@__polygon_0) AS [SymmetricDifference]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task ToBinary(bool async)
         {
             await base.ToBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].STAsBinary() AS [Binary]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task ToText(bool async)
         {
             await base.ToText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-//FROM [PointEntity] AS [e]");
+            AssertSql(
+                @"SELECT [p].[Id], [p].[Point].AsTextZM() AS [Text]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task Touches(bool async)
         {
             await base.Touches(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x000000000104040000000000000000000000000000000000F03F000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STTouches(@__polygon_0) AS [Touches]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STTouches(@__polygon_0) AS [Touches]
+FROM [PolygonEntity] AS [p]");
         }
 
         public override async Task Union(bool async)
         {
             await base.Union(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x0000000001040400000000000000000000000000000000000000000000000000...' (Size = 96) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Polygon].STUnion(@__polygon_0) AS [Union]
-//FROM [PolygonEntity] AS [e]");
+SELECT [p].[Id], [p].[Polygon].STUnion(@__polygon_0) AS [Union]
+FROM [PolygonEntity] AS [p]");
         }
 
         // No SqlServer Translation
@@ -691,12 +727,11 @@ FROM [LineStringEntity] AS [l]");
         {
             await base.Within(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
+            AssertSql(
+                @"@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Object)
 
-//SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
-//FROM [PointEntity] AS [e]");
+SELECT [p].[Id], [p].[Point].STWithin(@__polygon_0) AS [Within]
+FROM [PointEntity] AS [p]");
         }
 
         public override async Task X(bool async)
@@ -724,6 +759,53 @@ FROM [PointEntity] AS [p]");
             AssertSql(
                 @"SELECT [p].[Id], [p].[Point].Z AS [Z]
 FROM [PointEntity] AS [p]");
+        }
+
+        public override async Task IsEmpty_equal_to_null(bool async)
+        {
+            await base.IsEmpty_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [p].[Id]
+FROM [PointEntity] AS [p]
+WHERE [p].[Point] IS NULL");
+        }
+
+        public override async Task IsEmpty_not_equal_to_null(bool async)
+        {
+            await base.IsEmpty_not_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [p].[Id]
+FROM [PointEntity] AS [p]
+WHERE [p].[Point] IS NOT NULL");
+        }
+
+        public override async Task Intersects_equal_to_null(bool async)
+        {
+            await base.Intersects_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NULL",
+                //
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NULL");        }
+
+        public override async Task Intersects_not_equal_to_null(bool async)
+        {
+            await base.Intersects_not_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NOT NULL",
+                //
+                @"SELECT [l].[Id]
+FROM [LineStringEntity] AS [l]
+WHERE [l].[LineString] IS NOT NULL");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -134,7 +134,7 @@ WHERE length(""s"".""Banner"") = @__p_0");
 
 SELECT COUNT(*)
 FROM ""Squads"" AS ""s""
-WHERE (length(""s"".""Banner"") = length(@__byteArrayParam)) OR (length(""s"".""Banner"") IS NULL AND length(@__byteArrayParam) IS NULL)");
+WHERE length(""s"".""Banner"") = length(@__byteArrayParam)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindWhereQuerySqliteTest.cs
@@ -53,7 +53,7 @@ WHERE ""c"".""City"" = @__city_0", queryString, ignoreLineEndingDifferences: tru
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0) OR rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') IS NULL");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.') <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_utcnow(bool async)
@@ -65,7 +65,7 @@ WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime'), '0'), '.')
 
 SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0) OR rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') IS NULL");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDatetime_0");
         }
 
         public override async Task Where_datetime_today(bool async)
@@ -75,7 +75,7 @@ WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now'), '0'), '.') <> @__myDate
             AssertSql(
                 @"SELECT ""e"".""EmployeeID"", ""e"".""City"", ""e"".""Country"", ""e"".""FirstName"", ""e"".""ReportsTo"", ""e"".""Title""
 FROM ""Employees"" AS ""e""
-WHERE (rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') = rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.')) OR rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') IS NULL");
+WHERE rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.') = rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime', 'start of day'), '0'), '.')");
         }
 
         public override async Task Where_datetime_date_component(bool async)
@@ -188,7 +188,7 @@ WHERE length(""c"".""City"") = 6");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR instr(""c"".""City"", 'Sea') IS NULL");
+WHERE ((instr(""c"".""City"", 'Sea') - 1) <> -1) OR ""c"".""City"" IS NULL");
         }
 
         public override async Task Where_string_replace(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteFixture.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
@@ -39,7 +40,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 b => b.HasTranslation(
                     e => SqlFunctionExpression.Create(
                         "Distance",
-                        e,
+                        arguments: e,
+                        nullResultAllowed: true,
+                        argumentsPropagateNullability: e.Select(a => true).ToList(),
                         typeof(double),
                         null)));
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -88,20 +88,30 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.AsBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", AsBinary(""e"".""Point"") AS ""Binary""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", AsBinary(""p"".""Point"") AS ""Binary""
+FROM ""PointEntity"" AS ""p""");
+        }
+
+        public override async Task AsBinary_with_null_check(bool async)
+        {
+            await base.AsBinary_with_null_check(async);
+
+            AssertSql(
+                @"SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Point"" IS NULL THEN NULL
+    ELSE AsBinary(""p"".""Point"")
+END AS ""Binary""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task AsText(bool async)
         {
             await base.AsText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", AsText(""e"".""Point"") AS ""Text""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", AsText(""p"".""Point"") AS ""Text""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Boundary(bool async)
@@ -117,20 +127,18 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.Buffer(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", Buffer(""e"".""Polygon"", 1.0) AS ""Buffer""
-//FROM ""PolygonEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", Buffer(""p"".""Polygon"", 1.0) AS ""Buffer""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Buffer_quadrantSegments(bool async)
         {
             await base.Buffer_quadrantSegments(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", Buffer(""e"".""Polygon"", 1.0, 8) AS ""Buffer""
-//FROM ""PolygonEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", Buffer(""p"".""Polygon"", 1.0, 8) AS ""Buffer""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Centroid(bool async)
@@ -146,24 +154,22 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.Contains(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Contains(""e"".""Polygon"", @__point_0)
-//END AS ""Contains""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Contains(""p"".""Polygon"", @__point_0)
+END AS ""Contains""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task ConvexHull(bool async)
         {
             await base.ConvexHull(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", ConvexHull(""e"".""Polygon"") AS ""ConvexHull""
-//FROM ""PolygonEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", ConvexHull(""p"".""Polygon"") AS ""ConvexHull""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task IGeometryCollection_Count(bool async)
@@ -188,54 +194,50 @@ FROM ""LineStringEntity"" AS ""l""");
         {
             await base.CoveredBy(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Point"" IS NOT NULL THEN CoveredBy(""e"".""Point"", @__polygon_0)
-//END AS ""CoveredBy""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Point"" IS NOT NULL THEN CoveredBy(""p"".""Point"", @__polygon_0)
+END AS ""CoveredBy""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Covers(bool async)
         {
             await base.Covers(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x000100000000000000000000D03F000000000000D03F000000000000D03F0000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Covers(""e"".""Polygon"", @__point_0)
-//END AS ""Covers""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Covers(""p"".""Polygon"", @__point_0)
+END AS ""Covers""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Crosses(bool async)
         {
             await base.Crosses(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+            AssertSql(
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""LineString"" IS NOT NULL THEN Crosses(""e"".""LineString"", @__lineString_0)
-//END AS ""Crosses""
-//FROM ""LineStringEntity"" AS ""e""");
+SELECT ""l"".""Id"", CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Crosses(""l"".""LineString"", @__lineString_0)
+END AS ""Crosses""
+FROM ""LineStringEntity"" AS ""l""");
         }
 
         public override async Task Difference(bool async)
         {
             await base.Difference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", Difference(""e"".""Polygon"", @__polygon_0) AS ""Difference""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", Difference(""p"".""Polygon"", @__polygon_0) AS ""Difference""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Dimension(bool async)
@@ -247,72 +249,115 @@ FROM ""LineStringEntity"" AS ""l""");
 FROM ""PointEntity"" AS ""p""");
         }
 
-        public override async Task Disjoint(bool async)
+        public override async Task Disjoint_with_cast_to_nullable(bool async)
         {
-            await base.Disjoint(async);
+            await base.Disjoint_with_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Disjoint(""e"".""Polygon"", @__point_0)
-//END AS ""Disjoint""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Disjoint(""p"".""Polygon"", @__point_0)
+END AS ""Disjoint""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
-        public override async Task Distance(bool async)
+        public override async Task Disjoint_without_cast_to_nullable(bool async)
         {
-            await base.Distance(async);
+            await base.Disjoint_without_cast_to_nullable(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", Distance(""e"".""Point"", @__point_0) AS ""Distance""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Disjoint(""p"".""Polygon"", @__point_0)
+END AS ""Disjoint""
+FROM ""PolygonEntity"" AS ""p""");
+        }
+
+        public override async Task Disjoint_with_null_check(bool async)
+        {
+            await base.Disjoint_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x000100000000000000000000F03F000000000000F03F000000000000F03F0000...' (Size = 60) (DbType = String)
+
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NULL THEN NULL
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Disjoint(""p"".""Polygon"", @__point_0)
+END AS ""Disjoint""
+FROM ""PolygonEntity"" AS ""p""");
+        }
+
+        public override async Task Distance_without_null_check(bool async)
+        {
+            await base.Distance_without_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+
+SELECT ""p"".""Id"", Distance(""p"".""Point"", @__point_0) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
+        }
+
+        public override async Task Distance_with_null_check(bool async)
+        {
+            await base.Distance_with_null_check(async);
+
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+
+SELECT ""p"".""Id"", Distance(""p"".""Point"", @__point_0) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
+        }
+
+        public override async Task Distance_with_cast_to_nullable(bool async)
+        {
+            await base.Distance_with_cast_to_nullable(async);
+
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+
+SELECT ""p"".""Id"", Distance(""p"".""Point"", @__point_0) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Distance_geometry(bool async)
         {
             await base.Distance_geometry(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", Distance(""e"".""Geometry"", @__point_0) AS ""Distance""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", Distance(""p"".""Geometry"", @__point_0) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Distance_constant(bool async)
         {
             await base.Distance_constant(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", Distance(""e"".""Point"", GeomFromText('POINT (0 1)')) AS ""Distance""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", Distance(""p"".""Point"", GeomFromText('POINT (0 1)')) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Distance_constant_srid_4326(bool async)
         {
             await base.Distance_constant_srid_4326(async);
 
-            // isse #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", Distance(""e"".""Point"", GeomFromText('POINT (1 1)', 4326)) AS ""Distance""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", Distance(""p"".""Point"", GeomFromText('POINT (1 1)', 4326)) AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Distance_constant_lhs(bool async)
         {
             await base.Distance_constant_lhs(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", Distance(GeomFromText('POINT (0 1)'), ""e"".""Point"") AS ""Distance""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", Distance(GeomFromText('POINT (0 1)'), ""p"".""Point"") AS ""Distance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task EndPoint(bool async)
@@ -337,14 +382,13 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.EqualsTopologically(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x0001000000000000000000000000000000000000000000000000000000000000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000000000000000000000000000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Point"" IS NOT NULL THEN Equals(""e"".""Point"", @__point_0)
-//END AS ""EqualsTopologically""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Point"" IS NOT NULL THEN Equals(""p"".""Point"", @__point_0)
+END AS ""EqualsTopologically""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task ExteriorRing(bool async)
@@ -377,33 +421,42 @@ FROM ""PointEntity"" AS ""p""");
         {
             await base.GetGeometryN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", GeometryN(""e"".""MultiLineString"", 0 + 1) AS ""Geometry0""
-//FROM ""MultiLineStringEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""m"".""Id"", GeometryN(""m"".""MultiLineString"", 0 + 1) AS ""Geometry0""
+FROM ""MultiLineStringEntity"" AS ""m""");
+        }
+
+        public override async Task GetGeometryN_with_null_argument(bool async)
+        {
+            await base.GetGeometryN_with_null_argument(async);
+
+            AssertSql(
+                @"SELECT ""m0"".""Id"", GeometryN(""m0"".""MultiLineString"", (
+    SELECT MAX(""m"".""Id"")
+    FROM ""MultiLineStringEntity"" AS ""m""
+    WHERE 0) + 1) AS ""Geometry0""
+FROM ""MultiLineStringEntity"" AS ""m0""");
         }
 
         public override async Task GetInteriorRingN(bool async)
         {
             await base.GetInteriorRingN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NULL OR (NumInteriorRing(""e"".""Polygon"") = 0)
-//    THEN NULL ELSE InteriorRingN(""e"".""Polygon"", 0 + 1)
-//END AS ""InteriorRing0""
-//FROM ""PolygonEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", CASE
+    WHEN NumInteriorRing(""p"".""Polygon"") = 0 THEN NULL
+    ELSE InteriorRingN(""p"".""Polygon"", 0 + 1)
+END AS ""InteriorRing0""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task GetPointN(bool async)
         {
             await base.GetPointN(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", PointN(""e"".""LineString"", 0 + 1) AS ""Point0""
-//FROM ""LineStringEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""l"".""Id"", PointN(""l"".""LineString"", 0 + 1) AS ""Point0""
+FROM ""LineStringEntity"" AS ""l""");
         }
 
         public override async Task InteriorPoint(bool async)
@@ -419,26 +472,24 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.Intersection(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", Intersection(""e"".""Polygon"", @__polygon_0) AS ""Intersection""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", Intersection(""p"".""Polygon"", @__polygon_0) AS ""Intersection""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Intersects(bool async)
         {
             await base.Intersects(async);
 
-            // issue 16050
-//            AssertSql(
-//                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+            AssertSql(
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""LineString"" IS NOT NULL THEN Intersects(""e"".""LineString"", @__lineString_0)
-//END AS ""Intersects""
-//FROM ""LineStringEntity"" AS ""e""");
+SELECT ""l"".""Id"", CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Intersects(""l"".""LineString"", @__lineString_0)
+END AS ""Intersects""
+FROM ""LineStringEntity"" AS ""l""");
         }
 
         public override async Task ICurve_IsClosed(bool async)
@@ -511,25 +562,20 @@ FROM ""PointEntity"" AS ""p""");
         {
             await base.IsWithinDistance(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
+            AssertSql(
+                @"@__point_0='0x0001000000000000000000000000000000000000F03F00000000000000000000...' (Size = 60) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN Distance(""e"".""Point"", @__point_0) <= 1.0
-//    THEN 1 ELSE 0
-//END AS ""IsWithinDistance""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", Distance(""p"".""Point"", @__point_0) <= 1.0 AS ""IsWithinDistance""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Item(bool async)
         {
             await base.Item(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", GeometryN(""e"".""MultiLineString"", 0 + 1) AS ""Item0""
-//FROM ""MultiLineStringEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""m"".""Id"", GeometryN(""m"".""MultiLineString"", 0 + 1) AS ""Item0""
+FROM ""MultiLineStringEntity"" AS ""m""");
         }
 
         public override async Task Length(bool async)
@@ -598,14 +644,13 @@ FROM ""PointEntity"" AS ""p""");
         {
             await base.Overlaps(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Overlaps(""e"".""Polygon"", @__polygon_0)
-//END AS ""Overlaps""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Overlaps(""p"".""Polygon"", @__polygon_0)
+END AS ""Overlaps""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task PointOnSurface(bool async)
@@ -621,24 +666,22 @@ FROM ""PolygonEntity"" AS ""p""");
         {
             await base.Relate(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Relate(""e"".""Polygon"", @__polygon_0, '212111212')
-//END AS ""Relate""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Relate(""p"".""Polygon"", @__polygon_0, '212111212')
+END AS ""Relate""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Reverse(bool async)
         {
             await base.Reverse(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", ST_Reverse(""e"".""LineString"") AS ""Reverse""
-//FROM ""LineStringEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""l"".""Id"", ST_Reverse(""l"".""LineString"") AS ""Reverse""
+FROM ""LineStringEntity"" AS ""l""");
         }
 
         public override async Task SRID(bool async)
@@ -672,82 +715,75 @@ FROM ""LineStringEntity"" AS ""l""");
         {
             await base.SymmetricDifference(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", SymDifference(""e"".""Polygon"", @__polygon_0) AS ""SymmetricDifference""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", SymDifference(""p"".""Polygon"", @__polygon_0) AS ""SymmetricDifference""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task ToBinary(bool async)
         {
             await base.ToBinary(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", AsBinary(""e"".""Point"") AS ""Binary""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", AsBinary(""p"".""Point"") AS ""Binary""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task ToText(bool async)
         {
             await base.ToText(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", AsText(""e"".""Point"") AS ""Text""
-//FROM ""PointEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""p"".""Id"", AsText(""p"".""Point"") AS ""Text""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task Touches(bool async)
         {
             await base.Touches(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Polygon"" IS NOT NULL THEN Touches(""e"".""Polygon"", @__polygon_0)
-//END AS ""Touches""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Polygon"" IS NOT NULL THEN Touches(""p"".""Polygon"", @__polygon_0)
+END AS ""Touches""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Union(bool async)
         {
             await base.Union(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x00010000000000000000000000000000000000000000000000000000F03F0000...' (Size = 116) (DbType = String)
 
-//SELECT ""e"".""Id"", GUnion(""e"".""Polygon"", @__polygon_0) AS ""Union""
-//FROM ""PolygonEntity"" AS ""e""");
+SELECT ""p"".""Id"", GUnion(""p"".""Polygon"", @__polygon_0) AS ""Union""
+FROM ""PolygonEntity"" AS ""p""");
         }
 
         public override async Task Union_void(bool async)
         {
             await base.Union_void(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"SELECT ""e"".""Id"", UnaryUnion(""e"".""MultiLineString"") AS ""Union""
-//FROM ""MultiLineStringEntity"" AS ""e""");
+            AssertSql(
+                @"SELECT ""m"".""Id"", UnaryUnion(""m"".""MultiLineString"") AS ""Union""
+FROM ""MultiLineStringEntity"" AS ""m""");
         }
 
         public override async Task Within(bool async)
         {
             await base.Within(async);
 
-            // issue #16050
-//            AssertSql(
-//                @"@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
+            AssertSql(
+                @"@__polygon_0='0x000100000000000000000000F0BF000000000000F0BF00000000000000400000...' (Size = 132) (DbType = String)
 
-//SELECT ""e"".""Id"", CASE
-//    WHEN ""e"".""Point"" IS NOT NULL THEN Within(""e"".""Point"", @__polygon_0)
-//END AS ""Within""
-//FROM ""PointEntity"" AS ""e""");
+SELECT ""p"".""Id"", CASE
+    WHEN ""p"".""Point"" IS NOT NULL THEN Within(""p"".""Point"", @__polygon_0)
+END AS ""Within""
+FROM ""PointEntity"" AS ""p""");
         }
 
         public override async Task X(bool async)
@@ -775,6 +811,74 @@ FROM ""PointEntity"" AS ""p""");
             AssertSql(
                 @"SELECT ""p"".""Id"", Z(""p"".""Point"") AS ""Z""
 FROM ""PointEntity"" AS ""p""");
+        }
+
+        public override async Task IsEmpty_equal_to_null(bool async)
+        {
+            await base.IsEmpty_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT ""p"".""Id""
+FROM ""PointEntity"" AS ""p""
+WHERE CASE
+    WHEN ""p"".""Point"" IS NOT NULL THEN IsEmpty(""p"".""Point"")
+END IS NULL");
+        }
+
+        public override async Task IsEmpty_not_equal_to_null(bool async)
+        {
+            await base.IsEmpty_not_equal_to_null(async);
+
+            AssertSql(
+                @"SELECT ""p"".""Id""
+FROM ""PointEntity"" AS ""p""
+WHERE CASE
+    WHEN ""p"".""Point"" IS NOT NULL THEN IsEmpty(""p"".""Point"")
+END IS NOT NULL");
+        }
+
+        public override async Task Intersects_equal_to_null(bool async)
+        {
+            await base.Intersects_equal_to_null(async);
+
+            AssertSql(
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+
+SELECT ""l"".""Id""
+FROM ""LineStringEntity"" AS ""l""
+WHERE CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Intersects(""l"".""LineString"", @__lineString_0)
+END IS NULL",
+                //
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+
+SELECT ""l"".""Id""
+FROM ""LineStringEntity"" AS ""l""
+WHERE CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Intersects(@__lineString_0, ""l"".""LineString"")
+END IS NULL");
+        }
+
+        public override async Task Intersects_not_equal_to_null(bool async)
+        {
+            await base.Intersects_not_equal_to_null(async);
+
+            AssertSql(
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+
+SELECT ""l"".""Id""
+FROM ""LineStringEntity"" AS ""l""
+WHERE CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Intersects(""l"".""LineString"", @__lineString_0)
+END IS NOT NULL",
+                //
+                @"@__lineString_0='0x000100000000000000000000E03F000000000000E0BF000000000000E03F0000...' (Size = 80) (DbType = String)
+
+SELECT ""l"".""Id""
+FROM ""LineStringEntity"" AS ""l""
+WHERE CASE
+    WHEN ""l"".""LineString"" IS NOT NULL THEN Intersects(@__lineString_0, ""l"".""LineString"")
+END IS NOT NULL");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
When we need to compute whether a function is null, we often can just evaluate nullability of it's constituents (instance & arguments), e.g.
SUBSTRING(stringProperty, 0, 5) == null -> stringProperty == null

Adding metadata to SqlFunctionExpression:
canBeNull - indicates whether function can ever be null,
instancePropagatesNullability - indicates whether function instance can be used to calculate nullability of the entire function
argumentsPropagateNullability - array indicating which (if any) function arguments can be used to calculate nullability of the entire function

If "canBeNull" is set to false we can instantly compute IsNull/IsNotNull of that function.
Otherwise, we look at values of instancePropagatesNullability and argumentsPropagateNullability - if any of them are set to true, we use corresponding argument(s) to compute function nullability.
If all of them are set to false we must fallback to the old method and evaluate nullability of the entire function.

Resolves #18555