### PR TITLE
Fix to #19900 - Query/Test: add automatic null propagation for AssertQuery baselines (part1)

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable SimplifyConditionalTernaryExpression
@@ -849,7 +850,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().OrderBy(e => e.Id).Select(e => e.NullableStringA.IndexOf("oo")),
-                ss => ss.Set<NullSemanticsEntity1>().OrderBy(e => e.Id).Select(e => MaybeScalar<int>(e.NullableStringA, () => e.NullableStringA.IndexOf("oo")) ?? 0),
+                ss => ss.Set<NullSemanticsEntity1>().OrderBy(e => e.Id).Select(e => e.NullableStringA.MaybeScalar(x => x.IndexOf("oo")) ?? 0),
                 assertOrder: true);
         }
 
@@ -861,25 +862,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.IndexOf("oo") == e.NullableStringB.IndexOf("ar")).Select(e => e.Id),
                 ss => ss.Set<NullSemanticsEntity1>().Where(
-                    e => MaybeScalar<int>(e.NullableStringA, () => e.NullableStringA.IndexOf("oo"))
-                        == MaybeScalar<int>(
-                            e.NullableStringB, () => e.NullableStringB.IndexOf("ar"))).Select(e => e.Id));
+                    e => e.NullableStringA.MaybeScalar(x => x.IndexOf("oo"))
+                        == e.NullableStringB.MaybeScalar(x => x.IndexOf("ar"))).Select(e => e.Id));
 
             await AssertQueryScalar(
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.IndexOf("oo") != e.NullableStringB.IndexOf("ar")).Select(e => e.Id),
                 ss => ss.Set<NullSemanticsEntity1>().Where(
-                    e => MaybeScalar<int>(e.NullableStringA, () => e.NullableStringA.IndexOf("oo"))
-                        != MaybeScalar<int>(
-                            e.NullableStringB, () => e.NullableStringB.IndexOf("ar"))).Select(e => e.Id));
+                    e => e.NullableStringA.MaybeScalar(x => x.IndexOf("oo"))
+                        != e.NullableStringB.MaybeScalar(x => x.IndexOf("ar"))).Select(e => e.Id));
 
             await AssertQueryScalar(
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.IndexOf("oo") != e.NullableStringA.IndexOf("ar")).Select(e => e.Id),
                 ss => ss.Set<NullSemanticsEntity1>().Where(
-                    e => MaybeScalar<int>(e.NullableStringA, () => e.NullableStringA.IndexOf("oo"))
-                        != MaybeScalar<int>(
-                            e.NullableStringA, () => e.NullableStringA.IndexOf("ar"))).Select(e => e.Id));
+                    e => e.NullableStringA.MaybeScalar(x => x.IndexOf("oo"))
+                        != e.NullableStringA.MaybeScalar(x => x.IndexOf("ar"))).Select(e => e.Id));
         }
 
         [ConditionalTheory]
@@ -940,7 +938,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.Substring(0, e.IntA) != e.NullableStringB).Select(e => e.Id),
-                ss => ss.Set<NullSemanticsEntity1>().Where(e => Maybe(e.NullableIntA, () => e.NullableStringA.Substring(0, e.IntA)) != e.NullableStringB).Select(e => e.Id));
+                ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA.Maybe(x => x.Substring(0, e.IntA)) != e.NullableStringB).Select(e => e.Id));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Optional_FK1, "Id") == 0),
-                ss => ss.Set<Level1>().Where(l => MaybeScalar<int>(l.OneToOne_Optional_FK1, () => l.OneToOne_Optional_FK1.Id) == 0));
+                ss => ss.Set<Level1>().Where(l => l.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) == 0));
         }
 
         [ConditionalTheory]
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") > 7),
-                ss => ss.Set<Level1>().Where(l => MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) > 7));
+                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) > 7));
         }
 
         [ConditionalTheory]
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l => EF.Property<int>(EF.Property<Level2>(l, "OneToOne_Required_FK1"), "Id") == 7),
-                ss => ss.Set<Level1>().Where(l => MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
         }
 
         [ConditionalTheory]
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l => EF.Property<Level2>(l, "OneToOne_Required_FK1").Id == 7),
-                ss => ss.Set<Level1>().Where(l => MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
         }
 
         [ConditionalTheory]
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") == 7),
-                ss => ss.Set<Level1>().Where(l => MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
         }
 
         [ConditionalTheory]
@@ -148,8 +148,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l => l.OneToOne_Required_FK1 == new Level2 { Id = 1 }
                         || l.OneToOne_Required_FK1 == new Level2 { Id = 2 }),
                 ss => ss.Set<Level1>().Where(
-                    l => MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) == 1
-                        || MaybeScalar<int>(l.OneToOne_Required_FK1, () => l.OneToOne_Required_FK1.Id) == 2));
+                    l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 1
+                        || l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 2));
         }
 
         [ConditionalTheory]
@@ -263,9 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals MaybeScalar<int>(
-                        e2.OneToOne_Optional_FK_Inverse2,
-                        () => e2.OneToOne_Optional_FK_Inverse2.Id)
+                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -297,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where e2.OneToOne_Optional_PK_Inverse2.Id > 5
                       select e2.Id,
                 ss => from e2 in ss.Set<Level2>()
-                      where MaybeScalar<int>(e2.OneToOne_Optional_PK_Inverse2, () => e2.OneToOne_Optional_PK_Inverse2.Id) > 5
+                      where e2.OneToOne_Optional_PK_Inverse2.MaybeScalar(x => x.Id) > 5
                       select e2.Id);
         }
 
@@ -336,13 +334,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().GroupBy(
                         l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name)
-                    .Select(g => g.Count()),
-                ss => ss.Set<Level1>().GroupBy(
-                        l1 => Maybe(
-                            l1.OneToOne_Required_PK1,
-                            () => Maybe(
-                                l1.OneToOne_Required_PK1.OneToOne_Required_PK2,
-                                () => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name)))
                     .Select(g => g.Count()));
         }
 
@@ -354,16 +345,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().GroupBy(
                         l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name,
-                        l1 => new { Id = ((int?)l1.OneToOne_Required_PK1.Id ?? 0) })
+                        l1 => new { Id = (int?)l1.OneToOne_Required_PK1.Id ?? 0 })
                     .Where(g => g.Min(l1 => l1.Id) > 0)
                     .Select(g => g.Count()),
                 ss => ss.Set<Level1>().GroupBy(
-                        l1 => Maybe(
-                            l1.OneToOne_Required_PK1,
-                            () => Maybe(
-                                l1.OneToOne_Required_PK1.OneToOne_Required_PK2,
-                                () => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name)),
-                        l1 => new { Id = (MaybeScalar<int>(l1.OneToOne_Required_PK1, () => l1.OneToOne_Required_PK1.Id) ?? 0) })
+                        l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name,
+                        l1 => new { Id = l1.OneToOne_Required_PK1.MaybeScalar(x => x.Id) ?? 0 })
                     .Where(g => g.Min(l1 => l1.Id) > 0)
                     .Select(g => g.Count()));
         }
@@ -398,7 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where e1.OneToOne_Required_FK1.Name.StartsWith("L")
                       select e1,
                 ss => from e1 in ss.Set<Level1>()
-                      where MaybeScalar<bool>(e1.OneToOne_Required_FK1, () => e1.OneToOne_Required_FK1.Name.StartsWith("L")) == true
+                      where e1.OneToOne_Required_FK1.Name.MaybeScalar(x => x.StartsWith("L")) == true
                       select e1);
         }
 
@@ -423,7 +410,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where e1.OneToOne_Optional_FK1.Name.StartsWith("L")
                       select e1,
                 ss => from e1 in ss.Set<Level1>()
-                      where MaybeScalar<bool>(e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name.StartsWith("L")) == true
+                      where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith("L")) == true
                       select e1);
         }
 
@@ -437,7 +424,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where EF.Property<string>(EF.Property<Level2>(e1, "OneToOne_Optional_FK1"), "Name") == "L2 01"
                       select e1,
                 ss => from e1 in ss.Set<Level1>()
-                      where Maybe(e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name.ToUpper()) == "L2 01"
+                      where e1.OneToOne_Optional_FK1.Name == "L2 01"
                       select e1);
         }
 
@@ -451,7 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where e1.OneToOne_Optional_FK1.Name.ToUpper().StartsWith("L")
                       select e1,
                 ss => from e1 in ss.Set<Level1>()
-                      where MaybeScalar<bool>(e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name.ToUpper().StartsWith("L"))
+                      where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.ToUpper().StartsWith("L"))
                           == true
                       select e1);
         }
@@ -466,9 +453,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where e1.OneToOne_Optional_FK1.Name.StartsWith(e1.OneToOne_Optional_FK1.Name)
                       select e1,
                 ss => from e1 in ss.Set<Level1>()
-                      where MaybeScalar<bool>(
-                              e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name.StartsWith(e1.OneToOne_Optional_FK1.Name))
-                          == true
+                      where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith(x)) == true
                       select e1);
         }
 
@@ -484,8 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e1,
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    where MaybeScalar<DateTime>(e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Date.AddDays(10))
-                        > new DateTime(2000, 2, 1)
+                    where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(10)) > new DateTime(2000, 2, 1)
                     select e1);
         }
 
@@ -501,9 +485,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e1,
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    where MaybeScalar<DateTime>(
-                            e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Date.AddDays(10).AddDays(15).AddMonths(2))
-                        > new DateTime(2000, 2, 1)
+                    where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(10).AddDays(15).AddMonths(2)) > new DateTime(2000, 2, 1)
                     select e1);
         }
 
@@ -520,10 +502,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select e1,
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    where MaybeScalar<DateTime>(
-                            e1.OneToOne_Optional_FK1,
-                            () => e1.OneToOne_Optional_FK1.Date.AddDays(15).AddDays(e1.OneToOne_Optional_FK1.Id))
-                        > new DateTime(2000, 2, 1)
+                    where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(15).AddDays(x.Id)) > new DateTime(2000, 2, 1)
                     select e1);
         }
 
@@ -539,8 +518,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on MaybeScalar<int>(
-                        e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Id) equals e2.Id
+                    join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) equals e2.Id
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -557,11 +535,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id1 = e1.Id, Id3 = e3.Id },
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    join e3 in ss.Set<Level3>() on MaybeScalar(
-                        e1.OneToOne_Required_FK1,
-                        () => MaybeScalar<int>(
-                            e1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                            () => e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id)) equals e3.Id
+                    join e3 in ss.Set<Level3>()
+                    on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) equals e3.Id
                     select new { Id1 = e1.Id, Id3 = e3.Id },
                 e => (e.Id1, e.Id3));
         }
@@ -578,9 +553,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 ss =>
                     from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on MaybeScalar<int>(
-                        e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2,
-                        () => e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id) equals e1.Id
+                    join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id) equals e1.Id
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id1, e.Id3));
         }
