### PR TITLE
Fix to #19023 - Query: Log query plan

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class RelationalCommandCache
+    public class RelationalCommandCache : IPrintableExpression
     {
         private static readonly ConcurrentDictionary<object, object> _syncObjects
             = new ConcurrentDictionary<object, object>();
@@ -71,6 +71,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             return relationalCommand;
+        }
+
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.AppendLine("RelationalCommandCache.SelectExpression(");
+            using (expressionPrinter.Indent())
+            {
+                expressionPrinter.Visit(_selectExpression);
+                expressionPrinter.Append(")");
+            }
         }
 
         private readonly struct CommandCacheKey


### PR DESCRIPTION
Making RelationalCommandCache printable and printing it's SelectExpression.
Example query plan output:

```
queryContext => new QueryingEnumerable<int>(
    (RelationalQueryContext)queryContext,
    RelationalCommandCache.SelectExpression(
        (Projection Mapping:
            EmptyProjectionMember -> 0
        SELECT ((COUNT((*))))
        FROM (Customers AS c)
        WHERE ((c.CustomerID) == (N'ALFKI')))),
    null,
    ReaderColumn[] { ReaderColumn<int>, },
    Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, int>,
    TestModels.Northwind.NorthwindRelationalContext,
    DiagnosticsLogger<Query>)
    .Single()
```

Fixes #19023