### PR TITLE
Fix for #11482 - Overloads for Contains and FreeText to support binary columns

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -53,7 +53,50 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] string freeText)
             => FreeTextCore(propertyReference, freeText, null);
 
+        /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server FREETEXT store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="freeText">The text that will be searched for in the property.</param>
+        /// <param name="languageTerm">A Language ID from the sys.syslanguages table.</param>
+        public static bool FreeText(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] byte[] propertyReference,
+            [NotNull] string freeText,
+            int languageTerm)
+            => FreeTextCore(propertyReference, freeText, languageTerm);
+
+        /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server FREETEXT store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="freeText">The text that will be searched for in the property.</param>
+        public static bool FreeText(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] byte[] propertyReference,
+            [NotNull] string freeText)
+            => FreeTextCore(propertyReference, freeText, null);
+
         private static bool FreeTextCore(string propertyName, string freeText, int? languageTerm)
+        {
+            throw new InvalidOperationException(SqlServerStrings.FunctionOnClient(nameof(FreeText)));
+        }
+
+        private static bool FreeTextCore(byte[] propertyReference, string freeText, int? languageTerm)
         {
             throw new InvalidOperationException(SqlServerStrings.FunctionOnClient(nameof(FreeText)));
         }
@@ -96,7 +139,50 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] string searchCondition)
             => ContainsCore(propertyReference, searchCondition, null);
 
+        /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server CONTAINS store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="searchCondition">The text that will be searched for in the property and the condition for a match.</param>
+        public static bool Contains(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] byte[] propertyReference,
+            [NotNull] string searchCondition)
+            => ContainsCore(propertyReference, searchCondition, null);
+
+        /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server CONTAINS store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="searchCondition">The text that will be searched for in the property and the condition for a match.</param>
+        /// <param name="languageTerm">A Language ID from the sys.syslanguages table.</param>
+        public static bool Contains(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] byte[] propertyReference,
+            [NotNull] string searchCondition,
+            int languageTerm)
+            => ContainsCore(propertyReference, searchCondition, languageTerm);
+
         private static bool ContainsCore(string propertyName, string searchCondition, int? languageTerm)
+        {
+            throw new InvalidOperationException(SqlServerStrings.FunctionOnClient(nameof(Contains)));
+        }
+
+        private static bool ContainsCore(byte[] propertyReference, string searchCondition, int? languageTerm)
         {
             throw new InvalidOperationException(SqlServerStrings.FunctionOnClient(nameof(Contains)));
         }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -124,10 +124,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 table);
 
         /// <summary>
-        ///     The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'
+        ///     The expression passed to the 'propertyReference' parameter of the '{method}' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.{method}(e.SomeProperty, textToSearchFor) select e'
         /// </summary>
-        public static string InvalidColumnNameForFreeText
-            => GetString("InvalidColumnNameForFreeText");
+        public static string InvalidColumnNameForFreeTextOrContains([NotNull] string method)
+            => string.Format(
+                GetString("InvalidColumnNameForFreeTextOrContains", nameof(method)),
+                method);
 
         /// <summary>
         ///     Include property '{entityType}.{property}' cannot be defined multiple times

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -219,8 +219,8 @@
   <data name="InvalidTableToIncludeInScaffolding" xml:space="preserve">
     <value>The specified table '{table}' is not valid. Specify tables using the format '[schema].[table]'.</value>
   </data>
-  <data name="InvalidColumnNameForFreeText" xml:space="preserve">
-    <value>The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'</value>
+  <data name="InvalidColumnNameForFreeTextOrContains" xml:space="preserve">
+    <value>The expression passed to the 'propertyReference' parameter of the '{method}' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.{method}(e.SomeProperty, textToSearchFor) select e'</value>
   </data>
   <data name="IncludePropertyDuplicated" xml:space="preserve">
     <value>Include property '{entityType}.{property}' cannot be defined multiple times</value>