@@ -597,8 +570,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id2 = e2.Id, Id1 = e1.Id },
                 ss =>
                     from e2 in ss.Set<Level2>()
-                    join e1 in ss.Set<Level1>() on e2.Id equals MaybeScalar<int>(
-                        e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Id)
+                    join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)
                     select new { Id2 = e2.Id, Id1 = e1.Id },
                 e => (e.Id2, e.Id1));
         }
@@ -619,10 +591,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                           Id3 = e3.Id
                       },
                 ss => from e2 in ss.Set<Level2>()
-                      join e1 in ss.Set<Level1>() on e2.Id equals MaybeScalar<int>(
-                          e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Id)
-                      join e3 in ss.Set<Level3>() on e2.Id equals MaybeScalar<int>(
-                          e3.OneToOne_Optional_FK_Inverse3, () => e3.OneToOne_Optional_FK_Inverse3.Id)
+                      join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)
+                      join e3 in ss.Set<Level3>() on e2.Id equals e3.OneToOne_Optional_FK_Inverse3.MaybeScalar(x => x.Id)
                       select new
                       {
                           Id2 = e2.Id,
@@ -641,16 +611,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from e2 in ss.Set<Level2>()
                     join e1 in ss.Set<Level1>() on e2.Name equals e1.OneToOne_Optional_FK1.Name
-                    select new
-                    {
-                        Id2 = e2.Id,
-                        Name2 = e2.Name,
-                        Id1 = e1.Id,
-                        Name1 = e1.Name
-                    },
-                ss =>
-                    from e2 in ss.Set<Level2>()
-                    join e1 in ss.Set<Level1>() on e2.Name equals Maybe(e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name)
                     select new
                     {
                         Id2 = e2.Id,
@@ -677,17 +637,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         Id1 = e1.Id,
                         Name1 = e1.Name
                     },
-                ss =>
-                    from e2 in ss.Set<Level2>()
-                    join e1 in ss.Set<Level1>().OrderBy(l1 => l1.Id) on e2.Name equals Maybe(
-                        e1.OneToOne_Optional_FK1, () => e1.OneToOne_Optional_FK1.Name)
-                    select new
-                    {
-                        Id2 = e2.Id,
-                        Name2 = e2.Name,
-                        Id1 = e1.Id,
-                        Name1 = e1.Name
-                    },
                 e => (e.Id2, e.Name2, e.Id1, e.Name1));
         }
 
@@ -703,8 +652,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level1>() on e1.Id equals MaybeScalar<int>(
-                        e2.OneToMany_Optional_Self_Inverse1, () => e2.OneToMany_Optional_Self_Inverse1.Id)
+                    join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id)
                     select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -721,11 +669,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 ss =>
                     from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on e3.Id equals MaybeScalar(
-                        e1.OneToOne_Required_FK1,
-                        () => MaybeScalar<int>(
-                            e1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                            () => e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id))
+                    join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id3, e.Id1));
         }
@@ -742,11 +686,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 ss =>
                     from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals MaybeScalar(
-                        e1.OneToOne_Required_FK1,
-                        () => MaybeScalar<int>(
-                            e1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                            () => e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id))
+                    join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
                     select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id3, e.Id1));
         }
@@ -760,22 +700,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from e4 in ss.Set<Level4>()
                     join e1 in ss.Set<Level1>() on e4.Name equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToOne_Required_PK3.Name
-                    select new
-                    {
-                        Id4 = e4.Id,
-                        Name4 = e4.Name,
-                        Id1 = e1.Id,
-                        Name1 = e1.Name
-                    },
-                ss =>
-                    from e4 in ss.Set<Level4>()
-                    join e1 in ss.Set<Level1>() on e4.Name equals Maybe(
-                        e1.OneToOne_Required_FK1,
-                        () => Maybe(
-                            e1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                            () => Maybe(
-                                e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToOne_Required_PK3,
-                                () => e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToOne_Required_PK3.Name)))
                     select new
                     {
                         Id4 = e4.Id,
@@ -897,8 +821,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.Name),
-                ss => ss.Set<Level1>().Select(e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name)));
+                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.Name));
         }
 
         [ConditionalTheory]
@@ -916,7 +839,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 #pragma warning restore IDE0031 // Use null propagation
                 ss =>
                     from l1 in ss.Set<Level1>()
-                    join l2 in ss.Set<Level2>() on l1.Id equals MaybeScalar(l2, () => l2.Level1_Optional_Id) into groupJoin
+                    join l2 in ss.Set<Level2>() on l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id) into groupJoin
                     from l2 in groupJoin.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
                     select l2 == null ? null : l2.Name);
@@ -930,7 +853,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Id),
-                ss => ss.Set<Level1>().Select(e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Id)));
+                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)));
         }
 
         [ConditionalTheory]
@@ -944,8 +867,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                       from l2 in groupJoin.DefaultIfEmpty()
                       select l2 == null ? null : (int?)l2.Id,
                 ss => from l1 in ss.Set<Level1>()
-                      join l2 in ss.Set<Level2>() on l1.Id equals MaybeScalar(l2, () => l2.Level1_Optional_Id) into groupJoin
-                      from l2 in Maybe(groupJoin, () => groupJoin.DefaultIfEmpty())
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id) into groupJoin
+                      from l2 in groupJoin.DefaultIfEmpty()
                       select l2 == null ? null : (int?)l2.Id);
         }
 
@@ -955,8 +878,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level2>().Select(e => e.OneToOne_Optional_FK_Inverse2.Name),
-                ss => ss.Set<Level2>().Select(e => Maybe(e.OneToOne_Optional_FK_Inverse2, () => e.OneToOne_Optional_FK_Inverse2.Name)));
+                ss => ss.Set<Level2>().Select(e => e.OneToOne_Optional_FK_Inverse2.Name));
         }
 
         [ConditionalTheory]
@@ -967,11 +889,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>()
                     .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name == "L2 07")
-                    .Select(e => e.Id),
-                ss => ss.Set<Level1>()
-                    .Where(
-                        e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 05"
-                            || Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 07")
                     .Select(e => e.Id));
         }
 
@@ -1000,11 +917,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>()
                     .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name != "L2 42")
-                    .Select(e => e.Id),
-                ss => ss.Set<Level1>()
-                    .Where(
-                        e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) == "L2 05"
-                            || Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name) != "L2 42")
                     .Select(e => e.Id));
         }
 
@@ -1032,12 +944,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id),
-                ss => ss.Set<Level1>().Select(
-                    e => MaybeScalar(
-                        e.OneToOne_Optional_FK1,
-                        () => MaybeScalar<int>(
-                            e.OneToOne_Optional_FK1.OneToOne_Optional_FK2,
-                            () => e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id))));
+                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)));
         }
 
         [ConditionalTheory]
@@ -1049,15 +956,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name != "L3 05"
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    where Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => Maybe(
-                                l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2,
-                                () => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name))
-                        != "L3 05"
                     select l1);
         }
 
@@ -1070,15 +968,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name != null
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    where Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => Maybe(
-                                l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2,
-                                () => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name))
-                        != null
                     select l1);
         }
 
@@ -1091,13 +980,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2 == null
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    where Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
-                        == null
                     select l1);
         }
 
@@ -1110,13 +992,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l3 in ss.Set<Level3>()
                     where l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2 == null
-                    select l3,
-                ss =>
-                    from l3 in ss.Set<Level3>()
-                    where Maybe(
-                            l3.OneToOne_Optional_FK_Inverse3,
-                            () => l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2)
-                        == null
                     select l3);
         }
 
@@ -1129,13 +1004,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     where null != l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    where null
-                        != Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                     select l1);
         }
 
@@ -1148,12 +1016,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l3 in ss.Set<Level3>()
                     where null != l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2
-                    select l3,
-                ss =>
-                    from l3 in ss.Set<Level3>()
-                    where null
-                        != Maybe(
-                            l3.OneToOne_Optional_FK_Inverse3, () => l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2)
                     select l3);
         }
 
@@ -1163,14 +1025,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2.OneToOne_Required_FK3 == null),
-                ss => ss.Set<Level1>().Where(
-                    e => Maybe(
-                            e.OneToOne_Optional_FK1,
-                            () => Maybe(
-                                e.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                                () => e.OneToOne_Optional_FK1.OneToOne_Required_FK2.OneToOne_Required_FK3))
-                        == null));
+                ss => ss.Set<Level1>().Where(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2.OneToOne_Required_FK3 == null));
         }
 
         [ConditionalTheory]
@@ -1180,12 +1035,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id),
-                ss => ss.Set<Level1>().Select(
-                    e => MaybeScalar(
-                        e.OneToOne_Required_FK1,
-                        () => MaybeScalar<int>(
-                            e.OneToOne_Required_FK1.OneToOne_Required_FK2,
-                            () => e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id))));
+                ss => ss.Set<Level1>().Select(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2.MaybeScalar(x => x.Id)));
         }
 
         [ConditionalTheory]
@@ -1206,11 +1056,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l1 in ss.Set<Level1>()
                       select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id,
                 ss => from l1 in ss.Set<Level1>()
-                      select MaybeScalar(
-                          l1.OneToOne_Optional_FK1,
-                          () => MaybeScalar<int>(
-                              l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                              () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id)));
+                      select l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.MaybeScalar(x => x.Id));
         }
 
         [ConditionalTheory]
@@ -1222,15 +1068,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name != "L3 05"
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    where Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => Maybe(
-                                l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                                () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name))
-                        != "L3 05"
                     select l1);
         }
 
@@ -1267,7 +1104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     from l2 in ss.Set<Level2>()
-                    where l1.Id == MaybeScalar<int>(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Id)
+                    where l1.Id == l2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
                     select new { Id1 = l1.Id, Id2 = l2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -1286,7 +1123,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     from l2 in ss.Set<Level2>()
-                    where MaybeScalar<int>(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Id) == l2.Id
+                    where l1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) == l2.Id
                     select new { Id1 = l1.Id, Id2 = l2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -1302,12 +1139,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from l2 in ss.Set<Level2>()
                     where l1.OneToOne_Optional_FK1.Name == "L2 01" || l2.OneToOne_Required_FK_Inverse2.Name != "Bar"
                     select new { Id1 = (int?)l1.Id, Id2 = (int?)l2.Id },
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    from l2 in ss.Set<Level2>()
-                    where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) == "L2 01"
-                        || l2.OneToOne_Required_FK_Inverse2.Name != "Bar"
-                    select new { Id1 = (int?)l1.Id, Id2 = (int?)l2.Id },
                 e => (e.Id1, e.Id2));
         }
 
