### PR TITLE
Fix to #18147 - Where bool column needs to convert to equality when value converter is applied

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -100,12 +100,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(memberExpression, nameof(memberExpression));
 
-            return TryBindMember(memberExpression.Expression, MemberIdentity.Create(memberExpression.Member), out var result)
-                ? result
-                : TranslationFailed(memberExpression.Expression, Visit(memberExpression.Expression), out var sqlInnerExpression)
-                    ? null
-                    : _memberTranslatorProvider.Translate(sqlInnerExpression, memberExpression.Member, memberExpression.Type);
+            return CompensateForValueConverter(
+                TryBindMember(memberExpression.Expression, MemberIdentity.Create(memberExpression.Member), out var result)
+                    ? result
+                    : TranslationFailed(memberExpression.Expression, Visit(memberExpression.Expression), out var sqlInnerExpression)
+                        ? null
+                        : _memberTranslatorProvider.Translate(sqlInnerExpression, memberExpression.Member, memberExpression.Type));
         }
+
+        private Expression CompensateForValueConverter(Expression result)
+            => result != null
+                && result.Type == typeof(bool)
+                && result is KeyAccessExpression keyAccessExpression
+                && keyAccessExpression.TypeMapping.Converter != null
+                ? _sqlExpressionFactory.Equal(keyAccessExpression, _sqlExpressionFactory.Constant(true, keyAccessExpression.TypeMapping))
+                : result;
 
         private bool TryBindMember(Expression source, MemberIdentity member, out Expression expression)
         {
@@ -162,15 +171,19 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var propertyName))
             {
-                return TryBindMember(source, MemberIdentity.Create(propertyName), out var result)
-                    ? result
-                    : null;
+                return CompensateForValueConverter(
+                    TryBindMember(source, MemberIdentity.Create(propertyName), out var result)
+                        ? result
+                        : null);
             }
 
             // EF Indexer property
             if (methodCallExpression.TryGetIndexerArguments(_model, out source, out propertyName))
             {
-                return TryBindMember(source, MemberIdentity.Create(propertyName), out var result) ? result : null;
+                return CompensateForValueConverter(
+                    TryBindMember(source, MemberIdentity.Create(propertyName), out var result)
+                        ? result
+                        : null);
             }
 
             if (TranslationFailed(methodCallExpression.Object, Visit(methodCallExpression.Object), out var sqlObject))

--- a/src/EFCore.Relational/Query/NullabilityBasedSqlProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/NullabilityBasedSqlProcessingExpressionVisitor.cs
@@ -691,11 +691,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             if (IsTrueOrFalse(right) is bool rightTrueFalseValue
-                && !leftNullable)
+                && !leftNullable
+                && left.TypeMapping.Converter == null)
             {
                 _nullable = leftNullable;
 
-                // only correct in 2-value logic
+                // only correct in 2-value logic and only if 'a' doesn't have value converter applied to it
                 // a == true -> a
                 // a == false -> !a
                 // a != true -> !a
@@ -706,11 +707,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             if (IsTrueOrFalse(left) is bool leftTrueFalseValue
-                && !rightNullable)
+                && !rightNullable
+                && right.TypeMapping.Converter == null)
             {
                 _nullable = rightNullable;
 
-                // only correct in 2-value logic
+                // only correct in 2-value logic and only if 'a' doesn't have value converter applied to it
                 // true == a -> a
                 // false == a -> !a
                 // true != a -> !a

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         public CustomConvertersCosmosTest(CustomConvertersCosmosFixture fixture)
             : base(fixture)
         {
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         public override void Can_perform_query_with_max_length()
@@ -137,16 +138,43 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Value_conversion_is_appropriately_used_for_left_join_condition();
         }
 
-        [ConditionalFact(Skip = "Issue #18147")]
+        [ConditionalFact]
         public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used()
         {
             base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used();
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] IN (""Blog"", ""RssBlog"") AND (c[""IsVisible""] = ""Y""))");
         }
