### PR TITLE
[WIP] SQLite: Enable TimeSpan

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeAddTranslator.cs
@@ -71,30 +71,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
             if (modifier != null)
             {
-                return _sqlExpressionFactory.Function(
-                    "rtrim",
-                    new SqlExpression[]
-                    {
-                        _sqlExpressionFactory.Function(
-                            "rtrim",
-                            new SqlExpression[]
-                            {
-                                SqliteExpression.Strftime(
-                                    _sqlExpressionFactory,
-                                    method.ReturnType,
-                                    "%Y-%m-%d %H:%M:%f",
-                                    instance,
-                                    new[] { modifier }),
-                                _sqlExpressionFactory.Constant("0")
-                            },
-                            nullable: true,
-                            argumentsPropagateNullability: new[] { true, false },
-                            method.ReturnType),
-                        _sqlExpressionFactory.Constant(".")
-                    },
-                    nullable: true,
-                    argumentsPropagateNullability: new[] { true, false },
-                    method.ReturnType);
+                return SqliteExpression.DateTime(
+                    _sqlExpressionFactory,
+                    method.ReturnType,
+                    instance,
+                    new[] { modifier });
             }
 
             return null;

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateTimeMemberTranslator.cs
@@ -53,98 +53,69 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                         returnType);
                 }
 
-                if (string.Equals(memberName, nameof(DateTime.Ticks)))
-                {
-                    return _sqlExpressionFactory.Convert(
-                        _sqlExpressionFactory.Multiply(
-                            _sqlExpressionFactory.Subtract(
-                                _sqlExpressionFactory.Function(
-                                    "julianday",
-                                    new[] { instance },
-                                    nullable: true,
-                                    argumentsPropagateNullability: new[] { true },
-                                    typeof(double)),
-                                _sqlExpressionFactory.Constant(1721425.5)), // NB: Result of julianday('0001-01-01 00:00:00')
-                            _sqlExpressionFactory.Constant(TimeSpan.TicksPerDay)),
-                        typeof(long));
-                }
-
-                if (string.Equals(memberName, nameof(DateTime.Millisecond)))
-                {
-                    return _sqlExpressionFactory.Modulo(
-                        _sqlExpressionFactory.Multiply(
-                            _sqlExpressionFactory.Convert(
-                                SqliteExpression.Strftime(
-                                    _sqlExpressionFactory,
-                                    typeof(string),
-                                    "%f",
-                                    instance),
-                                typeof(double)),
-                            _sqlExpressionFactory.Constant(1000)),
-                        _sqlExpressionFactory.Constant(1000));
-                }
-
-                var format = "%Y-%m-%d %H:%M:%f";
-                SqlExpression timestring;
-                var modifiers = new List<SqlExpression>();
-
                 switch (memberName)
                 {
+                    case nameof(DateTime.Ticks):
+                        return _sqlExpressionFactory.Convert(
+                            _sqlExpressionFactory.Multiply(
+                                _sqlExpressionFactory.Subtract(
+                                        SqliteExpression.JulianDay(
+                                            _sqlExpressionFactory,
+                                            instance),
+                                        _sqlExpressionFactory.Constant(1721425.5)), // NB: Result of julianday('0001-01-01 00:00:00')
+                                    _sqlExpressionFactory.Constant(TimeSpan.TicksPerDay)),
+                                typeof(long));
+
+                    case nameof(DateTime.Millisecond):
+                        return _sqlExpressionFactory.Modulo(
+                            _sqlExpressionFactory.Multiply(
+                                _sqlExpressionFactory.Convert(
+                                    SqliteExpression.Strftime(
+                                        _sqlExpressionFactory,
+                                        typeof(string),
+                                        "%f",
+                                        instance),
+                                    typeof(double)),
+                                _sqlExpressionFactory.Constant(1000)),
+                            _sqlExpressionFactory.Constant(1000));
+
                     case nameof(DateTime.Now):
-                        timestring = _sqlExpressionFactory.Constant("now");
-                        modifiers.Add(_sqlExpressionFactory.Constant("localtime"));
-                        break;
+                        return SqliteExpression.DateTime(
+                            _sqlExpressionFactory,
+                            returnType,
+                            _sqlExpressionFactory.Constant("now"),
+                            new SqlExpression[] { _sqlExpressionFactory.Constant("localtime") });
 
                     case nameof(DateTime.UtcNow):
-                        timestring = _sqlExpressionFactory.Constant("now");
-                        break;
+                        return SqliteExpression.DateTime(
+                            _sqlExpressionFactory,
+                            returnType,
+                            _sqlExpressionFactory.Constant("now"));
 
                     case nameof(DateTime.Date):
-                        timestring = instance;
-                        modifiers.Add(_sqlExpressionFactory.Constant("start of day"));
-                        break;
+                        return SqliteExpression.DateTime(
+                            _sqlExpressionFactory,
+                            returnType,
+                            instance,
+                            new SqlExpression[] { _sqlExpressionFactory.Constant("start of day") });
 
                     case nameof(DateTime.Today):
-                        timestring = _sqlExpressionFactory.Constant("now");
-                        modifiers.Add(_sqlExpressionFactory.Constant("localtime"));
-                        modifiers.Add(_sqlExpressionFactory.Constant("start of day"));
-                        break;
-
-                    case nameof(DateTime.TimeOfDay):
-                        format = "%H:%M:%f";
-                        timestring = instance;
-                        break;
-
-                    default:
-                        return null;
-                }
-
-                Check.DebugAssert(timestring != null, "timestring is null");
-
-                return _sqlExpressionFactory.Function(
-                    "rtrim",
-                    new SqlExpression[]
-                    {
-                        _sqlExpressionFactory.Function(
-                            "rtrim",
+                        return SqliteExpression.DateTime(
+                            _sqlExpressionFactory,
+                            returnType,
+                            _sqlExpressionFactory.Constant("now"),
                             new SqlExpression[]
                             {
-                                SqliteExpression.Strftime(
-                                    _sqlExpressionFactory,
-                                    returnType,
-                                    format,
-                                    timestring,
-                                    modifiers),
-                                _sqlExpressionFactory.Constant("0")
-                            },
-                            nullable: true,
-                            argumentsPropagateNullability: new[] { true, false },
-                            returnType),
-                        _sqlExpressionFactory.Constant(".")
-                    },
-                    nullable: true,
-                    argumentsPropagateNullability: new[] { true, false },
-                    returnType);
+                                _sqlExpressionFactory.Constant("localtime"),
+                                _sqlExpressionFactory.Constant("start of day")
+                            });
+
+                    case nameof(DateTime.TimeOfDay):
+                        return SqliteExpression.Time(
+                            _sqlExpressionFactory,
+                            returnType,
+                            instance);
+                }
             }
 
             return null;

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
@@ -16,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             AddTranslators(
                 new IMemberTranslator[]
                 {
-                    new SqliteDateTimeMemberTranslator(sqlExpressionFactory), new SqliteStringLengthTranslator(sqlExpressionFactory)
+                    new SqliteDateTimeMemberTranslator(sqlExpressionFactory),
+                    new SqliteStringLengthTranslator(sqlExpressionFactory),
+                    new SqliteTimeSpanMemberTranslator(sqlExpressionFactory)
                 });
         }
     }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMethodCallTranslatorProvider.cs
