### PR TITLE
Sqlite: Support uninitialized EXPLAIN queries

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,10 +23,10 @@
     <NetTopologySuiteVersion>2.0.0</NetTopologySuiteVersion>
     <NetTopologySuiteIOSpatiaLiteVersion>2.0.0</NetTopologySuiteIOSpatiaLiteVersion>
     <NetTopologySuiteIOSqlServerBytesVersion>2.0.0</NetTopologySuiteIOSqlServerBytesVersion>
-    <SQLitePCLRawBundleESqlite3Version>2.0.2</SQLitePCLRawBundleESqlite3Version>
-    <SQLitePCLRawBundleESqlcipherVersion>2.0.2</SQLitePCLRawBundleESqlcipherVersion>
-    <SQLitePCLRawBundleWinsqlite3Version>2.0.2</SQLitePCLRawBundleWinsqlite3Version>
-    <SQLitePCLRawCoreVersion>2.0.2</SQLitePCLRawCoreVersion>
+    <SQLitePCLRawBundleESqlite3Version>2.0.3</SQLitePCLRawBundleESqlite3Version>
+    <SQLitePCLRawBundleESqlcipherVersion>2.0.3</SQLitePCLRawBundleESqlcipherVersion>
+    <SQLitePCLRawBundleWinsqlite3Version>2.0.3</SQLitePCLRawBundleWinsqlite3Version>
+    <SQLitePCLRawCoreVersion>2.0.3</SQLitePCLRawCoreVersion>
     <IdentityServer4EntityFrameworkVersion>3.0.0</IdentityServer4EntityFrameworkVersion>
     <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
     <BenchmarkDotNetVersion>0.12.0</BenchmarkDotNetVersion>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -342,7 +342,11 @@ namespace Microsoft.Data.Sqlite
                         }
                     }
 
-                    throw new InvalidOperationException(Resources.MissingParameters(string.Join(", ", unboundParams)));
+                    if (sqlite3_libversion_number() < 3028000 ||
+                        sqlite3_stmt_isexplain(stmt) == 0)
+                    {
+                        throw new InvalidOperationException(Resources.MissingParameters(string.Join(", ", unboundParams)));
+                    }
                 }
 
                 yield return stmt;

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -610,6 +610,30 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void ExecuteReader_works_on_EXPLAIN()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = " EXPLAIN SELECT 1 WHERE 1 = @a;";
+                connection.Open();
+
+                if (new Version(connection.ServerVersion) < new Version(3, 28, 0))
+                {
+                    command.Parameters.AddWithValue("@a", 1);
+                }
+
+                using (var reader = command.ExecuteReader())
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+                    Assert.Equal(8, reader.FieldCount);
+                    Assert.Equal("Init", reader.GetString(1));
+                }
+            }
+        }
+
+        [Fact]
         public void ExecuteReader_works()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))


### PR DESCRIPTION
We ignore now when paramters are not initialized in case a EXPLAIN query is used.

Fixes #16647