@@ -1319,18 +1150,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name == "L3 05" || l1.OneToOne_Optional_FK1.Name != "L2 05"
-                      select l1.Id,
-                ss => from l1 in ss.Set<Level1>()
-                      where Maybe(
-                              l1.OneToOne_Optional_FK1,
-                              () => Maybe(
-                                  l1.OneToOne_Optional_FK1.OneToOne_Required_FK2,
-                                  () => l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name))
-                          == "L3 05"
-                          || Maybe(
-                              l1.OneToOne_Optional_FK1,
-                              () => l1.OneToOne_Optional_FK1.Name)
-                          != "L2 05"
                       select l1.Id);
         }
 
@@ -1342,18 +1161,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       where l1.OneToOne_Optional_FK1.Name != "L2 05" || l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name == "L3 05"
-                      select l1.Id,
-                ss => from l1 in ss.Set<Level1>()
-                      where Maybe(
-                              l1.OneToOne_Optional_FK1,
-                              () => l1.OneToOne_Optional_FK1.Name)
-                          != "L2 05"
-                          || Maybe(
-                              l1.OneToOne_Required_FK1,
-                              () => Maybe(
-                                  l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                                  () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name))
-                          == "L3 05"
                       select l1.Id);
         }
 
@@ -1366,16 +1173,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l3 in ss.Set<Level3>()
                       where l3.OneToOne_Optional_FK_Inverse3.Name != "L2 05"
                           || l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Name == "L1 05"
-                      select l3.Id,
-                ss => from l3 in ss.Set<Level3>()
-                      where Maybe(
-                              l3.OneToOne_Optional_FK_Inverse3,
-                              () => l3.OneToOne_Optional_FK_Inverse3.Name)
-                          != "L2 05"
-                          || Maybe(
-                              l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2,
-                              () => l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Name)
-                          == "L1 05"
                       select l3.Id);
         }
 
@@ -1386,30 +1183,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
-                    .Where(
-                        e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
-                            && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id != 7)
-                    .Select(
-                        e => new { e.Name, Id = (int?)e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id }),
+                    .Where(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
+                        && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id != 7)
+                    .Select(e => new { e.Name, Id = (int?)e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id }),
                 ss => ss.Set<Level1>()
-                    .Where(
-                        e => Maybe(e.OneToOne_Required_FK1, () => e.OneToOne_Required_FK1.OneToOne_Required_FK2)
-                            == Maybe(
-                                e.OneToOne_Required_FK1, () => e.OneToOne_Required_FK1.OneToOne_Optional_FK2)
-                            && MaybeScalar(
-                                e.OneToOne_Required_FK1,
-                                () => MaybeScalar<int>(
-                                    e.OneToOne_Required_FK1.OneToOne_Optional_FK2, () => e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id))
-                            != 7)
-                    .Select(
-                        e => new
-                        {
-                            e.Name,
-                            Id = MaybeScalar(
-                                e.OneToOne_Required_FK1,
-                                () => MaybeScalar<int>(
-                                    e.OneToOne_Required_FK1.OneToOne_Optional_FK2, () => e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id))
-                        }),
+                    .Where(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
+                        && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) != 7)
+                    .Select(e => new { e.Name, Id = e.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) }),
                 elementSorter: e => (e.Name, e.Id));
         }
 
@@ -1429,16 +1209,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from e in ss.Set<Level3>()
                     where e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2
                         == e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2
-                        && MaybeScalar<int>(
-                            e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2,
-                            () => e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id)
+                        && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
                         != 7
                     select new
                     {
                         e.Name,
-                        Id = MaybeScalar<int>(
-                            e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2,
-                            () => e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id)
+                        Id = e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
                     },
                 e => (e.Name, e.Id));
         }
@@ -1489,9 +1265,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => ss.Set<Level1>().OrderBy(e => e.OneToOne_Optional_FK1.Name).ThenBy(e => e.Id).Select(e => e.Id),
-                ss => ss.Set<Level1>().OrderBy(e => Maybe(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Name))
-                    .ThenBy(e => e.Id)
-                    .Select(e => e.Id),
                 assertOrder: true);
         }
 
@@ -1519,8 +1292,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>(),
                 ss => ss.Set<Level1>(),
-                actualSelector: e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id,
-                expectedSelector: e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id));
+                actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
+                expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
         }
 
         [ConditionalTheory]
@@ -1531,8 +1304,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>(),
                 ss => ss.Set<Level1>(),
-                actualSelector: e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id,
-                expectedSelector: e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id));
+                actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
+                expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
         }
 
         [ConditionalTheory]
@@ -1543,8 +1316,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>(),
                 ss => ss.Set<Level1>(),
-                actualSelector: e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id,
-                expectedSelector: e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id));
+                actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
+                expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
         }
 
         [ConditionalTheory]
@@ -1555,8 +1328,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>(),
                 ss => ss.Set<Level1>(),
-                actualSelector: e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id,
-                expectedSelector: e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id));
+                actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
+                expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
         }
 
         [ConditionalTheory]
@@ -1567,7 +1340,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id),
                 ss => ss.Set<Level1>().Select(
-                    e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id)),
+                    e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id)),
                 actualSelector: e => e,
                 expectedSelector: e => e);
         }
@@ -1579,8 +1352,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertAverage(
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id),
-                ss => ss.Set<Level1>().Select(
-                    e => MaybeScalar<int>(e.OneToOne_Optional_FK1, () => e.OneToOne_Optional_FK1.Level1_Required_Id)));
+                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id)));
         }
 
         [ConditionalTheory]
@@ -1605,9 +1377,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
                       where l1.OneToOne_Optional_FK1.Name != "L2 05"
                       select l1,
-                ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
-                      where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 05"
-                      select l1,
                 new List<IExpectedInclude> { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1, "OneToOne_Optional_FK1") });
         }
 
@@ -1629,9 +1398,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                           .Include(e => e.OneToOne_Optional_FK1.OneToMany_Required2)
                           .ThenInclude(e => e.OneToOne_Required_FK3)
                       where l1.OneToOne_Optional_FK1.Name != "L2 09"
-                      select l1,
-                ss => from l1 in ss.Set<Level1>()
-                      where Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "L2 09"
                       select l1,
                 expectedIncludes);
         }
@@ -1722,11 +1488,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Required_FK1.OneToMany_Optional2),
-                ss => ss.Set<Level1>().SelectMany(
-                    l1 => Maybe(
-                            l1.OneToOne_Required_FK1,
-                            () => l1.OneToOne_Required_FK1.OneToMany_Optional2)
-                        ?? new List<Level3>()));
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Required_FK1.OneToMany_Optional2 ?? new List<Level3>()));
         }
 
         [ConditionalTheory]
@@ -1736,11 +1498,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2).Select(e => e.Name),
-                ss => ss.Set<Level1>().SelectMany(
-                    l1 => Maybe(
-                            l1.OneToOne_Optional_FK1,
-                            () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                        ?? new List<Level3>()).Select(e => e.Name));
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()).Select(e => e.Name));
         }
 
         [ConditionalTheory]
@@ -1758,12 +1516,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2)),
-                ss => ss.Set<Level1>().SelectMany(
-                    l1 => Maybe(
-                            l1.OneToMany_Optional1,
-                            () => l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2))
-                        ?? new List<Level3>()));
+                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory]
@@ -1773,13 +1526,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Required_FK1.OneToMany_Optional2.Count > 0),
-                ss => ss.Set<Level1>().Where(
-                    l1 => MaybeScalar(
-                            l1.OneToOne_Required_FK1,
-                            () => MaybeScalar<int>(
-                                l1.OneToOne_Required_FK1.OneToMany_Optional2,
-                                () => l1.OneToOne_Required_FK1.OneToMany_Optional2.Count))
-                        > 0));
+                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Required_FK1.OneToMany_Optional2.MaybeScalar(x => x.Count) > 0));
         }
 
         [ConditionalTheory]
@@ -1790,10 +1537,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level3>().Where(l3 => l3.OneToOne_Required_FK_Inverse3.OneToMany_Optional2.Count > 0),
                 ss => ss.Set<Level3>().Where(
-                    l3 => MaybeScalar<int>(
-                            l3.OneToOne_Required_FK_Inverse3.OneToMany_Optional2,
-                            () => l3.OneToOne_Required_FK_Inverse3.OneToMany_Optional2.Count)
-                        > 0));
+                    l3 => l3.OneToOne_Required_FK_Inverse3.OneToMany_Optional2.MaybeScalar(x => x.Count) > 0));
         }
 
         [ConditionalTheory]
@@ -1804,10 +1548,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level2>().Where(l2 => l2.OneToMany_Required_Inverse2.OneToMany_Optional1.Count() > 0),
                 ss => ss.Set<Level2>().Where(
-                    l2 => MaybeScalar<int>(
-                            l2.OneToMany_Required_Inverse2.OneToMany_Optional1,
-                            () => l2.OneToMany_Required_Inverse2.OneToMany_Optional1.Count())
-                        > 0));
+                    l2 => l2.OneToMany_Required_Inverse2.OneToMany_Optional1.MaybeScalar(x => x.Count()) > 0));
         }
 
         [ConditionalTheory]
@@ -1895,15 +1636,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
                     .Where(e => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name != "Foo")
                     .OrderBy(e => e.Id),
-                ss => ss.Set<Level1>()
-                    .Where(
-                        e => Maybe(
-                                e.OneToOne_Required_FK1,
-                                () => Maybe(
-                                    e.OneToOne_Required_FK1.OneToOne_Optional_PK2,
-                                    () => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name))
-                            != "Foo")
-                    .OrderBy(e => e.Id),
                 expectedIncludes,
                 assertOrder: true);
         }
@@ -1933,8 +1665,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     select new { Name1 = e1.Name, Id2 = e2.Id },
                 ss =>
                     from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals MaybeScalar<int>(
-                        e2.OneToOne_Optional_FK_Inverse2, () => e2.OneToOne_Optional_FK_Inverse2.Id)
+                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
                     where ss.Set<Level2>().Any(l2 => l2.Level1_Required_Id == e1.Id)
                     select new { Name1 = e1.Name, Id2 = e2.Id },
                 e => (e.Name1, e.Id2));
@@ -2064,9 +1795,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l2 => l2.OneToOne_Optional_FK2.Name),
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
-                    .OrderBy(l2 => MaybeScalar<int>(l2, () => l2.Id))
+                    .OrderBy(l2 => l2.MaybeScalar(x => x.Id))
                     .Take(10)
-                    .Select(l2 => Maybe(l2, () => Maybe(l2.OneToOne_Optional_FK2, () => l2.OneToOne_Optional_FK2.Name))),
+                    .Select(l2 => l2.OneToOne_Optional_FK2.Name),
                 assertOrder: true);
         }
 
