### PR TITLE
Fixes to TwoDatabasesTest

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TwoDatabasesTestBase.cs
@@ -20,10 +20,13 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public void Can_query_from_one_connection_string_and_save_changes_to_another()
+        public virtual void Can_query_from_one_connection_string_and_save_changes_to_another()
         {
             using var context1 = CreateBackingContext("TwoDatabasesOne");
             using var context2 = CreateBackingContext("TwoDatabasesTwo");
+
+            var connectionString1 = context1.Database.GetConnectionString();
+            var connectionString2 = context2.Database.GetConnectionString();
 
             Assert.NotEqual(context1.Database.GetConnectionString(), context2.Database.GetConnectionString());
 
@@ -32,13 +35,13 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new TwoDatabasesContext(CreateTestOptions(new DbContextOptionsBuilder()).Options))
             {
-                context.Database.SetConnectionString(context1.Database.GetConnectionString());
+                context.Database.SetConnectionString(connectionString1);
 
                 var data = context.Foos.ToList();
                 data[0].Bar = "Modified One";
                 data[1].Bar = "Modified Two";
 
-                context.Database.SetConnectionString(context2.Database.GetConnectionString());
+                context.Database.SetConnectionString(connectionString2);
 
                 context.SaveChanges();
             }
@@ -48,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public void Can_query_from_one_connection_and_save_changes_to_another()
+        public virtual void Can_query_from_one_connection_and_save_changes_to_another()
         {
             using var context1 = CreateBackingContext("TwoDatabasesOneB");
             using var context2 = CreateBackingContext("TwoDatabasesTwoB");
@@ -76,16 +79,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public void Can_set_connection_string_in_interceptor()
+        public virtual void Can_set_connection_string_in_interceptor()
         {
             using var context1 = CreateBackingContext("TwoDatabasesIntercept");
+
+            var connectionString1 = context1.Database.GetConnectionString();
 
             context1.Database.EnsureCreatedResiliently();
 
             using (var context = new TwoDatabasesContext(
                 CreateTestOptions(new DbContextOptionsBuilder(), withConnectionString: true)
                     .AddInterceptors(new ConnectionStringConnectionInterceptor(
-                        context1.Database.GetConnectionString(), DummyConnectionString))
+                        connectionString1, DummyConnectionString))
                     .Options))
             {
                 var data = context.Foos.ToList();

--- a/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Browse_ReturnsViewWithGenre()
+        public virtual async Task Browse_ReturnsViewWithGenre()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Index_CreatesViewWithGenres()
+        public virtual async Task Index_CreatesViewWithGenres()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Details_ReturnsAlbumDetail()
+        public virtual async Task Details_ReturnsAlbumDetail()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Index_GetsSixTopAlbums()
+        public virtual async Task Index_GetsSixTopAlbums()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task GenreMenuComponent_Returns_NineGenres()
+        public virtual async Task GenreMenuComponent_Returns_NineGenres()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -186,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task AddressAndPayment_RedirectToCompleteWhenSuccessful()
+        public virtual async Task AddressAndPayment_RedirectToCompleteWhenSuccessful()
         {
             const string cartId = "CartId_A";
 
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task AddressAndPayment_ReturnsOrderIfInvalidPromoCode()
+        public virtual async Task AddressAndPayment_ReturnsOrderIfInvalidPromoCode()
         {
             const string cartId = "CartId_A";
 
@@ -251,7 +251,7 @@ namespace Microsoft.EntityFrameworkCore
             };
 
         [ConditionalFact]
-        public async Task Complete_ReturnsOrderIdIfValid()
+        public virtual async Task Complete_ReturnsOrderIdIfValid()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Complete_ReturnsErrorIfInvalidOrder()
+        public virtual async Task Complete_ReturnsErrorIfInvalidOrder()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task CartSummaryComponent_returns_items()
+        public virtual async Task CartSummaryComponent_returns_items()
         {
             const string cartId = "CartId_A";
             const string albumTitle = "Good goat, M.A.A.D Village";
@@ -330,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async void Music_store_project_to_mapped_entity()
+        public virtual async void Music_store_project_to_mapped_entity()
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -368,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task RemoveFromCart_removes_items_from_cart()
+        public virtual async Task RemoveFromCart_removes_items_from_cart()
         {
             const string cartId = "CartId_A";
             const int numberOfItems = 5;
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalTheory]
         [InlineData(null)]
         [InlineData("CartId_A")]
-        public async Task Cart_is_empty_when_no_items_have_been_added(string cartId)
+        public virtual async Task Cart_is_empty_when_no_items_have_been_added(string cartId)
         {
             using var context = CreateContext();
             await context.Database.CreateExecutionStrategy().ExecuteAsync(
@@ -421,7 +421,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Cart_has_items_once_they_have_been_added()
+        public virtual async Task Cart_has_items_once_they_have_been_added()
         {
             const string cartId = "CartId_A";
 
@@ -450,7 +450,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public async Task Can_add_items_to_cart()
+        public virtual async Task Can_add_items_to_cart()
         {
             const string cartId = "CartId_A";
 


### PR DESCRIPTION
The tests in TwoDatabasesTest extract a connection string from a DbContext after its connection has been opened. This usually means that the password is scrubbed out when `Persist Security Info=false` (the default), so the connection string is copied without it. The EF Core tests use LocalDB and Sqlite where there's no security info in the connection string.

Also made tests virtual.
