### PR TITLE
Add Fluent API for skip navigations.

### DIFF
--- a/src/EFCore/Extensions/ConventionPropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/ConventionPropertyBaseExtensions.cs
@@ -57,10 +57,10 @@ namespace Microsoft.EntityFrameworkCore
                     propertyAccessMode, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
-        ///     Returns the configuration source for <see cref="PropertyBaseExtensions.GetPropertyAccessMode" />.
+        ///     Returns the configuration source for <see cref="IPropertyBase.GetPropertyAccessMode" />.
         /// </summary>
         /// <param name="property"> The property to find configuration source for. </param>
-        /// <returns> The configuration source for <see cref="PropertyBaseExtensions.GetPropertyAccessMode" />. </returns>
+        /// <returns> The configuration source for <see cref="IPropertyBase.GetPropertyAccessMode" />. </returns>
         public static ConfigurationSource? GetPropertyAccessModeConfigurationSource([NotNull] this IConventionPropertyBase property)
             => property.FindAnnotation(CoreAnnotationNames.PropertyAccessMode)?.GetConfigurationSource();
     }

--- a/src/EFCore/Extensions/PropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/PropertyBaseExtensions.cs
@@ -93,20 +93,5 @@ namespace Microsoft.EntityFrameworkCore
         public static bool IsIndexerProperty([NotNull] this IPropertyBase property)
             => Check.NotNull(property, nameof(property)).GetIdentifyingMemberInfo() is PropertyInfo propertyInfo
                 && propertyInfo == property.DeclaringType.FindIndexerPropertyInfo();
-
-        /// <summary>
-        ///     <para>
-        ///         Gets the <see cref="PropertyAccessMode" /> being used for this property.
-        ///         <c>null</c> indicates that the default property access mode is being used.
-        ///     </para>
-        /// </summary>
-        /// <param name="propertyBase"> The property for which to get the access mode. </param>
-        /// <returns> The access mode being used, or <c>null</c> if the default access mode is being used. </returns>
-        public static PropertyAccessMode GetPropertyAccessMode(
-            [NotNull] this IPropertyBase propertyBase)
-            => (PropertyAccessMode)(Check.NotNull(propertyBase, nameof(propertyBase))[CoreAnnotationNames.PropertyAccessMode]
-                ?? (propertyBase is INavigation
-                    ? propertyBase.DeclaringType.GetNavigationAccessMode()
-                    : propertyBase.DeclaringType.GetPropertyAccessMode()));
     }
 }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             {
                                 throw new InvalidOperationException(
                                     CoreStrings.AmbiguousOwnedNavigation(
-                                        entityType.ClrType.ShortDisplayName(), targetType.ShortDisplayName()));
+                                        entityType.DisplayName() + "." + actualProperty.Name, targetType.ShortDisplayName()));
                             }
 
                             throw new InvalidOperationException(
@@ -314,6 +314,32 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             throw new InvalidOperationException(
                                 CoreStrings.InheritedPropertyCannotBeIgnored(
                                     ignoredMember, entityType.DisplayName(), navigation.DeclaringEntityType.DisplayName()));
+                        }
+
+                        Check.DebugAssert(false, "Should never get here...");
+                    }
+
+                    var skipNavigation = entityType.FindSkipNavigation(ignoredMember);
+                    if (skipNavigation != null)
+                    {
+                        if (skipNavigation.DeclaringEntityType != entityType)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.InheritedPropertyCannotBeIgnored(
+                                    ignoredMember, entityType.DisplayName(), skipNavigation.DeclaringEntityType.DisplayName()));
+                        }
+
+                        Check.DebugAssert(false, "Should never get here...");
+                    }
+
+                    var serviceProperty = entityType.FindServiceProperty(ignoredMember);
+                    if (serviceProperty != null)
+                    {
+                        if (serviceProperty.DeclaringEntityType != entityType)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.InheritedPropertyCannotBeIgnored(
+                                    ignoredMember, entityType.DisplayName(), serviceProperty.DeclaringEntityType.DisplayName()));
                         }
 
                         Check.DebugAssert(false, "Should never get here...");

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -1,0 +1,164 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a one-to-many relationship.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class CollectionCollectionBuilder
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public CollectionCollectionBuilder(
+            [NotNull] IMutableEntityType leftEntityType,
+            [NotNull] IMutableEntityType rightEntityType,
+            [NotNull] IMutableSkipNavigation leftNavigation,
+            [NotNull] IMutableSkipNavigation rightNavigation)
+        {
+            Check.NotNull(leftEntityType, nameof(leftEntityType));
+            Check.NotNull(rightEntityType, nameof(rightEntityType));
+            Check.NotNull(leftNavigation, nameof(leftNavigation));
+            Check.NotNull(rightNavigation, nameof(rightNavigation));
+
+            Check.DebugAssert(((IConventionEntityType)leftEntityType).Builder != null, "Builder is null");
+            Check.DebugAssert(((IConventionEntityType)rightEntityType).Builder != null, "Builder is null");
+            Check.DebugAssert(((IConventionSkipNavigation)leftNavigation).Builder != null, "Builder is null");
+            Check.DebugAssert(((IConventionSkipNavigation)rightNavigation).Builder != null, "Builder is null");
+
+            LeftEntityType = leftEntityType;
+            RightEntityType = rightEntityType;
+            LeftNavigation = leftNavigation;
+            RightNavigation = rightNavigation;
+        }
+
+        /// <summary>
+        ///     One of the entity types involved in the relationship.
+        /// </summary>
+        protected virtual IMutableEntityType LeftEntityType { get; }
+
+        /// <summary>
+        ///     One of the entity types involved in the relationship.
+        /// </summary>
+        protected virtual IMutableEntityType RightEntityType { get; }
+
+        /// <summary>
+        ///     One of the navigations involved in the relationship.
+        /// </summary>
+        public virtual IMutableSkipNavigation LeftNavigation { get; private set; }
+
+        /// <summary>
+        ///     One of the navigations involved in the relationship.
+        /// </summary>
+        public virtual IMutableSkipNavigation RightNavigation { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        protected virtual InternalModelBuilder ModelBuilder => LeftEntityType.AsEntityType().Model.Builder;
+
+        /// <summary>
+        ///     Configures the relationships to the entity types participating in the many-to-many relationship.
+        /// </summary>
+        /// <param name="joinEntity"> The type of the join entity. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
+        /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <returns> The builder for the association type. </returns>
+        public virtual EntityTypeBuilder UsingEntity(
+            [NotNull] Type joinEntity,
+            [NotNull] Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureRight,
+            [NotNull] Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureLeft)
+        {
+            var entityTypeBuilder = new EntityTypeBuilder(
+                ModelBuilder.Entity(joinEntity, ConfigurationSource.Explicit).Metadata);
+
+            var leftForeignKey = configureLeft(entityTypeBuilder).Metadata;
+            var rightForeignKey = configureRight(entityTypeBuilder).Metadata;
+
+            Using(rightForeignKey, leftForeignKey);
+
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the relationships to the entity types participating in the many-to-many relationship.
+        /// </summary>
+        /// <param name="joinEntity"> The type of the join entity. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
+        /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureAssociation"> The configuration of the association type. </param>
+        /// <returns> The builder for the originating entity type so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder UsingEntity(
+            [NotNull] Type joinEntity,
+            [NotNull] Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureRight,
+            [NotNull] Func<EntityTypeBuilder, ReferenceCollectionBuilder> configureLeft,
+            [NotNull] Action<EntityTypeBuilder> configureAssociation)
+        {
+            var entityTypeBuilder = UsingEntity(joinEntity, configureRight, configureLeft);
+            configureAssociation(entityTypeBuilder);
+
+            return new EntityTypeBuilder(LeftEntityType);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        protected virtual void Using([NotNull] IMutableForeignKey rightForeignKey, [NotNull] IMutableForeignKey leftForeignKey)
+        {
+            var leftBuilder = ((SkipNavigation)LeftNavigation).Builder;
+            var rightBuilder = ((SkipNavigation)RightNavigation).Builder;
+
+            leftBuilder = leftBuilder.HasForeignKey((ForeignKey)leftForeignKey, ConfigurationSource.Explicit);
+            rightBuilder = rightBuilder.HasForeignKey((ForeignKey)rightForeignKey, ConfigurationSource.Explicit);
+
+            leftBuilder = leftBuilder.HasInverse(rightBuilder.Metadata, ConfigurationSource.Explicit);
+
+            LeftNavigation = leftBuilder.Metadata;
+            RightNavigation = leftBuilder.Metadata.Inverse;
+        }
+
+        #region Hidden System.Object members
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectEqualsIsObjectEquals
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
+    }
+}

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a many-to-many relationship.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TLeftEntity"> One of the entity types in this relationship. </typeparam>
+    /// <typeparam name="TRightEntity"> One of the entity types in this relationship. </typeparam>
+    public class CollectionCollectionBuilder<TLeftEntity, TRightEntity> : CollectionCollectionBuilder
+        where TLeftEntity : class
+        where TRightEntity : class
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public CollectionCollectionBuilder(
+            [NotNull] IMutableEntityType leftEntityType,
+            [NotNull] IMutableEntityType rightEntityType,
+            [NotNull] IMutableSkipNavigation leftNavigation,
+            [NotNull] IMutableSkipNavigation rightNavigation)
+            : base(leftEntityType, rightEntityType, leftNavigation, rightNavigation)
+        {
+        }
+
+        /// <summary>
+        ///     Configures the relationships to the entity types participating in the many-to-many relationship.
+        /// </summary>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
+        /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <typeparam name="TAssociationEntity"> The type of the association entity. </typeparam>
+        /// <returns> The builder for the association type. </returns>
+        public virtual EntityTypeBuilder<TAssociationEntity> UsingEntity<TAssociationEntity>(
+            [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
+            [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft)
+            where TAssociationEntity : class
+        {
+            var entityTypeBuilder = new EntityTypeBuilder<TAssociationEntity>(
+                ModelBuilder.Entity(typeof(TAssociationEntity), ConfigurationSource.Explicit).Metadata);
+
+            var leftForeignKey = configureLeft(entityTypeBuilder).Metadata;
+            var rightForeignKey = configureRight(entityTypeBuilder).Metadata;
+
+            Using(rightForeignKey, leftForeignKey);
+
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the relationships to the entity types participating in the many-to-many relationship.
+        /// </summary>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
+        /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureAssociation"> The configuration of the association type. </param>
+        /// <typeparam name="TAssociationEntity"> The type of the association entity. </typeparam>
+        /// <returns> The builder for the originating entity type so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+            [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
+            [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft,
+            [NotNull] Action<EntityTypeBuilder<TAssociationEntity>> configureAssociation)
+            where TAssociationEntity : class
+        {
+            var entityTypeBuilder = UsingEntity<TAssociationEntity>(configureRight, configureLeft);
+            configureAssociation(entityTypeBuilder);
+
+            return new EntityTypeBuilder<TLeftEntity>(LeftEntityType);
+        }
+    }
+}

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -584,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType).Metadata);
+                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>
@@ -627,7 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType).Metadata);
+                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>
@@ -684,26 +684,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = FindRelatedEntityType(relatedTypeName, navigationName);
-
-            InternalRelationshipBuilder relationship;
-            using (var batch = Builder.Metadata.Model.ConventionDispatcher.DelayConventions())
-            {
-                relationship = relatedEntityType.Builder
-                    .HasRelationship(Builder.Metadata, ConfigurationSource.Explicit)
-                    .IsUnique(false, ConfigurationSource.Explicit)
-                    .HasEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit).HasNavigation(
-                        navigationName,
-                        pointsToPrincipal: false,
-                        ConfigurationSource.Explicit);
-                relationship = batch.Run(relationship);
-            }
-
-            return new CollectionNavigationBuilder(
-                Builder.Metadata,
-                relatedEntityType,
-                navigationName,
-                relationship.Metadata);
+            return HasMany(navigationName, FindRelatedEntityType(relatedTypeName, navigationName));
         }
 
         /// <summary>
@@ -730,7 +711,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             if (Metadata.ClrType == null)
             {
-                return HasMany(navigationName, null);
+                return HasMany(navigationName, (string)null);
             }
 
             var memberType = Metadata.GetNavigationMemberInfo(navigationName).GetMemberType();
@@ -778,28 +759,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] string navigationName = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
-            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+            Check.NullButNotEmpty(navigationName, nameof(navigationName));;
 
-            var relatedEntityType = FindRelatedEntityType(relatedType, navigationName);
+            return HasMany(navigationName, FindRelatedEntityType(relatedType, navigationName));
+        }
 
-            InternalRelationshipBuilder relationship;
-            using (var batch = Builder.Metadata.Model.ConventionDispatcher.DelayConventions())
+        private CollectionNavigationBuilder HasMany(string navigationName, EntityType relatedEntityType)
+        {
+            var skipNavigation = navigationName != null ? Builder.Metadata.FindSkipNavigation(navigationName) : null;
+
+            InternalRelationshipBuilder relationship = null;
+            if (skipNavigation == null)
             {
-                relationship = relatedEntityType.Builder
-                    .HasRelationship(Builder.Metadata, ConfigurationSource.Explicit)
-                    .IsUnique(false, ConfigurationSource.Explicit)
-                    .HasEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit).HasNavigation(
-                        navigationName,
-                        pointsToPrincipal: false,
-                        ConfigurationSource.Explicit);
-                relationship = batch.Run(relationship);
+                relationship = Builder
+                    .HasRelationship(relatedEntityType, navigationName, ConfigurationSource.Explicit, targetIsPrincipal: false)
+                    .IsUnique(false, ConfigurationSource.Explicit);
             }
 
             return new CollectionNavigationBuilder(
                 Builder.Metadata,
                 relatedEntityType,
-                navigationName,
-                relationship.Metadata);
+                new MemberIdentity(navigationName),
+                relationship?.Metadata,
+                skipNavigation);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -479,7 +479,59 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="navigationName"> The name of the navigation. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> <c>true</c> if the configuration can be applied. </returns>
-        bool CanAddNavigation([NotNull] string navigationName, bool fromDataAnnotation = false);
+        [Obsolete("Use CanHaveNavigation")]
+        bool CanAddNavigation([NotNull] string navigationName, bool fromDataAnnotation = false)
+            => CanHaveNavigation(navigationName, fromDataAnnotation);
+
+        /// <summary>
+        ///     Returns a value indicating whether the given navigation can be added to this entity type.
+        /// </summary>
+        /// <param name="navigationName"> The name of the navigation. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the configuration can be applied. </returns>
+        bool CanHaveNavigation([NotNull] string navigationName, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a skip navigation between this and the target entity type.
+        /// </summary>
+        /// <param name="navigationToTarget"> The navigation property. </param>
+        /// <param name="targetEntityType"> The entity type that the navigation targets. </param>
+        /// <param name="collection"> Whether the navigation property is a collection property. </param>
+        /// <param name="onDependent">
+        ///     Whether the navigation property is defined on the dependent side of the underlying foreign key.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasSkipNavigation(
+            [NotNull] MemberInfo navigationToTarget,
+            [NotNull] IConventionEntityType targetEntityType,
+            bool collection = true,
+            bool onDependent = false,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a skip navigation between this and the target entity type.
+        /// </summary>
+        /// <param name="navigationName"> The navigation property name. </param>
+        /// <param name="targetEntityType"> The entity type that the navigation targets. </param>
+        /// <param name="collection"> Whether the navigation property is a collection property. </param>
+        /// <param name="onDependent">
+        ///     Whether the navigation property is defined on the dependent side of the underlying foreign key.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasSkipNavigation(
+            [NotNull] string navigationName,
+            [NotNull] IConventionEntityType targetEntityType,
+            bool collection = true,
+            bool onDependent = false,
+            bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
@@ -491,8 +543,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The same builder instance if the query filter was set,
         ///     <c>null</c> otherwise.
         /// </returns>
-        IConventionEntityTypeBuilder HasQueryFilter(
-            [CanBeNull] LambdaExpression filter, bool fromDataAnnotation = false);
+        IConventionEntityTypeBuilder HasQueryFilter([CanBeNull] LambdaExpression filter, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns a value indicating whether the given query filter can be set from the current configuration source.

--- a/src/EFCore/Metadata/Builders/IConventionRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionRelationshipBuilder.cs
@@ -317,7 +317,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
         /// <summary>
         ///     Returns a value indicating whether the backing field can be set for a navigation
-        ///     from the current configuration source.
+        ///     from the given configuration source.
         /// </summary>
         /// <param name="fieldName"> The field name. </param>
         /// <param name="pointsToPrincipal">
@@ -332,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
         /// <summary>
         ///     Returns a value indicating whether the backing field can be set for a navigation
-        ///     from the current configuration source.
+        ///     from the given configuration source.
         /// </summary>
         /// <param name="fieldInfo"> The field. </param>
         /// <param name="pointsToPrincipal">
@@ -344,6 +344,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] FieldInfo fieldInfo,
             bool pointsToPrincipal,
             bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the <see cref="PropertyAccessMode" /> to use for a navigation.
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for the navigation. </param>
+        /// <param name="pointsToPrincipal">
+        ///     A value indicating whether the navigation is on the dependent type pointing to the principal type.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionRelationshipBuilder UsePropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, bool pointsToPrincipal, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the <see cref="PropertyAccessMode" /> can be set for a navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for the navigation. </param>
+        /// <param name="pointsToPrincipal">
+        ///     A value indicating whether the navigation is on the dependent type pointing to the principal type.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the <see cref="PropertyAccessMode" /> can be set for this property. </returns>
+        bool CanSetPropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, bool pointsToPrincipal, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Configures whether this navigation should be eager loaded by default.

--- a/src/EFCore/Metadata/Builders/IConventionSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionSkipNavigationBuilder.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
+using JetBrains.Annotations;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
     /// <summary>
@@ -18,5 +21,113 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The navigation property being configured.
         /// </summary>
         new IConventionSkipNavigation Metadata { get; }
+
+        /// <summary>
+        ///     Sets the backing field to use for this navigation.
+        /// </summary>
+        /// <param name="fieldName"> The field name. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasField([CanBeNull] string fieldName, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the backing field to use for this navigation.
+        /// </summary>
+        /// <param name="fieldInfo"> The field. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasField([CanBeNull] FieldInfo fieldInfo, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the backing field can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="fieldName"> The field name. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the backing field can be set for this property. </returns>
+        bool CanSetField([CanBeNull] string fieldName, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the backing field can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="fieldInfo"> The field. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the backing field can be set for this property. </returns>
+        bool CanSetField([CanBeNull] FieldInfo fieldInfo, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the <see cref="PropertyAccessMode" /> to use for this navigation.
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for this navigation. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder UsePropertyAccessMode(PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the <see cref="PropertyAccessMode" /> can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for this navigation. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the <see cref="PropertyAccessMode" /> can be set for this property. </returns>
+        bool CanSetPropertyAccessMode(PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the foreign key.
+        /// </summary>
+        /// <param name="foreignKey">
+        ///     The foreign key. Passing <c>null</c> will result in there being no foreign key associated.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasForeignKey([CanBeNull] IConventionForeignKey foreignKey, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the <see cref="IConventionSkipNavigation.ForeignKey" /> can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="foreignKey">
+        ///     The foreign key. Passing <c>null</c> will result in there being no foreign key associated.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the <see cref="IConventionSkipNavigation.ForeignKey" /> can be set for this property. </returns>
+        bool CanSetForeignKey([CanBeNull] IConventionForeignKey foreignKey, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the inverse skip navigation.
+        /// </summary>
+        /// <param name="inverse">
+        ///     The inverse skip navigation. Passing <c>null</c> will result in there being no inverse navigation property defined.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionSkipNavigationBuilder HasInverse([CanBeNull] IConventionSkipNavigation inverse, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the <see cref="IConventionSkipNavigation.Inverse" /> can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="inverse">
+        ///     The inverse skip navigation. Passing <c>null</c> will result in there being no inverse navigation property defined.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the <see cref="IConventionSkipNavigation.Inverse" /> can be set for this property. </returns>
+        bool CanSetInverse([CanBeNull] IConventionSkipNavigation inverse, bool fromDataAnnotation = false);
     }
 }

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -597,7 +597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: DependentEntityType == relatedEntityType).Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>
@@ -672,7 +672,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: DependentEntityType == relatedEntityType).Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -534,7 +534,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: DependentEntityType == relatedEntityType).Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigation,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigation, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: DependentEntityType == relatedEntityType).Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null).Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && builder.Metadata.GetPrincipalToDependentConfigurationSource() == ConfigurationSource.Explicit
                 && collectionName != null)
             {
-                ThrowForConflictingNavigation(builder.Metadata, collectionName, false);
+                InternalRelationshipBuilder.ThrowForConflictingNavigation(builder.Metadata, collectionName, false);
             }
 
             builder = builder.IsUnique(false, ConfigurationSource.Explicit);
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey.GetPrincipalToDependentConfigurationSource() == ConfigurationSource.Explicit
                 && foreignKey.PrincipalToDependent.Name != collectionName)
             {
-                ThrowForConflictingNavigation(foreignKey, collectionName, false);
+                InternalRelationshipBuilder.ThrowForConflictingNavigation(foreignKey, collectionName, false);
             }
 
             return collection.MemberInfo == null || ReferenceMember == null
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && Builder.Metadata.GetPrincipalToDependentConfigurationSource() == ConfigurationSource.Explicit
                 && referenceName != null)
             {
-                ThrowForConflictingNavigation(Builder.Metadata, referenceName, false);
+                InternalRelationshipBuilder.ThrowForConflictingNavigation(Builder.Metadata, referenceName, false);
             }
 
             using var batch = Builder.Metadata.DeclaringEntityType.Model.ConventionDispatcher.DelayConventions();
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                         && foreignKey.GetPrincipalToDependentConfigurationSource() == ConfigurationSource.Explicit
                         && foreignKey.PrincipalToDependent.Name != referenceName)))
             {
-                ThrowForConflictingNavigation(foreignKey, referenceName, pointsToPrincipal);
+                InternalRelationshipBuilder.ThrowForConflictingNavigation(foreignKey, referenceName, pointsToPrincipal);
             }
 
             var referenceProperty = reference.MemberInfo;
