### PR TITLE
Fix for issue 16701. Brackets around tables names supports non-SQL Server providers

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -347,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -533,7 +533,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -559,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore
                 : base(DbCommandMethod.ExecuteNonQuery)
             {
                 MutatedSql =
-                    testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
+                    testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 78");
             }
 
             public override InterceptionResult<int> NonQueryExecuting(
@@ -739,7 +739,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 78");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -764,7 +764,7 @@ namespace Microsoft.EntityFrameworkCore
             public QueryReplacingNonQueryCommandInterceptor(CommandInterceptionTestBase testBase)
                 : base(DbCommandMethod.ExecuteNonQuery)
             {
-                commandText = testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
+                commandText = testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 77");
             }
 
             public override InterceptionResult<int> NonQueryExecuting(
@@ -1008,7 +1008,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 78");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -1062,7 +1062,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public virtual async Task Intercept_query_that_throws(bool async, bool inject)
         {
-            const string badSql = "SELECT * FROM TheVoid";
+            string badSql = NormalizeDelimitersInRawString("SELECT * FROM [TheVoid]");
 
             var (context, interceptor) = CreateContext<PassiveReaderCommandInterceptor>(inject);
             using (context)
@@ -1131,7 +1131,7 @@ namespace Microsoft.EntityFrameworkCore
             var (context, interceptor) = CreateContext<PassiveNonQueryCommandInterceptor>(inject);
             using (context)
             {
-                const string nonQuery = "DELETE FROM TheVoid WHERE Id = 555";
+                string nonQuery = NormalizeDelimitersInRawString("DELETE FROM [TheVoid] WHERE [Id] = 555");
 
                 try
                 {
@@ -1207,7 +1207,7 @@ namespace Microsoft.EntityFrameworkCore
                 using (context.Database.BeginTransaction())
                 {
                     string nonQuery =
-                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 77");
 
                     var exception = async
                         ? await Assert.ThrowsAsync<Exception>(() => context.Database.ExecuteSqlRawAsync(nonQuery))
@@ -1341,7 +1341,7 @@ namespace Microsoft.EntityFrameworkCore
             using (context.Database.BeginTransaction())
             {
                 string nonQuery =
-                    NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
+                    NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE [Id] = 78");
 
                 Assert.Equal(
                     7,
@@ -1872,6 +1872,5 @@ namespace Microsoft.EntityFrameworkCore
 
         private string NormalizeDelimitersInRawString(string sql)
             => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimitersInRawString(sql);
-
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -114,7 +115,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -344,7 +346,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -523,12 +526,14 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public virtual async Task Intercept_non_query_to_mutate_command(bool async, bool inject)
         {
-            var (context, interceptor) = CreateContext<MutatingNonQueryCommandInterceptor>(inject);
+            var interceptor = new MutatingNonQueryCommandInterceptor(this);
+            var context = inject ? CreateContext(null, interceptor) : CreateContext(interceptor);
             using (context)
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -539,7 +544,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     AssertNormalOutcome(context, interceptor, async);
 
-                    AssertSql(MutatingNonQueryCommandInterceptor.MutatedSql, interceptor.CommandText);
+                    AssertSql(interceptor.MutatedSql, interceptor.CommandText);
 
                     AssertExecutedEvents(listener);
                 }
@@ -548,11 +553,13 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class MutatingNonQueryCommandInterceptor : CommandInterceptorBase
         {
-            public const string MutatedSql = "DELETE FROM [Singularity] WHERE Id = 78";
+            public readonly string MutatedSql;
 
-            public MutatingNonQueryCommandInterceptor()
+            public MutatingNonQueryCommandInterceptor(CommandInterceptionTestBase testBase)
                 : base(DbCommandMethod.ExecuteNonQuery)
             {
+                MutatedSql =
+                    testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
             }
 
             public override InterceptionResult<int> NonQueryExecuting(
@@ -725,12 +732,14 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public virtual async Task Intercept_non_query_to_replace_execution(bool async, bool inject)
         {
-            var (context, interceptor) = CreateContext<QueryReplacingNonQueryCommandInterceptor>(inject);
+            var interceptor = new QueryReplacingNonQueryCommandInterceptor(this);
+            var context = inject ? CreateContext(null, interceptor) : CreateContext(interceptor);
             using (context)
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -750,9 +759,12 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class QueryReplacingNonQueryCommandInterceptor : CommandInterceptorBase
         {
-            public QueryReplacingNonQueryCommandInterceptor()
+            private readonly string commandText;
+
+            public QueryReplacingNonQueryCommandInterceptor(CommandInterceptionTestBase testBase)
                 : base(DbCommandMethod.ExecuteNonQuery)
             {
+                commandText = testBase.NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
             }
 
             public override InterceptionResult<int> NonQueryExecuting(
@@ -782,7 +794,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var newCommand = command.Connection.CreateCommand();
                 newCommand.Transaction = command.Transaction;
-                newCommand.CommandText = "DELETE FROM [Singularity] WHERE Id = 77";
+                newCommand.CommandText = commandText;
 
                 return newCommand;
             }
@@ -995,7 +1007,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -1193,7 +1206,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
+                    string nonQuery =
+                        NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 77");
 
                     var exception = async
                         ? await Assert.ThrowsAsync<Exception>(() => context.Database.ExecuteSqlRawAsync(nonQuery))
@@ -1318,15 +1332,16 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext(
                 new ResultReplacingNonQueryCommandInterceptor(),
-                new MutatingNonQueryCommandInterceptor());
+                new MutatingNonQueryCommandInterceptor(this));
             await TestCompositeNonQueryInterceptors(context, async);
         }
 
-        private static async Task TestCompositeNonQueryInterceptors(UniverseContext context, bool async)
+        private async Task TestCompositeNonQueryInterceptors(UniverseContext context, bool async)
         {
             using (context.Database.BeginTransaction())
             {
-                const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
+                string nonQuery =
+                    NormalizeDelimitersInRawString("DELETE FROM [Singularity] WHERE Id = 78");
 
                 Assert.Equal(
                     7,
@@ -1366,7 +1381,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext(
                 null,
-                new MutatingNonQueryCommandInterceptor(), new ResultReplacingNonQueryCommandInterceptor());
+                new MutatingNonQueryCommandInterceptor(this), new ResultReplacingNonQueryCommandInterceptor());
             await TestCompositeNonQueryInterceptors(context, async);
         }
 
@@ -1415,7 +1430,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Intercept_non_query_with_explicitly_composed_app_interceptor(bool async)
         {
             using var context = CreateContext(
-                new IInterceptor[] { new MutatingNonQueryCommandInterceptor(), new ResultReplacingNonQueryCommandInterceptor() });
+                new IInterceptor[] { new MutatingNonQueryCommandInterceptor(this), new ResultReplacingNonQueryCommandInterceptor() });
             await TestCompositeNonQueryInterceptors(context, async);
         }
 
@@ -1854,5 +1869,9 @@ namespace Microsoft.EntityFrameworkCore
                 FailedCalled = true;
             }
         }
+
+        private string NormalizeDelimitersInRawString(string sql)
+            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimitersInRawString(sql);
+
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/CommandInterceptionTestBase.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -528,7 +528,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -548,7 +548,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class MutatingNonQueryCommandInterceptor : CommandInterceptorBase
         {
-            public const string MutatedSql = "DELETE FROM Singularity WHERE Id = 78";
+            public const string MutatedSql = "DELETE FROM [Singularity] WHERE Id = 78";
 
             public MutatingNonQueryCommandInterceptor()
                 : base(DbCommandMethod.ExecuteNonQuery)
@@ -730,7 +730,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 78";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -782,7 +782,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var newCommand = command.Connection.CreateCommand();
                 newCommand.Transaction = command.Transaction;
-                newCommand.CommandText = "DELETE FROM Singularity WHERE Id = 77";
+                newCommand.CommandText = "DELETE FROM [Singularity] WHERE Id = 77";
 
                 return newCommand;
             }
@@ -995,7 +995,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 78";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
 
                     using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
                     var result = async
@@ -1193,7 +1193,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (context.Database.BeginTransaction())
                 {
-                    const string nonQuery = "DELETE FROM Singularity WHERE Id = 77";
+                    const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 77";
 
                     var exception = async
                         ? await Assert.ThrowsAsync<Exception>(() => context.Database.ExecuteSqlRawAsync(nonQuery))
@@ -1326,7 +1326,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (context.Database.BeginTransaction())
             {
-                const string nonQuery = "DELETE FROM Singularity WHERE Id = 78";
+                const string nonQuery = "DELETE FROM [Singularity] WHERE Id = 78";
 
                 Assert.Equal(
                     7,


### PR DESCRIPTION
Fixes issue #16701 . The tests work for SQL Server but in other providers the table names need square brackets (which are then re-interpreted as the provider's escape character).


