### PR TITLE
[release/3.1] Query: Simplify SQL generated for optional owned/weak entities when table splitting

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -151,32 +151,28 @@ namespace Microsoft.EntityFrameworkCore
                 @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [t].[UniqueNo], [t].[AdditionalDetails_Name], [t0].[UniqueNo], [t0].[Details_Name]
 FROM [Sample] AS [s]
 LEFT JOIN (
-    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo] AS [UniqueNo0]
+    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name]
     FROM [Sample] AS [s0]
-    INNER JOIN [Sample] AS [s1] ON [s0].[UniqueNo] = [s1].[UniqueNo]
     WHERE [s0].[AdditionalDetails_Name] IS NOT NULL
 ) AS [t] ON [s].[UniqueNo] = [t].[UniqueNo]
 LEFT JOIN (
-    SELECT [s2].[UniqueNo], [s2].[Details_Name], [s3].[UniqueNo] AS [UniqueNo0]
-    FROM [Sample] AS [s2]
-    INNER JOIN [Sample] AS [s3] ON [s2].[UniqueNo] = [s3].[UniqueNo]
-    WHERE [s2].[Details_Name] IS NOT NULL
+    SELECT [s1].[UniqueNo], [s1].[Details_Name]
+    FROM [Sample] AS [s1]
+    WHERE [s1].[Details_Name] IS NOT NULL
 ) AS [t0] ON [s].[UniqueNo] = [t0].[UniqueNo]
 WHERE [s].[UniqueNo] = 1",
                 //
                 @"SELECT TOP(1) [s].[UniqueNo], [s].[MaxLengthProperty], [s].[Name], [s].[RowVersion], [t].[UniqueNo], [t].[AdditionalDetails_Name], [t0].[UniqueNo], [t0].[Details_Name]
 FROM [Sample] AS [s]
 LEFT JOIN (
-    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name], [s1].[UniqueNo] AS [UniqueNo0]
+    SELECT [s0].[UniqueNo], [s0].[AdditionalDetails_Name]
     FROM [Sample] AS [s0]
-    INNER JOIN [Sample] AS [s1] ON [s0].[UniqueNo] = [s1].[UniqueNo]
     WHERE [s0].[AdditionalDetails_Name] IS NOT NULL
 ) AS [t] ON [s].[UniqueNo] = [t].[UniqueNo]
 LEFT JOIN (
-    SELECT [s2].[UniqueNo], [s2].[Details_Name], [s3].[UniqueNo] AS [UniqueNo0]
-    FROM [Sample] AS [s2]
-    INNER JOIN [Sample] AS [s3] ON [s2].[UniqueNo] = [s3].[UniqueNo]
-    WHERE [s2].[Details_Name] IS NOT NULL
+    SELECT [s1].[UniqueNo], [s1].[Details_Name]
+    FROM [Sample] AS [s1]
+    WHERE [s1].[Details_Name] IS NOT NULL
 ) AS [t0] ON [s].[UniqueNo] = [t0].[UniqueNo]
 WHERE [s].[UniqueNo] = 1",
                 //

--- a/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/PropertyEntrySqlServerTest.cs
@@ -21,9 +21,8 @@ namespace Microsoft.EntityFrameworkCore
                 @"SELECT TOP(1) [e].[Id], [e].[EngineSupplierId], [e].[Name], [t].[Id], [t].[StorageLocation_Latitude], [t].[StorageLocation_Longitude]
 FROM [Engines] AS [e]
 LEFT JOIN (
-    SELECT [e0].[Id], [e0].[StorageLocation_Latitude], [e0].[StorageLocation_Longitude], [e1].[Id] AS [Id0]
+    SELECT [e0].[Id], [e0].[StorageLocation_Latitude], [e0].[StorageLocation_Longitude]
     FROM [Engines] AS [e0]
-    INNER JOIN [Engines] AS [e1] ON [e0].[Id] = [e1].[Id]
     WHERE [e0].[StorageLocation_Longitude] IS NOT NULL AND [e0].[StorageLocation_Latitude] IS NOT NULL
 ) AS [t] ON [e].[Id] = [t].[Id]
 ORDER BY [e].[Id]",

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -20,85 +20,50 @@ namespace Microsoft.EntityFrameworkCore.Query
             await base.Query_with_owned_entity_equality_operator(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t1].[Id], [t4].[Id], [t4].[PersonAddress_Country_Name], [t4].[PersonAddress_Country_PlanetId], [t6].[Id], [t9].[Id], [t9].[BranchAddress_Country_Name], [t9].[BranchAddress_Country_PlanetId], [t11].[Id], [t14].[Id], [t14].[LeafAAddress_Country_Name], [t14].[LeafAAddress_Country_PlanetId], [t].[Id], [o16].[ClientId], [o16].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o1].[Id], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafAAddress_Country_Name], [t6].[LeafAAddress_Country_PlanetId], [t].[Id], [o9].[ClientId], [o9].[Id]
 FROM [OwnedPerson] AS [o]
 CROSS JOIN (
     SELECT [o0].[Id], [o0].[Discriminator]
     FROM [OwnedPerson] AS [o0]
     WHERE [o0].[Discriminator] = N'LeafB'
 ) AS [t]
+LEFT JOIN [OwnedPerson] AS [o1] ON [o].[Id] = [o1].[Id]
 LEFT JOIN (
-    SELECT [o1].[Id], [t0].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o1]
-    INNER JOIN (
-        SELECT [o2].[Id], [o2].[Discriminator]
-        FROM [OwnedPerson] AS [o2]
-        WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t0] ON [o1].[Id] = [t0].[Id]
-) AS [t1] ON [o].[Id] = [t1].[Id]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o2]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t0] ON [o1].[Id] = [t0].[Id]
 LEFT JOIN (
-    SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
+    SELECT [o3].[Id], [t1].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o3]
     INNER JOIN (
-        SELECT [o4].[Id], [t2].[Id] AS [Id0]
+        SELECT [o4].[Id], [o4].[Discriminator]
         FROM [OwnedPerson] AS [o4]
-        INNER JOIN (
-            SELECT [o5].[Id], [o5].[Discriminator]
-            FROM [OwnedPerson] AS [o5]
-            WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t2] ON [o4].[Id] = [t2].[Id]
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-    WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t4] ON [t1].[Id] = [t4].[Id]
+        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t1] ON [o3].[Id] = [t1].[Id]
+) AS [t2] ON [o].[Id] = [t2].[Id]
 LEFT JOIN (
-    SELECT [o6].[Id], [t5].[Id] AS [Id0]
+    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o5]
+    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t2].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o6].[Id], [t4].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o6]
     INNER JOIN (
         SELECT [o7].[Id], [o7].[Discriminator]
         FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t5] ON [o6].[Id] = [t5].[Id]
