### PR TITLE
[TINY] Adding tests for #15641 - GroupBy FK_Id.HasValue on Sql Server generates invalid sql

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7548,6 +7548,28 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Select(g => g.Nickname == nullParameter));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Group_by_nullable_property_HasValue_and_project_the_grouping_key(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Weapon>()
+                    .GroupBy(w => w.SynergyWithId.HasValue)
+                    .Select(g => g.Key));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Group_by_nullable_property_and_project_the_grouping_key_HasValue(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Weapon>()
+                    .GroupBy(w => w.SynergyWithId)
+                    .Select(g => g.Key.HasValue));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7527,6 +7527,35 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer')");
         }
 
+        public override async Task Group_by_nullable_property_HasValue_and_project_the_grouping_key(bool async)
+        {
+            await base.Group_by_nullable_property_HasValue_and_project_the_grouping_key(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [w].[SynergyWithId] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Weapons] AS [w]
+GROUP BY CASE
+    WHEN [w].[SynergyWithId] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+        }
+
+        public override async Task Group_by_nullable_property_and_project_the_grouping_key_HasValue(bool async)
+        {
+            await base.Group_by_nullable_property_and_project_the_grouping_key_HasValue(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [w].[SynergyWithId] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Weapons] AS [w]
+GROUP BY [w].[SynergyWithId]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
The issue has been fixed earlier.

Resolves #15641
