### PR TITLE
[release/3.1] Query: Assign datetime typemapping to DateTimeOffset.Date

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -51,6 +51,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 switch (memberName)
                 {
                     case nameof(DateTime.Date):
+                        if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue19052", out var isEnabled) && isEnabled)
+                        {
+                            return _sqlExpressionFactory.Function(
+                                "CONVERT",
+                                new[] { _sqlExpressionFactory.Fragment("date"), instance },
+                                returnType,
+                                instance.TypeMapping);
+                        }
+
                         return _sqlExpressionFactory.Function(
                             "CONVERT",
                             new[] { _sqlExpressionFactory.Fragment("date"), instance },

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -55,7 +55,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                             "CONVERT",
                             new[] { _sqlExpressionFactory.Fragment("date"), instance },
                             returnType,
-                            instance.TypeMapping);
+                            declaringType == typeof(DateTime)
+                                ? instance.TypeMapping
+                                : _sqlExpressionFactory.FindMapping(typeof(DateTime)));
 
                     case nameof(DateTime.TimeOfDay):
                         return _sqlExpressionFactory.Convert(instance, returnType);

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerDateTimeMethodTranslator.cs
@@ -41,6 +41,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         {
             if (_methodInfoDatePartMapping.TryGetValue(method, out var datePart))
             {
+                // DateAdd does not accept number argument outside of int range
+                // AddYears/AddMonths take int argument so no need to check for range
                 return !datePart.Equals("year")
                     && !datePart.Equals("month")
                     && arguments[0] is SqlConstantExpression sqlConstant

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7584,6 +7584,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (await Assert.ThrowsAsync<InvalidOperationException>(testCode)).Message);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task DateTimeOffset_Date_returns_datetime(bool async)
+        {
+            var dateTimeOffset = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0));
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Timeline.Date >= dateTimeOffset.Date));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7550,6 +7550,18 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND (CASE
 END = CAST(1 AS bit))");
         }
 
+        public override async Task DateTimeOffset_Date_returns_datetime(bool async)
+        {
+            await base.DateTimeOffset_Date_returns_datetime(async);
+
+            AssertSql(
+                @"@__dateTimeOffset_Date_0='0002-03-01T00:00:00'
+
+SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -86,6 +86,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertTranslationFailed(() => base.DateTimeOffset_Contains_Less_than_Greater_than(isAsync));
         }
 
+        // SQLite client-eval
+        public override Task DateTimeOffset_Date_returns_datetime(bool async)
+        {
+            return AssertTranslationFailed(() => base.DateTimeOffset_Date_returns_datetime(async));
+        }
+
         // Sqlite does not support cross/outer apply
         public override Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool isAsync) => null;
 


### PR DESCRIPTION
Resolves #19052

### Description

When DateTimeOffset.Date is translated, we kept resulting type mapping as datetimeoffset so during comparison with other date, the parameter is created using wrong store type.

### Customer Impact

Due to parameter type being wrong, it can have offset sometimes giving incorrect results of the query.

### How found

Reported by multiple customers.

### Test coverage

We did not have test coverage for specific scenario where DateTimeOffset.Date's type mapping mattered. This has been added.

### Regression?

Possibly. We have verified the exact behavior in 2.x because a lot has changed in how we translate this, but it's likely this was broken in 2.x at least for some cases.

### Risk

Low. Affects only translation of `DateTimeOffset.Date` which was incorrect before this fix.

Also, fix is on by default, but quirk switch is present to revert back to old behavior.