-) AS [t6] ON [o].[Id] = [t6].[Id]
+        WHERE [o7].[Discriminator] = N'LeafA'
+    ) AS [t4] ON [o6].[Id] = [t4].[Id]
+) AS [t5] ON [o].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o8].[Id], [o8].[BranchAddress_Country_Name], [o8].[BranchAddress_Country_PlanetId], [t8].[Id] AS [Id0], [t8].[Id0] AS [Id00]
+    SELECT [o8].[Id], [o8].[LeafAAddress_Country_Name], [o8].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [t7].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o9]
-        INNER JOIN (
-            SELECT [o10].[Id], [o10].[Discriminator]
-            FROM [OwnedPerson] AS [o10]
-            WHERE [o10].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t7] ON [o9].[Id] = [t7].[Id]
-    ) AS [t8] ON [o8].[Id] = [t8].[Id]
-    WHERE [o8].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t6].[Id] = [t9].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [t10].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o11]
-    INNER JOIN (
-        SELECT [o12].[Id], [o12].[Discriminator]
-        FROM [OwnedPerson] AS [o12]
-        WHERE [o12].[Discriminator] = N'LeafA'
-    ) AS [t10] ON [o11].[Id] = [t10].[Id]
-) AS [t11] ON [o].[Id] = [t11].[Id]
-LEFT JOIN (
-    SELECT [o13].[Id], [o13].[LeafAAddress_Country_Name], [o13].[LeafAAddress_Country_PlanetId], [t13].[Id] AS [Id0], [t13].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o13]
-    INNER JOIN (
-        SELECT [o14].[Id], [t12].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o14]
-        INNER JOIN (
-            SELECT [o15].[Id], [o15].[Discriminator]
-            FROM [OwnedPerson] AS [o15]
-            WHERE [o15].[Discriminator] = N'LeafA'
-        ) AS [t12] ON [o14].[Id] = [t12].[Id]
-    ) AS [t13] ON [o13].[Id] = [t13].[Id]
-    WHERE [o13].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t14] ON [t11].[Id] = [t14].[Id]
-LEFT JOIN [Order] AS [o16] ON [o].[Id] = [o16].[ClientId]
+    WHERE [o8].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t6] ON [t5].[Id] = [t6].[Id]
+LEFT JOIN [Order] AS [o9] ON [o].[Id] = [o9].[ClientId]
 WHERE CAST(0 AS bit) = CAST(1 AS bit)
-ORDER BY [o].[Id], [t].[Id], [o16].[ClientId], [o16].[Id]");
+ORDER BY [o].[Id], [t].[Id], [o9].[ClientId], [o9].[Id]");
         }
 
         public override async Task Query_for_base_type_loads_all_owned_navs(bool isAsync)
@@ -107,103 +72,59 @@ ORDER BY [o].[Id], [t].[Id], [o16].[ClientId], [o16].[Id]");
 
             // See issue #10067
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafBAddress_Country_Name], [t5].[LeafBAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafAAddress_Country_Name], [t8].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafB'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
+    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    SELECT [o8].[Id], [t6].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o8]
+    INNER JOIN (
+        SELECT [o9].[Id], [o9].[Discriminator]
+        FROM [OwnedPerson] AS [o9]
+        WHERE [o9].[Discriminator] = N'LeafA'
+    ) AS [t6] ON [o8].[Id] = [t6].[Id]
+) AS [t7] ON [o].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafB'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafB'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN (
-    SELECT [o15].[Id], [t14].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o15]
-    INNER JOIN (
-        SELECT [o16].[Id], [o16].[Discriminator]
-        FROM [OwnedPerson] AS [o16]
-        WHERE [o16].[Discriminator] = N'LeafA'
-    ) AS [t14] ON [o15].[Id] = [t14].[Id]
-) AS [t15] ON [o].[Id] = [t15].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [t16].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o18]
-        INNER JOIN (
-            SELECT [o19].[Id], [o19].[Discriminator]
-            FROM [OwnedPerson] AS [o19]
-            WHERE [o19].[Discriminator] = N'LeafA'
-        ) AS [t16] ON [o18].[Id] = [t16].[Id]
-    ) AS [t17] ON [o17].[Id] = [t17].[Id]
-    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t18] ON [t15].[Id] = [t18].[Id]
-LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
+    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t7].[Id] = [t8].[Id]
+LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
+ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
         }
 
         public override async Task No_ignored_include_warning_when_implicit_load(bool isAsync)
@@ -221,80 +142,45 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             await base.Query_for_branch_type_loads_all_owned_navs(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafAAddress_Country_Name], [t5].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafA'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafA'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
+    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
+LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
+ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
         }
 
         public override async Task Query_for_branch_type_loads_all_owned_navs_tracking(bool isAsync)
@@ -302,80 +188,45 @@ ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
             await base.Query_for_branch_type_loads_all_owned_navs_tracking(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafAAddress_Country_Name], [t5].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafA'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafA'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
+    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
+LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
+ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
         }
 
         public override async Task Query_for_leaf_type_loads_all_owned_navs(bool isAsync)
@@ -383,80 +234,45 @@ ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
             await base.Query_for_leaf_type_loads_all_owned_navs(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafAAddress_Country_Name], [t5].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafA'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafA'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
+    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
+LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
+ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
         }
 
         public override async Task Query_when_group_by(bool isAsync)