@@ -295,20 +295,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             }
 
             return batch.Run(builder);
-        }
-
-        private static void ThrowForConflictingNavigation(ForeignKey foreignKey, string newInverseName, bool newToPrincipal)
-        {
-            throw new InvalidOperationException(
-                CoreStrings.ConflictingRelationshipNavigation(
-                    foreignKey.PrincipalEntityType.DisplayName(),
-                    newToPrincipal ? foreignKey.PrincipalToDependent?.Name : newInverseName,
-                    foreignKey.DeclaringEntityType.DisplayName(),
-                    newToPrincipal ? newInverseName : foreignKey.DependentToPrincipal?.Name,
-                    foreignKey.PrincipalEntityType.DisplayName(),
-                    foreignKey.PrincipalToDependent?.Name,
-                    foreignKey.DeclaringEntityType.DisplayName(),
-                    foreignKey.DependentToPrincipal?.Name));
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/InversePropertyAttributeConvention.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionEntityTypeBuilder entityTypeBuilder, MemberInfo navigationMemberInfo, Type targetClrType,
             InversePropertyAttribute attribute)
         {
-            if (!entityTypeBuilder.CanAddNavigation(
+            if (!entityTypeBuilder.CanHaveNavigation(
                 navigationMemberInfo.GetSimpleMemberName(), fromDataAnnotation: true))
             {
                 return;

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -1102,6 +1102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public int Compare(MemberInfo x, MemberInfo y) => StringComparer.Ordinal.Compare(x.Name, y.Name);
         }
 
+        [DebuggerDisplay("{DebuggerDisplay(),nq}")]
         private sealed class RelationshipCandidate
         {
             public RelationshipCandidate(
@@ -1117,6 +1118,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public IConventionEntityTypeBuilder TargetTypeBuilder { [DebuggerStepThrough] get; }
             public List<PropertyInfo> NavigationProperties { [DebuggerStepThrough] get; }
             public List<PropertyInfo> InverseProperties { [DebuggerStepThrough] get; }
+
+            private string DebuggerDisplay() =>
+                TargetTypeBuilder.Metadata.ToDebugString(MetadataDebugStringOptions.SingleLineDefault)
+                + ": ["
+                + string.Join(", ", NavigationProperties.Select(p => p.Name))
+                + "] - ["
+                + string.Join(", ", InverseProperties.Select(p => p.Name))
+                + "]";
         }
     }
 }

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -181,7 +181,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     </para>
         /// </param>
         /// <param name="targetEntityType"> The entity type that the skip navigation property will hold an instance(s) of.</param>
-        /// <param name="foreignKey"> The foreign key to the association type. </param>
         /// <param name="collection"> Whether the navigation property is a collection property. </param>
         /// <param name="onDependent">
         ///     Whether the navigation property is defined on the dependent side of the underlying foreign key.
@@ -192,7 +191,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             [NotNull] string name,
             [CanBeNull] MemberInfo memberInfo,
             [NotNull] IConventionEntityType targetEntityType,
-            [CanBeNull] IConventionForeignKey foreignKey,
             bool collection,
             bool onDependent,
             bool fromDataAnnotation = false);

--- a/src/EFCore/Metadata/IConventionNavigation.cs
+++ b/src/EFCore/Metadata/IConventionNavigation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Returns the configuration source for this navigation property.
         /// </summary>
         /// <returns> The configuration source. </returns>
-        ConfigurationSource IConventionNavigationBase.GetConfigurationSource()
+        ConfigurationSource IConventionPropertyBase.GetConfigurationSource()
             => (ConfigurationSource)(IsOnDependent
                 ? ForeignKey.GetDependentToPrincipalConfigurationSource()
                 : ForeignKey.GetPrincipalToDependentConfigurationSource());

--- a/src/EFCore/Metadata/IConventionNavigationBase.cs
+++ b/src/EFCore/Metadata/IConventionNavigationBase.cs
@@ -27,12 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IConventionEntityType TargetEntityType => (IConventionEntityType)((INavigationBase)this).TargetEntityType;
 
         /// <summary>
-        ///     Returns the configuration source for this navigation property.
-        /// </summary>
-        /// <returns> The configuration source. </returns>
-        ConfigurationSource GetConfigurationSource();
-
-        /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
         new IConventionNavigationBase Inverse => (IConventionNavigationBase)((INavigationBase)this).Inverse;

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -27,12 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IConventionEntityType DeclaringEntityType { get; }
 
         /// <summary>
-        ///     Returns the configuration source for this property.
-        /// </summary>
-        /// <returns> The configuration source. </returns>
-        ConfigurationSource GetConfigurationSource();
-
-        /// <summary>
         ///     Returns the configuration source for <see cref="IPropertyBase.ClrType" />.
         /// </summary>
         /// <returns> The configuration source for <see cref="IPropertyBase.ClrType" />. </returns>

--- a/src/EFCore/Metadata/IConventionPropertyBase.cs
+++ b/src/EFCore/Metadata/IConventionPropertyBase.cs
@@ -23,6 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IConventionTypeBase DeclaringType { get; }
 
         /// <summary>
+        ///     Returns the configuration source for this property.
+        /// </summary>
+        /// <returns> The configuration source. </returns>
+        ConfigurationSource GetConfigurationSource();
+
+        /// <summary>
         ///     <para>
         ///         Sets the <see cref="FieldInfo" /> for the underlying CLR field that this property should use.
         ///     </para>

--- a/src/EFCore/Metadata/IConventionServiceProperty.cs
+++ b/src/EFCore/Metadata/IConventionServiceProperty.cs
@@ -29,12 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IConventionEntityType DeclaringEntityType { get; }
 
         /// <summary>
-        ///     Returns the configuration source for this property.
-        /// </summary>
-        /// <returns> The configuration source. </returns>
-        ConfigurationSource GetConfigurationSource();
-
-        /// <summary>
         ///     Sets the <see cref="ServiceParameterBinding" /> for this property.
         /// </summary>
         /// <param name="parameterBinding"> The parameter binding. </param>

--- a/src/EFCore/Metadata/IConventionTypeBase.cs
+++ b/src/EFCore/Metadata/IConventionTypeBase.cs
@@ -50,6 +50,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets all the ignored members.
         /// </summary>
         /// <returns> The list of ignored member names. </returns>
-        IReadOnlyList<string> GetIgnoredMembers();
+        IEnumerable<string> GetIgnoredMembers();
     }
 }

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -139,7 +139,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     </para>
         /// </param>
         /// <param name="targetEntityType"> The entity type that the skip navigation property will hold an instance(s) of.</param>
-        /// <param name="foreignKey"> The foreign key to the association type. </param>
         /// <param name="collection"> Whether the navigation property is a collection property. </param>
         /// <param name="onDependent">
         ///     Whether the navigation property is defined on the dependent side of the underlying foreign key.
@@ -149,7 +148,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             [NotNull] string name,
             [CanBeNull] MemberInfo memberInfo,
             [NotNull] IMutableEntityType targetEntityType,
-            [CanBeNull] IMutableForeignKey foreignKey,
             bool collection,
             bool onDependent);
 

--- a/src/EFCore/Metadata/IMutableTypeBase.cs
+++ b/src/EFCore/Metadata/IMutableTypeBase.cs
@@ -46,6 +46,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets all the ignored members.
         /// </summary>
         /// <returns> The list of ignored member names. </returns>
-        IReadOnlyList<string> GetIgnoredMembers();
+        IEnumerable<string> GetIgnoredMembers();
     }
 }

--- a/src/EFCore/Metadata/INavigationBase.cs
+++ b/src/EFCore/Metadata/INavigationBase.cs
@@ -42,5 +42,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The accessor. </returns>
         IClrCollectionAccessor GetCollectionAccessor();
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for this property.
+        ///         <c>null</c> indicates that the default property access mode is being used.
+        ///     </para>
+        /// </summary>
+        /// <returns> The access mode being used, or <c>null</c> if the default access mode is being used. </returns>
+        PropertyAccessMode IPropertyBase.GetPropertyAccessMode()
+            => (PropertyAccessMode)(this[CoreAnnotationNames.PropertyAccessMode]
+                ?? DeclaringType.GetNavigationAccessMode());
     }
 }

--- a/src/EFCore/Metadata/IProperty.cs
+++ b/src/EFCore/Metadata/IProperty.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -35,5 +37,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     changes will not be applied to the database.
         /// </summary>
         bool IsConcurrencyToken { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for this property.
+        ///         <c>null</c> indicates that the default property access mode is being used.
+        ///     </para>
+        /// </summary>
+        /// <returns> The access mode being used, or <c>null</c> if the default access mode is being used. </returns>
+        PropertyAccessMode IPropertyBase.GetPropertyAccessMode()
+            => (PropertyAccessMode)(this[CoreAnnotationNames.PropertyAccessMode]
+                ?? DeclaringType.GetPropertyAccessMode());
     }
 }

--- a/src/EFCore/Metadata/IPropertyBase.cs
+++ b/src/EFCore/Metadata/IPropertyBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
@@ -38,5 +39,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     This may be <c>null</c> for shadow properties or if the backing field is not known.
         /// </summary>
         FieldInfo FieldInfo { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for this property.
+        ///         <c>null</c> indicates that the default property access mode is being used.
+        ///     </para>
+        /// </summary>
+        /// <returns> The access mode being used, or <c>null</c> if the default access mode is being used. </returns>
+        PropertyAccessMode GetPropertyAccessMode()
+            => (PropertyAccessMode)(this[CoreAnnotationNames.PropertyAccessMode]
+                ?? PropertyAccessMode.PreferField);
     }
 }