@@ -2076,8 +1807,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level2>().Where(l2 => l2.OneToOne_Required_FK_Inverse2.Name == "L1 03")
-                    .OrderBy(l => l.Id).Take(3).Select(l2 => l2.Name));
+                ss => ss.Set<Level2>()
+                    .Where(l2 => l2.OneToOne_Required_FK_Inverse2.Name == "L1 03")
+                    .OrderBy(l => l.Id)
+                    .Take(3)
+                    .Select(l2 => l2.Name));
         }
 
         [ConditionalTheory]
@@ -2119,11 +1853,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>()
                     .Where(l1 => l1.OneToOne_Required_FK1.Name == "L2 03")
-                    .OrderBy(l1 => l1.Id)
-                    .Take(3)
-                    .Select(l1 => l1.Name),
-                ss => ss.Set<Level1>()
-                    .Where(l1 => Maybe(l1.OneToOne_Required_FK1, () => l1.OneToOne_Required_FK1.Name) == "L2 03")
                     .OrderBy(l1 => l1.Id)
                     .Take(3)
                     .Select(l1 => l1.Name));
@@ -2402,8 +2131,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l3 => l3.OneToMany_Optional3),
-                ss => ss.Set<Level1>()
-                    .Select(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional3")
@@ -2420,9 +2147,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l2 => l2.OneToOne_Optional_PK2)
                     .Include("OneToMany_Optional3"),
-                ss => ss.Set<Level1>()
-                    .Select(l1 => l1.OneToOne_Optional_FK1)
-                    .Select(l2 => Maybe(l2, () => l2.OneToOne_Optional_PK2)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToMany_Optional3")
@@ -2439,9 +2163,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                ss => ss.Set<Level1>()
-                    .Select(l1 => l1.OneToOne_Optional_FK1)
-                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional2")
@@ -2459,9 +2180,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                ss => ss.Set<Level1>()
-                    .Select(l1 => l1.OneToOne_Optional_FK1)
-                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional2")
@@ -2479,9 +2197,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                ss => ss.Set<Level1>()
-                    .SelectMany(l1 => l1.OneToMany_Optional1)
-                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional2")
@@ -2499,9 +2214,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                ss => ss.Set<Level1>()
-                    .SelectMany(l1 => l1.OneToMany_Optional1)
-                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional2")
@@ -2556,19 +2268,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    from l3 in l1.OneToOne_Required_FK1.OneToMany_Optional2.DefaultIfEmpty()
-                    where l3 != null
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    from l3 in Maybe(
-                            l1.OneToOne_Required_FK1,
-                            () => l1.OneToOne_Required_FK1.OneToMany_Optional2.DefaultIfEmpty())
-                        ?? new List<Level3>()
-                    where l3 != null
-                    select l1);
+                ss => from l1 in ss.Set<Level1>()
+                      from l3 in l1.OneToOne_Required_FK1.OneToMany_Optional2.DefaultIfEmpty()
+                      where l3 != null
+                      select l1,
+                ss => from l1 in ss.Set<Level1>()
+                      from l3 in l1.OneToOne_Required_FK1.OneToMany_Optional2.MaybeDefaultIfEmpty() ?? new List<Level3>()
+                      where l3 != null
+                      select l1);
         }
 
         [ConditionalTheory]
@@ -2577,18 +2284,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    from l3 in l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
-                    where l3 != null
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>().Where(l => l.OneToOne_Optional_FK1 != null)
-                    from l3 in Maybe(
-                        l1.OneToOne_Optional_FK1,
-                        () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty())
-                    where l3 != null
-                    select l1);
+                ss => from l1 in ss.Set<Level1>()
+                      from l3 in l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
+                      where l3 != null
+                      select l1,
+                ss => from l1 in ss.Set<Level1>().Where(l => l.OneToOne_Optional_FK1 != null)
+                      from l3 in l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
+                      where l3 != null
+                      select l1);
         }
 
         [ConditionalTheory]
@@ -2597,18 +2300,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    from l3 in l1.OneToOne_Required_FK1.OneToMany_Required2.Where(l => l.Id > 5).DefaultIfEmpty()
-                    where l3 != null
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1 != null)
-                    from l3 in Maybe(
-                        l1.OneToOne_Required_FK1,
-                        () => l1.OneToOne_Required_FK1.OneToMany_Required2.Where(l => l.Id > 5).DefaultIfEmpty())
-                    where l3 != null
-                    select l1);
+                    ss => from l1 in ss.Set<Level1>()
+                          from l3 in l1.OneToOne_Required_FK1.OneToMany_Required2.Where(l => l.Id > 5).DefaultIfEmpty()
+                          where l3 != null
+                          select l1,
+                    ss => from l1 in ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1 != null)
+                          from l3 in l1.OneToOne_Required_FK1.OneToMany_Required2.Where(l => l.Id > 5).DefaultIfEmpty()
+                          where l3 != null
+                          select l1);
         }
 
         [ConditionalTheory]
@@ -2624,12 +2323,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select new { l1, l2 },
                 ss => from l1 in ss.Set<Level1>()
                       join l2 in ss.Set<Level4>().SelectMany(
-                              l4 => Maybe(
-                                      l4.OneToOne_Required_FK_Inverse4,
-                                      () => Maybe(
-                                          l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3,
-                                          () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2))
-                                  ?? new List<Level2>()) on l1.Id
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2 ?? new List<Level2>()) on l1.Id
                           equals l2.Level1_Optional_Id
                       select new { l1, l2 },
                 elementSorter: e => (e.l1.Id, e.l2.Id),
@@ -2647,25 +2341,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss
-                    => from l1 in ss.Set<Level1>()
-                       join l2 in ss.Set<Level4>().SelectMany(
-                               l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2
-                                   .DefaultIfEmpty())
-                           on l1.Id equals l2.Level1_Optional_Id
-                       select new { l1, l2 },
-                ss
-                    => from l1 in ss.Set<Level1>()
-                       join l2 in ss.Set<Level4>().SelectMany(
-                               l4 => MaybeDefaultIfEmpty(
-                                   Maybe(
-                                       l4.OneToOne_Required_FK_Inverse4,
-                                       () => Maybe(
-                                           l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3,
-                                           () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
-                                               .OneToMany_Required_Self2)))) on
-                           l1.Id equals MaybeScalar(l2, () => l2.Level1_Optional_Id)
-                       select new { l1, l2 },
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level4>().SelectMany(
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2
+                                  .DefaultIfEmpty())
+                          on l1.Id equals l2.Level1_Optional_Id
+                      select new { l1, l2 },
+               ss => from l1 in ss.Set<Level1>()
+                     join l2 in ss.Set<Level4>().SelectMany(
+                             l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty()) on
+                         l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id)
+                     select new { l1, l2 },
                 elementSorter: e => (e.l1?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -2676,8 +2362,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany2(
-            bool async)
+        public virtual Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany2(bool async)
         {
             return AssertQuery(
                 async,
@@ -2688,13 +2373,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select new { l2, l1 },
                 ss
                     => from l2 in ss.Set<Level4>().SelectMany(
-                           l4 => MaybeDefaultIfEmpty(
-                               Maybe(
-                                   l4.OneToOne_Required_FK_Inverse4,
-                                   () => Maybe(
-                                       l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3,
-                                       () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2))))
-                       join l1 in ss.Set<Level1>() on MaybeScalar(l2, () => l2.Level1_Optional_Id) equals l1.Id
+                           l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
+                       join l1 in ss.Set<Level1>() on l2.MaybeScalar(x => x.Level1_Optional_Id) equals l1.Id
                        select new { l2, l1 },
                 elementSorter: e => (e.l2?.Id, e.l1?.Id),
                 elementAsserter: (e, a) =>
@@ -2716,13 +2396,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                       join l2 in ss.Set<Level2>() on l4.Id equals l2.Id
                       select new { l4, l2 },
                 ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => MaybeDefaultIfEmpty(
-                              Maybe(
-                                  l1.OneToOne_Required_FK1,
-                                  () => Maybe(
-                                      l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                                      () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3))))
-                      join l2 in ss.Set<Level2>() on MaybeScalar<int>(l4, () => l4.Id) equals l2.Id
+                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
+                      join l2 in ss.Set<Level2>() on l4.MaybeScalar(x => x.Id) equals l2.Id
                       select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
@@ -2747,13 +2422,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select new { l4, l2 },
                 ss
                     => from l4 in ss.Set<Level1>().SelectMany(
-                           l1 => MaybeDefaultIfEmpty(
-                               Maybe(
-                                   l1.OneToOne_Required_FK1,
-                                   () => Maybe(
-                                       l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                                       () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3))))
-                       join l2 in ss.Set<Level2>() on MaybeScalar<int>(l4, () => l4.Id) equals l2.Id into grouping
+                           l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
+                       join l2 in ss.Set<Level2>() on l4.MaybeScalar(x => x.Id) equals l2.Id into grouping
                        from l2 in grouping.DefaultIfEmpty()
                        select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
@@ -2778,21 +2448,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                           on l4.Id equals l2.Id
                       select new { l4, l2 },
                 ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => MaybeDefaultIfEmpty(
-                              Maybe(
-                                  l1.OneToOne_Required_FK1,
-                                  () => Maybe(
-                                      l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                                      () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3))))
+                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
                       join l2 in ss.Set<Level4>().SelectMany(
-                              l4 => MaybeDefaultIfEmpty(
-                                  Maybe(
-                                      l4.OneToOne_Required_FK_Inverse4,
-                                      () => Maybe(
-                                          l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3,
-                                          () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
-                                              .OneToMany_Required_Self2))))
-                          on MaybeScalar<int>(l4, () => l4.Id) equals MaybeScalar<int>(l2, () => l2.Id)
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
+                          on l4.MaybeScalar(x => x.Id) equals l2.MaybeScalar(x => x.Id)
                       select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
@@ -2804,9 +2463,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task
-            SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_same_navs(
-                bool async)
+        public virtual Task SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_followed_by_Select_required_navigation_using_same_navs(bool async)
         {
             return AssertQuery(
                 async,
@@ -2814,15 +2471,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                           l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty())
                       select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2,
                 ss => from l3 in ss.Set<Level4>().SelectMany(
-                          l4 => MaybeDefaultIfEmpty(
-                              Maybe(
-                                  l4.OneToOne_Required_FK_Inverse4,
-                                  () => Maybe(
-                                      l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3,
-                                      () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2))))
-                      select Maybe(
-                          l3,
-                          () => l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2));
+                          l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.MaybeDefaultIfEmpty())
+                      select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2);
         }
 
         [ConditionalTheory]
@@ -2835,14 +2485,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.DefaultIfEmpty())
                       select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2,