@@ -566,7 +382,7 @@ ORDER BY [t15].[Id]");
             AssertSql(
                 @"@__p_0='5'
 
-SELECT [t0].[Id], [t0].[Discriminator], [t4].[Id], [t7].[Id], [t7].[PersonAddress_Country_Name], [t7].[PersonAddress_Country_PlanetId], [t9].[Id], [t12].[Id], [t12].[BranchAddress_Country_Name], [t12].[BranchAddress_Country_PlanetId], [t14].[Id], [t17].[Id], [t17].[LeafBAddress_Country_Name], [t17].[LeafBAddress_Country_PlanetId], [t19].[Id], [t22].[Id], [t22].[LeafAAddress_Country_Name], [t22].[LeafAAddress_Country_PlanetId], [o22].[ClientId], [o22].[Id]
+SELECT [t0].[Id], [t0].[Discriminator], [o1].[Id], [t1].[Id], [t1].[PersonAddress_Country_Name], [t1].[PersonAddress_Country_PlanetId], [t3].[Id], [t4].[Id], [t4].[BranchAddress_Country_Name], [t4].[BranchAddress_Country_PlanetId], [t6].[Id], [t7].[Id], [t7].[LeafBAddress_Country_Name], [t7].[LeafBAddress_Country_PlanetId], [t9].[Id], [t10].[Id], [t10].[LeafAAddress_Country_Name], [t10].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id]
 FROM (
     SELECT TOP(@__p_0) [t].[Id], [t].[Discriminator]
     FROM (
@@ -576,109 +392,57 @@ FROM (
     ) AS [t]
     ORDER BY [t].[Id]
 ) AS [t0]
+LEFT JOIN [OwnedPerson] AS [o0] ON [t0].[Id] = [o0].[Id]
+LEFT JOIN [OwnedPerson] AS [o1] ON [t0].[Id] = [o1].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t1] ON [o0].[Id] = [t1].[Id]
-) AS [t2] ON [t0].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t3].[Id] AS [Id0]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t3] ON [o2].[Id] = [t3].[Id]
-) AS [t4] ON [t0].[Id] = [t4].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t1] ON [o1].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o4].[Id], [o4].[PersonAddress_Country_Name], [o4].[PersonAddress_Country_PlanetId], [t6].[Id] AS [Id0], [t6].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o4]
+    SELECT [o3].[Id], [t2].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o3]
     INNER JOIN (
-        SELECT [o5].[Id], [t5].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o5]
-        INNER JOIN (
-            SELECT [o6].[Id], [o6].[Discriminator]
-            FROM [OwnedPerson] AS [o6]
-            WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t5] ON [o5].[Id] = [t5].[Id]
-    ) AS [t6] ON [o4].[Id] = [t6].[Id]
-    WHERE [o4].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t7] ON [t4].[Id] = [t7].[Id]
+        SELECT [o4].[Id], [o4].[Discriminator]
+        FROM [OwnedPerson] AS [o4]
+        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t2] ON [o3].[Id] = [t2].[Id]
+) AS [t3] ON [t0].[Id] = [t3].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [t8].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o7]
+    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o5]
+    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t4] ON [t3].[Id] = [t4].[Id]
+LEFT JOIN (
+    SELECT [o6].[Id], [t5].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o6]
     INNER JOIN (
-        SELECT [o8].[Id], [o8].[Discriminator]
-        FROM [OwnedPerson] AS [o8]
-        WHERE [o8].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t8] ON [o7].[Id] = [t8].[Id]
-) AS [t9] ON [t0].[Id] = [t9].[Id]
+        SELECT [o7].[Id], [o7].[Discriminator]
+        FROM [OwnedPerson] AS [o7]
+        WHERE [o7].[Discriminator] = N'LeafB'
+    ) AS [t5] ON [o6].[Id] = [t5].[Id]
+) AS [t6] ON [t0].[Id] = [t6].[Id]
 LEFT JOIN (
-    SELECT [o9].[Id], [o9].[BranchAddress_Country_Name], [o9].[BranchAddress_Country_PlanetId], [t11].[Id] AS [Id0], [t11].[Id0] AS [Id00]
+    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o8]
+    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t7] ON [t6].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o9].[Id], [t8].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o9]
     INNER JOIN (
-        SELECT [o10].[Id], [t10].[Id] AS [Id0]
+        SELECT [o10].[Id], [o10].[Discriminator]
         FROM [OwnedPerson] AS [o10]
-        INNER JOIN (
-            SELECT [o11].[Id], [o11].[Discriminator]
-            FROM [OwnedPerson] AS [o11]
-            WHERE [o11].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t10] ON [o10].[Id] = [t10].[Id]
-    ) AS [t11] ON [o9].[Id] = [t11].[Id]
-    WHERE [o9].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t12] ON [t9].[Id] = [t12].[Id]
+        WHERE [o10].[Discriminator] = N'LeafA'
+    ) AS [t8] ON [o9].[Id] = [t8].[Id]
+) AS [t9] ON [t0].[Id] = [t9].[Id]
 LEFT JOIN (
-    SELECT [o12].[Id], [t13].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [o13].[Discriminator]
-        FROM [OwnedPerson] AS [o13]
-        WHERE [o13].[Discriminator] = N'LeafB'
-    ) AS [t13] ON [o12].[Id] = [t13].[Id]
-) AS [t14] ON [t0].[Id] = [t14].[Id]
-LEFT JOIN (
-    SELECT [o14].[Id], [o14].[LeafBAddress_Country_Name], [o14].[LeafBAddress_Country_PlanetId], [t16].[Id] AS [Id0], [t16].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o14]
-    INNER JOIN (
-        SELECT [o15].[Id], [t15].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o15]
-        INNER JOIN (
-            SELECT [o16].[Id], [o16].[Discriminator]
-            FROM [OwnedPerson] AS [o16]
-            WHERE [o16].[Discriminator] = N'LeafB'
-        ) AS [t15] ON [o15].[Id] = [t15].[Id]
-    ) AS [t16] ON [o14].[Id] = [t16].[Id]
-    WHERE [o14].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t17] ON [t14].[Id] = [t17].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [t18].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [o18].[Discriminator]
-        FROM [OwnedPerson] AS [o18]
-        WHERE [o18].[Discriminator] = N'LeafA'
-    ) AS [t18] ON [o17].[Id] = [t18].[Id]
-) AS [t19] ON [t0].[Id] = [t19].[Id]
-LEFT JOIN (
-    SELECT [o19].[Id], [o19].[LeafAAddress_Country_Name], [o19].[LeafAAddress_Country_PlanetId], [t21].[Id] AS [Id0], [t21].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o19]
-    INNER JOIN (
-        SELECT [o20].[Id], [t20].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o20]
-        INNER JOIN (
-            SELECT [o21].[Id], [o21].[Discriminator]
-            FROM [OwnedPerson] AS [o21]
-            WHERE [o21].[Discriminator] = N'LeafA'
-        ) AS [t20] ON [o20].[Id] = [t20].[Id]
-    ) AS [t21] ON [o19].[Id] = [t21].[Id]
-    WHERE [o19].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t22] ON [t19].[Id] = [t22].[Id]
-LEFT JOIN [Order] AS [o22] ON [t0].[Id] = [o22].[ClientId]
-ORDER BY [t0].[Id], [o22].[ClientId], [o22].[Id]");
+    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o11]
+    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t10] ON [t9].[Id] = [t10].[Id]
+LEFT JOIN [Order] AS [o12] ON [t0].[Id] = [o12].[ClientId]
+ORDER BY [t0].[Id], [o12].[ClientId], [o12].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool isAsync)
@@ -686,32 +450,15 @@ ORDER BY [t0].[Id], [o22].[ClientId], [o22].[Id]");
             await base.Navigation_rewrite_on_owned_reference_projecting_scalar(isAsync);
 
             AssertSql(
-                @"SELECT [t3].[PersonAddress_Country_Name]
+                @"SELECT [t].[PersonAddress_Country_Name]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([t3].[PersonAddress_Country_Name] = N'USA')");
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([t].[PersonAddress_Country_Name] = N'USA')");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_projecting_entity(bool isAsync)
@@ -719,103 +466,59 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND
             await base.Navigation_rewrite_on_owned_reference_projecting_entity(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafBAddress_Country_Name], [t5].[LeafBAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafAAddress_Country_Name], [t8].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafB'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