--- a/src/EFCore/Metadata/Internal/InternalAnnotatableBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalAnnotatableBuilder.cs
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void MergeAnnotationsFrom([NotNull] ConventionAnnotatable annotatable)
+        public virtual void MergeAnnotationsFrom([NotNull] IConventionAnnotatable annotatable)
             => MergeAnnotationsFrom(annotatable, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void MergeAnnotationsFrom(
-            [NotNull] ConventionAnnotatable annotatable,
+            [NotNull] IConventionAnnotatable annotatable,
             ConfigurationSource minimalConfigurationSource)
         {
             foreach (var annotation in annotatable.GetAnnotations())

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -419,15 +420,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             using (Metadata.ConventionDispatcher.DelayConventions())
             {
                 var entityTypeBuilder = entityType.Builder;
-                foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
-                {
-                    var removed = entityTypeBuilder.HasNoRelationship(foreignKey, configurationSource);
-                    Check.DebugAssert(removed != null, "removed is null");
-                }
-
                 foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
                 {
                     var removed = foreignKey.DeclaringEntityType.Builder.HasNoRelationship(foreignKey, configurationSource);
+                    Check.DebugAssert(removed != null, "removed is null");
+                }
+
+                foreach (var skipNavigation in entityType.GetDeclaredReferencingSkipNavigations().ToList())
+                {
+                    var removed = skipNavigation.DeclaringEntityType.Builder.HasNoSkipNavigation(skipNavigation, configurationSource);
                     Check.DebugAssert(removed != null, "removed is null");
                 }
 
@@ -515,7 +516,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionModel IConventionModelBuilder.Metadata => Metadata;
+        IConventionModel IConventionModelBuilder.Metadata
+        {
+            [DebuggerStepThrough] get => Metadata;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -523,6 +527,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionEntityTypeBuilder IConventionModelBuilder.Entity(string name, bool? shouldBeOwned, bool fromDataAnnotation)
             => Entity(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention, shouldBeOwned);
 
@@ -532,6 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionEntityTypeBuilder IConventionModelBuilder.Entity(Type type, bool? shouldBeOwned, bool fromDataAnnotation)
             => Entity(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention, shouldBeOwned);
 
@@ -541,6 +547,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionEntityTypeBuilder IConventionModelBuilder.Entity(
             string name, string definingNavigationName, IConventionEntityType definingEntityType, bool fromDataAnnotation)
             => Entity(
@@ -555,6 +562,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionEntityTypeBuilder IConventionModelBuilder.Entity(
             Type type, string definingNavigationName, IConventionEntityType definingEntityType, bool fromDataAnnotation)
             => Entity(
@@ -569,6 +577,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionOwnedEntityTypeBuilder IConventionModelBuilder.Owned(Type type, bool fromDataAnnotation)
             => Owned(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -578,6 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.IsIgnored(Type type, bool fromDataAnnotation)
             => IsIgnored(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -587,6 +597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.IsIgnored(string name, bool fromDataAnnotation)
             => IsIgnored(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -596,6 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionModelBuilder IConventionModelBuilder.Ignore(Type type, bool fromDataAnnotation)
             => Ignore(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -605,6 +617,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionModelBuilder IConventionModelBuilder.Ignore(string name, bool fromDataAnnotation)
             => Ignore(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -614,6 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionModelBuilder IConventionModelBuilder.HasNoEntityType(IConventionEntityType entityType, bool fromDataAnnotation)
             => HasNoEntityType(
                 (EntityType)entityType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -624,6 +638,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.CanIgnore(Type type, bool fromDataAnnotation)
             => CanIgnore(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -633,6 +648,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.CanIgnore(string name, bool fromDataAnnotation)
             => CanIgnore(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -642,6 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionModelBuilder IConventionModelBuilder.HasChangeTrackingStrategy(
             ChangeTrackingStrategy? changeTrackingStrategy, bool fromDataAnnotation)
             => UseChangeTrackingStrategy(
@@ -653,6 +670,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.CanSetChangeTrackingStrategy(ChangeTrackingStrategy? changeTrackingStrategy, bool fromDataAnnotation)
             => CanSetChangeTrackingStrategy(
                 changeTrackingStrategy, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -663,6 +681,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         IConventionModelBuilder IConventionModelBuilder.UsePropertyAccessMode(
             PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
             => UsePropertyAccessMode(
@@ -674,6 +693,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         bool IConventionModelBuilder.CanSetPropertyAccessMode(PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
             => CanSetPropertyAccessMode(
                 propertyAccessMode, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -171,29 +171,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
-        {
-            if (fieldName != null
-                && configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
-            {
-                var fieldInfo = PropertyBase.GetFieldInfo(
-                    fieldName, Metadata.DeclaringType, Metadata.Name,
-                    shouldThrow: false);
-                return fieldInfo != null
-                    && PropertyBase.IsCompatible(
-                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
-                        shouldThrow: false);
-            }
-
-            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public virtual InternalPropertyBuilder HasField([CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource())
@@ -204,6 +181,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                if (fieldName == null)
+                {
+                    return true;
+                }
+
+                var fieldInfo = PropertyBase.GetFieldInfo(
+                    fieldName, Metadata.DeclaringType, Metadata.Name,
+                    shouldThrow: false);
+                return fieldInfo != null
+                    && PropertyBase.IsCompatible(
+                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
+                        shouldThrow: false);
+            }
+
+            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
         }
 
         /// <summary>
@@ -248,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool CanSetPropertyAccessMode(
             PropertyAccessMode? propertyAccessMode, ConfigurationSource? configurationSource)
             => configurationSource.Overrides(Metadata.GetPropertyAccessModeConfigurationSource())
-                || Metadata.GetPropertyAccessMode() == propertyAccessMode;
+                || ((IProperty)Metadata).GetPropertyAccessMode() == propertyAccessMode;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -627,6 +631,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (oldValueGeneratedConfigurationSource.HasValue)
             {
                 newPropertyBuilder.ValueGenerated(Metadata.ValueGenerated, oldValueGeneratedConfigurationSource.Value);
+            }
+
+            var oldPropertyAccessModeConfigurationSource = Metadata.GetPropertyAccessModeConfigurationSource();
+            if (oldPropertyAccessModeConfigurationSource.HasValue)
+            {
+                newPropertyBuilder.UsePropertyAccessMode(
+                    ((IProperty)Metadata).GetPropertyAccessMode(), oldPropertyAccessModeConfigurationSource.Value);
             }
 
             var oldFieldInfoConfigurationSource = Metadata.GetFieldInfoConfigurationSource();

--- a/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -26,10 +27,410 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+        {
+            if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
+                || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                Metadata.SetField(fieldName, configurationSource);
+
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                if (fieldName == null)
+                {
+                    return true;
+                }
+
+                var fieldInfo = PropertyBase.GetFieldInfo(
+                    fieldName, Metadata.DeclaringType, Metadata.Name,
+                    shouldThrow: false);
+                return fieldInfo != null
+                    && PropertyBase.IsCompatible(
+                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
+                        shouldThrow: false);
+            }
+
+            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder HasField([CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource())
+                || Equals(Metadata.FieldInfo, fieldInfo))
+            {
+                Metadata.SetField(fieldInfo, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetField([CanBeNull] FieldInfo fieldInfo, ConfigurationSource? configurationSource)
+            => (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource())
+                    && (fieldInfo == null
+                        || PropertyBase.IsCompatible(
+                            fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
+                            shouldThrow: false)))
+                || Equals(Metadata.FieldInfo, fieldInfo);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder UsePropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, ConfigurationSource configurationSource)
+        {
+            if (CanSetPropertyAccessMode(propertyAccessMode, configurationSource))
+            {
+                Metadata.SetPropertyAccessMode(propertyAccessMode, configurationSource);
+
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetPropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, ConfigurationSource? configurationSource)
+            => configurationSource.Overrides(Metadata.GetPropertyAccessModeConfigurationSource())
+                || ((ISkipNavigation)Metadata).GetPropertyAccessMode() == propertyAccessMode;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder HasForeignKey([CanBeNull] ForeignKey foreignKey, ConfigurationSource configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetForeignKeyConfigurationSource())
+                || Equals(Metadata.ForeignKey, foreignKey))
+            {
+                if (foreignKey != null)
+                {
+                    foreignKey.UpdateConfigurationSource(configurationSource);
+                }
+
+                Metadata.SetForeignKey(foreignKey, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetForeignKey([CanBeNull] ForeignKey foreignKey, ConfigurationSource? configurationSource)
+        {
+            if (!configurationSource.Overrides(Metadata.GetForeignKeyConfigurationSource()))
+            {
+                return Equals(Metadata.ForeignKey, foreignKey);
+            }
+
+            if (foreignKey == null)
+            {
+                return true;
+            }
+
+            return (Metadata.DeclaringEntityType
+                    == (Metadata.IsOnDependent ? foreignKey.DeclaringEntityType : foreignKey.PrincipalEntityType))
+                            && (Metadata.Inverse?.AssociationEntityType == null
+                                || Metadata.Inverse.AssociationEntityType
+                                == (Metadata.IsOnDependent ? foreignKey.PrincipalEntityType : foreignKey.DeclaringEntityType));
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder HasInverse(
+            [CanBeNull] SkipNavigation inverse, ConfigurationSource configurationSource)
+        {
+            if (!Equals(Metadata.Inverse, inverse)
+                && (!configurationSource.Overrides(Metadata.GetInverseConfigurationSource())
+                    || inverse != null
+                        && !configurationSource.Overrides(inverse.GetInverseConfigurationSource())))
+            {
+                return null;
+            }
+
+            if (inverse != null)
+            {
+                inverse.UpdateConfigurationSource(configurationSource);
+            }
+
+            if (Metadata.Inverse != null
+                && Metadata.Inverse != inverse)
+            {
+                Metadata.Inverse.SetInverse(null, configurationSource);
+            }
+
+            Metadata.SetInverse(inverse, configurationSource);
+
+            if (inverse != null)
+            {
+                inverse.SetInverse(Metadata, configurationSource);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetInverse(
+            [CanBeNull] SkipNavigation inverse, ConfigurationSource? configurationSource)
+        {
+            if (!configurationSource.Overrides(Metadata.GetInverseConfigurationSource())
+                || (inverse != null
+                    && !configurationSource.Overrides(inverse.GetInverseConfigurationSource())))
+            {
+                return Equals(Metadata.Inverse, inverse);
+            }
+
+            if (inverse == null)
+            {
+                return true;
+            }
+
+            return Metadata.TargetEntityType == inverse.DeclaringEntityType
+                    && Metadata.DeclaringEntityType == inverse.TargetEntityType
+                    && (Metadata.AssociationEntityType == null
+                        || inverse.AssociationEntityType == null
+                        || Metadata.AssociationEntityType == inverse.AssociationEntityType);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalSkipNavigationBuilder Attach(
+            [CanBeNull] InternalEntityTypeBuilder entityTypeBuilder = null,
+            [CanBeNull] EntityType targetEntityType = null,
+            [CanBeNull] InternalSkipNavigationBuilder inverseBuilder = null)
+        {
+            entityTypeBuilder ??= Metadata.DeclaringEntityType.Builder;
+            if (entityTypeBuilder == null)
+            {
+                entityTypeBuilder = Metadata.DeclaringEntityType.Model.FindEntityType(Metadata.DeclaringEntityType.Name)?.Builder;
+                if (entityTypeBuilder == null)
+                {
+                    return null;
+                }
+            }
+
+            targetEntityType ??= Metadata.TargetEntityType;
+            if (targetEntityType.Builder == null)
+            {
+                targetEntityType = Metadata.DeclaringEntityType.Model.FindEntityType(targetEntityType.Name);
+                if (targetEntityType == null)
+                {
+                    return null;
+                }
+            }
+
+            var newSkipNavigationBuilder = entityTypeBuilder.HasSkipNavigation(
+                Metadata.CreateMemberIdentity(),
+                targetEntityType,
+                Metadata.GetConfigurationSource(),
+                Metadata.IsCollection,
+                Metadata.IsOnDependent);
+            if (newSkipNavigationBuilder == null)
+            {
+                return null;
+            }
+
+            newSkipNavigationBuilder.MergeAnnotationsFrom(Metadata);
+
+            var foreignKeyConfigurationSource = Metadata.GetForeignKeyConfigurationSource();
+            if (foreignKeyConfigurationSource.HasValue)
+            {
+                var foreignKey = Metadata.ForeignKey;
+                if (foreignKey.Builder == null)
+                {
+                    foreignKey = InternalRelationshipBuilder.FindCurrentRelationshipBuilder(
+                        foreignKey.PrincipalEntityType,
+                        foreignKey.DeclaringEntityType,
+                        foreignKey.DependentToPrincipal?.CreateMemberIdentity(),
+                        foreignKey.PrincipalToDependent?.CreateMemberIdentity(),
+                        dependentProperties: foreignKey.Properties,
+                        principalProperties: foreignKey.PrincipalKey.Properties)?.Metadata;
+                }
+
+                if (foreignKey != null)
+                {
+                    newSkipNavigationBuilder.HasForeignKey(foreignKey, foreignKeyConfigurationSource.Value);
+                }
+            }
+
+            var inverseConfigurationSource = Metadata.GetInverseConfigurationSource();
+            if (inverseConfigurationSource.HasValue)
+            {
+                var inverse = Metadata.Inverse;
+                if (inverse.Builder == null)
+                {
+                    inverse = inverse.DeclaringEntityType.FindSkipNavigation(inverse.Name);
+                }
+
+                if (inverseBuilder != null)
+                {
+                    inverse = inverseBuilder.Attach(targetEntityType.Builder, entityTypeBuilder.Metadata)?.Metadata
+                        ?? inverse;
+                }
+
+                if (inverse != null)
+                {
+                    newSkipNavigationBuilder.HasInverse(inverse, inverseConfigurationSource.Value);
+                }
+            }
+
+            var propertyAccessModeConfigurationSource = Metadata.GetPropertyAccessModeConfigurationSource();
+            if (propertyAccessModeConfigurationSource.HasValue)
+            {
+                newSkipNavigationBuilder.UsePropertyAccessMode(
+                    ((ISkipNavigation)Metadata).GetPropertyAccessMode(), propertyAccessModeConfigurationSource.Value);
+            }
+
+            var oldFieldInfoConfigurationSource = Metadata.GetFieldInfoConfigurationSource();
+            if (oldFieldInfoConfigurationSource.HasValue
+                && newSkipNavigationBuilder.CanSetField(Metadata.FieldInfo, oldFieldInfoConfigurationSource))
+            {
+                newSkipNavigationBuilder.HasField(Metadata.FieldInfo, oldFieldInfoConfigurationSource.Value);
+            }
+
+            return newSkipNavigationBuilder;
+        }
+
         IConventionSkipNavigation IConventionSkipNavigationBuilder.Metadata
         {
-            [DebuggerStepThrough]
-            get => Metadata;
+            [DebuggerStepThrough] get => Metadata;
         }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSkipNavigationBuilder IConventionSkipNavigationBuilder.HasField(string fieldName, bool fromDataAnnotation)
+            => HasField(
+                fieldName,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSkipNavigationBuilder IConventionSkipNavigationBuilder.HasField(FieldInfo fieldInfo, bool fromDataAnnotation)
+            => HasField(
+                fieldInfo,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSkipNavigationBuilder.CanSetField(string fieldName, bool fromDataAnnotation)
+            => CanSetField(
+                fieldName,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSkipNavigationBuilder.CanSetField(FieldInfo fieldInfo, bool fromDataAnnotation)
+            => CanSetField(
+                fieldInfo,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSkipNavigationBuilder IConventionSkipNavigationBuilder.UsePropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
+            => UsePropertyAccessMode(
+                propertyAccessMode,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSkipNavigationBuilder.CanSetPropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
+            => CanSetPropertyAccessMode(
+                propertyAccessMode,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSkipNavigationBuilder IConventionSkipNavigationBuilder.HasForeignKey(
+            IConventionForeignKey foreignKey, bool fromDataAnnotation)
+            => HasForeignKey(
+                (ForeignKey)foreignKey,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSkipNavigationBuilder.CanSetForeignKey(
+            IConventionForeignKey foreignKey, bool fromDataAnnotation)
+            => CanSetForeignKey(
+                (ForeignKey)foreignKey,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSkipNavigationBuilder IConventionSkipNavigationBuilder.HasInverse(
+            IConventionSkipNavigation inverse, bool fromDataAnnotation)
+            => HasInverse(
+                (SkipNavigation)inverse,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSkipNavigationBuilder.CanSetInverse(
+            IConventionSkipNavigation inverse, bool fromDataAnnotation)
+            => CanSetInverse(
+                (SkipNavigation)inverse,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }
 }

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] PropertyInfo propertyInfo,
             [CanBeNull] FieldInfo fieldInfo,
             [NotNull] ForeignKey foreignKey)
-            : base(name, propertyInfo, fieldInfo)
+            : base(name, propertyInfo, fieldInfo, ConfigurationSource.Convention)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 
@@ -121,10 +121,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ConfigurationSource GetConfigurationSource()
+        public override ConfigurationSource GetConfigurationSource()
             => (ConfigurationSource)(IsOnDependent
                 ? ForeignKey.GetDependentToPrincipalConfigurationSource()
                 : ForeignKey.GetPrincipalToDependentConfigurationSource());
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override void UpdateConfigurationSource(ConfigurationSource configurationSource)
+        {
+            if (IsOnDependent)
+            {
+                ForeignKey.UpdateDependentToPrincipalConfigurationSource(configurationSource);
+            }
+            else
+            {
+                ForeignKey.UpdatePrincipalToDependentConfigurationSource(configurationSource);
+            }
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -30,7 +30,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private bool? _isNullable;
         private ValueGenerated? _valueGenerated;
 
-        private ConfigurationSource _configurationSource;
         private ConfigurationSource? _typeConfigurationSource;
         private ConfigurationSource? _isNullableConfigurationSource;
         private ConfigurationSource? _isConcurrencyTokenConfigurationSource;
@@ -50,14 +49,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource,
             ConfigurationSource? typeConfigurationSource)
-            : base(name, propertyInfo, fieldInfo)
+            : base(name, propertyInfo, fieldInfo, configurationSource)
         {
             Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
             ClrType = clrType;
-            _configurationSource = configurationSource;
             _typeConfigurationSource = typeConfigurationSource;
 
             Builder = new InternalPropertyBuilder(this, declaringEntityType.Model.Builder);
@@ -98,38 +96,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual InternalPropertyBuilder Builder { get; [param: CanBeNull] set; }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual bool UpdateConfigurationSource(ConfigurationSource configurationSource)
-        {
-            var oldConfigurationSource = _configurationSource;
-            _configurationSource = configurationSource.Max(_configurationSource);
-            return _configurationSource != oldConfigurationSource;
-        }
-
-        // Needed for a workaround before reference counting is implemented
-        // Issue #15898
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void SetConfigurationSource(ConfigurationSource configurationSource)
-            => _configurationSource = configurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -381,15 +347,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string CheckAfterSaveBehavior(PropertySaveBehavior behavior)
-        {
-            if (behavior != PropertySaveBehavior.Throw
-                && this.IsKey())
-            {
-                return CoreStrings.KeyPropertyMustBeReadOnly(Name, DeclaringEntityType.DisplayName());
-            }
-
-            return null;
-        }
+            => behavior != PropertySaveBehavior.Throw
+                && this.IsKey()
+                ? CoreStrings.KeyPropertyMustBeReadOnly(Name, DeclaringEntityType.DisplayName())
+                : null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -426,19 +387,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string CheckValueConverter([CanBeNull] ValueConverter converter)
-        {
-            if (converter != null
-                && converter.ModelClrType.UnwrapNullableType() != ClrType.UnwrapNullableType())
-            {
-                return CoreStrings.ConverterPropertyMismatch(
+            => converter != null
+                && converter.ModelClrType.UnwrapNullableType() != ClrType.UnwrapNullableType()
+                ? CoreStrings.ConverterPropertyMismatch(
                     converter.ModelClrType.ShortDisplayName(),
                     DeclaringEntityType.DisplayName(),
                     Name,
-                    ClrType.ShortDisplayName());
-            }
-
-            return null;
-        }
+                    ClrType.ShortDisplayName())
+                : null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -490,19 +446,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string CheckValueComparer([CanBeNull] ValueComparer comparer)
-        {
-            if (comparer != null
-                && comparer.Type != ClrType)
-            {
-                return CoreStrings.ComparerPropertyMismatch(
+            => comparer != null
+                && comparer.Type != ClrType
+                ? CoreStrings.ComparerPropertyMismatch(
                     comparer.Type.ShortDisplayName(),
                     DeclaringEntityType.DisplayName(),
                     Name,
-                    ClrType.ShortDisplayName());
-            }
-
-            return null;
-        }
+                    ClrType.ShortDisplayName())
+                : null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private IClrPropertySetter _materializationSetter;
         private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
+        private ConfigurationSource _configurationSource;
         private IComparer<IUpdateEntry> _currentValueComparer;
 
         /// <summary>
@@ -43,13 +44,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected PropertyBase(
             [NotNull] string name,
             [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo)
+            [CanBeNull] FieldInfo fieldInfo,
+            ConfigurationSource configurationSource)
         {
             Check.NotEmpty(name, nameof(name));
 
             Name = name;
             PropertyInfo = propertyInfo;
             _fieldInfo = fieldInfo;
+            _configurationSource = configurationSource;
         }
 
         /// <summary>
@@ -89,6 +92,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [DebuggerStepThrough]
             set => SetField(value, ConfigurationSource.Explicit);
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+        {
+            var oldConfigurationSource = _configurationSource;
+            _configurationSource = configurationSource.Max(_configurationSource);
+        }
+
+        // Needed for a workaround before reference counting is implemented
+        // Issue #15898
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void SetConfigurationSource(ConfigurationSource configurationSource)
+            => _configurationSource = configurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -148,7 +182,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             if (Equals(FieldInfo, fieldInfo))
             {
-                UpdateFieldInfoConfigurationSource(configurationSource);
+                if (fieldInfo != null)
+                {
+                    UpdateFieldInfoConfigurationSource(configurationSource);
+                }
+
                 return;
             }
 
@@ -162,6 +200,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(
                         CoreStrings.BackingFieldOnIndexer(fieldInfo.GetSimpleMemberName(), DeclaringType.DisplayName(), Name));
                 }
+                UpdateFieldInfoConfigurationSource(configurationSource);
+            }
+            else
+            {
+                _fieldInfoConfigurationSource = null;
             }
 
             if (PropertyInfo == null
@@ -170,8 +213,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 throw new InvalidOperationException(
                     CoreStrings.FieldNameMismatch(fieldInfo?.GetSimpleMemberName(), DeclaringType.DisplayName(), Name));
             }
-
-            UpdateFieldInfoConfigurationSource(configurationSource);
 
             var oldFieldInfo = FieldInfo;
             _fieldInfo = fieldInfo;

--- a/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 
@@ -22,10 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public RelationshipSnapshot(
             [NotNull] InternalRelationshipBuilder relationship,
-            [CanBeNull] EntityType.Snapshot definedEntityTypeSnapshot)
+            [CanBeNull] EntityType.Snapshot definedEntityTypeSnapshot,
+            [CanBeNull] List<(SkipNavigation, ConfigurationSource)> referencingSkipNavigations)
         {
             Relationship = relationship;
             DefinedEntityTypeSnapshot = definedEntityTypeSnapshot;
+            ReferencingSkipNavigations = referencingSkipNavigations;
         }
 
         /// <summary>
@@ -50,15 +53,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual List<(SkipNavigation SkipNavigation, ConfigurationSource ForeignKeyConfigurationSource)> ReferencingSkipNavigations
+        {
+            [DebuggerStepThrough] get;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual InternalRelationshipBuilder Attach([CanBeNull] InternalEntityTypeBuilder entityTypeBuilder = null)
         {
             entityTypeBuilder ??= Relationship.Metadata.DeclaringEntityType.Builder;
-            var newRelationship = Relationship.Attach(entityTypeBuilder);
 
+            var newRelationship = Relationship.Attach(entityTypeBuilder);
             if (newRelationship != null)
             {
                 DefinedEntityTypeSnapshot?.Attach(
                     newRelationship.Metadata.ResolveOtherEntityType(entityTypeBuilder.Metadata).Builder);
+
+                if (ReferencingSkipNavigations != null)
+                {
+                    foreach (var referencingNavigationTuple in ReferencingSkipNavigations)
+                    {
+                        var skipNavigation = referencingNavigationTuple.SkipNavigation;
+                        if (skipNavigation.Builder == null)
+                        {
+                            var navigationEntityType = skipNavigation.DeclaringEntityType;
+                            skipNavigation = navigationEntityType.Builder == null
+                                ? null
+                                : navigationEntityType.FindSkipNavigation(skipNavigation.Name);
+                        }
+
+                        skipNavigation?.Builder.HasForeignKey(
+                            newRelationship.Metadata, referencingNavigationTuple.ForeignKeyConfigurationSource);
+                    }
+                }
             }
 
             return newRelationship;

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -21,7 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         private ServiceParameterBinding _parameterBinding;
 
-        private ConfigurationSource _configurationSource;
         private ConfigurationSource? _parameterBindingConfigurationSource;
 
         /// <summary>
@@ -36,13 +35,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] FieldInfo fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource)
-            : base(name, propertyInfo, fieldInfo)
+            : base(name, propertyInfo, fieldInfo, configurationSource)
         {
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
             ClrType = propertyInfo?.PropertyType ?? fieldInfo?.FieldType;
-            _configurationSource = configurationSource;
 
             Builder = new InternalServicePropertyBuilder(this, declaringEntityType.Model.Builder);
         }
@@ -87,23 +85,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [param: CanBeNull]
             set;
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
-            => _configurationSource = configurationSource.Max(_configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/SkipNavigationComparer.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigationComparer.cs
@@ -27,6 +27,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static readonly SkipNavigationComparer Instance = new SkipNavigationComparer();
 
         public int Compare(SkipNavigation x, SkipNavigation y)
-            => StringComparer.Ordinal.Compare(x.Name, y.Name);
+        {
+            var result = StringComparer.Ordinal.Compare(x.Name, y.Name);
+
+            return result != 0 ? result : EntityTypePathComparer.Instance.Compare(x.DeclaringEntityType, y.DeclaringEntityType);
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
@@ -23,6 +23,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static MemberIdentity CreateMemberIdentity([CanBeNull] this ISkipNavigation navigation)
+            => navigation?.GetIdentifyingMemberInfo() == null
+                ? MemberIdentity.Create(navigation?.Name)
+                : MemberIdentity.Create(navigation.GetIdentifyingMemberInfo());
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static string ToDebugString(
             [NotNull] this ISkipNavigation navigation,
             MetadataDebugStringOptions options,

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -278,8 +278,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IReadOnlyList<string> GetIgnoredMembers()
-            => _ignoredMembers.Keys.ToList();
+        public virtual IEnumerable<string> GetIgnoredMembers()
+            => _ignoredMembers.Keys;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -977,14 +977,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The type '{entityType}' cannot have base type '{baseType}' because both types include the navigations: {navigations}.
-        /// </summary>
-        public static string DuplicateNavigationsOnBase([CanBeNull] object entityType, [CanBeNull] object baseType, [CanBeNull] object navigations)
-            => string.Format(
-                GetString("DuplicateNavigationsOnBase", nameof(entityType), nameof(baseType), nameof(navigations)),
-                entityType, baseType, navigations);
-
-        /// <summary>
         ///     The entity types '{firstEntityType}' and '{secondEntityType}' do not belong to the same model.
         /// </summary>
         public static string EntityTypeModelMismatch([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType)
@@ -1375,12 +1367,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation first.
+        ///     Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation first.
         /// </summary>
-        public static string ConflictingRelationshipNavigation([CanBeNull] object newPrincipalEntityType, [CanBeNull] object newPrincipalNavigation, [CanBeNull] object newDependentEntityType, [CanBeNull] object newDependentNavigation, [CanBeNull] object existingPrincipalEntityType, [CanBeNull] object existingPrincipalNavigation, [CanBeNull] object existingDependentEntityType, [CanBeNull] object existingDependentNavigation)
+        public static string ConflictingRelationshipNavigation([CanBeNull] object newPrincipalNavigationSpecification, [CanBeNull] object newDependentNavigationSpecification, [CanBeNull] object existingPrincipalNavigationSpecification, [CanBeNull] object existingDependentNavigationSpecification)
             => string.Format(
-                GetString("ConflictingRelationshipNavigation", nameof(newPrincipalEntityType), nameof(newPrincipalNavigation), nameof(newDependentEntityType), nameof(newDependentNavigation), nameof(existingPrincipalEntityType), nameof(existingPrincipalNavigation), nameof(existingDependentEntityType), nameof(existingDependentNavigation)),
-                newPrincipalEntityType, newPrincipalNavigation, newDependentEntityType, newDependentNavigation, existingPrincipalEntityType, existingPrincipalNavigation, existingDependentEntityType, existingDependentNavigation);
+                GetString("ConflictingRelationshipNavigation", nameof(newPrincipalNavigationSpecification), nameof(newDependentNavigationSpecification), nameof(existingPrincipalNavigationSpecification), nameof(existingDependentNavigationSpecification)),
+                newPrincipalNavigationSpecification, newDependentNavigationSpecification, existingPrincipalNavigationSpecification, existingDependentNavigationSpecification);
 
         /// <summary>
         ///     Error generated for warning '{eventName}': {message} This exception can be suppressed or logged by passing event ID '{eventId}' to the 'ConfigureWarnings' method in 'DbContext.OnConfiguring' or 'AddDbContext'.
@@ -1527,12 +1519,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 dependentType);
 
         /// <summary>
-        ///     The entity type '{entityType}' cannot be removed because it is referencing '{referencedEntityType}' by foreign key {foreignKey}. All foreign keys must be removed before the entity type can be removed.
+        ///     The entity type '{entityType}' cannot be removed because it is being referenced by the skip navigation '{skipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before the entity type can be removed.
         /// </summary>
-        public static string EntityTypeInUseByForeignKey([CanBeNull] object entityType, [CanBeNull] object referencedEntityType, [CanBeNull] object foreignKey)
+        public static string EntityTypeInUseByReferencingSkipNavigation([CanBeNull] object entityType, [CanBeNull] object skipNavigation, [CanBeNull] object referencingEntityType)
             => string.Format(
-                GetString("EntityTypeInUseByForeignKey", nameof(entityType), nameof(referencedEntityType), nameof(foreignKey)),
-                entityType, referencedEntityType, foreignKey);
+                GetString("EntityTypeInUseByReferencingSkipNavigation", nameof(entityType), nameof(skipNavigation), nameof(referencingEntityType)),
+                entityType, skipNavigation, referencingEntityType);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot be added to the model because a weak entity type with the same name already exists.
@@ -1929,12 +1921,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ownedType);
 
         /// <summary>
-        ///     Unable to determine the owner for the relationship between '{entityType}' and '{otherEntityType}' as both types have been marked as owned. Either manually configure the ownership, or ignore the corresponding navigations using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
+        ///     Unable to determine the owner for the relationship between '{entityTypeNavigationSpecification}' and '{otherEntityType}' as both types have been marked as owned. Either manually configure the ownership, or ignore the corresponding navigations using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
         /// </summary>
-        public static string AmbiguousOwnedNavigation([CanBeNull] object entityType, [CanBeNull] object otherEntityType)
+        public static string AmbiguousOwnedNavigation([CanBeNull] object entityTypeNavigationSpecification, [CanBeNull] object otherEntityType)
             => string.Format(
-                GetString("AmbiguousOwnedNavigation", nameof(entityType), nameof(otherEntityType)),
-                entityType, otherEntityType);
+                GetString("AmbiguousOwnedNavigation", nameof(entityTypeNavigationSpecification), nameof(otherEntityType)),
+                entityTypeNavigationSpecification, otherEntityType);
 
         /// <summary>
         ///     The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.
@@ -2261,28 +2253,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 foreigKey, entityType, navigation, navigationEntityType);
 
         /// <summary>
-        ///     The skip navigation property '{navigation}' cannot be added to entity type '{entityType}' because it is expected to be on the dependent entity type '{dependentEntityType}' of the foreign key {foreignKey}.
-        /// </summary>
-        public static string SkipNavigationWrongDependentType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object dependentEntityType, [CanBeNull] object foreignKey)
-            => string.Format(
-                GetString("SkipNavigationWrongDependentType", nameof(navigation), nameof(entityType), nameof(dependentEntityType), nameof(foreignKey)),
-                navigation, entityType, dependentEntityType, foreignKey);
-
-        /// <summary>
         ///     The skip navigation '{inverse}' declared on the entity type '{inverseEntityType}' cannot be set as the inverse of '{navigation}' that targets '{targetEntityType}'. The inverse should be declared on the target entity type.
         /// </summary>
         public static string SkipNavigationWrongInverse([CanBeNull] object inverse, [CanBeNull] object inverseEntityType, [CanBeNull] object navigation, [CanBeNull] object targetEntityType)
             => string.Format(
                 GetString("SkipNavigationWrongInverse", nameof(inverse), nameof(inverseEntityType), nameof(navigation), nameof(targetEntityType)),
                 inverse, inverseEntityType, navigation, targetEntityType);
-
-        /// <summary>
-        ///     The skip navigation property '{navigation}' cannot be added to entity type '{entityType}' because it is expected to be on the principal entity type '{principalEntityType}' of the foreign key {foreignKey}.
-        /// </summary>
-        public static string SkipNavigationWrongPrincipalType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object principalEntityType, [CanBeNull] object foreignKey)
-            => string.Format(
-                GetString("SkipNavigationWrongPrincipalType", nameof(navigation), nameof(entityType), nameof(principalEntityType), nameof(foreignKey)),
-                navigation, entityType, principalEntityType, foreignKey);
 
         /// <summary>
         ///     The skip navigation property '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
@@ -2379,6 +2355,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("CannotFindEntityWithClrTypeWhenShared", nameof(clrType)),
                 clrType);
+
+        /// <summary>
+        ///     The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.
+        /// </summary>
+        public static string SkipNavigationInUseBySkipNavigation([CanBeNull] object skipNavigation, [CanBeNull] object inverseSkipNavigation, [CanBeNull] object referencingEntityType)
+            => string.Format(
+                GetString("SkipNavigationInUseBySkipNavigation", nameof(skipNavigation), nameof(inverseSkipNavigation), nameof(referencingEntityType)),
+                skipNavigation, inverseSkipNavigation, referencingEntityType);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -611,9 +611,6 @@
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
     <value>Entity type '{entityType}' has composite primary key defined with data annotations. To set composite primary key, use fluent API.</value>
   </data>
-  <data name="DuplicateNavigationsOnBase" xml:space="preserve">
-    <value>The type '{entityType}' cannot have base type '{baseType}' because both types include the navigations: {navigations}.</value>
-  </data>
   <data name="EntityTypeModelMismatch" xml:space="preserve">
     <value>The entity types '{firstEntityType}' and '{secondEntityType}' do not belong to the same model.</value>
   </data>
@@ -769,7 +766,7 @@
     <value>A parameterless constructor was not found on entity type '{entityType}'. In order to create an instance of '{entityType}' EF requires that a parameterless constructor be declared.</value>
   </data>
   <data name="ConflictingRelationshipNavigation" xml:space="preserve">
-    <value>Cannot create a relationship between '{newPrincipalEntityType}.{newPrincipalNavigation}' and '{newDependentEntityType}.{newDependentNavigation}', because there already is a relationship between '{existingPrincipalEntityType}.{existingPrincipalNavigation}' and '{existingDependentEntityType}.{existingDependentNavigation}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation first.</value>
+    <value>Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation first.</value>
   </data>
   <data name="WarningAsErrorTemplate" xml:space="preserve">
     <value>Error generated for warning '{eventName}': {message} This exception can be suppressed or logged by passing event ID '{eventId}' to the 'ConfigureWarnings' method in 'DbContext.OnConfiguring' or 'AddDbContext'.</value>
@@ -828,8 +825,8 @@
   <data name="ForeignKeySelfReferencingDependentEntityType" xml:space="preserve">
     <value>The foreign keys on entity type '{dependentType}' cannot target the same entity type because it is a weak entity type.</value>
   </data>
-  <data name="EntityTypeInUseByForeignKey" xml:space="preserve">
-    <value>The entity type '{entityType}' cannot be removed because it is referencing '{referencedEntityType}' by foreign key {foreignKey}. All foreign keys must be removed before the entity type can be removed.</value>
+  <data name="EntityTypeInUseByReferencingSkipNavigation" xml:space="preserve">
+    <value>The entity type '{entityType}' cannot be removed because it is being referenced by the skip navigation '{skipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before the entity type can be removed.</value>
   </data>
   <data name="ClashingWeakEntityType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be added to the model because a weak entity type with the same name already exists.</value>
@@ -1082,7 +1079,7 @@
     <comment>Debug CoreEventId.OptimisticConcurrencyException Exception</comment>
   </data>
   <data name="AmbiguousOwnedNavigation" xml:space="preserve">
-    <value>Unable to determine the owner for the relationship between '{entityType}' and '{otherEntityType}' as both types have been marked as owned. Either manually configure the ownership, or ignore the corresponding navigations using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
+    <value>Unable to determine the owner for the relationship between '{entityTypeNavigationSpecification}' and '{otherEntityType}' as both types have been marked as owned. Either manually configure the ownership, or ignore the corresponding navigations using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
   <data name="FkAttributeOnNonUniquePrincipal" xml:space="preserve">
     <value>The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.</value>
@@ -1227,14 +1224,8 @@
   <data name="ForeignKeyInUseSkipNavigation" xml:space="preserve">
     <value>Cannot remove foreign key {foreigKey} from entity type '{entityType}' because it is referenced by a skip navigation '{navigation}' on entity type '{navigationEntityType}'. All referencing skip navigation must be removed before the referenced foreign key can be removed.</value>
   </data>
-  <data name="SkipNavigationWrongDependentType" xml:space="preserve">
-    <value>The skip navigation property '{navigation}' cannot be added to entity type '{entityType}' because it is expected to be on the dependent entity type '{dependentEntityType}' of the foreign key {foreignKey}.</value>
-  </data>
   <data name="SkipNavigationWrongInverse" xml:space="preserve">
     <value>The skip navigation '{inverse}' declared on the entity type '{inverseEntityType}' cannot be set as the inverse of '{navigation}' that targets '{targetEntityType}'. The inverse should be declared on the target entity type.</value>
-  </data>
-  <data name="SkipNavigationWrongPrincipalType" xml:space="preserve">
-    <value>The skip navigation property '{navigation}' cannot be added to entity type '{entityType}' because it is expected to be on the principal entity type '{principalEntityType}' of the foreign key {foreignKey}.</value>
   </data>
   <data name="SkipNavigationWrongType" xml:space="preserve">
     <value>The skip navigation property '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
@@ -1271,5 +1262,8 @@
   </data>
   <data name="CannotFindEntityWithClrTypeWhenShared" xml:space="preserve">
     <value>Cannot find entity type with type '{clrType}' since model contains shared entity type(s) with same type.</value>
+  </data>
+  <data name="SkipNavigationInUseBySkipNavigation" xml:space="preserve">
+    <value>The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.</value>
   </data>
 </root>

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -24,6 +24,18 @@ namespace System.Reflection
                             || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces
                                 .Contains(propertyInfo.DeclaringType))));
 
+        public static bool IsOverridenBy(this MemberInfo propertyInfo, MemberInfo otherPropertyInfo)
+            => propertyInfo == null
+                ? otherPropertyInfo == null
+                : (otherPropertyInfo == null
+                    ? false
+                    : Equals(propertyInfo, otherPropertyInfo)
+                    || (propertyInfo.Name == otherPropertyInfo.Name
+                        && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
+                            || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
+                            || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces
+                                .Contains(propertyInfo.DeclaringType))));
+
         public static string GetSimpleMemberName(this MemberInfo member)
         {
             var name = member.Name;

--- a/test/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/test/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -74,7 +74,17 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<TitleSponsor>()
                 .OwnsOne(s => s.Details);
 
-            // TODO: Sponsor * <-> * Team. Many-to-many relationships are not supported without CLR class for join table. See issue #1368
+            modelBuilder.Entity<Team>()
+                .HasMany(t => t.Sponsors)
+                .WithMany(s => s.Teams)
+                .UsingEntity<TeamSponsor>(
+                    ts => ts
+                        .HasOne(t => t.Sponsor)
+                        .WithMany(),
+                    ts => ts
+                        .HasOne(t => t.Team)
+                        .WithMany())
+                .HasKey(ts => new { ts.SponsorId, ts.TeamId });
         }
 
         protected override void Seed(F1Context context) => F1Context.Seed(context);

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TeamSponsor.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TeamSponsor.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
+{
+    public class TeamSponsor
+    {
+        public int TeamId { get; set; }
+        public string SponsorId { get; set; }
+
+        public virtual Team Team { get; set; }
+        public virtual Sponsor Sponsor { get; set; }
+    }
+}

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -555,10 +555,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             orderProductEntity.SetPrimaryKey(new[] { orderProductForeignKey.Properties.Single(), productOrderForeignKey.Properties.Single() });
 
             var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, orderProductForeignKey, true, false);
+                nameof(Order.Products), null, productEntity, true, false);
+            productsNavigation.SetForeignKey(orderProductForeignKey);
 
             var ordersNavigation = productEntity.AddSkipNavigation(
-                nameof(Product.Orders), null, orderEntity, productOrderForeignKey, true, false);
+                nameof(Product.Orders), null, orderEntity, true, false);
+            ordersNavigation.SetForeignKey(productOrderForeignKey);
 
             productsNavigation.SetInverse(ordersNavigation);
             ordersNavigation.SetInverse(productsNavigation);
@@ -582,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             orderProductEntity.SetPrimaryKey(new[] { orderProductForeignKey.Properties.Single(), productOrderForeignKey.Properties.Single() });
 
             var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, null, true, false);
+                nameof(Order.Products), null, productEntity, true, false);
 
             VerifyError(
                 CoreStrings.SkipNavigationNoForeignKey(nameof(Order.Products), nameof(Order)),
@@ -605,7 +607,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             orderProductEntity.SetPrimaryKey(new[] { orderProductForeignKey.Properties.Single(), productOrderForeignKey.Properties.Single() });
 
             var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, orderProductForeignKey, true, false);
+                nameof(Order.Products), null, productEntity, true, false);
+            productsNavigation.SetForeignKey(orderProductForeignKey);
 
             VerifyError(
                 CoreStrings.SkipNavigationNoInverse(nameof(Order.Products), nameof(Order)),
@@ -782,7 +785,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             anotherEntityTypeBuilder.HasRelationship(
                 ownedTypeBuilder.Metadata, nameof(AnotherSampleEntity.ReferencedEntity), ConfigurationSource.Convention,
-                setTargetAsPrincipal: true);
+                targetIsPrincipal: true);
 
             VerifyError(
                 CoreStrings.PrincipalOwnedType(

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -1887,9 +1887,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [InlineData(false, false)]
-        //[InlineData(true, false)]
+        [InlineData(true, false)]
         [InlineData(false, true)]
-        //[InlineData(true, true)]
+        [InlineData(true, true)]
         [ConditionalTheory]
         public void OnSkipNavigationAdded_calls_conventions_in_order(bool useBuilder, bool useScope)
         {
@@ -1905,23 +1905,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(conventions));
             var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
-            var associationEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
-
-            var firstFk = associationEntityBuilder
-                .HasRelationship(typeof(Order), new [] { OrderProduct.OrderIdProperty }, ConfigurationSource.Convention)
-                .IsUnique(false, ConfigurationSource.Convention)
-                .Metadata;
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
             if (useBuilder)
             {
-                throw new NotImplementedException();
+                firstEntityBuilder.HasSkipNavigation(
+                    MemberIdentity.Create(nameof(Order.Products)), secondEntityBuilder.Metadata, ConfigurationSource.Convention);
             }
             else
             {
                 var result = firstEntityBuilder.Metadata.AddSkipNavigation(
-                    nameof(Order.Products), null, secondEntityBuilder.Metadata, firstFk, true, false, ConfigurationSource.Convention);
+                    nameof(Order.Products), null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
 
                 Assert.Equal(!useScope, result == null);
             }
@@ -1984,14 +1979,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(conventions));
             var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
-            var associationEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
 
-            var firstFk = associationEntityBuilder
-                .HasRelationship(typeof(Order), new[] { OrderProduct.OrderIdProperty }, ConfigurationSource.Convention)
-                .IsUnique(false, ConfigurationSource.Convention)
-                .Metadata;
             var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-                nameof(Order.Products), null, secondEntityBuilder.Metadata, firstFk, true, false, ConfigurationSource.Convention);
+                nameof(Order.Products), null, secondEntityBuilder.Metadata,  true, false, ConfigurationSource.Convention);
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2075,9 +2065,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [InlineData(false, false)]
-        //[InlineData(true, false)]
+        [InlineData(true, false)]
         [InlineData(false, true)]
-        //[InlineData(true, true)]
+        [InlineData(true, true)]
         [ConditionalTheory]
         public void OnSkipNavigationForeignKeyChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
         {
@@ -2095,22 +2085,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
             var associationEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
 
-            var firstFk = associationEntityBuilder
+            var foreignKey = associationEntityBuilder
                 .HasRelationship(typeof(Order), new[] { OrderProduct.OrderIdProperty }, ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention)
                 .Metadata;
             var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-                nameof(Order.Products), null, secondEntityBuilder.Metadata, null, true, false, ConfigurationSource.Convention);
+                nameof(Order.Products), null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
             if (useBuilder)
             {
-                throw new NotImplementedException();
+                navigation.Builder.HasForeignKey(foreignKey, ConfigurationSource.Explicit);
             }
             else
             {
-                navigation.SetForeignKey(firstFk, ConfigurationSource.Explicit);
+                navigation.SetForeignKey(foreignKey, ConfigurationSource.Explicit);
             }
 
             if (useScope)
@@ -2120,21 +2110,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 scope.Dispose();
             }
 
-            Assert.Equal(new[] { firstFk }, convention1.Calls);
-            Assert.Equal(new[] { firstFk }, convention2.Calls);
+            Assert.Equal(new[] { foreignKey }, convention1.Calls);
+            Assert.Equal(new[] { foreignKey }, convention2.Calls);
             Assert.Empty(convention3.Calls);
 
             if (useBuilder)
             {
-                throw new NotImplementedException();
+                navigation.Builder.HasForeignKey(null, ConfigurationSource.Explicit);
             }
             else
             {
                 navigation.SetForeignKey(null, ConfigurationSource.Explicit);
             }
 
-            Assert.Equal(new ForeignKey[] { firstFk, null }, convention1.Calls);
-            Assert.Equal(new ForeignKey[] { firstFk, null }, convention2.Calls);
+            Assert.Equal(new ForeignKey[] { foreignKey, null }, convention1.Calls);
+            Assert.Equal(new ForeignKey[] { foreignKey, null }, convention2.Calls);
             Assert.Empty(convention3.Calls);
         }
 
@@ -2171,9 +2161,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [InlineData(false, false)]
-        //[InlineData(true, false)]
+        [InlineData(true, false)]
         [InlineData(false, true)]
-        //[InlineData(true, true)]
+        [InlineData(true, true)]
         [ConditionalTheory]
         public void OnSkipNavigationInverseChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
         {
@@ -2189,30 +2179,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(conventions));
             var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
-            var associationEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
 
-            var firstFk = associationEntityBuilder
-                .HasRelationship(typeof(Order), new[] { OrderProduct.OrderIdProperty }, ConfigurationSource.Convention)
-                .IsUnique(false, ConfigurationSource.Convention)
-                .Metadata;
-            var secondFk = associationEntityBuilder
-                .HasRelationship(typeof(Product), new[] { OrderProduct.ProductIdProperty }, ConfigurationSource.Convention)
-                .IsUnique(false, ConfigurationSource.Convention)
-                .Metadata;
             var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-                nameof(Order.Products), null, secondEntityBuilder.Metadata, firstFk, true, false, ConfigurationSource.Convention);
+                nameof(Order.Products), null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            var inverse = secondEntityBuilder.Metadata.AddSkipNavigation(
+                nameof(Product.Orders), null, firstEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
             if (useBuilder)
             {
-                throw new NotImplementedException();
+                navigation.Builder.HasInverse(inverse, ConfigurationSource.Convention);
             }
             else
             {
-                var inverse = secondEntityBuilder.Metadata.AddSkipNavigation(
-                nameof(Product.Orders), null, firstEntityBuilder.Metadata, secondFk, true, false, ConfigurationSource.Convention);
-
                 var result = navigation.SetInverse(inverse, ConfigurationSource.Convention);
 
                 if (useScope)
@@ -2232,8 +2212,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 scope.Dispose();
             }
 
-            Assert.Equal(new[] { nameof(Product.Orders) }, convention1.Calls);
-            Assert.Equal(new[] { nameof(Product.Orders) }, convention2.Calls);
+            if (useBuilder)
+            {
+                Assert.Equal(new[] { nameof(Product.Orders), nameof(Order.Products) }, convention1.Calls);
+                Assert.Equal(new[] { nameof(Product.Orders), nameof(Order.Products) }, convention2.Calls);
+            }
+            else
+            {
+                Assert.Equal(new[] { nameof(Product.Orders) }, convention1.Calls);
+                Assert.Equal(new[] { nameof(Product.Orders) }, convention2.Calls);
+            }
             Assert.Empty(convention3.Calls);
         }
 
@@ -2281,14 +2269,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(conventions));
             var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
-            var associationEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
 
-            var firstFk = associationEntityBuilder
-                .HasRelationship(typeof(Order), new[] { OrderProduct.OrderIdProperty }, ConfigurationSource.Convention)
-                .IsUnique(false, ConfigurationSource.Convention)
-                .Metadata;
             var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-                nameof(Order.Products), null, secondEntityBuilder.Metadata, firstFk, true, false, ConfigurationSource.Convention);
+                nameof(Order.Products), null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
@@ -721,8 +721,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
             specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
-            Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, "Customer"),
+            Assert.Equal(CoreStrings.DuplicatePropertiesOnBase(nameof(SpecialOrder), nameof(Order),
+                nameof(SpecialOrder), nameof(Order.Customer), nameof(Order), nameof(Order.Customer)),
                 Assert.Throws<InvalidOperationException>(() => specialOrderType.BaseType = orderType).Message);
         }
 
@@ -752,8 +752,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
             verySpecialOrderType.BaseType = specialOrderType;
 
-            Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, nameof(Order.Customer)),
+            Assert.Equal(CoreStrings.DuplicatePropertiesOnBase(nameof(SpecialOrder), nameof(Order),
+                    nameof(VerySpecialOrder), nameof(Order.Customer), nameof(Order), nameof(Order.Customer)),
                 Assert.Throws<InvalidOperationException>(() => specialOrderType.BaseType = orderType).Message);
         }
 
@@ -784,7 +784,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(VerySpecialOrder).Name, typeof(SpecialOrder).Name, "Customer"),
+                CoreStrings.DuplicatePropertiesOnBase(nameof(VerySpecialOrder), nameof(SpecialOrder),
+                    nameof(VerySpecialOrder), nameof(Order.Customer), nameof(Order), nameof(Order.Customer)),
                 Assert.Throws<InvalidOperationException>(() => verySpecialOrderType.BaseType = specialOrderType).Message);
         }
 

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1689,85 +1689,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(2, dependentEntityBuilder.Metadata.GetProperties().Count());
         }
 
-        [ConditionalFact]
-        public void Can_ignore_same_or_lower_source_property()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var entityType = entityBuilder.Metadata;
-
-            Assert.NotNull(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-
-            Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
-            Assert.NotNull(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
-
-            Assert.NotNull(entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Explicit));
-        }
-
-        [ConditionalFact]
-        public void Cannot_ignore_higher_source_property()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var entityType = entityBuilder.Metadata;
-
-            Assert.NotNull(entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.Null(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
-            Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
-
-            Assert.Null(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
-
-            Assert.NotNull(entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
-            Assert.Null(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
-
-            Assert.NotNull(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
-        }
-
-        [ConditionalFact]
-        public void Can_ignore_existing_property()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var entityType = entityBuilder.Metadata;
-            var property = entityType.AddProperty(
-                Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit, ConfigurationSource.Explicit);
-
-            Assert.Same(property, entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.Convention).Metadata);
-
-            Assert.NotNull(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
-        }
-
         [ConditionalTheory]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.Convention)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.Convention)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.Convention)]
+        [MemberData(nameof(DataGenerator.GetCombinations),
+            new object[] { new Type[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+            MemberType = typeof(DataGenerator))]
         public void Can_ignore_property_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
         {
-            VerifyIgnoreProperty(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreProperty(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreProperty(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreProperty(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
-            VerifyIgnoreProperty(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
-            VerifyIgnoreProperty(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreProperty(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
 
-            VerifyIgnoreProperty(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreProperty(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreProperty(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreProperty(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
-            VerifyIgnoreProperty(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
-            VerifyIgnoreProperty(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreProperty(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
         }
 
         private void VerifyIgnoreProperty(
@@ -1778,10 +1718,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool setBaseFirst)
             => VerifyIgnoreMember(
                 ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
-                et => et.Metadata.FindProperty(OrderMinimal.CustomerIdProperty.Name) != null,
-                et => et.Property(OrderMinimal.CustomerIdProperty, addConfigurationSource) != null,
-                et => et.Property(OrderMinimal.CustomerIdProperty, ignoreConfigurationSource) != null,
-                OrderMinimal.CustomerIdProperty.Name);
+                et => et.Metadata.FindProperty(Order.CustomerIdProperty.Name) != null,
+                et => et.Property(Order.CustomerIdProperty, addConfigurationSource) != null,
+                et => et.Property(Order.CustomerIdProperty, ignoreConfigurationSource) != null,
+                Order.CustomerIdProperty.Name);
 
         private void VerifyIgnoreMember(
             Type ignoredOnType,
@@ -1795,31 +1735,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             string memberToIgnore)
         {
             var modelBuilder = CreateModelBuilder();
-            var customerTypeBuilder = modelBuilder.Entity(typeof(CustomerMinimal), ConfigurationSource.Convention);
-
-            customerTypeBuilder
-                .PrimaryKey(new[] { CustomerMinimal.IdProperty }, ConfigurationSource.Convention);
+            var customerTypeBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
+            customerTypeBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Convention);
+            var productTypeBuilder = modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention);
+            productTypeBuilder.PrimaryKey(new[] { Product.IdProperty }, ConfigurationSource.Convention);
 
             if (setBaseFirst)
             {
-                ConfigureOrdersHierarchyMinimal(modelBuilder);
+                ConfigureOrdersHierarchy(modelBuilder);
             }
 
             var ignoredEntityTypeBuilder = modelBuilder.Entity(ignoredOnType, ConfigurationSource.Convention);
-            var addedEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialOrderMinimal), ConfigurationSource.Convention);
-            Assert.False(findMember(addedEntityTypeBuilder));
+            var addedEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
 
-            var exceptionExpected = ignoredOnType == typeof(ExtraSpecialOrderMinimal)
+            var exceptionExpected = ignoredOnType == typeof(ExtraSpecialOrder)
                 && (ignoreConfigurationSource == ConfigurationSource.Explicit
                     || (!ignoredFirst && setBaseFirst));
 
-            var expectedAdded = ignoredOnType == typeof(ExtraSpecialOrderMinimal)
+            var expectedAdded = ignoredOnType == typeof(ExtraSpecialOrder)
                 || (addConfigurationSource.Overrides(ignoreConfigurationSource)
                     && (ignoreConfigurationSource != ConfigurationSource.Explicit
-                        || ignoredOnType != typeof(SpecialOrderMinimal)
+                        || ignoredOnType != typeof(SpecialOrder)
                         || ignoredFirst));
 
-            var expectedIgnored = (ignoredOnType != typeof(SpecialOrderMinimal)
+            var expectedIgnored = (ignoredOnType != typeof(SpecialOrder)
                     || !expectedAdded)
                 && !exceptionExpected;
 
@@ -1827,7 +1766,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 Assert.NotNull(ignoredEntityTypeBuilder.Ignore(memberToIgnore, ignoreConfigurationSource));
                 Assert.Equal(
-                    expectedAdded || (!setBaseFirst && ignoredOnType != typeof(SpecialOrderMinimal)), addMember(addedEntityTypeBuilder));
+                    expectedAdded || (!setBaseFirst && ignoredOnType != typeof(SpecialOrder)), addMember(addedEntityTypeBuilder));
             }
             else
             {
@@ -1837,8 +1776,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     Assert.Equal(
                         CoreStrings.InheritedPropertyCannotBeIgnored(
-                            memberToIgnore, typeof(ExtraSpecialOrderMinimal).ShortDisplayName(),
-                            typeof(SpecialOrderMinimal).ShortDisplayName()),
+                            memberToIgnore, typeof(ExtraSpecialOrder).ShortDisplayName(),
+                            typeof(SpecialOrder).ShortDisplayName()),
                         Assert.Throws<InvalidOperationException>(
                             () => ignoredEntityTypeBuilder.Ignore(memberToIgnore, ignoreConfigurationSource)).Message);
                     return;
@@ -1847,13 +1786,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Assert.Equal(
                     expectedIgnored
                     || (!setBaseFirst
-                        && (ignoreConfigurationSource == ConfigurationSource.Explicit || ignoredOnType != typeof(SpecialOrderMinimal))),
+                        && (ignoreConfigurationSource == ConfigurationSource.Explicit || ignoredOnType != typeof(SpecialOrder))),
                     ignoredEntityTypeBuilder.Ignore(memberToIgnore, ignoreConfigurationSource) != null);
             }
 
             if (!setBaseFirst)
             {
-                ConfigureOrdersHierarchyMinimal(modelBuilder);
+                ConfigureOrdersHierarchy(modelBuilder);
             }
 
             var modelValidator = InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelValidator>();
@@ -1863,8 +1802,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Assert.Equal(
                     CoreStrings.InheritedPropertyCannotBeIgnored(
                         memberToIgnore,
-                        typeof(ExtraSpecialOrderMinimal).ShortDisplayName(),
-                        typeof(SpecialOrderMinimal).ShortDisplayName()),
+                        typeof(ExtraSpecialOrder).ShortDisplayName(),
+                        typeof(SpecialOrder).ShortDisplayName()),
                     Assert.Throws<InvalidOperationException>(
                         () => modelValidator.Validate(
                             modelBuilder.Metadata,
@@ -1888,16 +1827,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityBuilder.HasBaseType(typeof(Order), ConfigurationSource.Explicit);
             var derivedEntityBuilder = modelBuilder.Entity(typeof(ExtraSpecialOrder), ConfigurationSource.Explicit);
             derivedEntityBuilder.HasBaseType(typeof(SpecialOrder), ConfigurationSource.Explicit);
-        }
-
-        private void ConfigureOrdersHierarchyMinimal(InternalModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity(typeof(OrderMinimal), ConfigurationSource.Explicit)
-                .PrimaryKey(new[] { OrderMinimal.IdProperty }, ConfigurationSource.Explicit);
-            var entityBuilder = modelBuilder.Entity(typeof(SpecialOrderMinimal), ConfigurationSource.Explicit);
-            entityBuilder.HasBaseType(typeof(OrderMinimal), ConfigurationSource.Explicit);
-            var derivedEntityBuilder = modelBuilder.Entity(typeof(ExtraSpecialOrderMinimal), ConfigurationSource.Explicit);
-            derivedEntityBuilder.HasBaseType(typeof(SpecialOrderMinimal), ConfigurationSource.Explicit);
         }
 
         [ConditionalFact]
@@ -2089,22 +2018,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
                 principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
 
-            Assert.True(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Convention));
+            Assert.True(dependentEntityBuilder.CanHaveNavigation(Order.CustomerProperty.Name, ConfigurationSource.Convention));
 
             foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: true,
                 ConfigurationSource.DataAnnotation);
 
-            Assert.True(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
-            Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
+            Assert.True(dependentEntityBuilder.CanHaveNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(principalEntityBuilder.CanHaveNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
 
             foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
                 Customer.OrdersProperty.Name,
                 pointsToPrincipal: false,
                 ConfigurationSource.DataAnnotation);
 
-            Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(principalEntityBuilder.CanHaveNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
 
             var newForeignKeyBuilder = dependentEntityBuilder
                 .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention).HasNavigation(
@@ -2125,169 +2054,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Same(foreignKeyBuilder.Metadata.PrincipalKey, principalEntityBuilder.Metadata.GetKeys().Single());
         }
 
-        [ConditionalFact]
-        public void Can_ignore_lower_or_equal_source_navigation()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-                typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
-                ConfigurationSource.DataAnnotation);
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Order.CustomerProperty.Name,
-                pointsToPrincipal: true,
-                ConfigurationSource.DataAnnotation);
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Customer.OrdersProperty.Name,
-                pointsToPrincipal: false,
-                ConfigurationSource.DataAnnotation);
-            Assert.NotNull(foreignKeyBuilder);
-
-            Assert.NotNull(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
-            Assert.NotNull(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
-
-            Assert.Null(dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name));
-            Assert.Null(principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name));
-            Assert.NotNull(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Convention));
-            Assert.NotNull(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
-            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
-
-            foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-                typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
-                ConfigurationSource.DataAnnotation);
-            Assert.Null(
-                foreignKeyBuilder.HasNavigation(
-                    Order.CustomerProperty.Name,
-                    pointsToPrincipal: true,
-                    ConfigurationSource.DataAnnotation));
-            Assert.Null(
-                foreignKeyBuilder.HasNavigation(
-                    Customer.OrdersProperty.Name,
-                    pointsToPrincipal: false,
-                    ConfigurationSource.DataAnnotation));
-
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Order.CustomerProperty.Name,
-                pointsToPrincipal: true,
-                ConfigurationSource.Explicit);
-            Assert.NotNull(foreignKeyBuilder);
-
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Customer.OrdersProperty.Name,
-                pointsToPrincipal: false,
-                ConfigurationSource.Explicit);
-            Assert.NotNull(foreignKeyBuilder);
-        }
-
-        [ConditionalFact]
-        public void Cannot_ignore_higher_source_navigation()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-                typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
-                ConfigurationSource.Convention);
-
-            Assert.NotNull(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.NotNull(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.False(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Convention));
-            Assert.False(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
-            Assert.True(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation));
-
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Order.CustomerProperty.Name,
-                pointsToPrincipal: true,
-                ConfigurationSource.Explicit);
-            foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
-                Customer.OrdersProperty.Name,
-                pointsToPrincipal: false,
-                ConfigurationSource.Explicit);
-
-            Assert.Null(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.Null(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation));
-            Assert.NotNull(dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name));
-            Assert.NotNull(principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name));
-
-            Assert.Same(
-                foreignKeyBuilder, foreignKeyBuilder.HasNavigation(
-                    Customer.OrdersProperty.Name,
-                    pointsToPrincipal: false,
-                    ConfigurationSource.Explicit));
-            Assert.Null(
-                foreignKeyBuilder.HasNavigation(
-                    (string)null,
-                    pointsToPrincipal: true,
-                    ConfigurationSource.DataAnnotation));
-        }
-
-        [ConditionalFact]
-        public void Can_ignore_existing_navigation()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var property1 = dependentEntityBuilder.Metadata.AddProperty(
-                Order.CustomerIdProperty.Name, typeof(int), ConfigurationSource.Explicit, ConfigurationSource.Explicit);
-            var property2 = dependentEntityBuilder.Metadata.AddProperty(
-                Order.CustomerUniqueProperty.Name, typeof(Guid?), ConfigurationSource.Explicit, ConfigurationSource.Explicit);
-            var foreignKey = dependentEntityBuilder.Metadata.AddForeignKey(
-                new[] { property1, property2 },
-                principalEntityBuilder.Metadata.FindPrimaryKey(),
-                principalEntityBuilder.Metadata,
-                ConfigurationSource.Explicit,
-                ConfigurationSource.Explicit);
-
-            var navigationToPrincipal = foreignKey.HasDependentToPrincipal(Order.CustomerProperty, ConfigurationSource.Explicit);
-            var navigationToDependent = foreignKey.HasPrincipalToDependent(Customer.OrdersProperty, ConfigurationSource.Explicit);
-
-            var relationship = dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, foreignKey.Properties, ConfigurationSource.Convention).HasNavigation(
-                navigationToPrincipal.Name,
-                pointsToPrincipal: true,
-                ConfigurationSource.Convention).HasNavigation(
-                navigationToDependent.Name,
-                pointsToPrincipal: false,
-                ConfigurationSource.Convention);
-            Assert.Same(foreignKey, relationship.Metadata);
-
-            Assert.NotNull(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
-            Assert.NotNull(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
-
-            Assert.Null(dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name));
-            Assert.Null(principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name));
-        }
-
         [ConditionalTheory]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.Explicit, ConfigurationSource.Convention)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.DataAnnotation, ConfigurationSource.Convention)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.Explicit)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.DataAnnotation)]