-                ss => from l3 in ss.Set<Level1>().SelectMany(
-                          l1 => MaybeDefaultIfEmpty(
-                              Maybe(
-                                  l1.OneToOne_Optional_FK1,
-                                  () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)))
-                      select Maybe(
-                          l3,
-                          () => l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2));
+                ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeDefaultIfEmpty())
+                      select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2);
         }
 
         [ConditionalTheory]
@@ -2871,55 +2515,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                           Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
                       },
                 ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => MaybeDefaultIfEmpty(
-                              Maybe(
-                                  l1.OneToOne_Required_FK1,
-                                  () => Maybe(
-                                      l1.OneToOne_Required_FK1.OneToOne_Optional_FK2,
-                                      () => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3))))
+                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
                       join l2 in ss.Set<Level4>().SelectMany(
-                              l4 => MaybeDefaultIfEmpty(
-                                  Maybe(
-                                      l4.OneToOne_Required_FK_Inverse4,
-                                      () => Maybe(
-                                          l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3,
-                                          () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2))))
-                          on MaybeScalar<int>(l4, () => l4.Id) equals MaybeScalar<int>(l2, () => l2.Id)
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
+                          on l4.MaybeScalar(x => x.Id) equals l2.MaybeScalar(x => x.Id)
                       join l3 in ss.Set<Level4>().SelectMany(
-                              l4 => MaybeDefaultIfEmpty(
-                                  Maybe(
-                                      l4.OneToOne_Required_FK_Inverse4,
-                                      () => Maybe(
-                                          l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3,
-                                          () => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2))))
-                          on MaybeScalar<int>(l2, () => l2.Id) equals MaybeScalar<int>(l3, () => l3.Id) into grouping
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.MaybeDefaultIfEmpty())
+                          on l2.MaybeScalar(x => x.Id) equals l3.MaybeScalar(x => x.Id) into grouping
                       from l3 in grouping.DefaultIfEmpty()
-                      where Maybe(
-                              l4,
-                              () => Maybe(
-                                  l4.OneToMany_Optional_Inverse4,
-                                  () => l4.OneToMany_Optional_Inverse4.Name))
-                          != "Foo"
-                      orderby MaybeScalar(
-                          l2,
-                          () => MaybeScalar<int>(
-                              l2.OneToOne_Optional_FK2,
-                              () => l2.OneToOne_Optional_FK2.Id))
+                      where l4.OneToMany_Optional_Inverse4.Name != "Foo"
+                      orderby l2.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
                       select new
                       {
                           Entity = l4,
-                          Collection = Maybe(
-                              l2,
-                              () => Maybe(
-                                  l2.OneToMany_Optional_Self2,
-                                  () => l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList())),
-                          Property = Maybe(
-                              l3,
-                              () => Maybe(
-                                  l3.OneToOne_Optional_FK_Inverse3,
-                                  () => Maybe(
-                                      l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2,
-                                      () => l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name)))
+                          Collection = l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList(),
+                          Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
                       },
                 elementSorter: e => e.Entity.Id,
                 elementAsserter: (e, a) =>
@@ -2998,10 +2608,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)),
                 ss => ss.Set<Level1>().Where(
-                    l1 => MaybeScalar<bool>(
-                            l1.OneToOne_Optional_FK1,
-                            () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1))
-                        == true));
+                    l1 => l1.OneToOne_Optional_FK1.MaybeScalar(x => x.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)) == true));
         }
 
         [ConditionalTheory]
@@ -3017,12 +2624,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 .All(l4 => ClientMethod(l4))),
                     ss => ss.Set<Level1>().Where(
                         l1 => l1.Id < 3
-                            && !l1.OneToMany_Optional1.Select(
-                                l2 => MaybeScalar(
-                                    l2.OneToOne_Optional_FK2,
-                                    () => MaybeScalar<int>(
-                                        l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3,
-                                        () => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id))).All(a => true))))).Message;
+                            && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.MaybeScalar(x => x.Id))
+                                .All(a => true))))).Message;
 
             Assert.Contains("ClientMethod((Nullable<int>)", message);
         }
@@ -3077,18 +2680,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l1_manual in ss.Set<Level1>()
-                    join l2_manual in ss.Set<Level2>() on l1_manual.Id equals l2_manual.Level1_Optional_Id into grouping
-                    from l2_manual in grouping.DefaultIfEmpty()
-                    where l2_manual.OneToOne_Required_FK_Inverse2.Name != "L3 02"
-                    select l2_manual.OneToOne_Required_FK_Inverse2.Name,
-                ss =>
-                    from l1_manual in ss.Set<Level1>()
-                    join l2_manual in ss.Set<Level2>() on l1_manual.Id equals l2_manual.Level1_Optional_Id into grouping
-                    from l2_manual in grouping.DefaultIfEmpty()
-                    where Maybe(l2_manual, () => l2_manual.OneToOne_Required_FK_Inverse2.Name) != "L3 02"
-                    select Maybe(l2_manual, () => l2_manual.OneToOne_Required_FK_Inverse2.Name));
+                ss => from l1_manual in ss.Set<Level1>()
+                      join l2_manual in ss.Set<Level2>() on l1_manual.Id equals l2_manual.Level1_Optional_Id into grouping
+                      from l2_manual in grouping.DefaultIfEmpty()
+                      where l2_manual.OneToOne_Required_FK_Inverse2.Name != "L3 02"
+                      select l2_manual.OneToOne_Required_FK_Inverse2.Name);
         }
 
         [ConditionalTheory]
@@ -3099,14 +2695,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss =>
                     from l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1)
-                    join l1 in ss.Set<Level2>() on l2_nav.Level1_Required_Id equals l1.Id into grouping
-                    from l1 in grouping.DefaultIfEmpty()
-                    select new { Id1 = (int?)l2_nav.Id, Id2 = (int?)l1.Id },
+                    join l2 in ss.Set<Level2>() on l2_nav.Level1_Required_Id equals l2.Id into grouping
+                    from l2 in grouping.DefaultIfEmpty()
+                    select new { Id1 = (int?)l2_nav.Id, Id2 = (int?)l2.Id },
                 ss =>
                     from l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1)
-                    join l1 in ss.Set<Level2>() on MaybeScalar<int>(l2_nav, () => l2_nav.Level1_Required_Id) equals l1.Id into grouping
-                    from l1 in grouping.DefaultIfEmpty()
-                    select new { Id1 = MaybeScalar<int>(l2_nav, () => l2_nav.Id), Id2 = MaybeScalar<int>(l1, () => l1.Id) },
+                    join l2 in ss.Set<Level2>() on l2_nav.MaybeScalar(x => x.Level1_Required_Id) equals l2.Id into grouping
+                    from l2 in grouping.DefaultIfEmpty()
+                    select new { Id1 = l2_nav.MaybeScalar(x => x.Id), Id2 = l2.MaybeScalar(x => x.Id) },
                 elementSorter: e => e.Id1);
         }
 
@@ -3118,16 +2714,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss =>
                     from l3 in ss.Set<Level3>()
-                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.Id into
-                        grouping
+                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.Id into grouping
                     from l2_nav in grouping.DefaultIfEmpty()
                     select new { Name1 = l3.Name, Name2 = l2_nav.Name },
                 ss =>
                     from l3 in ss.Set<Level3>()
-                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals MaybeScalar<int>(
-                        l2_nav, () => l2_nav.Id) into grouping
+                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.MaybeScalar(x => x.Id) into grouping
                     from l2_nav in grouping.DefaultIfEmpty()
-                    select new { Name1 = l3.Name, Name2 = Maybe(l2_nav, () => l2_nav.Name) },
+                    select new { Name1 = l3.Name, Name2 = l2_nav.Name },
                 elementSorter: e => (e.Name1, e.Name2));
         }
 
@@ -3152,9 +2746,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
                           from l2_inner in grouping_inner.DefaultIfEmpty()
                           select l2_inner
-                          on l3.Level2_Required_Id equals MaybeScalar<int>(l2_outer, () => l2_outer.Id) into grouping_outer
+                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select Maybe(l2_outer, () => l2_outer.Name));
+                      select l2_outer.Name);
         }
 
         [ConditionalTheory]
@@ -3178,9 +2772,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
                           from l2_inner in grouping_inner.DefaultIfEmpty()
                           select l2_inner
-                          on l3.Level2_Required_Id equals MaybeScalar<int>(l2_outer, () => l2_outer.Id) into grouping_outer
+                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select new { entity = l2_outer, property = Maybe(l2_outer, () => l2_outer.Name) },
+                      select new { entity = l2_outer, property = l2_outer.Name },
                 elementSorter: e => e.property,
                 elementAsserter: (e, a) =>
                 {
@@ -3215,9 +2809,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
                           from l2_inner in grouping_inner.DefaultIfEmpty()
                           select l2_inner
-                          on l3.Level2_Required_Id equals MaybeScalar<int>(l2_outer, () => l2_outer.Id) into grouping_outer
+                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select ClientMethodReturnSelf(Maybe(l2_outer, () => l2_outer.Name)));
+                      select ClientMethodReturnSelf(l2_outer.Name));
         }
 
         [ConditionalTheory]
@@ -3241,7 +2835,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select MaybeScalar<int>(subquery, () => subquery.Id));
+                      select subquery.MaybeScalar(x => x.Id));
         }
 
         [ConditionalTheory]
@@ -3265,7 +2859,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select MaybeScalar<int>(subquery, () => subquery.Id));
+                      select subquery.MaybeScalar(x => x.Id));
         }
 
         [ConditionalTheory]
@@ -3289,9 +2883,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
                           from l1_inner in grouping_inner.DefaultIfEmpty()
                           select l2_inner
-                          on l1_outer.Id equals MaybeScalar<int>(subquery, () => subquery.Level1_Required_Id) into grouping
+                          on l1_outer.Id equals subquery.MaybeScalar(x => x.Level1_Required_Id) into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select MaybeScalar<int>(subquery, () => subquery.Id));
+                      select subquery.MaybeScalar(x => x.Id));
         }
 
         [ConditionalTheory]
@@ -3309,17 +2903,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                          select l1).Take(2)
                     join l2_outer in ss.Set<Level2>() on x.Id equals l2_outer.Level1_Optional_Id into grouping_outer
                     from l2_outer in grouping_outer.DefaultIfEmpty()
-                    select l2_outer.Name,
-                ss =>
-                    from x in
-                        (from l1 in ss.Set<Level1>()
-                         join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
-                         from l2 in grouping.DefaultIfEmpty()
-                         orderby l1.Id
-                         select l1).Take(2)
-                    join l2_outer in ss.Set<Level2>() on x.Id equals l2_outer.Level1_Optional_Id into grouping_outer
-                    from l2_outer in grouping_outer.DefaultIfEmpty()
-                    select Maybe(l2_outer, () => l2_outer.Name));
+                    select l2_outer.Name);
         }
 
         [ConditionalTheory(Skip = "Issue #17328")]