@@ -19,7 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                     new SqliteByteArrayMethodTranslator(sqlExpressionFactory),
                     new SqliteDateTimeAddTranslator(sqlExpressionFactory),
                     new SqliteMathTranslator(sqlExpressionFactory),
-                    new SqliteStringMethodTranslator(sqlExpressionFactory)
+                    new SqliteStringMethodTranslator(sqlExpressionFactory),
+                    new SqliteTimeSpanMethodTranslator(sqlExpressionFactory)
                 });
         }
     }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -110,6 +110,25 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                     : null;
             }
 
+            if (unaryExpression.NodeType == ExpressionType.Negate
+                && unaryExpression.Operand.Type == typeof(TimeSpan))
+            {
+                return Visit(unaryExpression.Operand) is SqlExpression sqlExpression
+                    ? SqlExpressionFactory.Function(
+                        "ef_timespan",
+                        new[]
+                        {
+                            SqlExpressionFactory.Negate(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlExpression))
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        unaryExpression.Type)
+                    : null;
+            }
+
             var visitedExpression = base.VisitUnary(unaryExpression);
             if (visitedExpression == null)
             {
@@ -133,6 +152,272 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
             Check.NotNull(binaryExpression, nameof(binaryExpression));
+
+            if (binaryExpression.NodeType == ExpressionType.Add)
+            {
+                if (binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    if (binaryExpression.Left.Type == typeof(TimeSpan))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Add(
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlRight))
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                binaryExpression.Type)
+                            : null;
+                    }
+                    else if (binaryExpression.Left.Type == typeof(DateTime))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqliteExpression.DateTime(
+                                SqlExpressionFactory,
+                                binaryExpression.Type,
+                                SqlExpressionFactory.Add(
+                                    SqliteExpression.JulianDay(
+                                        SqlExpressionFactory,
+                                        sqlLeft),
+                                    SqliteExpression.Days(
+                                        SqlExpressionFactory,
+                                        sqlRight)))
+                            : null;
+                    }
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.Divide)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan))
+                {
+                    if (binaryExpression.Right.Type == typeof(double))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Divide(
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        sqlRight)
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                binaryExpression.Type)
+                            : null;
+                    }
+                    else if (binaryExpression.Right.Type == typeof(TimeSpan))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Divide(
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlRight))
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                binaryExpression.Type)
+                            : null;
+                    }
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.GreaterThan)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.GreaterThan(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlLeft),
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlRight))
+                            : null;
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.GreaterThanOrEqual)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.GreaterThanOrEqual(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlLeft),
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlRight))
+                            : null;
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.LessThan)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.LessThan(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlLeft),
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlRight))
+                            : null;
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.LessThanOrEqual)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.LessThanOrEqual(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlLeft),
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlRight))
+                            : null;
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.Multiply)
+            {
+                if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(double))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Multiply(
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        sqlRight)
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(TimeSpan))
+                            : null;
+                }
+                else if (binaryExpression.Left.Type == typeof(double)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Multiply(
+                                        sqlLeft,
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlRight))
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(TimeSpan))
+                            : null;
+                }
+            }
+            else if (binaryExpression.NodeType == ExpressionType.Subtract)
+            {
+                if (binaryExpression.Left.Type == typeof(DateTime))
+                {
+                    if (binaryExpression.Right.Type == typeof(DateTime))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Subtract(
+                                        SqliteExpression.JulianDay(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        SqliteExpression.JulianDay(
+                                            SqlExpressionFactory,
+                                            sqlRight))
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(TimeSpan))
+                            : null;
+                    }
+                    else if (binaryExpression.Right.Type == typeof(TimeSpan))
+                    {
+                        return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqliteExpression.DateTime(
+                                SqlExpressionFactory,
+                                typeof(DateTime),
+                                SqlExpressionFactory.Subtract(
+                                    SqliteExpression.JulianDay(
+                                        SqlExpressionFactory,
+                                        sqlLeft),
+                                    SqliteExpression.Days(
+                                        SqlExpressionFactory,
+                                        sqlRight)))
+                            : null;
+                    }
+                }
+                else if (binaryExpression.Left.Type == typeof(TimeSpan)
+                    && binaryExpression.Right.Type == typeof(TimeSpan))
+                {
+                    return Visit(binaryExpression.Left) is SqlExpression sqlLeft
+                                && Visit(binaryExpression.Right) is SqlExpression sqlRight
+                            ? SqlExpressionFactory.Function(
+                                "ef_timespan",
+                                new[]
+                                {
+                                    SqlExpressionFactory.Subtract(
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlLeft),
+                                        SqliteExpression.Days(
+                                            SqlExpressionFactory,
+                                            sqlRight))
+                                },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(TimeSpan))
+                            : null;
+                }
+            }
 
             var visitedExpression = (SqlExpression)base.VisitBinary(binaryExpression);
 