--- a/test/EFCore.InMemory.FunctionalTests/Query/BookStoreDbFunctionsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/BookStoreDbFunctionsQueryInMemoryTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class BookStoreDbFunctionsQueryInMemoryTest : BookStoreTestBase<BookStoreDbFunctionsQueryInMemoryTest.BookStoreDbFunctionsQueryInMemoryFixture>
+    {
+        public BookStoreDbFunctionsQueryInMemoryTest(BookStoreDbFunctionsQueryInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class BookStoreDbFunctionsQueryInMemoryFixture : BookStoreFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+
+            public override IDisposable BeginTransaction(DbContext context) => new InMemoryCleaner(context);
+
+            private class InMemoryCleaner : IDisposable
+            {
+                private readonly DbContext _context;
+                public InMemoryCleaner(DbContext context) => _context = context;
+                public void Dispose() => _context.Database.EnsureDeleted();
+            }
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -26,4 +26,9 @@
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="TestModels\BookStore\erlkoenig.txt" />
+    <EmbeddedResource Include="TestModels\BookStore\ulysses.txt" />
+  </ItemGroup>
+
 </Project>

--- a/test/EFCore.Specification.Tests/Query/BookStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/BookStoreTestBase.cs
@@ -2,12 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore.TestModels.BookStore;
 using Xunit;
-
-using File = Microsoft.EntityFrameworkCore.TestModels.BookStore.File;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {

--- a/test/EFCore.Specification.Tests/Query/BookStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/BookStoreTestBase.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.TestModels.BookStore;
+using Xunit;
+
+using File = Microsoft.EntityFrameworkCore.TestModels.BookStore.File;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class BookStoreTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : BookStoreTestBase<TFixture>.BookStoreFixtureBase, new()
+    {
+        protected BookStoreTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            fixture.ListLoggerFactory.Clear();
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected BookStoreContext CreateContext() => Fixture.CreateContext();
+
+        public abstract class BookStoreFixtureBase : SharedStoreFixtureBase<BookStoreContext>
+        {
+            public virtual IDisposable BeginTransaction(DbContext context) => context.Database.BeginTransaction();
+
+            protected override void Seed(BookStoreContext context) => BookStoreContext.Seed(context);
+
+            protected override string StoreName { get; } = "BookStore";
+
+            protected override bool UsePooling => false;
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/Author.cs
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/Author.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.BookStore
+{
+    public class Author
+    {
+        public int AuthorId { get; set; }
+
+        [Required]
+        [StringLength(160, MinimumLength = 2)]
+        public string FirstName { get; set; }
+
+        [Required]
+        [StringLength(160, MinimumLength = 2)]
+        public string LastName { get; set; }
+
+        public virtual List<Book> Books { get; set; }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/Book.cs
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/Book.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.BookStore
+{
+    public class Book
+    {
+        public int BookId { get; set; }
+
+        public int AuthorId { get; set; }
+
+        public int FileId { get; set; }
+
+        [Required]
+        [StringLength(160, MinimumLength = 2)]
+        public string Title { get; set; }
+
+        public virtual Author Author { get; set; }
+
+        public virtual File File { get; set; }
+
+        [Required]
+        public DateTime Created { get; set; }
+
+        public Book()
+        {
+            Created = DateTime.UtcNow;
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/BookStoreContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/BookStoreContext.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.BookStore
+{
+    public class BookStoreContext : PoolableDbContext
+    {
+        public BookStoreContext(DbContextOptions<BookStoreContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Book> Books { get; set; }
+        public DbSet<Author> Authors { get; set; }
+        public DbSet<File> Files { get; set; }
+
+        public static void Seed(BookStoreContext context)
+        {
+            var books = CreateTestBooks();
+            context.Books.AddRange(books);
+
+            context.SaveChanges();
+        }
+
+        private static Book[] CreateTestBooks()
+        {
+            return new[] {
+                new Book
+                {
+                    Title = "Erlkönig (Ballade)",
+                    Author = new Author { FirstName = "Johann Wolfgang", LastName = "Goethe" },
+                    File = new File
+                    {
+                        Name = "erlkoenig",
+                        FileExtension = ".txt",
+                        Data = ReadFullyFromResource("Microsoft.EntityFrameworkCore.TestModels.BookStore.erlkoenig.txt")
+                    }
+                },
+                new Book
+                {
+                    Title = "Ulysses",
+                    Author = new Author { FirstName = "Alfred", LastName = "Tennyson" },
+                    File = new File
+                    {
+                        Name = "ulysses",
+                        FileExtension = ".txt",
+                        Data = ReadFullyFromResource("Microsoft.EntityFrameworkCore.TestModels.BookStore.ulysses.txt")
+                    }
+                }};
+        }
+
+        private static byte[] ReadFullyFromResource(string resourceName)
+        {
+            static byte[] ReadFully(Stream input)
+            {
+                using var ms = new MemoryStream();
+                input.CopyTo(ms);
+                return ms.ToArray();
+            }
+
+            byte[] fileArray;
+
+            var assembly = Assembly.GetAssembly(typeof(BookStoreTestBase<>));
+            var names = assembly.GetManifestResourceNames();
+            
+            using (var stream = assembly.GetManifestResourceStream(resourceName))
+            {
+                fileArray = ReadFully(stream);
+            }
+
+            return fileArray;
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/File.cs
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/File.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.BookStore
+{
+    public class File
+    {
+        public int FileId { get; set; }
+
+        public string Name { get; set; }
+
+        [Required]
+        public byte[] Data { get; set; }
+
+        [StringLength(100)]
+        public string FileExtension { get; set; }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/erlkoenig.txt
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/erlkoenig.txt
@@ -1,0 +1,39 @@
+Wer reitet so spät durch Nacht und Wind?
+Es ist der Vater mit seinem Kind;
+Er hat den Knaben wohl in dem Arm,
+Er fasst ihn sicher, er hält ihn warm.
+
+Mein Sohn, was birgst du so bang dein Gesicht? –
+Siehst, Vater, du den Erlkönig nicht?
+Den Erlenkönig mit Kron’ und Schweif? –
+Mein Sohn, es ist ein Nebelstreif. –
+
+„Du liebes Kind, komm, geh mit mir!
+Gar schöne Spiele spiel’ ich mit dir;
+Manch’ bunte Blumen sind an dem Strand,
+Meine Mutter hat manch gülden Gewand.“ –
+
+Mein Vater, mein Vater, und hörest du nicht,
+Was Erlenkönig mir leise verspricht? –
+Sei ruhig, bleibe ruhig, mein Kind;
+In dürren Blättern säuselt der Wind. –
+
+„Willst, feiner Knabe, du mit mir gehn?
+Meine Töchter sollen dich warten schön;
+Meine Töchter führen den nächtlichen Reihn
+Und wiegen und tanzen und singen dich ein.“ –
+
+Mein Vater, mein Vater, und siehst du nicht dort
+Erlkönigs Töchter am düstern Ort? –
+Mein Sohn, mein Sohn, ich seh’ es genau:
+Es scheinen die alten Weiden so grau. –
+
+„Ich liebe dich, mich reizt deine schöne Gestalt;
+Und bist du nicht willig, so brauch’ ich Gewalt.“ –
+Mein Vater, mein Vater, jetzt fasst er mich an!
+Erlkönig hat mir ein Leids getan! –
+
+Dem Vater grauset’s; er reitet geschwind,
+Er hält in Armen das ächzende Kind,
+Erreicht den Hof mit Mühe und Not;
+In seinen Armen das Kind war tot.

--- a/test/EFCore.Specification.Tests/TestModels/BookStore/ulysses.txt
+++ b/test/EFCore.Specification.Tests/TestModels/BookStore/ulysses.txt
@@ -1,0 +1,72 @@
+It little profits that an idle king,
+By this still hearth, among these barren crags,
+Match'd with an aged wife, I mete and dole
+Unequal laws unto a savage race,
+That hoard, and sleep, and feed, and know not me.
+I cannot rest from travel: I will drink
+Life to the lees: All times I have enjoy'd
+Greatly, have suffer'd greatly, both with those
+That loved me, and alone, on shore, and when
+Thro' scudding drifts the rainy Hyades
+Vext the dim sea: I am become a name;
+For always roaming with a hungry heart
+Much have I seen and known; cities of men
+And manners, climates, councils, governments,
+Myself not least, but honour'd of them all;
+And drunk delight of battle with my peers,
+Far on the ringing plains of windy Troy.
+I am a part of all that I have met;
+Yet all experience is an arch wherethro'
+Gleams that untravell'd world whose margin fades
+For ever and forever when I move.
+How dull it is to pause, to make an end,
+To rust unburnish'd, not to shine in use!
+As tho' to breathe were life! Life piled on life
+Were all too little, and of one to me
+Little remains: but every hour is saved
+From that eternal silence, something more,
+A bringer of new things; and vile it were
+For some three suns to store and hoard myself,
+And this gray spirit yearning in desire
+To follow knowledge like a sinking star,
+Beyond the utmost bound of human thought.
+
+         This is my son, mine own Telemachus,
+To whom I leave the sceptre and the isle,—
+Well-loved of me, discerning to fulfil
+This labour, by slow prudence to make mild
+A rugged people, and thro' soft degrees
+Subdue them to the useful and the good.
+Most blameless is he, centred in the sphere
+Of common duties, decent not to fail
+In offices of tenderness, and pay
+Meet adoration to my household gods,
+When I am gone. He works his work, I mine.
+
+         There lies the port; the vessel puffs her sail:
+There gloom the dark, broad seas. My mariners,
+Souls that have toil'd, and wrought, and thought with me—
+That ever with a frolic welcome took
+The thunder and the sunshine, and opposed
+Free hearts, free foreheads—you and I are old;
+Old age hath yet his honour and his toil;
+Death closes all: but something ere the end,
+Some work of noble note, may yet be done,
+Not unbecoming men that strove with Gods.
+The lights begin to twinkle from the rocks:
+The long day wanes: the slow moon climbs: the deep
+Moans round with many voices. Come, my friends,
+'T is not too late to seek a newer world.
+Push off, and sitting well in order smite
+The sounding furrows; for my purpose holds
+To sail beyond the sunset, and the baths
+Of all the western stars, until I die.
+It may be that the gulfs will wash us down:
+It may be we shall touch the Happy Isles,
+And see the great Achilles, whom we knew.
+Tho' much is taken, much abides; and tho'
+We are not now that strength which in old days
+Moved earth and heaven, that which we are, we are;
+One equal temper of heroic hearts,
+Made weak by time and fate, but strong in will
+To strive, to seek, to find, and not to yield.

--- a/test/EFCore.SqlServer.FunctionalTests/Query/BookStoreDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/BookStoreDbFunctionsQuerySqlServerTest.cs
@@ -1,0 +1,250 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class BookStoreDbFunctionsQuerySqlServerTest : BookStoreTestBase<BookStoreDbFunctionsQuerySqlServerTest.BookStoreSqlServerFixture>
+    {
+        public BookStoreDbFunctionsQuerySqlServerTest(BookStoreSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class BookStoreSqlServerFixture : BookStoreFixtureBase
+        {
+            public BookStoreSqlServerFixture()
+            {
+                var fullTextEnabled = ((SqlServerTestStore)TestStore).ExecuteScalar<int>(@"SELECT FULLTEXTSERVICEPROPERTY('IsFullTextInstalled')") == 1;
+                if (fullTextEnabled)
+                {
+                    ((SqlServerTestStore)TestStore).ExecuteNonQuery(
+                        @"IF EXISTS (SELECT * FROM sys.fulltext_catalogs WHERE name = 'BookStore_FTC')
+                            BEGIN
+                                DROP FULLTEXT CATALOG BookStore_FTC  
+                            END");
+
+                    ((SqlServerTestStore)TestStore).ExecuteNonQuery(
+                        @"CREATE FULLTEXT CATALOG BookStore_FTC AS DEFAULT;
+                             CREATE FULLTEXT INDEX ON Files(Data TYPE COLUMN FileExtension LANGUAGE 0 /* 0 = Neutral, 1033 = American English  */)  
+                             KEY INDEX PK_Files WITH (STOPLIST = OFF); /* Or use (stoplist = Off) for no stoplist */");
+
+                    ((SqlServerTestStore)TestStore).ExecuteNonQuery(
+                        @"IF EXISTS (SELECT * FROM sysobjects WHERE id = object_id(N'[dbo].[WaitForFullTextIndexing]') AND OBJECTPROPERTY(id, N'IsProcedure') = 1)
+                            BEGIN
+                                DROP PROCEDURE dbo.WaitForFullTextIndexing
+                            END");
+
+                    ((SqlServerTestStore)TestStore).ExecuteNonQuery(
+                        @"CREATE PROCEDURE WaitForFullTextIndexing
+                            @CatalogName VARCHAR(MAX)
+                            AS
+                            BEGIN
+                                DECLARE @status int;
+                                SET @status = 1;
+                                DECLARE @waitLoops int;
+                                SET @waitLoops = 0;
+
+                                WHILE @status > 0 AND @waitLoops < 100
+                                BEGIN       
+                                    SELECT @status = FULLTEXTCATALOGPROPERTY(@CatalogName,'PopulateStatus')
+                                    FROM sys.fulltext_catalogs AS cat;
+
+                                    IF @status > 0
+                                    BEGIN
+                                        -- prevent thrashing
+                                        WAITFOR DELAY '00:00:00.1';
+                                    END
+                                    SET @waitLoops = @waitLoops + 1;
+                                END
+                            END");
+
+                    ((SqlServerTestStore)TestStore).ExecuteNonQuery(@"WaitForFullTextIndexing 'BookStore_FTC'");
+                }
+            }
+
+            protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_literal()
+        {
+            using var context = CreateContext();
+            var result =  context.Books.Single(c => EF.Functions.FreeText(c.File.Data, "heroic"));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE FREETEXT([f].[Data], N'heroic')");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_multiple_words()
+        {
+            using var context = CreateContext();
+            var result = context.Books.Single(c => EF.Functions.FreeText(c.File.Data, "heroic hearts"));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE FREETEXT([f].[Data], N'heroic hearts')");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_with_language_term()
+        {
+            using var context = CreateContext();
+            var result = context.Books.Single(c => EF.Functions.FreeText(c.File.Data, "heroic", 1033));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE FREETEXT([f].[Data], N'heroic', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_with_multiple_words_and_language_term()
+        {
+            using var context = CreateContext();
+            var result = context.Books
+                .Single(c => EF.Functions.FreeText(c.File.Data, "heroic hearts", 1033));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE FREETEXT([f].[Data], N'heroic hearts', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_multiple_predicates()
+        {
+            using var context = CreateContext();
+            var result = context.Books
+                .Single(
+                    c => EF.Functions.FreeText(c.File.Data, "Nebelstreif")
+                        && EF.Functions.FreeText(c.File.Data, "Vater", 1031));
+
+            Assert.Equal(1, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE FREETEXT([f].[Data], N'Nebelstreif') AND FREETEXT([f].[Data], N'Vater', LANGUAGE 1031)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public async Task Contains_literal()
+        {
+            using var context = CreateContext();
+            var result = await context.Books
+                .Where(c => EF.Functions.Contains(c.File.Data, "Achilles"))
+                .ToListAsync();
+
+            Assert.Equal(2, result.First().BookId);
+
+            AssertSql(
+                @"SELECT [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE CONTAINS([f].[Data], N'Achilles')");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void Contains_with_language_term()
+        {
+            using var context = CreateContext();
+            var result = context.Books.Single(c => EF.Functions.Contains(c.File.Data, "Achilles", 1033));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE CONTAINS([f].[Data], N'Achilles', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public async Task Contains_with_logical_operator()
+        {
+            using var context = CreateContext();
+            var result = await context.Books
+                .Where(c => EF.Functions.Contains(c.File.Data, "Achilles OR Nebelstreif"))
+                .ToListAsync();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1, result.First().BookId);
+
+            AssertSql(
+                @"SELECT [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE CONTAINS([f].[Data], N'Achilles OR Nebelstreif')");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public async Task Contains_with_prefix_term_and_language_term()
+        {
+            using var context = CreateContext();
+            var result = await context.Books
+                .SingleOrDefaultAsync(c => EF.Functions.Contains(c.File.Data, "\"govern*\"", 1033));
+
+            Assert.Equal(2, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE CONTAINS([f].[Data], N'""govern*""', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public async Task Contains_with_proximity_term_and_language_term()
+        {
+            using var context = CreateContext();
+            var result = await context.Books
+                .SingleOrDefaultAsync(c => EF.Functions.Contains(c.File.Data, "NEAR((bunte, Blumen), 1)", 1033));
+
+            Assert.Equal(1, result.BookId);
+
+            AssertSql(
+                @"SELECT TOP(2) [b].[BookId], [b].[AuthorId], [b].[Created], [b].[FileId], [b].[Title]
+FROM [Books] AS [b]
+INNER JOIN [Files] AS [f] ON [b].[FileId] = [f].[FileId]
+WHERE CONTAINS([f].[Data], N'NEAR((bunte, Blumen), 1)', LANGUAGE 1033)");
+        }
+
+        private void AssertSql(params string[] expected)
+            => testSqlLoggerFactory.AssertBaseline(expected);
+
+        private TestSqlLoggerFactory testSqlLoggerFactory => (TestSqlLoggerFactory)Fixture.ListLoggerFactory;
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -75,6 +75,8 @@ WHERE FREETEXT([e].[Title], N'Representative')");
         {
             Assert.Throws<InvalidOperationException>(() => EF.Functions.FreeText("teststring", "teststring"));
             Assert.Throws<InvalidOperationException>(() => EF.Functions.FreeText("teststring", "teststring", 1033));
+            Assert.Throws<InvalidOperationException>(() => EF.Functions.FreeText(new byte[] { 0, 1, 2, 3 }, "teststring"));
+            Assert.Throws<InvalidOperationException>(() => EF.Functions.FreeText(new byte[] { 0, 1, 2, 3 }, "teststring", 1033));
         }
 
         [ConditionalFact]
@@ -243,7 +245,17 @@ WHERE ((FREETEXT([c.Manager].[Title], N'President', LANGUAGE 1033)) AND (FREETEX
                 SqlServerStrings.FunctionOnClient(nameof(SqlServerDbFunctionsExtensions.Contains)),
                 exNoLang.Message);
 
+            exNoLang = Assert.Throws<InvalidOperationException>(() => EF.Functions.Contains(new byte[] { 0, 1, 2, 3 }, "teststring"));
+            Assert.Equal(
+                SqlServerStrings.FunctionOnClient(nameof(SqlServerDbFunctionsExtensions.Contains)),
+                exNoLang.Message);
+
             var exLang = Assert.Throws<InvalidOperationException>(() => EF.Functions.Contains("teststring", "teststring", 1033));
+            Assert.Equal(
+                SqlServerStrings.FunctionOnClient(nameof(SqlServerDbFunctionsExtensions.Contains)),
+                exLang.Message);
+
+            exLang = Assert.Throws<InvalidOperationException>(() => EF.Functions.Contains(new byte[] { 0, 1, 2, 3 }, "teststring", 1033));
             Assert.Equal(
                 SqlServerStrings.FunctionOnClient(nameof(SqlServerDbFunctionsExtensions.Contains)),
                 exLang.Message);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BookStoreDbFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BookStoreDbFunctionsQuerySqliteTest.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class BookStoreDbFunctionsQuerySqliteTest : BookStoreTestBase<BookStoreDbFunctionsQuerySqliteTest.BookStoreDbFunctionsQuerySqliteFixture>
+    {
+        public BookStoreDbFunctionsQuerySqliteTest(BookStoreDbFunctionsQuerySqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class BookStoreDbFunctionsQuerySqliteFixture : BookStoreFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+        }
+    }
+}


### PR DESCRIPTION
Adds support for using FreeText/Contains DbFunctions in SQL-Server with binary columns (`varbinary/varbinary(max)`) by adding overloads for `byte[]` properties.

<del> - No unit tests for `EF.Functions.FreeText(byte[], ...)` and `EF.Functions.Contains(byte[], ...)` yet, because the Northwind context has no suitable tables with binary columns (which are also fulltext indexed). </del>
<del> - Instructions required on how to extend either the context (which I guess is discouraged) or switch (move tests) to another suitable context (which requires a lot of refactoring on [NorthwindDbFunctionsQuerySqlServerTest.cs](https://github.com/dotnet/efcore/blob/master/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs)). </del>

Fixes #11482
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


