### PR TITLE
SqlServerValueGenerationStrategy which conflicts now causes warning

### DIFF
--- a/src/EFCore.SqlServer/Diagnostics/ConflictingValueGenerationStrategiesEventData.cs
+++ b/src/EFCore.SqlServer/Diagnostics/ConflictingValueGenerationStrategiesEventData.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events that have
+    ///     a property.
+    /// </summary>
+    public class ConflictingValueGenerationStrategiesEventData : EventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="sqlServerValueGenerationStrategy"> The SQL Server value generation strategy. </param>
+        /// <param name="otherValueGenerationStrategy"> The other value generation strategy. </param>
+        /// <param name="property"> The property. </param>
+        public ConflictingValueGenerationStrategiesEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
+            [NotNull] string sqlServerValueGenerationStrategy,
+            [NotNull] string otherValueGenerationStrategy,
+            [NotNull] IProperty property)
+            : base(eventDefinition, messageGenerator)
+        {
+            SqlServerValueGenerationStrategy = sqlServerValueGenerationStrategy;
+            OtherValueGenerationStrategy = otherValueGenerationStrategy;
+            Property = property;
+        }
+
+        /// <summary>
+        ///     The SQL Server value generation strategy.
+        /// </summary>
+        public virtual string SqlServerValueGenerationStrategy { get; }
+
+        /// <summary>
+        ///     The other value generation strategy.
+        /// </summary>
+        public virtual string OtherValueGenerationStrategy { get; }
+
+        /// <summary>
+        ///     The property.
+        /// </summary>
+        public virtual IProperty Property { get; }
+    }
+}

--- a/src/EFCore.SqlServer/Diagnostics/ConflictingValueGenerationStrategiesEventData.cs
+++ b/src/EFCore.SqlServer/Diagnostics/ConflictingValueGenerationStrategiesEventData.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public ConflictingValueGenerationStrategiesEventData(
             [NotNull] EventDefinitionBase eventDefinition,
             [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
-            [NotNull] string sqlServerValueGenerationStrategy,
+            SqlServerValueGenerationStrategy sqlServerValueGenerationStrategy,
             [NotNull] string otherValueGenerationStrategy,
             [NotNull] IProperty property)
             : base(eventDefinition, messageGenerator)
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     The SQL Server value generation strategy.
         /// </summary>
-        public virtual string SqlServerValueGenerationStrategy { get; }
+        public virtual SqlServerValueGenerationStrategy SqlServerValueGenerationStrategy { get; }
 
         /// <summary>
         ///     The other value generation strategy.

--- a/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
+++ b/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
@@ -140,5 +140,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public EventDefinitionBase LogReflexiveConstraintIgnored;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public EventDefinitionBase LogConflictingValueGenerationStrategies;
     }
 }

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             // Model validation events
             DecimalTypeDefaultWarning = CoreEventId.ProviderBaseId,
             ByteIdentityColumnWarning,
+            ConflictingValueGenerationStrategiesWarning,
 
             // Scaffolding events
             ColumnFound = CoreEventId.ProviderDesignBaseId,
@@ -88,6 +89,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId ByteIdentityColumnWarning = MakeValidationId(Id.ByteIdentityColumnWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         There are conflicting value generation methods for a property.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ConflictingValueGenerationStrategiesEventData" />
+        ///         payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId ConflictingValueGenerationStrategiesWarning = MakeValidationId(Id.ConflictingValueGenerationStrategiesWarning);
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);

--- a/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbContextOptionsBuilderExtensions.cs
@@ -169,9 +169,13 @@ namespace Microsoft.EntityFrameworkCore
                 = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()
                 ?? new CoreOptionsExtension();
 
-            coreOptionsExtension = coreOptionsExtension.WithWarningsConfiguration(
+            coreOptionsExtension = coreOptionsExtension.
+                WithWarningsConfiguration(
                 coreOptionsExtension.WarningsConfiguration.TryWithExplicit(
-                    RelationalEventId.AmbientTransactionWarning, WarningBehavior.Throw));
+                    RelationalEventId.AmbientTransactionWarning, WarningBehavior.Throw)).
+                WithWarningsConfiguration(
+                coreOptionsExtension.WarningsConfiguration.TryWithExplicit(
+                    SqlServerEventId.ConflictingValueGenerationStrategiesWarning, WarningBehavior.Throw));
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(coreOptionsExtension);
         }

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         /// </summary>
         public static void ConflictingValueGenerationStrategiesWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