@@ -184,6 +469,24 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         {
             Check.NotNull(expression, nameof(expression));
 
+            if (expression.Type == typeof(TimeSpan))
+            {
+                return Translate(expression) is SqlExpression sqlExpression
+                    ? SqlExpressionFactory.Function(
+                        "ef_timespan",
+                        new[]
+                        {
+                            base.TranslateMax(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlExpression))
+                        },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                        typeof(TimeSpan))
+                    : null;
+            }
+
             var visitedExpression = base.TranslateMax(expression);
             var argumentType = GetProviderType(visitedExpression);
             if (argumentType == typeof(DateTimeOffset)
@@ -200,6 +503,24 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         public override SqlExpression TranslateMin(Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
+
+            if (expression.Type == typeof(TimeSpan))
+            {
+                return Translate(expression) is SqlExpression sqlExpression
+                    ? SqlExpressionFactory.Function(
+                        "ef_timespan",
+                        new[]
+                        {
+                            base.TranslateMin(
+                                SqliteExpression.Days(
+                                    SqlExpressionFactory,
+                                    sqlExpression))
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(TimeSpan))
+                    : null;
+            }
 
             var visitedExpression = base.TranslateMin(expression);
             var argumentType = GetProviderType(visitedExpression);

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteTimeSpanMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteTimeSpanMemberTranslator.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
+{
+    public class SqliteTimeSpanMemberTranslator : IMemberTranslator
+    {
+        private const int HoursPerDay = 24;
+        private const int MinutesPerDay = 60 * HoursPerDay;
+        private const int SecondsPerDay = 60 * MinutesPerDay;
+        private const int MillisecondsPerDay = 1000 * SecondsPerDay;
+        private const double DaysPerHour = 1.0 / HoursPerDay;
+        private const double DaysPerMinute = 1.0 / MinutesPerDay;
+        private const double DaysPerSecond = 1.0 / SecondsPerDay;
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        public SqliteTimeSpanMemberTranslator([NotNull] ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        public virtual SqlExpression Translate(SqlExpression instance, MemberInfo member, Type returnType)
+        {
+            Check.NotNull(member, nameof(member));
+            Check.NotNull(returnType, nameof(returnType));
+
+            if (member.DeclaringType != typeof(TimeSpan))
+                return null;
+
+            switch (member.Name)
+            {
+                case nameof(TimeSpan.Days):
+                    return _sqlExpressionFactory.Convert(
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            instance),
+                        typeof(int));
+
+                case nameof(TimeSpan.Hours):
+                    return _sqlExpressionFactory.Multiply(
+                        _sqlExpressionFactory.Function(
+                            "ef_mod",
+                            new[]
+                            {
+                                SqliteExpression.Days(
+                                    _sqlExpressionFactory,
+                                    instance),
+                                _sqlExpressionFactory.Constant(1.0)
+                            },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(double)),
+                        _sqlExpressionFactory.Constant(HoursPerDay));
+
+                case nameof(TimeSpan.Minutes):
+                    return _sqlExpressionFactory.Multiply(
+                        _sqlExpressionFactory.Function(
+                            "ef_mod",
+                            new[]
+                            {
+                                SqliteExpression.Days(
+                                    _sqlExpressionFactory,
+                                    instance),
+                                _sqlExpressionFactory.Constant(DaysPerHour)
+                            },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(double)),
+                        _sqlExpressionFactory.Constant(MinutesPerDay));
+
+                case nameof(TimeSpan.Seconds):
+                    // TODO: Round in more places. Cast to INTEGER
+                    return _sqlExpressionFactory.Function(
+                            "round",
+                            new SqlExpression[]
+                            {
+                                _sqlExpressionFactory.Multiply(
+                                    _sqlExpressionFactory.Function(
+                                        "ef_mod",
+                                        new[]
+                                        {
+                                            SqliteExpression.Days(
+                                                _sqlExpressionFactory,
+                                                instance),
+                                            _sqlExpressionFactory.Constant(DaysPerMinute)
+                                        },
+                                        nullable: true,
+                                        argumentsPropagateNullability: new[] { true, true },
+                                        typeof(double)),
+                                    _sqlExpressionFactory.Constant(SecondsPerDay)),
+                                _sqlExpressionFactory.Constant(3)
+                            },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(double));
+
+                case nameof(TimeSpan.Milliseconds):
+                    return _sqlExpressionFactory.Multiply(
+                        _sqlExpressionFactory.Function(
+                            "ef_mod",
+                            new[]
+                            {
+                                SqliteExpression.Days(
+                                    _sqlExpressionFactory,
+                                    instance),
+                                _sqlExpressionFactory.Constant(DaysPerSecond)
+                            },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true, true },
+                            typeof(double)),
+                        _sqlExpressionFactory.Constant(MillisecondsPerDay));
+
+                case nameof(TimeSpan.Ticks):
+                    return _sqlExpressionFactory.Convert(
+                        _sqlExpressionFactory.Multiply(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            _sqlExpressionFactory.Constant(TimeSpan.TicksPerDay)),
+                        typeof(long));
+
+                case nameof(TimeSpan.TotalDays):
+                    return SqliteExpression.Days(
+                        _sqlExpressionFactory,
+                        instance);
+
+                case nameof(TimeSpan.TotalHours):
+                    return _sqlExpressionFactory.Multiply(
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            instance),
+                        _sqlExpressionFactory.Constant(HoursPerDay));
+
+                case nameof(TimeSpan.TotalMinutes):
+                    return _sqlExpressionFactory.Multiply(
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            instance),
+                        _sqlExpressionFactory.Constant(MinutesPerDay));
+
+                case nameof(TimeSpan.TotalSeconds):
+                    return _sqlExpressionFactory.Multiply(
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            instance),
+                        _sqlExpressionFactory.Constant(SecondsPerDay));
+
+                case nameof(TimeSpan.TotalMilliseconds):
+                    return _sqlExpressionFactory.Multiply(
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            instance),
+                        _sqlExpressionFactory.Constant(MillisecondsPerDay));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteTimeSpanMethodTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteTimeSpanMethodTranslator.cs
@@ -1,0 +1,328 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
+{
+    public class SqliteTimeSpanMethodTranslator : IMethodCallTranslator
+    {
+        private const double HoursPerDay = 24;
+        private const double MinutesPerDay = 60 * HoursPerDay;
+        private const double SecondsPerDay = 60 * MinutesPerDay;
+        private const double MillisecondsPerDay = 1000 * SecondsPerDay;
+        private const double TicksPerDay = TimeSpan.TicksPerDay;
+
+        private static readonly MethodInfo _add = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Add), new[] { typeof(TimeSpan) });
+
+        private static readonly MethodInfo _divideDouble = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Divide), new[] { typeof(double) });
+
+        private static readonly MethodInfo _divideTimeSpan = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Divide), new[] { typeof(TimeSpan) });
+
+        private static readonly MethodInfo _duration = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Duration), Type.EmptyTypes);
+
+        private static readonly MethodInfo _fromDays = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromDays), new[] { typeof(double) });
+
+        private static readonly MethodInfo _fromHours = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromHours), new[] { typeof(double) });
+
+        private static readonly MethodInfo _fromMilliseconds = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromMilliseconds), new[] { typeof(double) });
+
+        private static readonly MethodInfo _fromMinutes = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromMinutes), new[] { typeof(double) });
+
+        private static readonly MethodInfo _fromSeconds = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromSeconds), new[] { typeof(double) });
+
+        private static readonly MethodInfo _fromTicks = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.FromTicks), new[] { typeof(long) });
+
+        private static readonly MethodInfo _multiply = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Multiply), new[] { typeof(double) });
+
+        private static readonly MethodInfo _negate = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Negate), Type.EmptyTypes);
+
+        private static readonly MethodInfo _subtract = typeof(TimeSpan)
+            .GetRuntimeMethod(nameof(TimeSpan.Subtract), new[] { typeof(TimeSpan) });
+
+        private static readonly MethodInfo _dateTimeAdd = typeof(DateTime)
+            .GetRuntimeMethod(nameof(DateTime.Add), new[] { typeof(TimeSpan) });
+
+        private static readonly MethodInfo _dateTimeSubtractDateTime = typeof(DateTime)
+            .GetRuntimeMethod(nameof(DateTime.Subtract), new[] { typeof(DateTime) });
+
+        private static readonly MethodInfo _dateTimeSubtractTimeSpan = typeof(DateTime)
+            .GetRuntimeMethod(nameof(DateTime.Subtract), new[] { typeof(TimeSpan) });
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        public SqliteTimeSpanMethodTranslator([NotNull] ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        public virtual SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (Equals(method, _add))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Add(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                arguments[0]))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _divideDouble))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            arguments[0])
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _divideTimeSpan))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                arguments[0]))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _duration))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Function(
+                            "abs",
+                            new[]
+                            {
+                                SqliteExpression.Days(
+                                    _sqlExpressionFactory,
+                                    instance)
+                            },
+                            nullable: true,
+                            argumentsPropagateNullability: new[] { true },
+                            typeof(double))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromDays))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[] { arguments[0] },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromHours))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            arguments[0],
+                            _sqlExpressionFactory.Constant(HoursPerDay))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromMilliseconds))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            arguments[0],
+                            _sqlExpressionFactory.Constant(MillisecondsPerDay))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromMinutes))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            arguments[0],
+                            _sqlExpressionFactory.Constant(MinutesPerDay))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromSeconds))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            arguments[0],
+                            _sqlExpressionFactory.Constant(SecondsPerDay))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _fromTicks))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Divide(
+                            arguments[0],
+                            _sqlExpressionFactory.Constant(TicksPerDay))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _multiply))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Multiply(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            arguments[0])
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _negate))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Negate(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _subtract))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Subtract(
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                instance),
+                            SqliteExpression.Days(
+                                _sqlExpressionFactory,
+                                arguments[0]))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _dateTimeAdd))
+            {
+                return SqliteExpression.DateTime(
+                    _sqlExpressionFactory,
+                    typeof(DateTime),
+                    _sqlExpressionFactory.Add(
+                        SqliteExpression.JulianDay(
+                            _sqlExpressionFactory,
+                            instance),
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            arguments[0])));
+            }
+            else if (Equals(method, _dateTimeSubtractDateTime))
+            {
+                return _sqlExpressionFactory.Function(
+                    "ef_timespan",
+                    new[]
+                    {
+                        _sqlExpressionFactory.Subtract(
+                            SqliteExpression.JulianDay(
+                                _sqlExpressionFactory,
+                                instance),
+                            SqliteExpression.JulianDay(
+                                _sqlExpressionFactory,
+                                arguments[0]))
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(TimeSpan));
+            }
+            else if (Equals(method, _dateTimeSubtractTimeSpan))
+            {
+                return SqliteExpression.DateTime(
+                    _sqlExpressionFactory,
+                    typeof(DateTime),
+                    _sqlExpressionFactory.Subtract(
+                        SqliteExpression.JulianDay(
+                            _sqlExpressionFactory,
+                            instance),
+                        SqliteExpression.Days(
+                            _sqlExpressionFactory,
+                            arguments[0])));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -113,6 +113,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
                     sqliteConnection.DefaultTimeout = _commandTimeout.Value;
                 }
 
+                sqliteConnection.CreateFunction(
+                    "ef_days",
+                    (TimeSpan? value) => value?.TotalDays,
+                    isDeterministic: true);
+
                 sqliteConnection.CreateFunction<object, object, object>(
                     "ef_mod",
                     (dividend, divisor) =>
@@ -129,7 +134,16 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 
                         return Convert.ToDouble(dividend, CultureInfo.InvariantCulture) %
                             Convert.ToDouble(divisor, CultureInfo.InvariantCulture);
-                    });
+                    },
+                    isDeterministic: true);
+
+                sqliteConnection.CreateFunction(
+                    "ef_timespan",
+                    (double? value) => value.HasValue
+                        // TODO: Round to the nearest millisecond
+                        ? TimeSpan.FromDays(value.Value)
+                        : default(TimeSpan?),
+                    isDeterministic: true);
             }
             else
             {

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7324,6 +7324,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeSpan_Days(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>()
+                    .Where(m => m.Duration.Days == 1));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_TimeSpan_Hours(bool async)
         {
             return AssertQuery(
@@ -7361,6 +7371,53 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Mission>()
                     .Where(m => m.Duration.Milliseconds == 1));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeSpan_Ticks(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>()
+                    .Where(m => m.Duration.Ticks == 1));
+        }
+
+        // TODO
+        // TimeSpan_TotalDays
+        // TimeSpan_TotalHours
+        // TimeSpan_TotalMilliseconds
+        // TimeSpan_TotalMinutes
+        // TimeSpan_TotalSeconds
+        // TimeSpan_Add
+        // TimeSpan_Divide_double
+        // TimeSpan_Divide_TimeSpan
+        // TimeSpan_Duration
+        // TimeSpan_FromDays
+        // TimeSpan_FromHours
+        // TimeSpan_FromMilliseconds
+        // TimeSpan_FromMinutes
+        // TimeSpan_FromSeconds
+        // TimeSpan_FromTicks
+        // TimeSpan_Multiply
+        // TimeSpan_Negate
+        // TimeSpan_op_Addition
+        // TimeSpan_op_Division_double
+        // TimeSpan_op_GreaterThan
+        // TimeSpan_op_GreaterThanOrEqual
+        // TimeSpan_op_LessThan
+        // TimeSpan_op_LessThanOrEqual
+        // TimeSpan_op_Multiply_double_right
+        // TimeSpan_op_Multiply_double_left
+        // TimeSpan_op_Subtraction
+        // TimeSpan_op_UnaryNegation
+        // Max_TimeSpan
+        // Min_TimeSpan
+        // DateTime_Add
+        // DateTime_op_Addition
+        // DateTime_op_Subtraction_DateTime
+        // DateTime_op_Subtraction_TimeSpan
+        // DateTime_Subtract_DateTime
+        // DateTime_Subtract_TimeSpan
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -120,6 +120,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                     CodeName = "Lightmass Offensive",
                     Rating = 2.1,
                     Timeline = new DateTimeOffset(599898024001234567, new TimeSpan(1, 30, 0)),
+                    //TimelineUtc = new DateTime(599897970001234567),
                     Duration = new TimeSpan(1, 2, 3)
                 },
                 new Mission