+    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    SELECT [o8].[Id], [t6].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o8]
+    INNER JOIN (
+        SELECT [o9].[Id], [o9].[Discriminator]
+        FROM [OwnedPerson] AS [o9]
+        WHERE [o9].[Discriminator] = N'LeafA'
+    ) AS [t6] ON [o8].[Id] = [t6].[Id]
+) AS [t7] ON [o].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafB'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafB'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN (
-    SELECT [o15].[Id], [t14].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o15]
-    INNER JOIN (
-        SELECT [o16].[Id], [o16].[Discriminator]
-        FROM [OwnedPerson] AS [o16]
-        WHERE [o16].[Discriminator] = N'LeafA'
-    ) AS [t14] ON [o15].[Id] = [t14].[Id]
-) AS [t15] ON [o].[Id] = [t15].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [t16].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o18]
-        INNER JOIN (
-            SELECT [o19].[Id], [o19].[Discriminator]
-            FROM [OwnedPerson] AS [o19]
-            WHERE [o19].[Discriminator] = N'LeafA'
-        ) AS [t16] ON [o18].[Id] = [t16].[Id]
-    ) AS [t17] ON [o17].[Id] = [t17].[Id]
-    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t18] ON [t15].[Id] = [t18].[Id]
-LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
-WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([t3].[PersonAddress_Country_Name] = N'USA')
-ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
+    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t7].[Id] = [t8].[Id]
+LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
+WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([t].[PersonAddress_Country_Name] = N'USA')
+ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_collection(bool isAsync)
@@ -857,40 +560,23 @@ ORDER BY [o0].[Id]");
 
             AssertSql(
                 @"SELECT (
-    SELECT TOP(1) [t4].[PersonAddress_Country_Name]
+    SELECT TOP(1) [t0].[PersonAddress_Country_Name]
     FROM [Order] AS [o]
     LEFT JOIN (
         SELECT [o0].[Id], [o0].[Discriminator]
         FROM [OwnedPerson] AS [o0]
         WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
     ) AS [t] ON [o].[ClientId] = [t].[Id]
+    LEFT JOIN [OwnedPerson] AS [o1] ON [t].[Id] = [o1].[Id]
     LEFT JOIN (
-        SELECT [o1].[Id], [t0].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o1]
-        INNER JOIN (
-            SELECT [o2].[Id], [o2].[Discriminator]
-            FROM [OwnedPerson] AS [o2]
-            WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t0] ON [o1].[Id] = [t0].[Id]
-    ) AS [t1] ON [t].[Id] = [t1].[Id]
-    LEFT JOIN (
-        SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [t2].[Id] AS [Id0]
-            FROM [OwnedPerson] AS [o4]
-            INNER JOIN (
-                SELECT [o5].[Id], [o5].[Discriminator]
-                FROM [OwnedPerson] AS [o5]
-                WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-            ) AS [t2] ON [o4].[Id] = [t2].[Id]
-        ) AS [t3] ON [o3].[Id] = [t3].[Id]
-        WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
-    ) AS [t4] ON [t1].[Id] = [t4].[Id]
-    WHERE [o6].[Id] = [o].[ClientId]
+        SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
+        FROM [OwnedPerson] AS [o2]
+        WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+    ) AS [t0] ON [o1].[Id] = [t0].[Id]
+    WHERE [o3].[Id] = [o].[ClientId]
     ORDER BY [o].[Id])
-FROM [OwnedPerson] AS [o6]
-WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
+FROM [OwnedPerson] AS [o3]
+WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
         public override async Task SelectMany_on_owned_collection(bool isAsync)
@@ -911,30 +597,13 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [p].[Id], [p].[StarId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
@@ -943,35 +612,18 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             await base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o5].[ClientId], [o5].[Id]
+                @"SELECT [o].[Id], [o2].[ClientId], [o2].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o5] ON [o].[Id] = [o5].[ClientId]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o2] ON [o].[Id] = [o2].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([p].[Id] <> 42) OR [p].[Id] IS NULL)
-ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
+ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
         }
 
         public override async Task Project_multiple_owned_navigations(bool isAsync)
@@ -979,35 +631,18 @@ ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
             await base.Project_multiple_owned_navigations(isAsync);
 
             AssertSql(
-                @"SELECT [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o].[Id], [o5].[ClientId], [o5].[Id]
+                @"SELECT [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o].[Id], [o2].[ClientId], [o2].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o5] ON [o].[Id] = [o5].[ClientId]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o2] ON [o].[Id] = [o2].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
+ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
         }
 
         public override async Task Project_multiple_owned_navigations_with_expansion_on_owned_collections(bool isAsync)
@@ -1023,59 +658,25 @@ ORDER BY [o].[Id], [o5].[ClientId], [o5].[Id]");
         FROM [OwnedPerson] AS [o0]
         WHERE [o0].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
     ) AS [t] ON [o].[ClientId] = [t].[Id]
+    LEFT JOIN [OwnedPerson] AS [o1] ON [t].[Id] = [o1].[Id]
     LEFT JOIN (
-        SELECT [o1].[Id], [t0].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o1]
-        INNER JOIN (
-            SELECT [o2].[Id], [o2].[Discriminator]
-            FROM [OwnedPerson] AS [o2]
-            WHERE [o2].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t0] ON [o1].[Id] = [t0].[Id]
-    ) AS [t1] ON [t].[Id] = [t1].[Id]
-    LEFT JOIN (
-        SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId], [t3].[Id] AS [Id0], [t3].[Id0] AS [Id00]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [t2].[Id] AS [Id0]
-            FROM [OwnedPerson] AS [o4]
-            INNER JOIN (
-                SELECT [o5].[Id], [o5].[Discriminator]
-                FROM [OwnedPerson] AS [o5]
-                WHERE [o5].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-            ) AS [t2] ON [o4].[Id] = [t2].[Id]
-        ) AS [t3] ON [o3].[Id] = [t3].[Id]
-        WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
-    ) AS [t4] ON [t1].[Id] = [t4].[Id]
-    LEFT JOIN [Planet] AS [p] ON [t4].[PersonAddress_Country_PlanetId] = [p].[Id]
+        SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
+        FROM [OwnedPerson] AS [o2]
+        WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+    ) AS [t0] ON [o1].[Id] = [t0].[Id]
+    LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
     LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
-    WHERE ([o6].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
-FROM [OwnedPerson] AS [o6]
+    WHERE ([o3].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
+FROM [OwnedPerson] AS [o3]
+LEFT JOIN [OwnedPerson] AS [o4] ON [o3].[Id] = [o4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [t5].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [o8].[Discriminator]
-        FROM [OwnedPerson] AS [o8]
-        WHERE [o8].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t5] ON [o7].[Id] = [t5].[Id]
-) AS [t6] ON [o6].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [o9].[PersonAddress_Country_Name], [o9].[PersonAddress_Country_PlanetId], [t8].[Id] AS [Id0], [t8].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [t7].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o10]
-        INNER JOIN (
-            SELECT [o11].[Id], [o11].[Discriminator]
-            FROM [OwnedPerson] AS [o11]
-            WHERE [o11].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t7] ON [o10].[Id] = [t7].[Id]
-    ) AS [t8] ON [o9].[Id] = [t8].[Id]
-    WHERE [o9].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t6].[Id] = [t9].[Id]
-LEFT JOIN [Planet] AS [p0] ON [t9].[PersonAddress_Country_PlanetId] = [p0].[Id]
-WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-ORDER BY [o6].[Id]");
+    SELECT [o5].[Id], [o5].[PersonAddress_Country_Name], [o5].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o5]
+    WHERE [o5].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t1] ON [o4].[Id] = [t1].[Id]
+LEFT JOIN [Planet] AS [p0] ON [t1].[PersonAddress_Country_PlanetId] = [p0].[Id]
+WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
+ORDER BY [o3].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(bool isAsync)
@@ -1083,104 +684,60 @@ ORDER BY [o6].[Id]");
             await base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafBAddress_Country_Name], [t5].[LeafBAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafAAddress_Country_Name], [t8].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafB'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
