### PR TITLE
[TINY] Enabling tests for #19020 - Parameter based optimization tries to group by constant

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -76,5 +76,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Select_subquery_projecting_single_constant_inside_anonymous(async);
         }
+
+        [ConditionalTheory(Skip = "issue #19683")]
+        public override Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
+        {
+            return base.Group_by_on_StartsWith_with_null_parameter_as_argument(async);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7105,7 +7105,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => new { g.Key, Aggregate = g.Max() })));
         }
 
-        [ConditionalTheory(Skip = "issue #19020")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
         {
@@ -7113,7 +7113,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Gear>().GroupBy(g => g.FullName.StartsWith(prm)).Select(g => g.Key));
+                ss => ss.Set<Gear>().GroupBy(g => g.FullName.StartsWith(prm)).Select(g => g.Key),
+                ss => ss.Set<Gear>().Select(g => false));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7043,7 +7043,9 @@ GROUP BY [c].[Name]");
             await base.Group_by_on_StartsWith_with_null_parameter_as_argument(async);
 
             AssertSql(
-                @"");
+                @"SELECT CAST(0 AS bit)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
         }
 
         public override async Task Group_by_with_having_StartsWith_with_null_parameter_as_argument(bool async)


### PR DESCRIPTION
Issue has already been fixed earlier, likely by null semantics improvements.

Resolves #19020