@@ -3347,7 +2931,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                          select ClientLevel1(l1)).Take(2)
                     join l2_outer in ss.Set<Level2>() on x.Id equals l2_outer.Level1_Optional_Id into grouping_outer
                     from l2_outer in grouping_outer.DefaultIfEmpty()
-                    select Maybe(l2_outer, () => l2_outer.Name));
+                    select l2_outer.Name);
         }
 
         private static Level1 ClientLevel1(Level1 arg)
@@ -3378,9 +2962,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                          from l2 in grouping.DefaultIfEmpty()
                          orderby l1.Id
                          select l2).Take(2)
-                    join l1_outer in ss.Set<Level1>() on MaybeScalar(x, () => x.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
+                    join l1_outer in ss.Set<Level1>() on x.MaybeScalar(xx => xx.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
                     from l1_outer in grouping_outer.DefaultIfEmpty()
-                    select Maybe(l1_outer, () => l1_outer.Name));
+                    select l1_outer.Name);
         }
 
         [ConditionalTheory]
@@ -3407,9 +2991,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                          from l2 in grouping.DefaultIfEmpty()
                          orderby l1.Id
                          select l2).Take(2)
-                    join l1_outer in ss.Set<Level1>() on MaybeScalar(x, () => x.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
+                    join l1_outer in ss.Set<Level1>() on x.MaybeScalar(xx => xx.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
                     from l1_outer in grouping_outer.DefaultIfEmpty()
-                    select Maybe(l1_outer, () => l1_outer.Name));
+                    select l1_outer.Name);
         }
 
         [ConditionalTheory]
@@ -3422,10 +3006,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .ThenBy(l1 => l1.Id)
                     .Take(2)
                     .Select(x => new { x.Id, Brand = x.OneToOne_Optional_FK1.Name }),
-                ss => ss.Set<Level1>().OrderBy(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name))
-                    .ThenBy(l1 => l1.Id)
-                    .Take(2)
-                    .Select(x => new { x.Id, Brand = Maybe(x.OneToOne_Optional_FK1, () => x.OneToOne_Optional_FK1.Name) }),
                 e => e.Id);
         }
 
@@ -3439,14 +3019,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     from l2 in ss.Set<Level2>()
                     join l1 in ss.Set<Level1>().OrderBy(x => x.OneToOne_Optional_FK1.Name).Take(2) on l2.Level1_Optional_Id equals l1.Id
                         into grouping
-                    from l1 in grouping.DefaultIfEmpty()
-#pragma warning disable IDE0031 // Use null propagation
-                    select new { l2.Id, Name = l1 != null ? l1.Name : null },
-#pragma warning restore IDE0031 // Use null propagation
-                ss =>
-                    from l2 in ss.Set<Level2>()
-                    join l1 in ss.Set<Level1>().OrderBy(x => Maybe(x.OneToOne_Optional_FK1, () => x.OneToOne_Optional_FK1.Name)).Take(2)
-                        on l2.Level1_Optional_Id equals l1.Id into grouping
                     from l1 in grouping.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
                     select new { l2.Id, Name = l1 != null ? l1.Name : null },
@@ -3621,10 +3193,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.Name != "Foo")
                     .OrderBy(l1 => l1.Id)
                     .Take(15)
-                    .Select(l1 => l1.Id),
-                ss => ss.Set<Level1>().Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != "Foo")
-                    .OrderBy(l1 => l1.Id)
-                    .Take(15)
                     .Select(l1 => l1.Id));
         }
 
@@ -3754,7 +3322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     join l2 in ss.Set<Level2>()
-                        on new { A = MaybeScalar<int>(l1.OneToMany_Optional_Self_Inverse1, () => l1.OneToMany_Optional_Self_Inverse1.Id) }
+                        on new { A = l1.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id) }
                         equals new { A = l2.Level1_Optional_Id }
                     select l1);
         }
@@ -3784,13 +3352,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join l2 in ss.Set<Level2>()
                         on new
                         {
-                            A = MaybeScalar<int>(l1.OneToMany_Optional_Self_Inverse1, () => l1.OneToMany_Optional_Self_Inverse1.Id),
-                            B = MaybeScalar<int>(l1.OneToOne_Optional_Self1, () => l1.OneToOne_Optional_Self1.Id)
+                            A = l1.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id),
+                            B = l1.OneToOne_Optional_Self1.MaybeScalar(x => x.Id)
                         }
                         equals new
                         {
                             A = l2.Level1_Optional_Id,
-                            B = MaybeScalar<int>(l2.OneToMany_Optional_Self_Inverse2, () => l2.OneToMany_Optional_Self_Inverse2.Id)
+                            B = l2.OneToMany_Optional_Self_Inverse2.MaybeScalar(x => x.Id)
                         }
                     select l1);
         }
@@ -3818,11 +3386,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                          join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
                          from l2_inner in grouping_inner.DefaultIfEmpty()
                          select l2_inner).Take(2)
-                    join l2_outer in ss.Set<Level2>() on MaybeScalar<int>(l1_outer, () => l1_outer.Id) equals l2_outer.Level1_Optional_Id
+                    join l2_outer in ss.Set<Level2>() on l1_outer.MaybeScalar(x => x.Id) equals l2_outer.Level1_Optional_Id
                         into
                         grouping_outer
                     from l2_outer in grouping_outer.DefaultIfEmpty()
-                    select Maybe(l2_outer, () => l2_outer.Name));
+                    select l2_outer.Name);
         }
 
         [ConditionalTheory]
@@ -3844,10 +3412,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l3 in ss.Set<Level3>()
                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
-                      select l3.Id,
-                ss => from l3 in ss.Set<Level3>()
-                      where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2)
-                          != null
                       select l3.Id);
         }
 
@@ -3860,16 +3424,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l3 in ss.Set<Level3>()
                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name != "L1 07"
                       where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
-                      select l3.Id,
-                ss => from l3 in ss.Set<Level3>()
-                      where Maybe(
-                              l3.OneToMany_Optional_Inverse3,
-                              () => Maybe(
-                                  l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2,
-                                  () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name))
-                          != "L1 07"
-                      where Maybe(l3.OneToMany_Optional_Inverse3, () => l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2)
-                          != null
                       select l3.Id);
         }
 
@@ -3917,13 +3471,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Required_FK2).Any()
                       select l2.Name,
                 ss => from l2 in ss.Set<Level2>()
-                      where MaybeScalar(
-                              l2.OneToOne_Required_FK2,
-                              () => MaybeScalar<bool>(
-                                  l2.OneToOne_Required_FK2.OneToMany_Optional3,
-                                  () => l2.OneToOne_Required_FK2.OneToMany_Optional3
-                                      .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Required_FK2).Any()))
-                          == true
+                      where l2.OneToOne_Required_FK2.MaybeScalar(
+                          x => x.OneToMany_Optional3.MaybeScalar(
+                              xx => xx.Select(i => i.OneToOne_Optional_PK_Inverse4 == x).Any())) == true
                       select l2.Name);
         }
 
@@ -3938,13 +3488,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                           .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any()
                       select l2.Name,
                 ss => from l2 in ss.Set<Level2>()
-                      where MaybeScalar(
-                              l2.OneToOne_Required_FK2,
-                              () => MaybeScalar<bool>(
-                                  l2.OneToOne_Required_FK2.OneToMany_Optional3,
-                                  () => l2.OneToOne_Required_FK2.OneToMany_Optional3
-                                      .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any()))
-                          == true
+                      where l2.OneToOne_Required_FK2.MaybeScalar(
+                          x => x.OneToMany_Optional3.MaybeScalar(
+                              xx => xx.Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any())) == true
                       select l2.Name);
         }
 
@@ -3975,10 +3521,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 == null).Select(l1 => l1.Id),
-                ss => ss.Set<Level1>()
-                    .Where(l1 => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) == null)
-                    .Select(l1 => l1.Id));
+                ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 == null).Select(l1 => l1.Id));
         }
 
         [ConditionalTheory]
@@ -4058,7 +3601,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l1 in ss.Set<Level1>()
                       select l1.OneToOne_Optional_FK1.OneToMany_Optional2,
                 ss => from l1 in ss.Set<Level1>()
-                      select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>(),
+                      select l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>(),
                 elementSorter: e => e.Count,
                 elementAsserter: (e, a) => AssertCollection(e, a));
         }
@@ -4072,8 +3615,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l1 in ss.Set<Level1>()
                       select l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50),
                 ss => from l1 in ss.Set<Level1>()
-                      select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50))
-                          ?? new List<Level3>(),
+                      select (l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()).Take(50),
                 elementSorter: e => e?.Count() ?? 0,
                 elementAsserter: (e, a) => AssertCollection(e, a));
         }
@@ -4091,7 +3633,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               "OneToOne_Optional_FK1"),
                           "OneToMany_Optional2"),
                 ss => from l1 in ss.Set<Level1>()
-                      select Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2) ?? new List<Level3>(),
+                      select l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>(),
                 elementSorter: e => e.Count,
                 elementAsserter: (e, a) => AssertCollection(e, a));
         }
@@ -4108,10 +3650,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select new
                       {
                           l1.Id,
-                          OneToMany_Optional2 = Maybe(
-                                  l1.OneToOne_Optional_FK1,
-                                  () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                              ?? new List<Level3>()
+                          OneToMany_Optional2 = l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()
                       },
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
@@ -4130,16 +3669,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from l1 in ss.Set<Level1>()
                       select new { l1.Id, l1.OneToOne_Optional_FK1.OneToMany_Optional2.Count },
                 ss => from l1 in ss.Set<Level1>()
-                      select new
-                      {
-                          l1.Id,
-                          Count = MaybeScalar(
-                                  l1.OneToOne_Optional_FK1,
-                                  () => MaybeScalar<int>(
-                                      l1.OneToOne_Optional_FK1.OneToMany_Optional2,
-                                      () => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Count))
-                              ?? 0
-                      },
+                      select new { l1.Id, Count = l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeScalar(x => x.Count) ?? 0 },
                 elementSorter: e => e.Id);
         }
 
@@ -4204,8 +3734,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select new
                       {
                           l1.OneToOne_Optional_FK1,
-                          OneToMany_Optional2 = Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                              ?? new List<Level3>()
+                          OneToMany_Optional2 = l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()
                       },
                 elementSorter: e => e.OneToOne_Optional_FK1?.Id,
                 elementAsserter: (e, a) =>