+    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    SELECT [o8].[Id], [t6].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o8]
+    INNER JOIN (
+        SELECT [o9].[Id], [o9].[Discriminator]
+        FROM [OwnedPerson] AS [o9]
+        WHERE [o9].[Discriminator] = N'LeafA'
+    ) AS [t6] ON [o8].[Id] = [t6].[Id]
+) AS [t7] ON [o].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafB'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafB'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN (
-    SELECT [o15].[Id], [t14].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o15]
-    INNER JOIN (
-        SELECT [o16].[Id], [o16].[Discriminator]
-        FROM [OwnedPerson] AS [o16]
-        WHERE [o16].[Discriminator] = N'LeafA'
-    ) AS [t14] ON [o15].[Id] = [t14].[Id]
-) AS [t15] ON [o].[Id] = [t15].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [t16].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o18]
-        INNER JOIN (
-            SELECT [o19].[Id], [o19].[Discriminator]
-            FROM [OwnedPerson] AS [o19]
-            WHERE [o19].[Discriminator] = N'LeafA'
-        ) AS [t16] ON [o18].[Id] = [t16].[Id]
-    ) AS [t17] ON [o17].[Id] = [t17].[Id]
-    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t18] ON [t15].[Id] = [t18].[Id]
-LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
+    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t7].[Id] = [t8].[Id]
+LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND (([p].[Id] <> 7) OR [p].[Id] IS NULL)
-ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
+ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool isAsync)
@@ -1190,30 +747,13 @@ ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
             AssertSql(
                 @"SELECT [p].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
 
@@ -1224,30 +764,13 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [o].[Id], [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
 ORDER BY [o].[Id], [m].[Id]");
@@ -1260,30 +783,13 @@ ORDER BY [o].[Id], [m].[Id]");
             AssertSql(
                 @"SELECT [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 INNER JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
@@ -1295,30 +801,13 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 INNER JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
@@ -1331,30 +820,13 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
@@ -1369,30 +841,13 @@ ORDER BY [o].[Id], [e].[Id]");
             AssertSql(
                 @"SELECT [s].[Name]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
         }
@@ -1406,30 +861,13 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
-LEFT JOIN [Planet] AS [p] ON [t3].[PersonAddress_Country_PlanetId] = [p].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
+LEFT JOIN [Planet] AS [p] ON [t].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([s].[Name] = N'Sol')
@@ -1441,80 +879,45 @@ ORDER BY [o].[Id], [e].[Id]");
             await base.Query_with_OfType_eagerly_loads_correct_owned_navigations(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafAAddress_Country_Name], [t13].[LeafAAddress_Country_PlanetId], [o15].[ClientId], [o15].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafAAddress_Country_Name], [t5].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafA'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafAAddress_Country_Name], [o12].[LeafAAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafA'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN [Order] AS [o15] ON [o].[Id] = [o15].[ClientId]
+    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
+LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([o].[Discriminator] = N'LeafA')
-ORDER BY [o].[Id], [o15].[ClientId], [o15].[Id]");
+ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
         }
 
         public override async Task Preserve_includes_when_applying_skip_take_after_anonymous_type_select(bool isAsync)
@@ -1530,7 +933,7 @@ WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')",
 @__p_1='0'
 @__p_2='100'
 
-SELECT [t].[Id], [t].[Discriminator], [t3].[Id], [t6].[Id], [t6].[PersonAddress_Country_Name], [t6].[PersonAddress_Country_PlanetId], [t8].[Id], [t11].[Id], [t11].[BranchAddress_Country_Name], [t11].[BranchAddress_Country_PlanetId], [t13].[Id], [t16].[Id], [t16].[LeafBAddress_Country_Name], [t16].[LeafBAddress_Country_PlanetId], [t18].[Id], [t21].[Id], [t21].[LeafAAddress_Country_Name], [t21].[LeafAAddress_Country_PlanetId], [t].[c], [o22].[ClientId], [o22].[Id]
+SELECT [t].[Id], [t].[Discriminator], [o1].[Id], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [t].[c], [o12].[ClientId], [o12].[Id]
 FROM (
     SELECT [o].[Id], [o].[Discriminator], @__Count_0 AS [c]
     FROM [OwnedPerson] AS [o]
@@ -1538,109 +941,57 @@ FROM (
     ORDER BY [o].[Id]
     OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
 ) AS [t]
+LEFT JOIN [OwnedPerson] AS [o0] ON [t].[Id] = [o0].[Id]
+LEFT JOIN [OwnedPerson] AS [o1] ON [t].[Id] = [o1].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t0].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t0] ON [o0].[Id] = [t0].[Id]
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t2].[Id] AS [Id0]
+    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-) AS [t3] ON [t].[Id] = [t3].[Id]
+    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t0] ON [o1].[Id] = [t0].[Id]
 LEFT JOIN (
-    SELECT [o4].[Id], [o4].[PersonAddress_Country_Name], [o4].[PersonAddress_Country_PlanetId], [t5].[Id] AS [Id0], [t5].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o4]
+    SELECT [o3].[Id], [t1].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o3]
     INNER JOIN (
-        SELECT [o5].[Id], [t4].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o5]
-        INNER JOIN (
-            SELECT [o6].[Id], [o6].[Discriminator]
-            FROM [OwnedPerson] AS [o6]
-            WHERE [o6].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t4] ON [o5].[Id] = [t4].[Id]
-    ) AS [t5] ON [o4].[Id] = [t5].[Id]
-    WHERE [o4].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t3].[Id] = [t6].[Id]
+        SELECT [o4].[Id], [o4].[Discriminator]
+        FROM [OwnedPerson] AS [o4]
+        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t1] ON [o3].[Id] = [t1].[Id]
+) AS [t2] ON [t].[Id] = [t2].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o7]
+    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o5]
+    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t3] ON [t2].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [o6].[Id], [t4].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o6]
     INNER JOIN (
-        SELECT [o8].[Id], [o8].[Discriminator]
-        FROM [OwnedPerson] AS [o8]
-        WHERE [o8].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-) AS [t8] ON [t].[Id] = [t8].[Id]
+        SELECT [o7].[Id], [o7].[Discriminator]
+        FROM [OwnedPerson] AS [o7]
+        WHERE [o7].[Discriminator] = N'LeafB'
+    ) AS [t4] ON [o6].[Id] = [t4].[Id]
+) AS [t5] ON [t].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o9].[Id], [o9].[BranchAddress_Country_Name], [o9].[BranchAddress_Country_PlanetId], [t10].[Id] AS [Id0], [t10].[Id0] AS [Id00]
+    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o8]
+    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t6] ON [t5].[Id] = [t6].[Id]
+LEFT JOIN (
+    SELECT [o9].[Id], [t7].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o9]
     INNER JOIN (
-        SELECT [o10].[Id], [t9].[Id] AS [Id0]
+        SELECT [o10].[Id], [o10].[Discriminator]
         FROM [OwnedPerson] AS [o10]
-        INNER JOIN (
-            SELECT [o11].[Id], [o11].[Discriminator]
-            FROM [OwnedPerson] AS [o11]
-            WHERE [o11].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t9] ON [o10].[Id] = [t9].[Id]
-    ) AS [t10] ON [o9].[Id] = [t10].[Id]
-    WHERE [o9].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t8].[Id] = [t11].[Id]
+        WHERE [o10].[Discriminator] = N'LeafA'
+    ) AS [t7] ON [o9].[Id] = [t7].[Id]
+) AS [t8] ON [t].[Id] = [t8].[Id]
 LEFT JOIN (
-    SELECT [o12].[Id], [t12].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [o13].[Discriminator]
-        FROM [OwnedPerson] AS [o13]
-        WHERE [o13].[Discriminator] = N'LeafB'
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-) AS [t13] ON [t].[Id] = [t13].[Id]
-LEFT JOIN (
-    SELECT [o14].[Id], [o14].[LeafBAddress_Country_Name], [o14].[LeafBAddress_Country_PlanetId], [t15].[Id] AS [Id0], [t15].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o14]
-    INNER JOIN (
-        SELECT [o15].[Id], [t14].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o15]
-        INNER JOIN (
-            SELECT [o16].[Id], [o16].[Discriminator]
-            FROM [OwnedPerson] AS [o16]
-            WHERE [o16].[Discriminator] = N'LeafB'
-        ) AS [t14] ON [o15].[Id] = [t14].[Id]
-    ) AS [t15] ON [o14].[Id] = [t15].[Id]
-    WHERE [o14].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t16] ON [t13].[Id] = [t16].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [t17].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [o18].[Discriminator]
-        FROM [OwnedPerson] AS [o18]
-        WHERE [o18].[Discriminator] = N'LeafA'
-    ) AS [t17] ON [o17].[Id] = [t17].[Id]
-) AS [t18] ON [t].[Id] = [t18].[Id]
-LEFT JOIN (
-    SELECT [o19].[Id], [o19].[LeafAAddress_Country_Name], [o19].[LeafAAddress_Country_PlanetId], [t20].[Id] AS [Id0], [t20].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o19]
-    INNER JOIN (
-        SELECT [o20].[Id], [t19].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o20]
-        INNER JOIN (
-            SELECT [o21].[Id], [o21].[Discriminator]
-            FROM [OwnedPerson] AS [o21]
-            WHERE [o21].[Discriminator] = N'LeafA'
-        ) AS [t19] ON [o20].[Id] = [t19].[Id]
-    ) AS [t20] ON [o19].[Id] = [t20].[Id]
-    WHERE [o19].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t21] ON [t18].[Id] = [t21].[Id]
-LEFT JOIN [Order] AS [o22] ON [t].[Id] = [o22].[ClientId]
-ORDER BY [t].[Id], [o22].[ClientId], [o22].[Id]");
+    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o11]
+    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t9] ON [t8].[Id] = [t9].[Id]
+LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
+ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
         }
 
         public override async Task Unmapped_property_projection_loads_owned_navigations(bool isAsync)