-        [InlineData(ConfigurationSource.Convention, ConfigurationSource.Convention)]
+        [MemberData(nameof(DataGenerator.GetCombinations),
+            new object[] { new Type[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+            MemberType = typeof(DataGenerator))]
         public void Can_ignore_navigation_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
         {
-            VerifyIgnoreNavigation(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreNavigation(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreNavigation(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
-            VerifyIgnoreNavigation(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
-            VerifyIgnoreNavigation(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
-            VerifyIgnoreNavigation(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
 
-            VerifyIgnoreNavigation(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreNavigation(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreNavigation(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
-            VerifyIgnoreNavigation(typeof(OrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
-            VerifyIgnoreNavigation(typeof(SpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
-            VerifyIgnoreNavigation(typeof(ExtraSpecialOrderMinimal), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
         }
 
         private void VerifyIgnoreNavigation(
@@ -2298,20 +2083,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool setBaseFirst)
             => VerifyIgnoreMember(
                 ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
-                et => et.Metadata.FindNavigation(OrderMinimal.CustomerProperty.Name) != null,
+                et => et.Metadata.FindNavigation(Order.CustomerProperty.Name) != null,
                 et => et.HasRelationship(
-                        et.ModelBuilder.Entity(typeof(CustomerMinimal), ConfigurationSource.Explicit).Metadata,
-                        OrderMinimal.CustomerProperty.Name,
-                        CustomerMinimal.OrdersProperty.Name,
+                        et.ModelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit).Metadata,
+                        Order.CustomerProperty,
+                        Customer.OrdersProperty,
                         addConfigurationSource)
                     != null,
                 et => et.HasRelationship(
-                        et.ModelBuilder.Entity(typeof(CustomerMinimal), ConfigurationSource.Explicit).Metadata,
-                        OrderMinimal.CustomerProperty.Name,
-                        CustomerMinimal.OrdersProperty.Name,
+                        et.ModelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit).Metadata,
+                        Order.CustomerProperty,
+                        Customer.OrdersProperty,
                         ignoreConfigurationSource)
                     != null,
-                OrderMinimal.CustomerProperty.Name);
+                Order.CustomerProperty.Name);
 
         [ConditionalFact]
         public void Can_merge_with_intrahierarchical_relationship_of_higher_source()
@@ -2352,6 +2137,229 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.NotSame(
                 relationshipBuilder, orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Equal(2, orderEntityBuilder.Metadata.GetForeignKeys().Count());
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetCombinations),
+            new object[] { new Type[] { typeof(ConfigurationSource), typeof(ConfigurationSource) } },
+            MemberType = typeof(DataGenerator))]
+        public void Can_ignore_skip_navigation_in_hierarchy(ConfigurationSource ignoreSource, ConfigurationSource addSource)
+        {
+            VerifyIgnoreSkipNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreSkipNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreSkipNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: true);
+            VerifyIgnoreSkipNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreSkipNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+            VerifyIgnoreSkipNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: true);
+
+            VerifyIgnoreSkipNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreSkipNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreSkipNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: true, setBaseFirst: false);
+            VerifyIgnoreSkipNavigation(typeof(Order), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreSkipNavigation(typeof(SpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+            VerifyIgnoreSkipNavigation(typeof(ExtraSpecialOrder), ignoreSource, addSource, ignoredFirst: false, setBaseFirst: false);
+        }
+
+        private void VerifyIgnoreSkipNavigation(
+            Type ignoredOnType,
+            ConfigurationSource ignoreConfigurationSource,
+            ConfigurationSource addConfigurationSource,
+            bool ignoredFirst,
+            bool setBaseFirst)
+            => VerifyIgnoreMember(
+                ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
+                et => et.Metadata.FindSkipNavigation(nameof(Order.Products)) != null,
+                et => et.HasSkipNavigation(
+                        MemberIdentity.Create(Order.ProductsProperty),
+                        et.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        addConfigurationSource)
+                    != null,
+                et => et.HasSkipNavigation(
+                        MemberIdentity.Create(Order.ProductsProperty),
+                        et.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        ignoreConfigurationSource)
+                    != null,
+                nameof(Order.Products));
+
+        [ConditionalTheory]
+        [MemberData(nameof(DataGenerator.GetCombinations), new object[] { new Type[] {
+                typeof(ConfigurationSource), typeof(ConfigurationSource), typeof(MemberType), typeof(MemberType), typeof(bool) } },
+            MemberType = typeof(DataGenerator))]
+        public void Can_override_members_in_hierarchy(
+            ConfigurationSource firstSource,
+            ConfigurationSource secondSource,
+            MemberType firstMemberType,
+            MemberType secondMemberType,
+            bool setBaseFirst)
+        {
+            VerifyOverrideMembers(typeof(Order), firstSource, secondSource, firstMemberType, secondMemberType, setBaseFirst);
+            VerifyOverrideMembers(typeof(SpecialOrder), firstSource, secondSource, firstMemberType, secondMemberType, setBaseFirst);
+            VerifyOverrideMembers(typeof(ExtraSpecialOrder), firstSource, secondSource, firstMemberType, secondMemberType, setBaseFirst);
+        }
+
+        private void VerifyOverrideMembers(
+            Type firstType,
+            ConfigurationSource firstSource,
+            ConfigurationSource secondSource,
+            MemberType firstMemberType,
+            MemberType secondMemberType,
+            bool setBaseFirst)
+        {
+            var modelBuilder = CreateModelBuilder();
+            var productTypeBuilder = modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention);
+            productTypeBuilder.PrimaryKey(new[] { Product.IdProperty }, ConfigurationSource.Convention);
+
+            if (setBaseFirst)
+            {
+                ConfigureOrdersHierarchy(modelBuilder);
+            }
+
+            var firstEntityTypeBuilder = modelBuilder.Entity(firstType, ConfigurationSource.Convention);
+            var secondEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+
+            Assert.True(ConfigureMember(firstEntityTypeBuilder, firstMemberType, firstSource));
+
+            if ((!setBaseFirst && firstEntityTypeBuilder != secondEntityTypeBuilder)
+                || firstSource != ConfigurationSource.Explicit
+                || secondSource != ConfigurationSource.Explicit
+                || firstMemberType == secondMemberType)
+            {
+                Assert.Equal((!setBaseFirst && firstEntityTypeBuilder != secondEntityTypeBuilder)
+                                || firstMemberType == secondMemberType
+                                || secondSource.Overrides(firstSource),
+                    ConfigureMember(secondEntityTypeBuilder, secondMemberType, secondSource));
+            }
+            else
+            {
+                var message = "";
+                if (firstMemberType == MemberType.Navigation
+                    && secondMemberType == MemberType.Property)
+                {
+                    message = CoreStrings.PropertyCalledOnNavigation(nameof(Order.Products), nameof(SpecialOrder));
+                }
+                else
+                {
+                    message = CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Products), nameof(SpecialOrder), firstEntityTypeBuilder.Metadata.DisplayName());
+                }
+
+                Assert.Equal(message,
+                    Assert.Throws<InvalidOperationException>(
+                        () => ConfigureMember(secondEntityTypeBuilder, secondMemberType, secondSource)).Message);
+
+                return;
+            }
+
+            if (!setBaseFirst)
+            {
+                if (firstEntityTypeBuilder == secondEntityTypeBuilder
+                    || firstSource != ConfigurationSource.Explicit
+                    || secondSource != ConfigurationSource.Explicit
+                    || firstMemberType == secondMemberType)
+                {
+                    ConfigureOrdersHierarchy(modelBuilder);
+                }
+                else
+                {
+                    if (firstType == typeof(Order))
+                    {
+                        Assert.Equal(CoreStrings.DuplicatePropertiesOnBase(nameof(SpecialOrder), nameof(Order),
+                            nameof(SpecialOrder), nameof(Order.Products), nameof(Order), nameof(Order.Products)),
+                            Assert.Throws<InvalidOperationException>(
+                                () => ConfigureOrdersHierarchy(modelBuilder)).Message);
+                    }
+                    else
+                    {
+                        Assert.Equal(CoreStrings.DuplicatePropertiesOnBase(nameof(ExtraSpecialOrder), nameof(SpecialOrder),
+                            nameof(ExtraSpecialOrder), nameof(Order.Products), nameof(SpecialOrder), nameof(Order.Products)),
+                            Assert.Throws<InvalidOperationException>(
+                                () => ConfigureOrdersHierarchy(modelBuilder)).Message);
+                    }
+
+                    return;
+                }
+            }
+
+            var leastDerivedType = firstEntityTypeBuilder.Metadata.LeastDerivedType(secondEntityTypeBuilder.Metadata);
+            var shouldSecondWin = secondSource.Overrides(firstSource)
+                    && (secondSource != firstSource
+                        || setBaseFirst
+                        || secondEntityTypeBuilder.Metadata == leastDerivedType);
+
+            var expectedDeclaringType = firstMemberType == secondMemberType
+                ? leastDerivedType
+                : shouldSecondWin
+                    ? secondEntityTypeBuilder.Metadata
+                    : firstEntityTypeBuilder.Metadata;
+
+            var expectedMemberType = shouldSecondWin
+                ? secondMemberType
+                : firstMemberType;
+
+            AssertDeclaringType(
+                modelBuilder.Entity(typeof(ExtraSpecialOrder), ConfigurationSource.Convention),
+                expectedDeclaringType,
+                expectedMemberType);
+        }
+
+        private bool ConfigureMember(
+            InternalEntityTypeBuilder entityTypeBuilder,
+            MemberType memberType,
+            ConfigurationSource configurationSource)
+        {
+            switch (memberType)
+            {
+                case MemberType.Property:
+                    return entityTypeBuilder.Property(Order.ProductsProperty, configurationSource) != null;
+                case MemberType.ServiceProperty:
+                    return entityTypeBuilder.ServiceProperty(Order.ProductsProperty, configurationSource) != null;
+                case MemberType.Navigation:
+                    return entityTypeBuilder.HasRelationship(
+                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        Order.ProductsProperty,
+                        null,
+                        configurationSource) != null;
+                case MemberType.SkipNavigation:
+                    return entityTypeBuilder.HasSkipNavigation(
+                        MemberIdentity.Create(Order.ProductsProperty),
+                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        configurationSource) != null;
+            }
+
+            return false;
+        }
+
+        private void AssertDeclaringType(
+            InternalEntityTypeBuilder entityTypeBuilder,
+            EntityType expectedDeclaringType,
+            MemberType memberType)
+        {
+            Assert.Same(memberType == MemberType.Property ? expectedDeclaringType : null,
+                GetDeclaringType(entityTypeBuilder, MemberType.Property));
+            Assert.Same(memberType == MemberType.ServiceProperty ? expectedDeclaringType : null,
+                GetDeclaringType(entityTypeBuilder, MemberType.ServiceProperty));
+            Assert.Same(memberType == MemberType.Navigation ? expectedDeclaringType : null,
+                GetDeclaringType(entityTypeBuilder, MemberType.Navigation));
+            Assert.Same(memberType == MemberType.SkipNavigation ? expectedDeclaringType : null,
+                GetDeclaringType(entityTypeBuilder, MemberType.SkipNavigation));
+        }
+
+        private EntityType GetDeclaringType(
+            InternalEntityTypeBuilder entityTypeBuilder,
+            MemberType memberType)
+        {
+            switch (memberType)
+            {
+                case MemberType.Property:
+                    return entityTypeBuilder.Metadata.FindProperty(nameof(Order.Products))?.DeclaringEntityType;
+                case MemberType.ServiceProperty:
+                    return entityTypeBuilder.Metadata.FindServiceProperty(nameof(Order.Products))?.DeclaringEntityType;
+                case MemberType.Navigation:
+                    return entityTypeBuilder.Metadata.FindNavigation(nameof(Order.Products))?.DeclaringEntityType;
+                case MemberType.SkipNavigation:
+                    return entityTypeBuilder.Metadata.FindSkipNavigation(nameof(Order.Products))?.DeclaringEntityType;
+            }
+
+            return null;
         }
 
         [ConditionalFact]
@@ -2631,7 +2639,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Can_only_set_base_type_if_relationship_with_conflicting_navigation_of_data_annotation_or_lower_source()
+        public void Cannot_set_base_type_for_relationship_with_explicit_conflicting_incompatible_navigations()
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
@@ -2649,16 +2657,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
             Assert.Single(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
 
-            Assert.Same(
-                derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit));
-            Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
-            Assert.Single(dependentEntityBuilder.Metadata.GetDeclaredNavigations());
-            Assert.Empty(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
+            Assert.Equal(CoreStrings.DuplicatePropertiesOnBase(nameof(SpecialOrder), nameof(Order),
+                nameof(SpecialOrder), nameof(Order.Customer), nameof(Order), nameof(Order.Customer)),
+                Assert.Throws<InvalidOperationException>(
+                    () => derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit)).Message);
         }
 
         [ConditionalFact]
-        public void Can_set_base_type_if_relationship_with_conflicting_foreign_key_of_data_annotation_or_lower_source()
+        public void Can_set_base_type_for_relationship_with_explicit_conflicting_foreign_key()
         {
             var modelBuilder = CreateModelBuilder();
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
@@ -2775,13 +2781,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Order.CustomerProperty.Name,
                     Customer.SpecialOrdersProperty.Name,
                     ConfigurationSource.Explicit)
-                .HasForeignKey(new[] { derivedIdProperty }, ConfigurationSource.Explicit);
-
-            Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
+                .HasForeignKey(new[] { derivedIdProperty }, ConfigurationSource.Convention);
 
             Assert.Same(
                 derivedDependentEntityBuilder,
-                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Explicit));
+                derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
             Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
             var fk = derivedDependentEntityBuilder.Metadata.GetForeignKeys().Single();
             Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
@@ -2791,7 +2795,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Setting_base_type_removes_duplicate_service_properties()
+        public void Setting_base_type_removes_duplicate_derived_service_properties()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            entityBuilder.PrimaryKey(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
+            entityBuilder.ServiceProperty(Order.ContextProperty, ConfigurationSource.Explicit);
+            var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+            derivedEntityBuilder.PrimaryKey(new[] { Order.IdProperty }, ConfigurationSource.Convention);
+            derivedEntityBuilder.ServiceProperty(Order.ContextProperty, ConfigurationSource.Convention);
+
+            Assert.Same(
+                derivedEntityBuilder,
+                derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention));
+
+            Assert.Single(entityBuilder.Metadata.GetServiceProperties());
+            Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredServiceProperties());
+        }
+
+        [ConditionalFact]
+        public void Setting_base_type_preserves_duplicate_base_service_properties()
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
@@ -2803,10 +2826,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Same(
                 derivedEntityBuilder,
-                derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Explicit));
+                derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Single(entityBuilder.Metadata.GetServiceProperties());
-            Assert.Single(derivedEntityBuilder.Metadata.GetServiceProperties());
+            Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredServiceProperties());
         }
 
         [ConditionalFact]
@@ -3034,19 +3057,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private InternalModelBuilder CreateModelBuilder() => new InternalModelBuilder(new Model());
 
+        public enum MemberType
+        {
+            Property,
+            ServiceProperty,
+            Navigation,
+            SkipNavigation
+        }
+
         private class Order
         {
-            public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
-            public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId");
-            public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty("CustomerUnique");
-            public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty("Customer");
+            public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
+            public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId));
+            public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique));
+            public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer));
             public static readonly PropertyInfo ContextProperty = typeof(Order).GetProperty(nameof(Context));