@@ -4548,7 +4077,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1.Id),
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                    .OrderBy(l1 => MaybeScalar<int>(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Id)),
+                    .OrderBy(l1 => l1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1, "OneToOne_Optional_FK1"),
@@ -4575,9 +4104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l1 => names.All(n => l1.OneToOne_Optional_FK1.Name != n)),
-                ss => ss.Set<Level1>().Where(
-                    l1 => names.All(n => Maybe(l1.OneToOne_Optional_FK1, () => l1.OneToOne_Optional_FK1.Name) != n)));
+                ss => ss.Set<Level1>().Where(l1 => names.All(n => l1.OneToOne_Optional_FK1.Name != n)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
@@ -4610,8 +4137,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Select(l3 => l3.OneToOne_Required_FK3).Include(l4 => l4.OneToMany_Optional_Self4),
-                ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
-                    .Select(l3 => Maybe(l3, () => l3.OneToOne_Required_FK3)),
                 new List<IExpectedInclude> { new ExpectedInclude<Level4>(l4 => l4.OneToMany_Optional_Self4, "OneToMany_Optional_Self4") });
         }
 
@@ -4860,10 +4385,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertIncludeQuery(
                 async,
-                ss => ss.Set<Level2>().Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar")
-                    .Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
-                ss => ss.Set<Level2>().Where(
-                        l2 => Maybe(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Name) != "Fubar")
+                ss => ss.Set<Level2>()
+                    .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar")
                     .Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
                 expectedIncludes);
         }
@@ -4879,10 +4402,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertIncludeQuery(
                 async,
-                ss => ss.Set<Level2>().Include(l2 => l2.OneToOne_Optional_FK_Inverse2)
+                ss => ss.Set<Level2>()
+                    .Include(l2 => l2.OneToOne_Optional_FK_Inverse2)
                     .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar"),
-                ss => ss.Set<Level2>().Include(l2 => l2.OneToOne_Optional_FK_Inverse2).Where(
-                    l2 => Maybe(l2.OneToOne_Optional_FK_Inverse2, () => l2.OneToOne_Optional_FK_Inverse2.Name) != "Fubar"),
                 expectedIncludes);
         }
 
@@ -5063,8 +4585,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertIncludeQuery(
                 async,
                 ss => ss.Set<Level1>().OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1).Take(10),
-                ss => ss.Set<Level1>().OrderBy(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name))
-                    .Include(x => x.OneToOne_Optional_FK1).Take(10),
                 expectedIncludes);
         }
 
@@ -5080,7 +4600,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertIncludeQuery(
                 async,
                 ss => ss.Set<Level1>().Where(x => x.OneToOne_Required_FK1.Name != "Foo").Include(x => x.OneToOne_Optional_FK1).Distinct(),
-                ss => ss.Set<Level1>().Where(x => Maybe(x.OneToOne_Required_FK1, () => x.OneToOne_Required_FK1.Name) != "Foo").Distinct(),
                 expectedIncludes);
         }
 
@@ -5088,7 +4607,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Include18_3()
         {
             using var ctx = CreateContext();
-            var query = ctx.LevelOne.OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1)
+            var query = ctx.LevelOne
+                .OrderBy(x => x.OneToOne_Required_FK1.Name)
+                .Include(x => x.OneToOne_Optional_FK1)
                 .Select(l1 => new { foo = l1, bar = l1 }).Take(10);
 
             var result = query.ToList();
@@ -5098,8 +4619,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Include18_3_1()
         {
             using var ctx = CreateContext();
-            var query = ctx.LevelOne.OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1)
-                .Select(l1 => new { foo = l1, bar = l1 }).Take(10).Select(x => new { x.foo, x.bar });
+            var query = ctx.LevelOne
+                .OrderBy(x => x.OneToOne_Required_FK1.Name)
+                .Include(x => x.OneToOne_Optional_FK1)
+                .Select(l1 => new { foo = l1, bar = l1 })
+                .Take(10)
+                .Select(x => new { x.foo, x.bar });
 
             var result = query.ToList();
         }
@@ -5108,8 +4633,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Include18_3_2()
         {
             using var ctx = CreateContext();
-            var query = ctx.LevelOne.OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1)
-                .Select(l1 => new { outer_foo = new { inner_foo = l1, inner_bar = l1.Name }, outer_bar = l1 }).Take(10);
+            var query = ctx.LevelOne
+                .OrderBy(x => x.OneToOne_Required_FK1.Name)
+                .Include(x => x.OneToOne_Optional_FK1)
+                .Select(l1 => new { outer_foo = new { inner_foo = l1, inner_bar = l1.Name }, outer_bar = l1 })
+                .Take(10);
 
             var result = query.ToList();
         }
@@ -5125,7 +4653,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertIncludeQuery(
                 async,
-                ss => ss.Set<Level1>().Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2).Select(l1 => l1.OneToOne_Optional_FK1)
+                ss => ss.Set<Level1>()
+                    .Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
+                    .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Distinct(),
                 expectedIncludes);
         }
@@ -5143,8 +4673,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Include18()
         {
             using var ctx = CreateContext();
-            var query = ctx.LevelOne.Include(x => x.OneToOne_Optional_FK1)
-                .Select(l1 => new { foo = l1, bar = l1.OneToOne_Optional_PK1 }).OrderBy(x => x.foo.Id).Take(10);
+            var query = ctx.LevelOne
+                .Include(x => x.OneToOne_Optional_FK1)
+                .Select(l1 => new { foo = l1, bar = l1.OneToOne_Optional_PK1 })
+                .OrderBy(x => x.foo.Id)
+                .Take(10);
 
             var result = query.ToList();
         }
@@ -5153,8 +4686,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Include19()
         {
             using var ctx = CreateContext();
-            var query = ctx.LevelOne.Include(x => x.OneToOne_Optional_FK1)
-                .Select(l1 => new { foo = l1.OneToOne_Optional_FK1, bar = l1.OneToOne_Optional_PK1 }).Distinct();
+            var query = ctx.LevelOne
+                .Include(x => x.OneToOne_Optional_FK1)
+                .Select(l1 => new { foo = l1.OneToOne_Optional_FK1, bar = l1.OneToOne_Optional_PK1 })
+                .Distinct();
 
             var result = query.ToList();
         }
@@ -5282,14 +4817,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
                     .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
                     .Where(l1 => l1.OneToMany_Optional1.Where(l2 => l2.OneToOne_Optional_PK2.Name != "Foo").Count() > 0),
-                ss => ss.Set<Level1>()
-                    .Include(l1 => l1.OneToMany_Optional1)
-                    .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                    .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
-                    .Where(
-                        l1 => l1.OneToMany_Optional1
-                                .Where(l2 => Maybe(l2.OneToOne_Optional_PK2, () => l2.OneToOne_Optional_PK2.Name) != "Foo").Count()
-                            > 0),
                 expectedIncludes);
         }
 
@@ -5402,13 +4929,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault().OneToMany_Optional2.OrderBy(l3 => l3.Id)
                         .FirstOrDefault().Name),
                 ss => ss.Set<Level1>().Select(
-                    l1 => Maybe(
-                        l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault(),
-                        () => Maybe(
-                            l1.OneToMany_Optional1.OrderBy(l2 => MaybeScalar<int>(l2, () => l2.Id)).FirstOrDefault().OneToMany_Optional2
-                                .OrderBy(l3 => l3.Id).FirstOrDefault(),
-                            () => l1.OneToMany_Optional1.OrderBy(l2 => MaybeScalar<int>(l2, () => l2.Id)).FirstOrDefault()
-                                .OneToMany_Optional2.OrderBy(l3 => l3.Id).FirstOrDefault().Name))));
+                    l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault().Maybe(x => x.OneToMany_Optional2.OrderBy(l3 => l3.Id)
+                        .FirstOrDefault().Maybe(xx => xx.Name))));
         }
 
         [ConditionalTheory]
@@ -5483,7 +5005,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Concat(ss.Set<Level2>().GroupJoin(ss.Set<Level1>(), l2 => l2.Level1_Optional_Id, l1 => l1.Id, (l2, l1s) => new { l2, l1s })
                         .SelectMany(g => g.l1s.DefaultIfEmpty(), (g, l1) => new { l1, g.l2 })
                         .Where(e => e.l1 == null))
-                    .Select(e => MaybeScalar<int>(Maybe<Level1>(e, () => e.l1), () => e.l1.Id) ?? 0));
+                    .Select(e => e.l1.MaybeScalar(x => x.Id) ?? 0));
         }
 
         [ConditionalTheory]
@@ -5553,10 +5075,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(l1 => l1.OneToOne_Required_FK1.OneToMany_Required2.Count())
                     .ThenBy(l1 => l1.OneToOne_Required_FK1.OneToOne_Required_FK2.Name),
                 ss => ss.Set<Level1>()
-                    .OrderBy(l1 => MaybeScalar<int>(Maybe(l1.OneToOne_Required_FK1, () => l1.OneToOne_Required_FK1.OneToMany_Required2),
-                        () => l1.OneToOne_Required_FK1.OneToMany_Required2.Count()) ?? 0)
-                    .ThenBy(l1 => Maybe(Maybe(l1.OneToOne_Required_FK1, () => l1.OneToOne_Required_FK1.OneToOne_Required_FK2),
-                        () => l1.OneToOne_Required_FK1.OneToOne_Required_FK2.Name)),
+                    .OrderBy(l1 => l1.OneToOne_Required_FK1.OneToMany_Required2.MaybeScalar(x => x.Count()) ?? 0)
+                    .ThenBy(l1 => l1.OneToOne_Required_FK1.OneToOne_Required_FK2.Name),
                 assertOrder: true);
         }
 
@@ -5614,7 +5134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().Where(w => w.Id == w.OneToOne_Optional_FK1.Id as int?),
                 ss => ss.Set<Level1>()
-                    .Where(w => w.Id == (MaybeScalar<int>(w.OneToOne_Optional_FK1, () => w.OneToOne_Optional_FK1.Id) as int?)));
+                    .Where(w => w.Id == (w.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) as int?)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -30,13 +30,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains("%B")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains("a_")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("a_")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
@@ -52,19 +52,19 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains("_Ba_")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("_Ba_")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("%B%a%r")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains("%B%a%r")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains("%B%a%r")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains("")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains("")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
@@ -81,14 +81,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains(prm1)) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm1)) == true)
                     .Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains(prm2)) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm2)) == true)
                     .Select(c => c.FirstName));
 
             var prm3 = (string)null;
@@ -107,14 +107,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains(prm5)) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm5)) == true)
                     .Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm6)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.Contains(prm6)) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.Contains(prm6)) == true)
                     .Select(c => c.FirstName));
 
             var prm7 = "";
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.Contains(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.Contains(r.ln))) == true),
+                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -149,7 +149,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Equal(e.ln, a.ln);
                 });
         }
-
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_contains_on_argument_with_wildcard_column_negated(bool async)
@@ -161,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => !r.fn.Contains(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln != "" && !MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.Contains(r.ln))) == true));
+                    .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true));
         }
 
         [ConditionalTheory]