+
+        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_EFProperty()
+        {
+            base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_EFProperty();
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] IN (""Blog"", ""RssBlog"") AND (c[""IsVisible""] = ""Y""))");
+        }
+
+        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_indexer()
+        {
+            base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_indexer();
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (c[""Discriminator""] IN (""Blog"", ""RssBlog"") AND NOT((c[""IndexerVisible""] = ""Aye"")))");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
         public class CustomConvertersCosmosFixture : CustomConvertersFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => CosmosTestStoreFactory.Instance;
-
             public override bool StrictEquality => true;
 
             public override int IntegerPrecision => 53;
@@ -162,6 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             public override bool SupportsDecimalComparisons => true;
 
             public override DateTime DefaultDateTime => new DateTime();
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             {

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore
         public CustomConvertersSqliteTest(CustomConvertersSqliteFixture fixture)
             : base(fixture)
         {
+            Fixture.TestSqlLoggerFactory.Clear();
         }
 
         // Disabled: SQLite database is case-sensitive
@@ -19,23 +20,67 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
-        [ConditionalFact(Skip = "Issue#18147")]
+        [ConditionalFact]
         public override void Value_conversion_is_appropriately_used_for_join_condition()
         {
             base.Value_conversion_is_appropriately_used_for_join_condition();
+
+            AssertSql(
+                @"@__blogId_0='1' (DbType = String)
+
+SELECT ""b"".""Url""
+FROM ""Blog"" AS ""b""
+INNER JOIN ""Post"" AS ""p"" ON ((""b"".""BlogId"" = ""p"".""BlogId"") AND (""b"".""IsVisible"" = 'Y')) AND (""b"".""BlogId"" = @__blogId_0)
+WHERE ""b"".""Discriminator"" IN ('Blog', 'RssBlog') AND (""b"".""IsVisible"" = 'Y')");
         }
 
-        [ConditionalFact(Skip = "Issue#18147")]
+        [ConditionalFact]
         public override void Value_conversion_is_appropriately_used_for_left_join_condition()
         {
             base.Value_conversion_is_appropriately_used_for_left_join_condition();
+
+            AssertSql(
+                @"@__blogId_0='1' (DbType = String)
+
+SELECT ""b"".""Url""
+FROM ""Blog"" AS ""b""
+LEFT JOIN ""Post"" AS ""p"" ON ((""b"".""BlogId"" = ""p"".""BlogId"") AND (""b"".""IsVisible"" = 'Y')) AND (""b"".""BlogId"" = @__blogId_0)
+WHERE ""b"".""Discriminator"" IN ('Blog', 'RssBlog') AND (""b"".""IsVisible"" = 'Y')");
         }
 
-        [ConditionalFact(Skip = "Issue#18147")]
+        [ConditionalFact]
         public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used()
         {
             base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used();
+
+            AssertSql(
+                @"SELECT ""b"".""BlogId"", ""b"".""Discriminator"", ""b"".""IndexerVisible"", ""b"".""IsVisible"", ""b"".""Url"", ""b"".""RssUrl""
+FROM ""Blog"" AS ""b""
+WHERE ""b"".""Discriminator"" IN ('Blog', 'RssBlog') AND (""b"".""IsVisible"" = 'Y')");
         }
+
+        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_EFProperty()
+        {
+            base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_EFProperty();
+
+            AssertSql(
+                @"SELECT ""b"".""BlogId"", ""b"".""Discriminator"", ""b"".""IndexerVisible"", ""b"".""IsVisible"", ""b"".""Url"", ""b"".""RssUrl""
+FROM ""Blog"" AS ""b""
+WHERE ""b"".""Discriminator"" IN ('Blog', 'RssBlog') AND (""b"".""IsVisible"" = 'Y')");
+        }
+
+        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_indexer()
+        {
+            base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used_using_indexer();
+
+            AssertSql(
+                @"SELECT ""b"".""BlogId"", ""b"".""Discriminator"", ""b"".""IndexerVisible"", ""b"".""IsVisible"", ""b"".""Url"", ""b"".""RssUrl""
+FROM ""Blog"" AS ""b""
+WHERE ""b"".""Discriminator"" IN ('Blog', 'RssBlog') AND (""b"".""IndexerVisible"" <> 'Aye')");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
         public class CustomConvertersSqliteFixture : CustomConvertersFixtureBase
         {


### PR DESCRIPTION
Fix is to detect bool columns with value converters (upon initial translation) and apply comparison with constant true (with the same mapping). Also, we need to recognize this pattern during SqlExpression optimization, so that it' doesn't get simplified from 'a == true' to 'a'

Resolves #18147