### PR TITLE
Query: Snapshot selector shape correctly for better match

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1522,13 +1522,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 case NewExpression newExpression:
                 {
+                    var allDefault = true;
                     var arguments = new Expression[newExpression.Arguments.Count];
                     for (var i = 0; i < newExpression.Arguments.Count; i++)
                     {
                         arguments[i] = SnapshotExpression(newExpression.Arguments[i]);
+                        allDefault &= arguments[i].NodeType == ExpressionType.Default;
                     }
 
-                    return newExpression.Update(arguments);
+                    return allDefault
+                        ? Expression.Default(newExpression.Type)
+                        : (Expression)newExpression.Update(arguments);
                 }
 
                 case OwnedNavigationReference ownedNavigationReference:

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2398,6 +2398,27 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Key);
         }
 
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_scalar_aggregate_in_set_operation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Where(c => c.CustomerID.StartsWith("F"))
+                    .Select(c => new { c.CustomerID, Sequence = 0 })
+                    .Union(ss.Set<Order>()
+                        .GroupBy(o => o.CustomerID)
+                        .Select(g => new
+                        {
+                            CustomerID = g.Key,
+                            Sequence = 1
+                        })),
+                elementSorter: e => e.CustomerID);
+        }
+
         #endregion
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1916,6 +1916,20 @@ GROUP BY [o].[CustomerID]");
             AssertSql(" ");
         }
 
+        public override async Task GroupBy_scalar_aggregate_in_set_operation(bool async)
+        {
+            await base.GroupBy_scalar_aggregate_in_set_operation(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], 0 AS [Sequence]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'
+UNION
+SELECT [o].[CustomerID], 1 AS [Sequence]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
If all components are NewExpression are default then just make it wholy default so that it can match to GroupBy-Aggregate shape

Resolves #19705
