### PR TITLE
Support lower case GUID serialization

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Data.Sqlite
 
                 if (_parameters.IsValueCreated)
                 {
-                    boundParams = _parameters.Value.Bind(stmt);
+                    boundParams = _parameters.Value.Bind(_connection, stmt);
                 }
 
                 var expectedParams = sqlite3_bind_parameter_count(stmt);

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -648,7 +648,7 @@ namespace Microsoft.Data.Sqlite
                         // TODO: Avoid closure by passing function via user_data
                         var result = function((TState)user_data, values);
 
-                        new SqliteResultBinder(ctx, result).Bind();
+                        new SqliteResultBinder(this, ctx, result).Bind();
                     }
                     catch (Exception ex)
                     {
@@ -734,7 +734,7 @@ namespace Microsoft.Data.Sqlite
                             // TODO: Avoid closure by passing resultSelector via user_data
                             var result = resultSelector(context.Accumulate);
 
-                            new SqliteResultBinder(ctx, result).Bind();
+                            new SqliteResultBinder(this, ctx, result).Bind();
                         }
                         catch (Exception ex)
                         {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Data.Sqlite
         private const string PasswordKeyword = "Password";
         private const string ForeignKeysKeyword = "Foreign Keys";
         private const string RecursiveTriggersKeyword = "Recursive Triggers";
+        private const string LowerCaseGuidsKeyword = "Lower Case Guids";
 
         private enum Keywords
         {
@@ -36,7 +37,8 @@ namespace Microsoft.Data.Sqlite
             Cache,
             Password,
             ForeignKeys,
-            RecursiveTriggers
+            RecursiveTriggers,
+            LowerCaseGuids
         }
 
         private static readonly IReadOnlyList<string> _validKeywords;
@@ -48,16 +50,18 @@ namespace Microsoft.Data.Sqlite
         private string _password = string.Empty;
         private bool? _foreignKeys;
         private bool _recursiveTriggers;
+        private bool _lowerCaseGuids;
 
         static SqliteConnectionStringBuilder()
         {
-            var validKeywords = new string[6];
+            var validKeywords = new string[7];
             validKeywords[(int)Keywords.DataSource] = DataSourceKeyword;
             validKeywords[(int)Keywords.Mode] = ModeKeyword;
             validKeywords[(int)Keywords.Cache] = CacheKeyword;
             validKeywords[(int)Keywords.Password] = PasswordKeyword;
             validKeywords[(int)Keywords.ForeignKeys] = ForeignKeysKeyword;
             validKeywords[(int)Keywords.RecursiveTriggers] = RecursiveTriggersKeyword;
+            validKeywords[(int)Keywords.LowerCaseGuids] = LowerCaseGuidsKeyword;
             _validKeywords = validKeywords;
 
             _keywords = new Dictionary<string, Keywords>(8, StringComparer.OrdinalIgnoreCase)
@@ -68,7 +72,7 @@ namespace Microsoft.Data.Sqlite
                 [PasswordKeyword] = Keywords.Password,
                 [ForeignKeysKeyword] = Keywords.ForeignKeys,
                 [RecursiveTriggersKeyword] = Keywords.RecursiveTriggers,
-
+                [LowerCaseGuidsKeyword] = Keywords.LowerCaseGuids,
                 // aliases
                 [FilenameKeyword] = Keywords.DataSource,
                 [DataSourceNoSpaceKeyword] = Keywords.DataSource
@@ -184,6 +188,16 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
+        ///     Gets or sets a value indicating whether to serialize GUID values in upper or lower case.
+        /// </summary>
+        /// <value>A value indicating whether to make GUID values upper-case.</value>
+        public bool LowerCaseGuids
+        {
+            get => _lowerCaseGuids;
+            set => base[LowerCaseGuidsKeyword] = _lowerCaseGuids = value;
+        }
+
+        /// <summary>
         ///     Gets or sets the value associated with the specified key.
         /// </summary>
         /// <param name="keyword">The key.</param>
@@ -224,6 +238,10 @@ namespace Microsoft.Data.Sqlite
 
                     case Keywords.RecursiveTriggers:
                         RecursiveTriggers = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
+                        return;
+
+                    case Keywords.LowerCaseGuids:
+                        LowerCaseGuids = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
                         return;
 
                     default:
@@ -366,6 +384,9 @@ namespace Microsoft.Data.Sqlite
                 case Keywords.RecursiveTriggers:
                     return RecursiveTriggers;
 
+                case Keywords.LowerCaseGuids:
+                    return LowerCaseGuids;
+
                 default:
                     Debug.Assert(false, "Unexpected keyword: " + index);
                     return null;
@@ -403,6 +424,10 @@ namespace Microsoft.Data.Sqlite
 
                 case Keywords.RecursiveTriggers:
                     _recursiveTriggers = false;
+                    return;
+
+                case Keywords.LowerCaseGuids:
+                    _lowerCaseGuids = false;
                     return;
 
                 default:

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Data.Sqlite
             SqliteType = SqliteType.Text;
         }
 
-        internal bool Bind(sqlite3_stmt stmt)
+        internal bool Bind(SqliteConnection connection, sqlite3_stmt stmt)
         {
             if (string.IsNullOrEmpty(ParameterName))
             {
@@ -208,7 +208,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Resources.RequiresSet(nameof(Value)));
             }
 
-            new SqliteParameterBinder(stmt, index, _value, _size, _sqliteType).Bind();
+            new SqliteParameterBinder(connection, stmt, index, _value, _size, _sqliteType).Bind();
 
             return true;
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Data.Sqlite
         private readonly int _index;
         private readonly int? _size;
 
-        public SqliteParameterBinder(sqlite3_stmt stmt, int index, object value, int? size, SqliteType? sqliteType)
-            : base(value, sqliteType)
+        public SqliteParameterBinder(SqliteConnection connection, sqlite3_stmt stmt, int index, object value, int? size, SqliteType? sqliteType)
+            : base(connection, value, sqliteType)
         {
             _stmt = stmt;
             _index = index;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
@@ -330,12 +330,12 @@ namespace Microsoft.Data.Sqlite
         protected override void SetParameter(string parameterName, DbParameter value)
             => SetParameter(IndexOfChecked(parameterName), value);
 
-        internal int Bind(sqlite3_stmt stmt)
+        internal int Bind(SqliteConnection connection, sqlite3_stmt stmt)
         {
             var bound = 0;
             foreach (var parameter in _parameters)
             {
-                if (parameter.Bind(stmt))
+                if (parameter.Bind(connection, stmt))
                 {
                     bound++;
                 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Data.Sqlite
     {
         private readonly sqlite3_context _ctx;
 
-        public SqliteResultBinder(sqlite3_context ctx, object value)
-            : base(value)
+        public SqliteResultBinder(SqliteConnection connection, sqlite3_context ctx, object value)
+            : base(connection, value)
         {
             _ctx = ctx;
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
@@ -13,16 +13,18 @@ namespace Microsoft.Data.Sqlite
     {
         private readonly object _value;
         private readonly SqliteType? _sqliteType;
+        private readonly SqliteConnection _sqliteconnection;
 
-        protected SqliteValueBinder(object value)
-            : this(value, null)
+        protected SqliteValueBinder(SqliteConnection connection, object value)
+            : this(connection, value, null)
         {
         }
 
-        protected SqliteValueBinder(object value, SqliteType? sqliteType)
+        protected SqliteValueBinder(SqliteConnection connection, object value, SqliteType? sqliteType)
         {
             _value = value;
             _sqliteType = sqliteType;
+            _sqliteconnection = connection;
         }
 
         protected abstract void BindInt64(long value);
@@ -136,7 +138,7 @@ namespace Microsoft.Data.Sqlite
                 var guid = (Guid)_value;
                 if (_sqliteType != SqliteType.Blob)
                 {
-                    var value = guid.ToString().ToUpper();
+                    var value = _sqliteconnection.ConnectionOptions.LowerCaseGuids ? guid.ToString() : guid.ToString().ToUpper();
                     BindText(value);
                 }
                 else

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
@@ -33,6 +33,15 @@ namespace Microsoft.Data.Sqlite
             Assert.Equal(SqliteOpenMode.Memory, builder.Mode);
         }
 
+
+        [Fact]
+        public void Ctor_parses_LowerCaseGuids()
+        {
+            var builder = new SqliteConnectionStringBuilder("Lower Case Guids = True");
+
+            Assert.True(builder.LowerCaseGuids);
+        }
+
         [Fact]
         public void Filename_is_alias_for_DataSource()
         {
@@ -81,6 +90,22 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void LowerCaseGuid_defaults_to_False()
+        {
+            Assert.False(new SqliteConnectionStringBuilder().LowerCaseGuids);
+        }
+
+        [Fact]
+        public void LowerCaseGuids_works()
+        {
+            var builder = new SqliteConnectionStringBuilder();
+
+            builder.LowerCaseGuids = true;
+
+            Assert.True(builder.LowerCaseGuids);
+        }
+
+        [Fact]
         public void Cache_defaults()
         {
             Assert.Equal(SqliteCacheMode.Default, new SqliteConnectionStringBuilder().Cache);
@@ -98,13 +123,14 @@ namespace Microsoft.Data.Sqlite
             var keys = (ICollection<string>)new SqliteConnectionStringBuilder().Keys;
 
             Assert.True(keys.IsReadOnly);
-            Assert.Equal(6, keys.Count);
+            Assert.Equal(7, keys.Count);
             Assert.Contains("Data Source", keys);
             Assert.Contains("Mode", keys);
             Assert.Contains("Cache", keys);
             Assert.Contains("Password", keys);
             Assert.Contains("Foreign Keys", keys);
             Assert.Contains("Recursive Triggers", keys);
+            Assert.Contains("Lower Case Guids", keys);
         }
 
         [Fact]
@@ -113,7 +139,7 @@ namespace Microsoft.Data.Sqlite
             var values = (ICollection<object>)new SqliteConnectionStringBuilder().Values;
 
             Assert.True(values.IsReadOnly);
-            Assert.Equal(6, values.Count);
+            Assert.Equal(7, values.Count);
         }
 
         [Fact]
@@ -183,40 +209,51 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Theory]
-        [InlineData(1, true)]
-        [InlineData("True", true)]
-        [InlineData(0, false)]
-        [InlineData("False", false)]
-        [InlineData(null, null)]
-        [InlineData("", null)]
-        public void Item_converts_to_bool_on_set(object value, bool? expected)
+        [InlineData("Foreign Keys", 1, true)]
+        [InlineData("Foreign Keys", "True", true)]
+        [InlineData("Foreign Keys", 0, false)]
+        [InlineData("Foreign Keys", "False", false)]
+        [InlineData("Foreign Keys", null, null)]
+        [InlineData("Foreign Keys", "", null)]
+        [InlineData("Lower Case Guids", 1, true)]
+        [InlineData("Lower Case Guids", "True", true)]
+        [InlineData("Lower Case Guids", 0, false)]
+        [InlineData("Lower Case Guids", "False", false)]
+        public void Item_converts_to_bool_on_set(string item, object value, bool? expected)
         {
             var builder = new SqliteConnectionStringBuilder();
 
-            builder["Foreign Keys"] = value;
+            builder[item] = value;
 
-            Assert.Equal(expected, builder["Foreign Keys"]);
+            Assert.Equal(expected, builder[item]);
         }
 
         [Theory]
-        [InlineData("1")]
-        [InlineData("Yes")]
-        [InlineData("On")]
-        [InlineData("0")]
-        [InlineData("No")]
-        [InlineData("Off")]
-        public void Item_throws_when_cannot_convert_to_bool_on_set(object value)
+        [InlineData("Foreign Keys", "1")]
+        [InlineData("Foreign Keys", "Yes")]
+        [InlineData("Foreign Keys", "On")]
+        [InlineData("Foreign Keys", "0")]
+        [InlineData("Foreign Keys", "No")]
+        [InlineData("Foreign Keys", "Off")]
+        [InlineData("Lower Case Guids", "1")]
+        [InlineData("Lower Case Guids", "Yes")]
+        [InlineData("Lower Case Guids", "On")]
+        [InlineData("Lower Case Guids", "0")]
+        [InlineData("Lower Case Guids", "No")]
+        [InlineData("Lower Case Guids", "Off")]
+
+        public void Item_throws_when_cannot_convert_to_bool_on_set(string item, object value)
         {
             var builder = new SqliteConnectionStringBuilder();
 
-            Assert.ThrowsAny<FormatException>(() => builder["Foreign Keys"] = value);
+            Assert.ThrowsAny<FormatException>(() => builder[item] = value);
         }
 
         [Fact]
         public void Clear_resets_everything()
         {
             var builder = new SqliteConnectionStringBuilder(
-                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True");
+                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Lower Case Guids=True");
 
             builder.Clear();
 
@@ -226,6 +263,7 @@ namespace Microsoft.Data.Sqlite
             Assert.Empty(builder.Password);
             Assert.Null(builder.ForeignKeys);
             Assert.False(builder.RecursiveTriggers);
+            Assert.False(builder.LowerCaseGuids);
         }
 
         [Fact]
@@ -307,11 +345,12 @@ namespace Microsoft.Data.Sqlite
                 Mode = SqliteOpenMode.Memory,
                 Password = "test",
                 ForeignKeys = true,
-                RecursiveTriggers = true
+                RecursiveTriggers = true,
+                LowerCaseGuids = true
             };
 
             Assert.Equal(
-                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True",
+                "Data Source=test.db;Mode=Memory;Cache=Shared;Password=test;Foreign Keys=True;Recursive Triggers=True;Lower Case Guids=True",
                 builder.ToString());
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -242,11 +242,33 @@ namespace Microsoft.Data.Sqlite
                 new byte[] { 0xDB, 0x2D, 0x90, 0x1C, 0xB6, 0xF4, 0x45, 0x49, 0xAF, 0x38, 0x0D, 0xC1, 0xB0, 0x76, 0x04, 0x65 },
                 SqliteType.Blob);
 
+        private void BindGuid_works(Guid value, object coercedValue, bool lowerCase)
+        {
+            using (var connection = new SqliteConnection($"Data Source=:memory:;Lower Case Guids={(lowerCase ? "True" : "False")}"))
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = "SELECT @Parameter;";
+                var sqliteParameter = command.Parameters.AddWithValue("@Parameter", value);
+
+                connection.Open();
+
+                var result = command.ExecuteScalar();
+
+                Assert.Equal(coercedValue, result);
+            }
+        }
+
         [Fact]
-        public void Bind_works_when_Guid()
-            => Bind_works(
+        public void Bind_works_when_Guid_without_lower_case_guids()
+            => BindGuid_works(
                 new Guid("1c902ddb-f4b6-4945-af38-0dc1b0760465"),
-                "1C902DDB-F4B6-4945-AF38-0DC1B0760465");
+                "1C902DDB-F4B6-4945-AF38-0DC1B0760465", false);
+
+        [Fact]
+        public void Bind_works_when_Guid_with_lower_case_guids()
+            => BindGuid_works(
+                new Guid("1c902ddb-f4b6-4945-af38-0dc1b0760465"),
+                "1c902ddb-f4b6-4945-af38-0dc1b0760465", true);
 
         [Fact]
         public void Bind_works_when_Nullable()


### PR DESCRIPTION
`Microsoft.Data.Sqlite` currently serializes GUIDs as text in upper case.  Since SQLite does not have a database-global case insensitivity collation mode, and EF Core Migrations do not currently allow the `COLLATE NOCASE` option to be added to GUID columns, this can lead to problems when inter-operating with raw SQL queries (since the default `.ToString()` implentation for `Guid` serializes in lower case) 

* This MR adds a new 'Lower Case Guids' option to `SqliteConnectionStringBuilder` and adjusts 
 `SqliteResultBinder` to generate upper or lower case GUID strings according to the value

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines



 