### PR TITLE
Query: Convert Set to entity queryables in explicitly compiled query

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void DbSet_query_first()
         {
             var query = EF.CompileQuery(
-                (NorthwindContext context) => context.Customers.OrderBy(c => c.CustomerID).First());
+                (NorthwindContext context) => context.Set<Customer>().OrderBy(c => c.CustomerID).First());
 
             using (var context = CreateContext())
             {
@@ -537,6 +537,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 Assert.True(query(context, "ALFKI"));
+            }
+        }
+
+        [ConditionalFact(Skip = "Issue#19209")]
+        public virtual void Compiled_query_when_using_member_on_context()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context)
+                    => context.Customers.Where(c => c.CustomerID.StartsWith(context.TenantPrefix)));
+
+            using (var context = CreateContext())
+            {
+                context.TenantPrefix = "A";
+                Assert.Equal(6, query(context).Count());
+
+                context.TenantPrefix = "B";
+                Assert.Equal(4, query(context).Count());
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2214,6 +2214,29 @@ WHERE [e].[Name] IS NULL");
             }
         }
 
+        [ConditionalFact]
+        public virtual void Explicitly_compiled_query_does_not_add_cache_entry()
+        {
+            var parameter = Expression.Parameter(typeof(Entity8909));
+            var predicate = Expression.Lambda<Func<Entity8909, bool>>(
+                Expression.MakeBinary(ExpressionType.Equal,
+                    Expression.PropertyOrField(parameter, "Id"),
+                    Expression.Constant(1)),
+                parameter);
+            var query = EF.CompileQuery((MyContext8909 context) => context.Set<Entity8909>().SingleOrDefault(predicate));
+            using (CreateDatabase8909())
+            {
+                using var context = new MyContext8909(_options);
+                context.Cache.Compact(1);
+                Assert.Equal(0, context.Cache.Count);
+
+                query(context);
+
+                // 1 entry for RelationalCommandCache
+                Assert.Equal(1, context.Cache.Count);
+            }
+        }
+
         private SqlServerTestStore CreateDatabase8909()
         {
             return CreateTestStore(


### PR DESCRIPTION
Resolves #19322

Also block evaluation of DbContext inside Parameter extractor. It would throw exception rather than using first time context value every time (which would be incorrect results) till true funcletizer is implemented in #19209