@@ -1648,103 +999,59 @@ ORDER BY [t].[Id], [o22].[ClientId], [o22].[Id]");
             await base.Unmapped_property_projection_loads_owned_navigations(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [t0].[Id], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t8].[Id], [t8].[BranchAddress_Country_Name], [t8].[BranchAddress_Country_PlanetId], [t10].[Id], [t13].[Id], [t13].[LeafBAddress_Country_Name], [t13].[LeafBAddress_Country_PlanetId], [t15].[Id], [t18].[Id], [t18].[LeafAAddress_Country_Name], [t18].[LeafAAddress_Country_PlanetId], [o20].[ClientId], [o20].[Id]
+                @"SELECT [o].[Id], [o].[Discriminator], [o0].[Id], [t].[Id], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t1].[Id], [t2].[Id], [t2].[BranchAddress_Country_Name], [t2].[BranchAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[LeafBAddress_Country_Name], [t5].[LeafBAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafAAddress_Country_Name], [t8].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id]
 FROM [OwnedPerson] AS [o]
+LEFT JOIN [OwnedPerson] AS [o0] ON [o].[Id] = [o0].[Id]
 LEFT JOIN (
-    SELECT [o0].[Id], [t].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o0]
-    INNER JOIN (
-        SELECT [o1].[Id], [o1].[Discriminator]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-) AS [t0] ON [o].[Id] = [t0].[Id]
+    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o1]
+    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
+) AS [t] ON [o0].[Id] = [t].[Id]
 LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [t2].[Id] AS [Id0], [t2].[Id0] AS [Id00]
+    SELECT [o2].[Id], [t0].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o2]
     INNER JOIN (
-        SELECT [o3].[Id], [t1].[Id] AS [Id0]
+        SELECT [o3].[Id], [o3].[Discriminator]
         FROM [OwnedPerson] AS [o3]
-        INNER JOIN (
-            SELECT [o4].[Id], [o4].[Discriminator]
-            FROM [OwnedPerson] AS [o4]
-            WHERE [o4].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA')
-        ) AS [t1] ON [o3].[Id] = [t1].[Id]
-    ) AS [t2] ON [o2].[Id] = [t2].[Id]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t0].[Id] = [t3].[Id]
+        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
+    ) AS [t0] ON [o2].[Id] = [t0].[Id]
+) AS [t1] ON [o].[Id] = [t1].[Id]
 LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