+            public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
 
             public int Id { get; set; }
             public int CustomerId { get; set; }
             public Guid? CustomerUnique { get; set; }
             public Customer Customer { get; set; }
             public DbContext Context { get; set; }
+            public ICollection<Product> Products { get; set; }
         }
 
         private class SpecialOrder : Order, IEnumerable<Order>
@@ -3073,11 +3106,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private class Customer
         {
-            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-            public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty("Unique");
-            public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty("Orders");
-            public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty("NotCollectionOrders");
-            public static readonly PropertyInfo SpecialOrdersProperty = typeof(Customer).GetProperty("SpecialOrders");
+            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
+            public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty(nameof(Unique));
+            public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders));
+            public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders));
+            public static readonly PropertyInfo SpecialOrdersProperty = typeof(Customer).GetProperty(nameof(SpecialOrders));
 
             public int Id { get; set; }
             public Guid Unique { get; set; }
@@ -3092,44 +3125,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             internal Customer Customer { get; set; }
         }
 
-        private class OrderMinimal
+        private class OrderProduct
         {
-            public static readonly PropertyInfo IdProperty = typeof(OrderMinimal).GetProperty("Id");
-            public static readonly PropertyInfo CustomerIdProperty = typeof(OrderMinimal).GetProperty("CustomerId");
-            public static readonly PropertyInfo CustomerProperty = typeof(OrderMinimal).GetProperty("Customer");
+            public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
+            public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+
+            public int OrderId { get; set; }
+            public int ProductId { get; set; }
+            public virtual Order Order { get; set; }
+            public virtual Product Product { get; set; }
+        }
+
+        private class Product
+        {
+            public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
 
             public int Id { get; set; }
-            public int CustomerId { get; set; }
-            public CustomerMinimal Customer { get; set; }
+
+            public virtual ICollection<Order> Orders { get; set; }
         }
 