-            [NotNull] string sqlServerValueGenerationStrategy,
+            SqlServerValueGenerationStrategy sqlServerValueGenerationStrategy,
             [NotNull] string otherValueGenerationStrategy,
             [NotNull] IProperty property)
         {
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
 
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, sqlServerValueGenerationStrategy, otherValueGenerationStrategy,
+                definition.Log(diagnostics, sqlServerValueGenerationStrategy.ToString(), otherValueGenerationStrategy,
                     property.Name, property.DeclaringEntityType.DisplayName());
             }
 
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var d = (EventDefinition<string, string, string, string>)definition;
             var p = (ConflictingValueGenerationStrategiesEventData)payload;
             return d.GenerateMessage(
-                p.SqlServerValueGenerationStrategy,
+                p.SqlServerValueGenerationStrategy.ToString(),
                 p.OtherValueGenerationStrategy,
                 p.Property.Name,
                 p.Property.DeclaringEntityType.DisplayName());

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -96,6 +96,50 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static void ConflictingValueGenerationStrategiesWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] string sqlServerValueGenerationStrategy,
+            [NotNull] string otherValueGenerationStrategy,
+            [NotNull] IProperty property)
+        {
+            var definition = SqlServerResources.LogConflictingValueGenerationStrategies(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, sqlServerValueGenerationStrategy, otherValueGenerationStrategy,
+                    property.Name, property.DeclaringEntityType.DisplayName());
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new ConflictingValueGenerationStrategiesEventData(
+                    definition,
+                    ConflictingValueGenerationStrategiesWarning,
+                    sqlServerValueGenerationStrategy,
+                    otherValueGenerationStrategy,
+                    property);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
+
+        private static string ConflictingValueGenerationStrategiesWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string, string, string>)definition;
+            var p = (ConflictingValueGenerationStrategiesEventData)payload;
+            return d.GenerateMessage(
+                p.SqlServerValueGenerationStrategy,
+                p.OtherValueGenerationStrategy,
+                p.Property.Name,
+                p.Property.DeclaringEntityType.DisplayName());
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static void ColumnFound(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
             [NotNull] string tableName,

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -102,25 +103,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (property.GetValueGenerationStrategyConfigurationSource() != null
                 && property.GetValueGenerationStrategy() != SqlServerValueGenerationStrategy.None)
             {
+                var generationStrategy = property.GetValueGenerationStrategy().ToString();
+
                 if (property.GetDefaultValue() != null)
                 {
-                    throw new InvalidOperationException(
-                        RelationalStrings.ConflictingColumnServerGeneration(
-                            "SqlServerValueGenerationStrategy", property.Name, "DefaultValue"));
+                    Dependencies.ValidationLogger.ConflictingValueGenerationStrategiesWarning(
+                        generationStrategy, "DefaultValue", property);
                 }
 
                 if (property.GetDefaultValueSql() != null)
                 {
-                    throw new InvalidOperationException(
-                        RelationalStrings.ConflictingColumnServerGeneration(
-                            "SqlServerValueGenerationStrategy", property.Name, "DefaultValueSql"));
+                    Dependencies.ValidationLogger.ConflictingValueGenerationStrategiesWarning(
+                        generationStrategy, "DefaultValueSql", property);
                 }
 
                 if (property.GetComputedColumnSql() != null)
                 {
-                    throw new InvalidOperationException(
-                        RelationalStrings.ConflictingColumnServerGeneration(
-                            "SqlServerValueGenerationStrategy", property.Name, "ComputedColumnSql"));
+                    Dependencies.ValidationLogger.ConflictingValueGenerationStrategiesWarning(
+                        generationStrategy, "ComputedColumnSql", property);
                 }
             }
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerStoreGenerationConvention.cs
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (property.GetValueGenerationStrategyConfigurationSource() != null
                 && property.GetValueGenerationStrategy() != SqlServerValueGenerationStrategy.None)
             {
-                var generationStrategy = property.GetValueGenerationStrategy().ToString();
+                var generationStrategy = property.GetValueGenerationStrategy();
 
                 if (property.GetDefaultValue() != null)
                 {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -574,7 +574,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.
+        ///     Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogConflictingValueGenerationStrategies([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -572,5 +572,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
 
             return (EventDefinition<string, string>)definition;
         }
+
+        /// <summary>
+        ///     Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.
+        /// </summary>
+        public static EventDefinition<string, string, string, string> LogConflictingValueGenerationStrategies([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogConflictingValueGenerationStrategies;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogConflictingValueGenerationStrategies,
+                    () => new EventDefinition<string, string, string, string>(
+                        logger.Options,
+                        SqlServerEventId.ConflictingValueGenerationStrategiesWarning,
+                        LogLevel.Warning,
+                        "SqlServerEventId.ConflictingValueGenerationStrategiesWarning",
+                        level => LoggerMessage.Define<string, string, string, string>(
+                            level,
+                            SqlServerEventId.ConflictingValueGenerationStrategiesWarning,
+                            _resourceManager.GetString("LogConflictingValueGenerationStrategies"))));
+            }
+
+            return (EventDefinition<string, string, string, string>)definition;
+        }
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -242,7 +242,7 @@
     <value>The '{methodName}' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
   <data name="LogConflictingValueGenerationStrategies" xml:space="preserve">
-    <value>Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.</value>
+    <value>Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.</value>
     <comment>Warning SqlServerEventId.ConflictingValueGenerationStrategiesWarning string string string string</comment>
   </data>
 </root>

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -241,4 +241,8 @@
   <data name="FunctionOnClient" xml:space="preserve">
     <value>The '{methodName}' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
+  <data name="LogConflictingValueGenerationStrategies" xml:space="preserve">
+    <value>Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.</value>
+    <comment>Warning SqlServerEventId.ConflictingValueGenerationStrategiesWarning string string string string</comment>
+  </data>
 </root>

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationConflictTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationConflictTest.cs
@@ -1,0 +1,150 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore
+{
+    public class SqlServerValueGenerationStrategyThrowTest :
+        SqlServerValueGenerationConflictTest<SqlServerValueGenerationStrategyThrowTest.ThrowContext>
+    {
+        public SqlServerValueGenerationStrategyThrowTest(
+            SqlServerValueGenerationStrategyFixture<ThrowContext> fixture)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalFact]
+        public virtual void SqlServerValueGeneration_conflicting_with_existing_ValueGeneration_strategy_throws()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<Fred>()
+                .Property(e => e.Id)
+                .HasDefaultValueSql("2")
+                .UseHiLo();
+
+            Assert.Equal(
+                CoreStrings.WarningAsErrorTemplate(
+                    SqlServerEventId.ConflictingValueGenerationStrategiesWarning,
+                    SqlServerResources.LogConflictingValueGenerationStrategies(
+                        new TestLogger<SqlServerLoggingDefinitions>())
+                        .GenerateMessage(SqlServerValueGenerationStrategy.SequenceHiLo.ToString(), "DefaultValueSql", "Id", nameof(Fred)),
+                    "SqlServerEventId.ConflictingValueGenerationStrategiesWarning"),
+                Assert.Throws<InvalidOperationException>(() => Validate(modelBuilder)).Message);
+        }
+
+        public class ThrowContext : DbContext
+        {
+            public ThrowContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public virtual DbSet<Fred> Freds { get; set; }
+
+            // use the normal behavior of ConflictingValueGenerationStrategiesWarning
+            // defined in UseSqlServer()
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlServer();
+        }
+    }
+
+    public class SqlServerValueGenerationStrategyNoThrowTest :
+        SqlServerValueGenerationConflictTest<SqlServerValueGenerationStrategyNoThrowTest.NoThrowContext>
+    {
+        public SqlServerValueGenerationStrategyNoThrowTest(
+            SqlServerValueGenerationStrategyFixture<NoThrowContext> fixture)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalFact]
+        public virtual void SqlServerValueGeneration_conflicting_with_existing_ValueGeneration_strategy_warns()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<Fred>()
+                .Property(e => e.Id)
+                .HasDefaultValueSql("2")
+                .UseHiLo();
+
+            // Assert - this does not throw
+            Validate(modelBuilder);
+
+            var logEntry = Fixture.ListLoggerFactory.Log.Single(
+                l => l.Level == LogLevel.Warning && l.Id == SqlServerEventId.ConflictingValueGenerationStrategiesWarning);
+            Assert.Equal(SqlServerResources.LogConflictingValueGenerationStrategies(
+                        new TestLogger<SqlServerLoggingDefinitions>())
+                        .GenerateMessage(SqlServerValueGenerationStrategy.SequenceHiLo.ToString(), "DefaultValueSql", "Id", nameof(Fred)),
+                        logEntry.Message);
+        }
+
+        public class NoThrowContext : DbContext
+        {
+            public NoThrowContext(DbContextOptions options) : base(options)
+            {
+            }
+
+            public virtual DbSet<Fred> Freds { get; set; }
+
+            // override the normal behavior of ConflictingValueGenerationStrategiesWarning
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseSqlServer()
+                    .ConfigureWarnings(
+                        b => b.Log(SqlServerEventId.ConflictingValueGenerationStrategiesWarning));
+        }
+    }
+
+    public class SqlServerValueGenerationConflictTest<TContext>
+        : IClassFixture<SqlServerValueGenerationStrategyFixture<TContext>>
+        where TContext : DbContext
+    {
+        public SqlServerValueGenerationConflictTest(SqlServerValueGenerationStrategyFixture<TContext> fixture)
+            => Fixture = fixture;
+
+        protected SqlServerValueGenerationStrategyFixture<TContext> Fixture { get; }
+
+        public TContext CreateContext() => (TContext)Fixture.CreateContext();
+
+        protected virtual ModelBuilder CreateModelBuilder()
+        {
+            var conventionSet = CreateConventionSetBuilder(CreateContext()).CreateConventionSet();
+
+            return new ModelBuilder(conventionSet);
+        }
+
+        protected virtual IConventionSetBuilder CreateConventionSetBuilder(DbContext context)
+            => context.GetService<IConventionSetBuilder>();
+
+        protected virtual IModel Validate(ModelBuilder modelBuilder)
+            => modelBuilder.FinalizeModel();
+
+        public class Fred
+        {
+            public int Id { get; set; }
+        }
+    }
+
+    public class SqlServerValueGenerationStrategyFixture<TContext> : SharedStoreFixtureBase<DbContext>
+        where TContext : DbContext
+    {
+        protected override string StoreName { get; } = "SqlServerValueGenerationStrategy";
+        protected override Type ContextType { get; } = typeof(TContext);
+        protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+        protected override bool ShouldLogCategory(string logCategory)
+            => logCategory == DbLoggerCategory.Model.Validation.Name;
+        protected override bool UsePooling => false;
+    }
+}

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -255,6 +255,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             Assert.Equal(expectedMessage, logEntry.Message);
         }
 
+        protected virtual void VerifyWarnings(string[] expectedMessages, IMutableModel model, LogLevel level = LogLevel.Warning)
+        {
+            Validate(model);
+            var logEntries = LoggerFactory.Log.Where(l => l.Level == level);
+            Assert.Equal(expectedMessages.Length, logEntries.Count());
+
+            int count = 0;
+            foreach (var logEntry in logEntries)
+            {
+                Assert.Equal(expectedMessages[count++], logEntry.Message);
+            }
+        }
+
         protected virtual void VerifyError(string expectedMessage, IMutableModel model)
         {
             var message = Assert.Throws<InvalidOperationException>(() => Validate(model)).Message;


### PR DESCRIPTION
Instead of throwing as it used to do. This fixes #16814.

By default the warning is still set up to throw, but now you could turn that off if you're sure you know what you're doing. Tests for that latter part will be forthcoming, but I wanted to get feedback that I'm going the right direction, plus agree on the message etc.