+    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o4]
+    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [o5].[Id], [t3].[Id] AS [Id0]
     FROM [OwnedPerson] AS [o5]
     INNER JOIN (
         SELECT [o6].[Id], [o6].[Discriminator]
         FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
+        WHERE [o6].[Discriminator] = N'LeafB'
+    ) AS [t3] ON [o5].[Id] = [t3].[Id]
+) AS [t4] ON [o].[Id] = [t4].[Id]
 LEFT JOIN (
-    SELECT [o7].[Id], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [t7].[Id] AS [Id0], [t7].[Id0] AS [Id00]
+    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o7]
-    INNER JOIN (
-        SELECT [o8].[Id], [t6].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o8]
-        INNER JOIN (
-            SELECT [o9].[Id], [o9].[Discriminator]
-            FROM [OwnedPerson] AS [o9]
-            WHERE [o9].[Discriminator] IN (N'Branch', N'LeafA')
-        ) AS [t6] ON [o8].[Id] = [t6].[Id]
-    ) AS [t7] ON [o7].[Id] = [t7].[Id]
-    WHERE [o7].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t5].[Id] = [t8].[Id]
+    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
+) AS [t5] ON [t4].[Id] = [t5].[Id]
 LEFT JOIN (
-    SELECT [o10].[Id], [t9].[Id] AS [Id0]
+    SELECT [o8].[Id], [t6].[Id] AS [Id0]
+    FROM [OwnedPerson] AS [o8]
+    INNER JOIN (
+        SELECT [o9].[Id], [o9].[Discriminator]
+        FROM [OwnedPerson] AS [o9]
+        WHERE [o9].[Discriminator] = N'LeafA'
+    ) AS [t6] ON [o8].[Id] = [t6].[Id]
+) AS [t7] ON [o].[Id] = [t7].[Id]
+LEFT JOIN (
+    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o10]
-    INNER JOIN (
-        SELECT [o11].[Id], [o11].[Discriminator]
-        FROM [OwnedPerson] AS [o11]
-        WHERE [o11].[Discriminator] = N'LeafB'
-    ) AS [t9] ON [o10].[Id] = [t9].[Id]
-) AS [t10] ON [o].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o12].[Id], [o12].[LeafBAddress_Country_Name], [o12].[LeafBAddress_Country_PlanetId], [t12].[Id] AS [Id0], [t12].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o12]
-    INNER JOIN (
-        SELECT [o13].[Id], [t11].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o13]
-        INNER JOIN (
-            SELECT [o14].[Id], [o14].[Discriminator]
-            FROM [OwnedPerson] AS [o14]
-            WHERE [o14].[Discriminator] = N'LeafB'
-        ) AS [t11] ON [o13].[Id] = [t11].[Id]
-    ) AS [t12] ON [o12].[Id] = [t12].[Id]
-    WHERE [o12].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t13] ON [t10].[Id] = [t13].[Id]
-LEFT JOIN (
-    SELECT [o15].[Id], [t14].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o15]
-    INNER JOIN (
-        SELECT [o16].[Id], [o16].[Discriminator]
-        FROM [OwnedPerson] AS [o16]
-        WHERE [o16].[Discriminator] = N'LeafA'
-    ) AS [t14] ON [o15].[Id] = [t14].[Id]
-) AS [t15] ON [o].[Id] = [t15].[Id]
-LEFT JOIN (
-    SELECT [o17].[Id], [o17].[LeafAAddress_Country_Name], [o17].[LeafAAddress_Country_PlanetId], [t17].[Id] AS [Id0], [t17].[Id0] AS [Id00]
-    FROM [OwnedPerson] AS [o17]
-    INNER JOIN (
-        SELECT [o18].[Id], [t16].[Id] AS [Id0]
-        FROM [OwnedPerson] AS [o18]
-        INNER JOIN (
-            SELECT [o19].[Id], [o19].[Discriminator]
-            FROM [OwnedPerson] AS [o19]
-            WHERE [o19].[Discriminator] = N'LeafA'
-        ) AS [t16] ON [o18].[Id] = [t16].[Id]
-    ) AS [t17] ON [o17].[Id] = [t17].[Id]
-    WHERE [o17].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t18] ON [t15].[Id] = [t18].[Id]
-LEFT JOIN [Order] AS [o20] ON [o].[Id] = [o20].[ClientId]
+    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
+) AS [t8] ON [t7].[Id] = [t8].[Id]
+LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
 WHERE [o].[Discriminator] IN (N'OwnedPerson', N'Branch', N'LeafB', N'LeafA') AND ([o].[Id] = 1)
-ORDER BY [o].[Id], [o20].[ClientId], [o20].[Id]");
+ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2493,18 +2493,16 @@ WHERE [e].[Name] IS NULL");
                         @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info], [t1].[Id], [t1].[Movie9202Id], [t1].[Name], [t1].[Id0], [t1].[Details_Info]
 FROM [Movies] AS [m]
 LEFT JOIN (
-    SELECT [m0].[Id], [m0].[Details_Info], [m1].[Id] AS [Id0]
+    SELECT [m0].[Id], [m0].[Details_Info]
     FROM [Movies] AS [m0]
-    INNER JOIN [Movies] AS [m1] ON [m0].[Id] = [m1].[Id]
     WHERE [m0].[Details_Info] IS NOT NULL
 ) AS [t] ON [m].[Id] = [t].[Id]
 LEFT JOIN (
     SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [t0].[Id] AS [Id0], [t0].[Details_Info]
     FROM [Actors] AS [a]
     LEFT JOIN (
-        SELECT [a0].[Id], [a0].[Details_Info], [a1].[Id] AS [Id0]
+        SELECT [a0].[Id], [a0].[Details_Info]
         FROM [Actors] AS [a0]
-        INNER JOIN [Actors] AS [a1] ON [a0].[Id] = [a1].[Id]
         WHERE [a0].[Details_Info] IS NOT NULL
     ) AS [t0] ON [a].[Id] = [t0].[Id]
 ) AS [t1] ON [m].[Id] = [t1].[Movie9202Id]
@@ -2532,18 +2530,16 @@ ORDER BY [m].[Id], [t1].[Id]");
                         @"SELECT [m].[Id], [m].[Title], [t].[Id], [t].[Details_Info], [t1].[Id], [t1].[Movie9202Id], [t1].[Name], [t1].[Id0], [t1].[Details_Info]
 FROM [Movies] AS [m]
 LEFT JOIN (
-    SELECT [m0].[Id], [m0].[Details_Info], [m1].[Id] AS [Id0]
+    SELECT [m0].[Id], [m0].[Details_Info]
     FROM [Movies] AS [m0]
-    INNER JOIN [Movies] AS [m1] ON [m0].[Id] = [m1].[Id]
     WHERE [m0].[Details_Info] IS NOT NULL
 ) AS [t] ON [m].[Id] = [t].[Id]
 LEFT JOIN (
     SELECT [a].[Id], [a].[Movie9202Id], [a].[Name], [t0].[Id] AS [Id0], [t0].[Details_Info]
     FROM [Actors] AS [a]
     LEFT JOIN (
-        SELECT [a0].[Id], [a0].[Details_Info], [a1].[Id] AS [Id0]
+        SELECT [a0].[Id], [a0].[Details_Info]
         FROM [Actors] AS [a0]
-        INNER JOIN [Actors] AS [a1] ON [a0].[Id] = [a1].[Id]
         WHERE [a0].[Details_Info] IS NOT NULL
     ) AS [t0] ON [a].[Id] = [t0].[Id]
 ) AS [t1] ON [m].[Id] = [t1].[Movie9202Id]
@@ -4792,9 +4788,8 @@ LEFT JOIN (
     END AS [c], [t].[Turnovers_AmountIn], [a].[Id], [a].[Partner13157Id]
     FROM [Address13157] AS [a]
     LEFT JOIN (
-        SELECT [a0].[Id], [a0].[Turnovers_AmountIn], [a1].[Id] AS [Id0]
+        SELECT [a0].[Id], [a0].[Turnovers_AmountIn]
         FROM [Address13157] AS [a0]
-        INNER JOIN [Address13157] AS [a1] ON [a0].[Id] = [a1].[Id]
         WHERE [a0].[Turnovers_AmountIn] IS NOT NULL
     ) AS [t] ON [a].[Id] = [t].[Id]
 ) AS [t0] ON [p].[Id] = [t0].[Partner13157Id]