@@ -128,6 +129,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                     CodeName = "Hollow Storm",
                     Rating = 4.2,
                     Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)),
+                    //TimelineUtc = new DateTime(2, 3, 1, 13, 0, 0),
                     Duration = new TimeSpan(0, 1, 2, 3, 456)
                 },
                 new Mission

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public string CodeName { get; set; }
         public double? Rating { get; set; }
         public DateTimeOffset Timeline { get; set; }
+        //public DateTime TimelineUtc { get; set; }
         public TimeSpan Duration { get; set; }
 
         public virtual ICollection<SquadMission> ParticipatingSquads { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7191,7 +7191,7 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
 
         public override async Task Bitwise_operation_with_null_arguments(bool async)
         {
-            await  base.Bitwise_operation_with_null_arguments(async);
+            await base.Bitwise_operation_with_null_arguments(async);
 
             AssertSql(
                 @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
@@ -7471,7 +7471,7 @@ END
 FROM [Weapons] AS [w]
 GROUP BY [w].[SynergyWithId]");
         }
-        
+
         public override async Task Checked_context_with_cast_does_not_fail(bool isAsync)
         {
             await base.Checked_context_with_cast_does_not_fail(isAsync);
@@ -7528,6 +7528,9 @@ FROM [Missions] AS [m]");
 FROM [Missions] AS [m]");
         }
 
+        public override Task Where_TimeSpan_Days(bool async)
+            => Task.CompletedTask; // No translation
+
         public override async Task Where_TimeSpan_Hours(bool async)
         {
             await base.Where_TimeSpan_Hours(async);
@@ -7567,6 +7570,9 @@ WHERE DATEPART(second, [m].[Duration]) = 1");
 FROM [Missions] AS [m]
 WHERE DATEPART(millisecond, [m].[Duration]) = 1");
         }
+
+        public override Task Where_TimeSpan_Ticks(bool async)
+            => Task.CompletedTask; // No translation
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -148,29 +148,66 @@ FROM ""Squads"" AS ""s""
 WHERE ""s"".""Banner5"" = @__byteArrayParam_0");
         }
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task TimeSpan_Hours(bool async) => base.TimeSpan_Hours(async);
+        public override async Task TimeSpan_Hours(bool async)
+        {
+            await base.TimeSpan_Hours(async);
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task TimeSpan_Minutes(bool async) => base.TimeSpan_Minutes(async);
+            AssertSql(
+                @"SELECT ef_mod(ef_days(""m"".""Duration""), 1.0) * 24.0
+FROM ""Missions"" AS ""m""");
+        }
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task TimeSpan_Seconds(bool async) => base.TimeSpan_Seconds(async);
+        public override async Task TimeSpan_Minutes(bool async)
+        {
+            await base.TimeSpan_Minutes(async);
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task TimeSpan_Milliseconds(bool async) => base.TimeSpan_Milliseconds(async);
+            AssertSql(
+                @"SELECT ef_mod(ef_days(""m"".""Duration""), 0.041666666666666664) * 1440.0
+FROM ""Missions"" AS ""m""");
+        }
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task Where_TimeSpan_Hours(bool async) => base.Where_TimeSpan_Hours(async);
+        public override async Task TimeSpan_Seconds(bool async)
+        {
+            await base.TimeSpan_Seconds(async);
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task Where_TimeSpan_Minutes(bool async) => base.Where_TimeSpan_Minutes(async);
+            AssertSql(
+                @"SELECT round(ef_mod(ef_days(""m"".""Duration""), 0.00069444444444444447) * 86400.0, 3)
+FROM ""Missions"" AS ""m""");
+        }
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task Where_TimeSpan_Seconds(bool async) => base.Where_TimeSpan_Seconds(async);
+        public override async Task TimeSpan_Milliseconds(bool async)
+        {
+            await base.TimeSpan_Milliseconds(async);
 
-        [ConditionalTheory(Skip = "PR #19774")]
-        public override Task Where_TimeSpan_Milliseconds(bool async) => base.Where_TimeSpan_Milliseconds(async);
+            AssertSql(
+                @"SELECT ef_mod(ef_days(""m"".""Duration""), 1.1574074074074073E-05) * 86400000.0
+FROM ""Missions"" AS ""m""");
+        }
+
+        public override async Task Where_TimeSpan_Days(bool async)
+        {
+            await base.Where_TimeSpan_Days(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(ef_days(""m"".""Duration"") AS INTEGER) = 1");
+        }
+
+        public override async Task Where_TimeSpan_Ticks(bool async)
+        {
+            await base.Where_TimeSpan_Ticks(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST((ef_days(""m"".""Duration"") * 864000000000.0) AS INTEGER) = 1");
+        }
+
+        // TODO
+        // JulianDay collapses strftime
+        // JulianDay collapses strftime from double without modifiers
+        // Days collapses timespan
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
We can enable these by registering two UDFs on the connection:

``` csharp
CreateFunction("ef_days", (TimeSpan value) => value.TotalDays);
CreateFunction("ef_timespan", (double value) => TimeSpan.FromDays(value));
```

The following translations are enabled.

.NET | SQL
--- | ---
timeSpan1 + timeSpan2 | ef_timespan(ef_days($timeSpan1) + ef_days($timeSpan2))
timeSpan1 - timeSpan2 | ef_timespan(ef_days($timeSpan1) - ef_days($timeSpan2))
timeSpan1 / timeSpan2 | ef_days($timeSpan1) / ef_days($timeSpan2)
timeSpan / d | ef_timespan(ef_days($timeSpan) / $d)
timeSpan1 > timeSpan2 | ef_days($timeSpan1) > ef_days($timeSpan2)
timeSpan1 >= timeSpan2 | ef_days($timeSpan1) >= ef_days($timeSpan2)
timeSpan1 < timeSpan2 | ef_days($timeSpan1) < ef_days($timeSpan2)
timeSpan1 <= timeSpan2 | ef_days($timeSpan1) <= ef_days($timeSpan2)
d * timeSpan | ef_timespan($d * ef_days($timeSpan))
timeSpan * d | ef_timespan(ef_days($timeSpan) * $d)
-timeSpan | ef_timespan(-ef_days($timeSpan))
dateTime + timeSpan | datetime(julianday($dateTime) + ef_days($timeSpan))
dateTime - timeSpan | datetime(julianday($dateTime) - ef_days($timeSpan))
dateTime1 - dateTime2 | ef_timespan(julianday($dateTime1) - julianday($dateTime2))
timeSpan.Days | CAST(ef_days($timeSpan) AS INTEGER)
timeSpan.Hours | ef_mod(ef_days($timeSpan), 1.0) * 24
timeSpan.Milliseconds | ef_mod(ef_days($timeSpan), 0.00001157) * 86400000
timeSpan.Minutes | ef_mod(ef_days($timeSpan), 0.04166667) * 1440
timeSpan.Seconds | ef_mod(ef_days($timeSpan), 0.00069444) * 86400
timeSpan.Ticks | CAST(ef_days($timeSpan) * 864000000000 AS INTEGER)
timeSpan.TotalDays | ef_days($timeSpan)
timeSpan.TotalHours | ef_days($timeSpan) * 24
timeSpan.TotalMilliseconds | ef_days(%timeSpan) * 86400000
timeSpan.TotalMinutes | ef_days($timeSpan) * 1440
timeSpan.TotalSeconds | ef_days($timeSpan) * 86400
timeSpan.Duration() | ef_timespan(abs(ef_days($timeSpan)))
timeSpan.FromDays(value) | ef_timespan($value)
TimeSpan.FromHours(value) | ef_timespan($value / 24)
TimeSpan.FromMilliseconds(value) | ef_timespan($value / 86400000)
TimeSpan.FromMinutes(value) | ef_timespan($value / 1440)
TimeSpan.FromSeconds(value) | ef_timespan($value / 86400)
TimeSpan.FromTicks(value) | ef_timespan($value / 864000000000)
Max(t => t.TimeSpan) | ef_timespan(max(ef_days(t.TimeSpan)))
Min(t => t.TimeSpan) | ef_timespan(min(ef_days(t.TimeSpan)))

**Notes:**
* Most .NET operators have equivalent methods that are translated too
* `datetime()` is actually be translated as `rtrim(rtrim(strftime('%Y-%m-%d %H:%M:%f'), '0'), '.')`
* `julianday(datetime(text, modifiers))` is reduced to `julianday(text, modifiers)`
* `julianday(datetime(real))` is reduced to `real`
* `ef_days(ef_timespan(real))` is reduced to `real`

Fixes #18844
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


