### PR TITLE
Generate parameter name properly for ExecuteSqlInterpolated

### DIFF
--- a/src/EFCore.Relational/Storage/Internal/RawSqlCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/Internal/RawSqlCommandBuilder.cs
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         dbParameter.ParameterName = _sqlGenerationHelper.GenerateParameterName(parameterNameGenerator.GenerateNext());
                     }
 
-                    substitutions.Add(dbParameter.ParameterName);
+                    substitutions.Add(_sqlGenerationHelper.GenerateParameterName(dbParameter.ParameterName));
                     relationalCommandBuilder.AddRawParameter(dbParameter.ParameterName, dbParameter);
                 }
                 else

--- a/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -169,6 +169,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Query_with_DbParameters_interpolated()
+        {
+            var city = CreateDbParameter("city", "London");
+            var contactTitle = CreateDbParameter( "contactTitle", "Sales Representative");
+
+            using var context = CreateContext();
+            var actual = context.Database
+                .ExecuteSqlInterpolated(
+                    $@"SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = {city} AND ""ContactTitle"" = {contactTitle}");
+
+            Assert.Equal(-1, actual);
+        }
+
+        [ConditionalFact]
         public virtual async Task Executes_stored_procedure_async()
         {
             using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SqlExecutorSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SqlExecutorSqlServerTest.cs
@@ -114,6 +114,17 @@ SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" =
 SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         }
 
+        public override void Query_with_DbParameters_interpolated()
+        {
+            base.Query_with_DbParameters_interpolated();
+
+            AssertSql(
+                @"city='London' (Nullable = false) (Size = 6)
+contactTitle='Sales Representative' (Nullable = false) (Size = 20)
+
+SELECT COUNT(*) FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = @contactTitle");
+        }
+
         public override async Task Query_with_parameters_async()
         {
             await base.Query_with_parameters_async();


### PR DESCRIPTION
Use sql generation helper to generate parameter name to write in sql command.

Resolves #19493