@@ -5914,9 +5909,8 @@ WHERE EXISTS (
                         @"SELECT [r].[Id], [r].[IsRemoved], [r].[Removed], [r].[RemovedByUser], [t].[Id], [t].[OwnedEntity_OwnedValue]
 FROM [RemovableEntities] AS [r]
 LEFT JOIN (
-    SELECT [r0].[Id], [r0].[OwnedEntity_OwnedValue], [r1].[Id] AS [Id0]
+    SELECT [r0].[Id], [r0].[OwnedEntity_OwnedValue]
     FROM [RemovableEntities] AS [r0]
-    INNER JOIN [RemovableEntities] AS [r1] ON [r0].[Id] = [r1].[Id]
     WHERE [r0].[OwnedEntity_OwnedValue] IS NOT NULL
 ) AS [t] ON [r].[Id] = [t].[Id]
 WHERE [r].[IsRemoved] <> CAST(1 AS bit)");
@@ -5959,9 +5953,8 @@ WHERE [r].[IsRemoved] = CAST(1 AS bit)");
                         @"SELECT [r].[Id], [r].[IsRemoved], [r].[Removed], [r].[RemovedByUser], [t].[Id], [t].[OwnedEntity_OwnedValue]
 FROM [RemovableEntities] AS [r]
 LEFT JOIN (
-    SELECT [r0].[Id], [r0].[OwnedEntity_OwnedValue], [r1].[Id] AS [Id0]
+    SELECT [r0].[Id], [r0].[OwnedEntity_OwnedValue]
     FROM [RemovableEntities] AS [r0]
-    INNER JOIN [RemovableEntities] AS [r1] ON [r0].[Id] = [r1].[Id]
     WHERE [r0].[OwnedEntity_OwnedValue] IS NOT NULL
 ) AS [t] ON [r].[Id] = [t].[Id]
 WHERE [t].[OwnedEntity_OwnedValue] = N'Abc'");

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -100,16 +100,14 @@ namespace Microsoft.EntityFrameworkCore
                 @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""AdditionalDetails_Name"", ""t0"".""UniqueNo"", ""t0"".""Details_Name""
 FROM ""Sample"" AS ""s""
 LEFT JOIN (
-    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"" AS ""UniqueNo0""
+    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name""
     FROM ""Sample"" AS ""s0""
-    INNER JOIN ""Sample"" AS ""s1"" ON ""s0"".""UniqueNo"" = ""s1"".""UniqueNo""
     WHERE ""s0"".""AdditionalDetails_Name"" IS NOT NULL
 ) AS ""t"" ON ""s"".""UniqueNo"" = ""t"".""UniqueNo""
 LEFT JOIN (
-    SELECT ""s2"".""UniqueNo"", ""s2"".""Details_Name"", ""s3"".""UniqueNo"" AS ""UniqueNo0""
-    FROM ""Sample"" AS ""s2""
-    INNER JOIN ""Sample"" AS ""s3"" ON ""s2"".""UniqueNo"" = ""s3"".""UniqueNo""
-    WHERE ""s2"".""Details_Name"" IS NOT NULL
+    SELECT ""s1"".""UniqueNo"", ""s1"".""Details_Name""
+    FROM ""Sample"" AS ""s1""
+    WHERE ""s1"".""Details_Name"" IS NOT NULL
 ) AS ""t0"" ON ""s"".""UniqueNo"" = ""t0"".""UniqueNo""
 WHERE ""s"".""UniqueNo"" = 1
 LIMIT 1",
@@ -117,16 +115,14 @@ LIMIT 1",
                 @"SELECT ""s"".""UniqueNo"", ""s"".""MaxLengthProperty"", ""s"".""Name"", ""s"".""RowVersion"", ""t"".""UniqueNo"", ""t"".""AdditionalDetails_Name"", ""t0"".""UniqueNo"", ""t0"".""Details_Name""
 FROM ""Sample"" AS ""s""
 LEFT JOIN (
-    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name"", ""s1"".""UniqueNo"" AS ""UniqueNo0""
+    SELECT ""s0"".""UniqueNo"", ""s0"".""AdditionalDetails_Name""
     FROM ""Sample"" AS ""s0""
-    INNER JOIN ""Sample"" AS ""s1"" ON ""s0"".""UniqueNo"" = ""s1"".""UniqueNo""
     WHERE ""s0"".""AdditionalDetails_Name"" IS NOT NULL
 ) AS ""t"" ON ""s"".""UniqueNo"" = ""t"".""UniqueNo""
 LEFT JOIN (
-    SELECT ""s2"".""UniqueNo"", ""s2"".""Details_Name"", ""s3"".""UniqueNo"" AS ""UniqueNo0""
-    FROM ""Sample"" AS ""s2""
-    INNER JOIN ""Sample"" AS ""s3"" ON ""s2"".""UniqueNo"" = ""s3"".""UniqueNo""
-    WHERE ""s2"".""Details_Name"" IS NOT NULL
+    SELECT ""s1"".""UniqueNo"", ""s1"".""Details_Name""
+    FROM ""Sample"" AS ""s1""
+    WHERE ""s1"".""Details_Name"" IS NOT NULL
 ) AS ""t0"" ON ""s"".""UniqueNo"" = ""t0"".""UniqueNo""
 WHERE ""s"".""UniqueNo"" = 1
 LIMIT 1",

--- a/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/PropertyEntrySqliteTest.cs
@@ -19,9 +19,8 @@ namespace Microsoft.EntityFrameworkCore
                 @"SELECT ""e"".""Id"", ""e"".""EngineSupplierId"", ""e"".""Name"", ""t"".""Id"", ""t"".""StorageLocation_Latitude"", ""t"".""StorageLocation_Longitude""
 FROM ""Engines"" AS ""e""
 LEFT JOIN (
-    SELECT ""e0"".""Id"", ""e0"".""StorageLocation_Latitude"", ""e0"".""StorageLocation_Longitude"", ""e1"".""Id"" AS ""Id0""
+    SELECT ""e0"".""Id"", ""e0"".""StorageLocation_Latitude"", ""e0"".""StorageLocation_Longitude""
     FROM ""Engines"" AS ""e0""
-    INNER JOIN ""Engines"" AS ""e1"" ON ""e0"".""Id"" = ""e1"".""Id""
     WHERE ""e0"".""StorageLocation_Longitude"" IS NOT NULL AND ""e0"".""StorageLocation_Latitude"" IS NOT NULL
 ) AS ""t"" ON ""e"".""Id"" = ""t"".""Id""
 ORDER BY ""e"".""Id""


### PR DESCRIPTION
Partial fix for #18299

### Description

Issue: The way we construct SelectExpression for owned entity type involves adding inner joins to owner when table splitting so that only owned entity for given owner is in result. Considering the fact that any owned entity translation would originate from a query root which would be non-owned, the join condition is unnecessary when it is same as outer query root which initiated this owned entity.
Fix: When we are generating join condition for linking FK if the FK is ownership for entity type and principal type is root entity type then the join condition would be redundant hence we skip adding it.

Notes:
- The joins would be unnecessary even for derived type if the owned navigation is on base type or the given entity type but integrating that information involves breaking change to API. Essentially when generating SelectExpression for owned entity we need to keep track of which selectExpression initiated it.

When generating SQL for owned entity we add inner join with the owner to make sure that we are selecting owned entity for requested owner. But in some cases the inner join can be eliminated as outer filter achieves the same effect.

### Customer Impact

Many customers are unhappy with the way queries are generated for these cases since 3.0. This was due to a design change which in retrospect we probably should not have made in 3.0 since it is not complete enough for them to get back to the 2.x behavior.

We have analyzed the design change holistically and concluded that it cannot be fundamentally changed in a patch. However, we are now looking at tactical changes to specific cases that we can patch. This is the first of those changes.

### How found

Reported by multiple customers.

### Test coverage

We have test coverage, but the generated SQL isn't what customers want.

### Regression?

This is a regression in experience due to an intentional design change.

### Risk

Low. Affects only in case of owned entity.

Also, fix is on by default, but quirk switch is present to revert back to old behavior.