-        private class SpecialOrderMinimal : OrderMinimal, IEnumerable<OrderMinimal>
-        {
-            public static readonly PropertyInfo SpecialtyProperty = typeof(SpecialOrderMinimal).GetProperty("Specialty");
-
-            public IEnumerator<OrderMinimal> GetEnumerator()
-            {
-                yield return this;
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        private class ExtraSpecialOrderMinimal : SpecialOrderMinimal
+        private class SpecialProduct : Product
         {
         }
 
-        private class BackOrderMinimal : OrderMinimal
+        private class ExtraSpecialProduct : SpecialProduct
         {
-        }
-
-        private class CustomerMinimal
-        {
-            public static readonly PropertyInfo IdProperty = typeof(CustomerMinimal).GetProperty("Id");
-            public static readonly PropertyInfo OrdersProperty = typeof(CustomerMinimal).GetProperty("Orders");
-
-            public int Id { get; set; }
-            public ICollection<OrderMinimal> Orders { get; set; }
         }
 
         private class Splot

--- a/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -251,7 +251,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Can_only_override_lower_or_equal_source_unicode()
+        public void Can_only_override_lower_or_equal_source_IsUnicode()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Can_only_override_existing_unicode_value_explicitly()
+        public void Can_only_override_existing_IsUnicode_value_explicitly()
         {
             var metadata = CreateProperty();
             metadata.SetIsUnicode(true);

--- a/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
@@ -1,0 +1,247 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public class InternalSkipNavigationBuilderTest
+    {
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_HasField()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            var metadata = builder.Metadata;
+
+            Assert.Null(metadata.FieldInfo);
+            Assert.Null(metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField(Order.ProductsField, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField(Order.ProductsField, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(Order.ProductsField, metadata.FieldInfo);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField(Order.ProductsField, ConfigurationSource.Convention));
+            Assert.False(builder.CanSetField(Order.OtherProductsField, ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasField(Order.ProductsField, ConfigurationSource.Convention));
+            Assert.Null(builder.HasField(Order.OtherProductsField, ConfigurationSource.Convention));
+
+            Assert.Equal(Order.ProductsField, metadata.FieldInfo);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField(Order.OtherProductsField, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField(Order.OtherProductsField, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(Order.OtherProductsField, metadata.FieldInfo);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+
+            Assert.Null(metadata.FieldInfo);
+            Assert.Null(metadata.GetFieldInfoConfigurationSource());
+        }
+
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_HasField_string()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            var metadata = builder.Metadata;
+
+            Assert.Null(metadata.FieldInfo);
+            Assert.Null(metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_products", ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField("_products", ConfigurationSource.DataAnnotation));
+
+            Assert.Equal("_products", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_products", ConfigurationSource.Convention));
+            Assert.False(builder.CanSetField("_otherProducts", ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasField("_products", ConfigurationSource.Convention));
+            Assert.Null(builder.HasField("_otherProducts", ConfigurationSource.Convention));
+
+            Assert.Equal("_products", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_otherProducts", ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField("_otherProducts", ConfigurationSource.DataAnnotation));
+
+            Assert.Equal("_otherProducts", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+
+            Assert.Null(metadata.FieldInfo);
+            Assert.Null(metadata.GetFieldInfoConfigurationSource());
+        }
+
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_PropertyAccessMode()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            IConventionSkipNavigation metadata = builder.Metadata;
+
+            Assert.Equal(PropertyAccessMode.PreferField, metadata.GetPropertyAccessMode());
+            Assert.Null(metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferProperty, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.Convention));
+            Assert.False(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.Convention));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.Convention));
+            Assert.Null(builder.UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.Convention));
+
+            Assert.Equal(PropertyAccessMode.PreferProperty, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferFieldDuringConstruction, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(null, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferField, metadata.GetPropertyAccessMode());
+            Assert.Null(metadata.GetPropertyAccessModeConfigurationSource());
+        }
+
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_ForeignKey()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            IConventionSkipNavigation metadata = builder.Metadata;
+
+            var fk = (ForeignKey)metadata.DeclaringEntityType.Model.Builder.Entity(typeof(OrderProduct))
+                .HasRelationship(metadata.DeclaringEntityType, nameof(OrderProduct.Order))
+                .IsUnique(false)
+                .Metadata;
+
+            Assert.Null(metadata.ForeignKey);
+            Assert.Null(metadata.GetForeignKeyConfigurationSource());
+
+            Assert.True(builder.CanSetForeignKey(fk, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasForeignKey(fk, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(fk, metadata.ForeignKey);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetForeignKeyConfigurationSource());
+
+            Assert.True(builder.CanSetForeignKey(fk, ConfigurationSource.Convention));
+            Assert.False(builder.CanSetForeignKey(null, ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasForeignKey(fk, ConfigurationSource.Convention));
+            Assert.Null(builder.HasForeignKey(null, ConfigurationSource.Convention));
+
+            Assert.Equal(fk, metadata.ForeignKey);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetForeignKeyConfigurationSource());
+
+            Assert.True(builder.CanSetForeignKey(null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasForeignKey(null, ConfigurationSource.DataAnnotation));
+
+            Assert.Null(metadata.ForeignKey);
+            Assert.Null(metadata.GetForeignKeyConfigurationSource());
+        }
+
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_Inverse()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            IConventionSkipNavigation metadata = builder.Metadata;
+
+            var inverse = (SkipNavigation)metadata.TargetEntityType.Builder.HasSkipNavigation(
+                Product.OrdersProperty,
+                metadata.DeclaringEntityType)
+                .Metadata;
+
+            Assert.Null(metadata.Inverse);
+            Assert.Null(metadata.GetInverseConfigurationSource());
+            Assert.Null(inverse.Inverse);
+            Assert.Null(inverse.GetInverseConfigurationSource());
+
+            Assert.True(builder.CanSetInverse(inverse, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasInverse(inverse, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(inverse, metadata.Inverse);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetInverseConfigurationSource());
+            Assert.Equal(metadata, inverse.Inverse);
+            Assert.Equal(ConfigurationSource.DataAnnotation, inverse.GetInverseConfigurationSource());
+
+            Assert.True(builder.CanSetInverse(inverse, ConfigurationSource.Convention));
+            Assert.False(builder.CanSetInverse(null, ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasInverse(inverse, ConfigurationSource.Convention));
+            Assert.Null(builder.HasInverse(null, ConfigurationSource.Convention));
+
+            Assert.Equal(inverse, metadata.Inverse);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetInverseConfigurationSource());
+            Assert.Equal(metadata, inverse.Inverse);
+            Assert.Equal(ConfigurationSource.DataAnnotation, inverse.GetInverseConfigurationSource());
+
+            Assert.True(builder.CanSetInverse(null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasInverse(null, ConfigurationSource.DataAnnotation));
+
+            Assert.Null(metadata.Inverse);
+            Assert.Null(metadata.GetInverseConfigurationSource());
+            Assert.Null(inverse.Inverse);
+            Assert.Null(inverse.GetInverseConfigurationSource());
+        }
+
+        private InternalSkipNavigationBuilder CreateInternalSkipNavigationBuilder()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
+
+            return modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)
+                .HasSkipNavigation(
+                    MemberIdentity.Create(Order.ProductsProperty),
+                    modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention).Metadata,
+                    ConfigurationSource.Convention);
+        }
+
+        protected class Order
+        {
+            public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
+            public static readonly FieldInfo ProductsField = typeof(Order)
+                .GetField(nameof(_products), BindingFlags.Instance | BindingFlags.NonPublic);
+            public static readonly FieldInfo OtherProductsField = typeof(Order)
+                .GetField(nameof(_otherProducts), BindingFlags.Instance | BindingFlags.NonPublic);
+
+            public int OrderId { get; set; }
+
+            private ICollection<Product> _products;
+            private readonly ICollection<Product> _otherProducts = new List<Product>();
+            public ICollection<Product> Products { get => _products; set => _products = value; }
+        }
+
+        private class OrderProduct
+        {
+            public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
+            public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+
+            public int OrderId { get; set; }
+            public int ProductId { get; set; }
+            public virtual Order Order { get; set; }
+            public virtual Product Product { get; set; }
+        }
+
+        protected class Product
+        {
+            public static readonly PropertyInfo OrdersProperty = typeof(Product).GetProperty(nameof(Orders));
+
+            public int Id { get; set; }
+
+            public virtual ICollection<Order> Orders { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
@@ -181,18 +181,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Assert.Throws<InvalidOperationException>(
                     () => dependentOrderType.AddForeignKey(fkProperty, orderKey, dependentOrderType)).Message);
 
-            Assert.Equal(
-                CoreStrings.EntityTypeInUseByForeignKey(
-                    nameof(Customer) + "." + nameof(Customer.Orders) + "#" + nameof(Order),
-                    nameof(Customer), fk.Properties.Format()),
-                Assert.Throws<InvalidOperationException>(() => model.RemoveEntityType(dependentOrderType)).Message);
-
-            dependentOrderType.RemoveForeignKey(fk.Properties, fk.PrincipalKey, fk.PrincipalEntityType);
-
             Assert.Same(
                 dependentOrderType, model.RemoveEntityType(
                     typeof(Order), nameof(Customer.Orders), customerType));
             Assert.Null(((EntityType)dependentOrderType).Builder);
+            Assert.Empty(customerType.GetReferencingForeignKeys());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
@@ -24,8 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var firstFk = associationEntityBuilder
                 .AddForeignKey(new[] { orderIdProperty }, firstKey, firstEntity);
 
-            var navigation = firstEntity.AddSkipNavigation(
-                nameof(Order.Products), null, secondEntity, firstFk, true, false);
+            var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, secondEntity, true, false);
+            navigation.SetForeignKey(firstFk);
 
             Assert.True(navigation.IsCollection);
             Assert.False(navigation.IsOnDependent);
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var firstFk = associationEntityBuilder
                 .AddForeignKey(new[] { orderIdProperty }, firstKey, firstEntity);
 
-            var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, secondEntity, null, true, false);
+            var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, secondEntity, true, false);
 
             Assert.Null(navigation.ForeignKey);
             Assert.Null(navigation.GetForeignKeyConfigurationSource());
@@ -82,8 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var orderProductFkProperty = orderProductEntity.AddProperty(nameof(OrderProduct.OrderId), typeof(int));
             var orderProductForeignKey = orderProductEntity.AddForeignKey(orderProductFkProperty, orderKey, orderEntity);
 
-            var navigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, null, true, true);
+            var navigation = orderEntity.AddSkipNavigation(nameof(Order.Products), null, productEntity, true, true);
 
             Assert.Equal(
                 CoreStrings.SkipNavigationForeignKeyWrongDependentType(
@@ -104,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var orderProductForeignKey = orderProductEntity.AddForeignKey(orderProductFkProperty, orderKey, orderEntity);
 
             var navigation = orderProductEntity.AddSkipNavigation(
-                nameof(OrderProduct.Order), null, orderEntity, null, false, false);
+                nameof(OrderProduct.Order), null, orderEntity, false, false);
 
             Assert.Equal(
                 CoreStrings.SkipNavigationForeignKeyWrongPrincipalType(
@@ -130,11 +129,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var productOrderForeignKey = productEntity
                 .AddForeignKey(new[] { productFkProperty }, productKey, productEntity);
 
-            var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, null, true, false);
+            var productsNavigation = orderEntity.AddSkipNavigation(nameof(Order.Products), null, productEntity, true, false);
 
-            var ordersNavigation = productEntity.AddSkipNavigation(
-                nameof(Product.Orders), null, orderEntity, productOrderForeignKey, true, false);
+            var ordersNavigation = productEntity.AddSkipNavigation(nameof(Product.Orders), null, orderEntity, true, false);
+            ordersNavigation.SetForeignKey(productOrderForeignKey);
 
             productsNavigation.SetInverse(ordersNavigation);
 
@@ -163,11 +161,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var productOrderForeignKey = orderProductEntity
                 .AddForeignKey(new[] { productOrderFkProperty }, productKey, productEntity);
 
-            var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, orderProductForeignKey, true, false);
+            var productsNavigation = orderEntity.AddSkipNavigation(nameof(Order.Products), null, productEntity, true, false);
+            productsNavigation.SetForeignKey(orderProductForeignKey);
 
-            var ordersNavigation = productEntity.AddSkipNavigation(
-                nameof(Product.Orders), null, orderEntity, productOrderForeignKey, true, false);
+            var ordersNavigation = productEntity.AddSkipNavigation(nameof(Product.Orders), null, orderEntity, true, false);
+            ordersNavigation.SetForeignKey(productOrderForeignKey);
 
             productsNavigation.SetInverse(ordersNavigation);
             ordersNavigation.SetInverse(productsNavigation);
@@ -178,6 +176,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(ConfigurationSource.Explicit, ((IConventionSkipNavigation)ordersNavigation).GetConfigurationSource());
             Assert.Equal(ConfigurationSource.Explicit, ((IConventionSkipNavigation)productsNavigation).GetInverseConfigurationSource());
             Assert.Equal(ConfigurationSource.Explicit, ((IConventionSkipNavigation)ordersNavigation).GetInverseConfigurationSource());
+
+            Assert.Equal(CoreStrings.SkipNavigationInUseBySkipNavigation(nameof(Order.Products), nameof(Product.Orders), nameof(Product)),
+                Assert.Throws<InvalidOperationException>(() => orderEntity.RemoveSkipNavigation(productsNavigation)).Message);
 
             productsNavigation.SetInverse(null);
             ordersNavigation.SetInverse(null);
@@ -204,11 +205,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var productOrderForeignKey = orderProductEntity
                 .AddForeignKey(new[] { productOrderFkProperty }, productKey, productEntity);
 
-            var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, orderProductForeignKey, true, false);
+            var productsNavigation = orderEntity.AddSkipNavigation(nameof(Order.Products), null, productEntity, true, false);
+            productsNavigation.SetForeignKey(orderProductForeignKey);
 
-            var ordersNavigation = orderProductEntity.AddSkipNavigation(
-                nameof(OrderProduct.Product), null, productEntity, productOrderForeignKey, false, true);
+            var ordersNavigation = orderProductEntity.AddSkipNavigation(nameof(OrderProduct.Product), null, productEntity, false, true);
+            ordersNavigation.SetForeignKey(productOrderForeignKey);
 
             Assert.Equal(CoreStrings.SkipNavigationWrongInverse(
                     nameof(OrderProduct.Product), nameof(OrderProduct), nameof(Order.Products), nameof(Product)),
@@ -233,11 +234,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var productOrderForeignKey = productEntity
                 .AddForeignKey(new[] { productFkProperty }, productKey, productEntity);
 
-            var productsNavigation = orderEntity.AddSkipNavigation(
-                nameof(Order.Products), null, productEntity, orderProductForeignKey, true, false);
+            var productsNavigation = orderEntity.AddSkipNavigation(nameof(Order.Products), null, productEntity, true, false);
+            productsNavigation.SetForeignKey(orderProductForeignKey);
 
-            var ordersNavigation = productEntity.AddSkipNavigation(
-                nameof(Product.Orders), null, orderEntity, productOrderForeignKey, true, false);
+            var ordersNavigation = productEntity.AddSkipNavigation(nameof(Product.Orders), null, orderEntity, true, false);
+            ordersNavigation.SetForeignKey(productOrderForeignKey);
 
             Assert.Equal(CoreStrings.SkipInverseMismatchedAssociationType(
                     nameof(Product.Orders), nameof(Product), nameof(Order.Products), nameof(OrderProduct)),

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.ModelBuilding
+{
+    public abstract partial class ModelBuilderTest
+    {
+        public abstract class ManyToManyTestBase : ModelBuilderTestBase
+        {
+            [ConditionalFact]
+            public virtual void Finds_existing_navigations_and_uses_associated_FK()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Category>().Ignore(c => c.Products);
+                modelBuilder.Entity<Product>().Ignore(p => p.Categories);
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(o => o.Products).WithMany(c => c.Categories)
+                    .UsingEntity<ProductCategory>(
+                        pcb => pcb.HasOne(pc => pc.Product).WithMany(),
+                        pcb => pcb.HasOne(pc => pc.Category).WithMany(c => c.ProductCategories))
+                    .HasKey(pc => new { pc.ProductId, pc.CategoryId });
+
+                var productType = model.FindEntityType(typeof(Product));
+                var categoryType = model.FindEntityType(typeof(Category));
+                var productCategoryType = model.FindEntityType(typeof(ProductCategory));
+
+                var categoriesNavigation = productType.GetSkipNavigations().Single();
+                var productsNavigation = categoryType.GetSkipNavigations().Single();
+
+                var categoriesFk = categoriesNavigation.ForeignKey;
+                var productsFk = productsNavigation.ForeignKey;
+
+                Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
+                Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
+                Assert.Equal(2, productCategoryType.GetForeignKeys().Count());
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(o => o.Products).WithMany(c => c.Categories)
+                    .UsingEntity<ProductCategory>(
+                        pcb => pcb.HasOne(pc => pc.Product).WithMany(),
+                        pcb => pcb.HasOne(pc => pc.Category).WithMany(c => c.ProductCategories));
+
+                modelBuilder.FinalizeModel();
+
+                Assert.Same(categoriesNavigation, productType.GetSkipNavigations().Single());
+                Assert.Same(productsNavigation, categoryType.GetSkipNavigations().Single());
+                Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
+                Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
+                Assert.Equal(2, productCategoryType.GetForeignKeys().Count());
+            }
+
+            [ConditionalFact]
+            public virtual void Configures_association_type()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Category>().Ignore(c => c.Products);
+                modelBuilder.Entity<Product>().Ignore(p => p.Categories);
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(o => o.Products).WithMany(c => c.Categories)
+                    .UsingEntity<ProductCategory>(
+                        pcb => pcb.HasOne(pc => pc.Product).WithMany(),
+                        pcb => pcb.HasOne(pc => pc.Category).WithMany(c => c.ProductCategories),
+                        pcb => pcb.HasKey(pc => new { pc.ProductId, pc.CategoryId }));
+
+                modelBuilder.FinalizeModel();
+
+                var productType = model.FindEntityType(typeof(Product));
+                var categoryType = model.FindEntityType(typeof(Category));
+                var productCategoryType = model.FindEntityType(typeof(ProductCategory));
+
+                var categoriesNavigation = productType.GetSkipNavigations().Single();
+                var productsNavigation = categoryType.GetSkipNavigations().Single();
+
+                var categoriesFk = categoriesNavigation.ForeignKey;
+                var productsFk = productsNavigation.ForeignKey;
+
+                Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
+                Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
+                Assert.Equal(2, productCategoryType.GetForeignKeys().Count());
+
+                var key = productCategoryType.FindPrimaryKey();
+                Assert.Equal(
+                    new[] { nameof(ProductCategory.ProductId), nameof(ProductCategory.CategoryId) },
+                    key.Properties.Select(p => p.Name));
+            }
+
+            [ConditionalFact]
+            public virtual void Can_ignore_existing_navigations()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+                modelBuilder.Entity<Category>()
+                    .HasMany(p => p.Products).WithMany(c => c.Categories);
+
+                modelBuilder.Entity<Category>().Ignore(c => c.Products);
+                modelBuilder.Entity<Product>().Ignore(p => p.Categories);
+
+                // Issue #19550
+                modelBuilder.Ignore<ProductCategory>();
+
+                var productType = model.FindEntityType(typeof(Product));
+                var categoryType = model.FindEntityType(typeof(Category));
+
+                Assert.Empty(productType.GetSkipNavigations());
+                Assert.Empty(categoryType.GetSkipNavigations());
+
+                modelBuilder.FinalizeModel();
+            }
+
+            [ConditionalFact]
+            public virtual void Throws_for_conflicting_many_to_one_on_left()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(o => o.Products).WithOne();
+
+                Assert.Equal(
+                    CoreStrings.ConflictingRelationshipNavigation(
+                        nameof(Category) + "." + nameof(Category.Products),
+                        nameof(Product) + "." + nameof(Product.Categories),
+                        nameof(Category) + "." + nameof(Category.Products),
+                        nameof(Product)),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<Category>()
+                            .HasMany(o => o.Products).WithMany(c => c.Categories)).Message);
+            }
+
+            [ConditionalFact]
+            public virtual void Throws_for_conflicting_many_to_one_on_right()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Category>()
+                    .HasMany(o => o.Products).WithOne();
+
+                Assert.Equal(
+                    CoreStrings.ConflictingRelationshipNavigation(
+                        nameof(Product) + "." + nameof(Product.Categories),
+                        nameof(Category) + "." + nameof(Category.Products),
+                        nameof(Category) + "." + nameof(Category.Products),
+                        nameof(Product)),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<Product>()
+                            .HasMany(o => o.Categories).WithMany(c => c.Products)).Message);
+            }
+        }
+    }
+}

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -1740,14 +1740,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(
                     CoreStrings.ConflictingRelationshipNavigation(
-                        principalType.DisplayName(),
-                        nameof(Nob.Hobs),
-                        dependentType.DisplayName(),
-                        nameof(Hob.Nob),
-                        principalType.DisplayName(),
-                        nameof(Nob.Hob),
-                        dependentType.DisplayName(),
-                        nameof(Hob.Nob)),
+                        principalType.DisplayName() + "." + nameof(Nob.Hobs),
+                        dependentType.DisplayName() + "." + nameof(Hob.Nob),
+                        principalType.DisplayName() + "." + nameof(Nob.Hob),
+                        dependentType.DisplayName() + "." + nameof(Hob.Nob)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             modelBuilder.Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs)).Message);

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
@@ -155,8 +155,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     CollectionNavigationBuilder.WithOne(navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
         }
 