@@ -171,13 +170,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("%B")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("a_")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("a_")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
@@ -193,19 +192,19 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("_Ba_")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("_Ba_")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("%B%a%r")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith("%B%a%r")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("")) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith("")) == true)
                     .Select(c => c.FirstName));
 
             await AssertQuery(
@@ -222,15 +221,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm1)) == true)
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true)
                     .Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm2)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true).Select(c => c.FirstName));
 
             var prm3 = (string)null;
             await AssertQuery(
@@ -248,15 +246,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm5)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm5)) == true).Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm6)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.StartsWith(prm6)) == true).Select(c => c.FirstName));
 
             var prm7 = "";
             await AssertQuery(
@@ -278,41 +274,41 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("[")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("[")) == true));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("B[")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[")) == true));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith("B[[a^")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[[a^")) == true));
 
             var prm1 = "[";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm1)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true));
 
             var prm2 = "B[";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm2)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true));
 
             var prm3 = "B[[a^";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(prm3)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm3)) == true));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)),
                 ss => ss.Set<FunkyCustomer>().Where(
-                    c => c.LastName != null && MaybeScalar<bool>(c.FirstName, () => c.FirstName.StartsWith(c.LastName)) == true));
+                    c => c.LastName != null && c.FirstName.MaybeScalar(x => x.StartsWith(c.LastName)) == true));
         }
 
         [ConditionalTheory]
@@ -326,7 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.StartsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.StartsWith(r.ln))) == true),
+                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -346,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => !r.fn.StartsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln != "" && !MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.StartsWith(r.ln))) == true));
+                    .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true));
         }
 
         [ConditionalTheory]
@@ -356,14 +352,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith("%B")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("%B")) == true).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith("a_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("a_")) == true).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -378,20 +372,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith("_Ba_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("_Ba_")) == true).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("%B%a%r")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith("%B%a%r")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith("%B%a%r")) == true).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith("")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith("")) == true).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -407,15 +398,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith(prm1)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm1)) == true).Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith(prm2)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm2)) == true).Select(c => c.FirstName));
 
             var prm3 = (string)null;
             await AssertQuery(
@@ -433,15 +422,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith(prm5)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm5)) == true).Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
                 async,
                 ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm6)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => !MaybeScalar<bool>(c.FirstName, () => c.FirstName.EndsWith(prm6)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.MaybeScalar(x => x.EndsWith(prm6)) == true).Select(c => c.FirstName));
 
             var prm7 = "";
             await AssertQuery(
@@ -467,7 +454,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.EndsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.EndsWith(r.ln))) == true),
+                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -487,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => !r.fn.EndsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln != "" && !MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.EndsWith(r.ln))) == true));
+                    .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true));
         }
 
         [ConditionalTheory]
@@ -502,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
                     .Where(
-                        r => r.ln == "" || MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.EndsWith(r.ln))) == true
+                        r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true
                             ? true
                             : false),
                 elementSorter: e => (e.fn, e.ln),
@@ -525,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
                     .Where(
-                        r => r.ln != "" && !MaybeScalar(r.fn, () => MaybeScalar<bool>(r.ln, () => r.fn.EndsWith(r.ln))) == true
+                        r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true
                             ? true
                             : false));
         }
@@ -539,11 +526,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                     .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value),
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                    .Where(
-                        r => MaybeScalar(
-                                r.c1.FirstName, () => MaybeScalar<bool>(r.c2.LastName, () => r.c1.FirstName.EndsWith(r.c2.LastName)))
-                            == true
-                            == MaybeScalar<bool>(r.c1.NullableBool, () => r.c1.NullableBool.Value)),
+                    .Where(r => r.c1.FirstName.MaybeScalar(x => r.c2.LastName.MaybeScalar(xx => x.EndsWith(xx))) == true
+                        == r.c1.NullableBool.MaybeScalar(x => x.Value)),
                 elementSorter: e => (e.c1.Id, e.c2.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -561,11 +545,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                     .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value),
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                    .Where(
-                        r => MaybeScalar(
-                                r.c1.FirstName, () => MaybeScalar<bool>(r.c2.LastName, () => r.c1.FirstName.EndsWith(r.c2.LastName)))
-                            == true
-                            != MaybeScalar<bool>(r.c1.NullableBool, () => r.c1.NullableBool.Value)),
+                    .Where(r => r.c1.FirstName.MaybeScalar(x => r.c2.LastName.MaybeScalar(xx => x.EndsWith(xx))) == true
+                        != r.c1.NullableBool.MaybeScalar(x => x.Value)),
                 elementSorter: e => (e.c1.Id, e.c2.Id),
                 elementAsserter: (e, a) =>
                 {

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -927,12 +927,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()),
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
-                    c => Maybe(
-                        Maybe(
-                            c.Orders.OrderBy(o => o.OrderID).FirstOrDefault(),
-                            () => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails),
-                        () => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID)
-                            .FirstOrDefault())));
+                    c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
+                        .Maybe(x => x.OrderDetails)
+                        .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault()))); 
         }
 
         [ConditionalTheory]
@@ -945,12 +942,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     c => (int?)c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()
                         .ProductID),
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
-                    c => MaybeScalar<int>(
-                        Maybe(
-                            c.Orders.OrderBy(o => o.OrderID).FirstOrDefault(),
-                            () => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails),
-                        () => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()
-                            .ProductID)));
+                    c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
+                        .Maybe(x => x.OrderDetails)
+                        .MaybeScalar(x => x.OrderBy(od => od.ProductID).FirstOrDefault().ProductID)));
         }
 
         [ConditionalTheory]
@@ -1785,11 +1779,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                     .Where(c => c.Orders.OrderByDescending(o => o.OrderID).Last().CustomerID == c.CustomerID),
                 ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                    .Where(
-                        c => Maybe(
-                                c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault(),
-                                () => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().CustomerID)
-                            == c.CustomerID),
+                    .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().Maybe(x => x.CustomerID) == c.CustomerID),
                 entryCount: 7);
         }
 
@@ -1802,11 +1792,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                     .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().CustomerID == c.CustomerID),
                 ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                    .Where(
-                        c => Maybe(
-                                c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault(),
-                                () => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().CustomerID)
-                            == c.CustomerID),
+                    .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().Maybe(x => x.CustomerID) == c.CustomerID),
                 entryCount: 7);
         }
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -281,9 +281,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from e in ss.Set<Employee>()
                       where e.Manager.Manager == null
                       select e,
-                ss => from e in ss.Set<Employee>()
-                      where Maybe(e.Manager, () => e.Manager.Manager) == null
-                      select e,
                 entryCount: 6);
         }
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1669,7 +1669,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()).Select(e => e.EmployeeID),
                 ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault())
-                    .Select(e => MaybeScalar(e, () => e.EmployeeID)));
+                    .Select(e => e.MaybeScalar(x => x.EmployeeID)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -794,11 +794,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery(
                 async,
                 ss => ss.Set<Employee>().Where(e => nullableIntPrm.Equals(e.ReportsTo)),
+                ss => ss.Set<Employee>().Where(e => e.ReportsTo == nullableIntPrm),
                 entryCount: 1);
 
             await AssertQuery(
                 async,
                 ss => ss.Set<Employee>().Where(e => e.ReportsTo.Equals(nullableIntPrm)),
+                ss => ss.Set<Employee>().Where(e => e.ReportsTo == nullableIntPrm),
                 entryCount: 1);
         }
 

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -1130,26 +1130,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertCollection(expected, actual, ordered, elementSorter, elementAsserter);
         }
 
-        protected static TResult Maybe<TResult>(object caller, Func<TResult> expression)
-            where TResult : class
-        {
-            return caller == null ? null : expression();
-        }
-
-        protected static TResult? MaybeScalar<TResult>(object caller, Func<TResult?> expression)
-            where TResult : struct
-        {
-            return caller == null ? null : expression();
-        }
-
-        protected static IEnumerable<TResult> MaybeDefaultIfEmpty<TResult>(IEnumerable<TResult> caller)
-            where TResult : class
-        {
-            return caller == null
-                ? new List<TResult> { default }
-                : caller.DefaultIfEmpty();
-        }
-
         protected static async Task AssertTranslationFailed(Func<Task> query)
             => Assert.Contains(
                 CoreStrings.TranslationFailed("").Substring(21),

--- a/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class ExpectedQueryRewritingVisitor : ExpressionVisitor
+    {
+        private static readonly MethodInfo _maybeMethod
+            = typeof(QueryTestExtensions).GetMethod(nameof(QueryTestExtensions.Maybe));
+
+        protected override Expression VisitMember(MemberExpression memberExpression)
+        {
+            if (!memberExpression.Type.IsValueType
+                && !memberExpression.Type.IsNullableValueType()
+                && memberExpression.Expression != null)
+            { 
+                var expression = Visit(memberExpression.Expression);
+
+                var lambdaParameter = Expression.Parameter(expression.Type, "x");
+                var lambda = Expression.Lambda(memberExpression.Update(lambdaParameter), lambdaParameter);
+                var method = _maybeMethod.MakeGenericMethod(expression.Type, memberExpression.Type);
+
+                return Expression.Call(method, expression, lambda);
+            }
+
+            return base.VisitMember(memberExpression);
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public static class QueryTestExtensions
+    {
+        public static TResult Maybe<TSource, TResult>(this TSource caller, Func<TSource, TResult> result)
+            where TResult : class
+            => caller == null ? null : result(caller);
+
+        public static TResult? MaybeScalar<TSource, TResult>(this TSource caller, Func<TSource, TResult> result)
+            where TResult : struct
+            => caller != null ? (TResult?)result(caller) : null;
+        
+        public static TResult? MaybeScalar<TSource, TResult>(this TSource caller, Func<TSource, TResult?> result)
+            where TResult : struct
+            => caller != null ? result(caller) : null;
+        
+        public static IEnumerable<TResult> MaybeDefaultIfEmpty<TResult>(this IEnumerable<TResult> caller)
+            where TResult : class
+            => caller == null ? new List<TResult> { default } : caller.DefaultIfEmpty();
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6331,8 +6331,7 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Nickname] <> N'Dom')");
         }
 
-        public override async Task
-            Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation(bool async)
+        public override async Task Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation(bool async)
         {
             await base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation(async);
 
@@ -6340,11 +6339,9 @@ WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ([g].[Nickname] <> N'Dom'
                 @"");
         }
 
-        public override async Task
-            Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool async)
+        public override async Task Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool async)
         {
-            await base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(
-                async);
+            await base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(async);
 
             AssertSql(
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]


### PR DESCRIPTION
Added visitor that injects Maybe methods for all non-scalar member accesses.
Also refactored Maybe methods to be more composible and so that when used manually, they don't require type arguments to be specified.