-        private class GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity> : GenericTestReferenceCollectionBuilder<TEntity,
-            TRelatedEntity>
+        private class GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>
+            : GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>
             where TEntity : class
             where TRelatedEntity : class
         {

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -341,6 +341,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null);
+
+            public abstract TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression);
         }
 
         public abstract class TestReferenceNavigationBuilder<TEntity, TRelatedEntity>
@@ -408,6 +411,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> IsRequired(bool isRequired = true);
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior);
+        }
+
+        public abstract class TestCollectionCollectionBuilder<TLeftEntity, TRightEntity>
+            where TLeftEntity : class
+            where TRightEntity : class
+        {
+            public abstract TestEntityTypeBuilder<TAssociationEntity> UsingEntity<TAssociationEntity>(
+                Func<TestEntityTypeBuilder<TAssociationEntity>,
+                    TestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
+                Func<TestEntityTypeBuilder<TAssociationEntity>,
+                    TestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft)
+                where TAssociationEntity : class;
+
+            public abstract TestEntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+                Func<TestEntityTypeBuilder<TAssociationEntity>,
+                    TestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
+                Func<TestEntityTypeBuilder<TAssociationEntity>,
+                    TestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft,
+                Action<TestEntityTypeBuilder<TAssociationEntity>> configureAssociation)
+                where TAssociationEntity : class;
         }
 
         public abstract class TestOwnershipBuilder<TEntity, TDependentEntity>

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -2824,6 +2824,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Can_create_relationship_if_navigations_have_same_name()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                var dependentEntityTypeBuilder = modelBuilder.Entity<BaseTypeWithKeyAnnotation>();
+                var principalEntityTypeBuilder = modelBuilder.Entity<PrincipalTypeWithKeyAnnotation>();
+
+                var foreignKey1 = dependentEntityTypeBuilder.HasOne(p => p.Navigation).WithOne(d => d.Navigation).Metadata;
+
+                var foreignKey2 = principalEntityTypeBuilder.HasOne(p => p.Navigation).WithOne(d => d.Navigation).Metadata;
+
+                modelBuilder.FinalizeModel();
+
+                Assert.Same(foreignKey1, foreignKey2);
+                Assert.Same(dependentEntityTypeBuilder.Metadata, foreignKey1.DeclaringEntityType);
+                Assert.Equal(nameof(PrincipalTypeWithKeyAnnotation.Navigation), foreignKey1.DependentToPrincipal?.Name);
+                Assert.Equal(nameof(BaseTypeWithKeyAnnotation.Navigation), foreignKey1.PrincipalToDependent?.Name);
+            }
+
+            [ConditionalFact]
             public virtual void Can_specify_shadow_fk_before_configuring_principal_PK()
             {
                 var modelBuilder = CreateModelBuilder();
@@ -3251,14 +3271,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(
                     CoreStrings.ConflictingRelationshipNavigation(
-                        principalType.DisplayName(),
-                        nameof(Hob.Nob),
-                        dependentType.DisplayName(),
-                        nameof(Nob.Hob),
-                        dependentType.DisplayName(),
-                        nameof(Nob.Hobs),
-                        principalType.DisplayName(),
-                        nameof(Hob.Nob)),
+                        principalType.DisplayName() + "." + nameof(Hob.Nob),
+                        dependentType.DisplayName() + "." + nameof(Nob.Hob),
+                        dependentType.DisplayName() + "." + nameof(Nob.Hobs),
+                        principalType.DisplayName() + "." + nameof(Hob.Nob)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)).Message);
@@ -3304,14 +3320,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(
                     CoreStrings.ConflictingRelationshipNavigation(
-                        principalType.DisplayName(),
-                        nameof(Hob.Nob),
-                        dependentType.DisplayName(),
-                        nameof(Nob.Hob),
-                        principalType.DisplayName(),
-                        nameof(Hob.Nobs),
-                        dependentType.DisplayName(),
-                        nameof(Nob.Hob)),
+                        principalType.DisplayName() + "." + nameof(Hob.Nob),
+                        dependentType.DisplayName() + "." + nameof(Nob.Hob),
+                        principalType.DisplayName() + "." + nameof(Hob.Nobs),
+                        dependentType.DisplayName() + "." + nameof(Nob.Hob)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)).Message);
@@ -3753,7 +3765,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_self_referencing_relationship_without_navigations()
+            public virtual void Can_create_self_referencing_relationship_without_navigations()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<SelfRef>(
@@ -3775,7 +3787,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_relationship_if_dependent_has_matching_property_with_navigation_name()
+            public virtual void Can_create_relationship_if_dependent_has_matching_property_with_navigation_name()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<OneToOnePrincipalEntity>(
@@ -3800,7 +3812,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_relationship_if_dependent_has_matching_property_with_entity_type_name()
+            public virtual void Can_create_relationship_if_dependent_has_matching_property_with_entity_type_name()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<OneToOnePrincipalEntity>(
@@ -3825,7 +3837,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_invert_one_to_one_relationship_if_principal_has_matching_property_with_navigation_name()
+            public virtual void Can_invert_relationship_if_principal_has_matching_property_with_navigation_name()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<OneToOnePrincipalEntity>(b => b.Ignore(e => e.OneToOneDependentEntityId));
@@ -3850,7 +3862,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_invert_one_to_one_relationship_if_principal_has_matching_property_with_entity_type_name()
+            public virtual void Can_invert_relationship_if_principal_has_matching_property_with_entity_type_name()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<OneToOnePrincipalEntity>(b => b.Ignore(e => e.NavOneToOneDependentEntityId));
@@ -4057,7 +4069,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_relationship_if_user_specify_foreign_key_property()
+            public virtual void Can_create_relationship_if_user_specify_foreign_key_property()
             {
                 var modelBuilder = CreateModelBuilder();
 
@@ -4077,7 +4089,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_relationship_if_user_specifies_principal_key_property()
+            public virtual void Can_create_relationship_if_user_specifies_principal_key_property()
             {
                 var modelBuilder = CreateModelBuilder();
 
@@ -4099,7 +4111,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_create_one_to_one_relationship_if_foreign_key_attribute_is_used()
+            public virtual void Can_create_relationship_if_foreign_key_attribute_is_used()
             {
                 var modelBuilder = CreateModelBuilder();
 

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -141,14 +141,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int? CustomerId { get; set; }
             public Guid AnotherCustomerId { get; set; }
             public Customer Customer { get; set; }
-
             public OrderCombination OrderCombination { get; set; }
-
             public OrderDetails Details { get; set; }
             public ICollection<Product> Products { get; set; }
 
             public event PropertyChangedEventHandler PropertyChanged;
-
             protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
             {
                 if (PropertyChanged == null)
@@ -158,18 +155,45 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
         }
 
+        private class OrderProduct
+        {
+            public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
+            public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+
+            public int OrderId { get; set; }
+            public int ProductId { get; set; }
+            public virtual Order Order { get; set; }
+            public virtual Product Product { get; set; }
+        }
+
         [NotMapped]
         protected class Product
         {
             public int Id { get; set; }
+
+            [NotMapped]
             public Order Order { get; set; }
+
+            [NotMapped]
+            public virtual ICollection<Order> Orders { get; set; }
+
+            public virtual ICollection<Category> Categories { get; set; }
         }
 
         protected class ProductCategory
         {
+            public int ProductId { get; set; }
+            public int CategoryId { get; set; }
+            public virtual Product Product { get; set; }
+            public virtual Category Category { get; set; }
+        }
+
+        protected class Category
+        {
             public int Id { get; set; }
             public string Name { get; set; }
-            public ICollection<Product> Products { get; set; }
+            public virtual ICollection<ProductCategory> ProductCategories { get; set; }
+            public virtual ICollection<Product> Products { get; set; }
         }
 
         [Owned]
@@ -596,6 +620,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class PrincipalTypeWithKeyAnnotation
         {
             public int Id { get; set; }
+
+            [NotMapped]
+            public BaseTypeWithKeyAnnotation Navigation { get; set; }
         }
 
         protected class CityViewModel
@@ -727,7 +754,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class PrincipalShadowFk
         {
             public Guid PrincipalShadowFkId { get; set; }
-            public List<DependentShadowFk> Dependends { get; set; }
+            public List<DependentShadowFk> Dependents { get; set; }
         }
 
         protected class BaseOwner


### PR DESCRIPTION
Make sure conflicting members are dealt with consistently when setting the base type.
Preserve the service property with the same name on the base type.
Preserve the configuration of conflicting service property with the same name on the derived type.

Part of #19003

