### PR TITLE
Add EF Core CI testing using Helix queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ variables:
   - name: _CosmosToken
     value: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - group: DotNet-HelixApi-Access
     - group: DotNet-MSRC-Storage
     - name: _InternalRuntimeDownloadArgs
       value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
@@ -21,7 +22,7 @@ variables:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - name: _InternalRuntimeDownloadArgs
       value: ''
-    
+
   # used for post-build phases, internal builds only
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-EFCore-SDLValidation-Params
@@ -44,11 +45,11 @@ stages:
         enablePublishBuildArtifacts: true
         enablePublishBuildAssets: true
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-        enablePublishTestResults: true
         enableTelemetry: true
         helixRepo: dotnet/efcore
         jobs:
           - job: Windows
+            enablePublishTestResults: true
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCorePublic-Pool
@@ -108,6 +109,7 @@ stages:
                   parallel: true
 
           - job: macOS
+            enablePublishTestResults: true
             pool:
               vmImage: macOS-10.13
             steps:
@@ -123,7 +125,7 @@ stages:
                     arguments: $(Build.SourcesDirectory)/NuGet.config $Token
                   env:
                     Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --binaryLog --prepareMachine $(_InternalRuntimeDownloadArgs)
+              - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine $(_InternalRuntimeDownloadArgs)
                 env:
                   Test__Cosmos__DefaultConnection: $(_CosmosConnectionUrl)
                 name: Build
@@ -139,6 +141,7 @@ stages:
 
           - job: Linux
             timeoutInMinutes: 120
+            enablePublishTestResults: true
             pool:
               vmImage: ubuntu-16.04
             variables:
@@ -181,6 +184,87 @@ stages:
                   artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
                   artifactType: Container
                   parallel: true
+
+          - job: Helix_Windows
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: NetCorePublic-Pool
+                queue: BuildPool.Windows.10.Amd64.VS2017.Open
+              ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                name: NetCoreInternal-Pool
+                queue: BuildPool.Windows.10.Amd64.VS2017
+            variables:
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                - name: HelixTargetQueues
+                  value: Windows.10.Amd64.Open
+                - name: Creator
+                  value: efcore
+                - name: _HelixAccessToken
+                  value: '' # Needed for public queues
+              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                - name: HelixTargetQueues
+                  value: Windows.10.Amd64
+                - name: _HelixAccessToken
+                  value: $(HelixApiAccessToken) # Needed for internal queues
+            steps:
+              - task: NuGetCommand@2
+                displayName: 'Clear NuGet caches'
+                condition: succeeded()
+                inputs:
+                  command: custom
+                  arguments: 'locals all -clear'
+              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                - task: PowerShell@2
+                  displayName: Setup Private Feeds Credentials
+                  inputs:
+                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+                    arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+                  env:
+                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - script: restore.cmd -ci /p:configuration=$(_BuildConfig)
+                displayName: Restore packages
+              - script: .dotnet\dotnet msbuild eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+                displayName: Send job to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+          - job: Helix_Linux
+            pool:
+              vmImage: ubuntu-16.04
+            variables:
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                - name: HelixTargetQueues
+                  value: Ubuntu.1804.Amd64.Open;OSX.1014.Amd64.Open
+                - name: Creator
+                  value: efcore
+                - name: _HelixAccessToken
+                  value: '' # Needed for public queues
+              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                - name: HelixTargetQueues
+                  value: Ubuntu.1804.Amd64;OSX.1014.Amd64
+                - name: _HelixAccessToken
+                  value: $(HelixApiAccessToken) # Needed for internal queues
+            steps:
+              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+                - task: Bash@3
+                  displayName: Setup Private Feeds Credentials
+                  inputs:
+                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+                    arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+                  env:
+                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
+              - script: ./restore.sh --restore -ci /p:configuration=$(_BuildConfig)
+                displayName: Restore packages
+              - script: .dotnet/dotnet msbuild eng/helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+                displayName: Send job to helix
+                env:
+                  HelixAccessToken: $(_HelixAccessToken)
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -67,5 +67,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2086e534f12e6116889ee480646ef54c1f781887</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20116.1">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2086e534f12e6116889ee480646ef54c1f781887</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <PropertyGroup>
+    <HelixType>test/product/</HelixType>
+    <HelixBuild>$(BUILD_BUILDNUMBER)</HelixBuild>
+    <HelixTargetQueues>$(HelixTargetQueues)</HelixTargetQueues>
+    <Creator>$(Creator)</Creator>
+    <HelixAccessToken>$(HelixAccessToken)</HelixAccessToken>
+
+    <IncludeDotNetCli>true</IncludeDotNetCli>
+    <DotNetCliPackageType>sdk</DotNetCliPackageType>
+    <DotNetCliVersion>3.1.100</DotNetCliVersion>
+
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <FailOnTestFailure>true</FailOnTestFailure>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <XUnitProject Include="$(RepoRoot)/test/**/*.csproj"/>
+    <XUnitProject Remove="$(RepoRoot)/test/EFCore.Specification.Tests/*.csproj"/>
+    <XUnitProject Remove="$(RepoRoot)/test/EFCore.Relational.Specification.Tests/*.csproj"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <XUnitPublishTargetFramework>netcoreapp3.1</XUnitPublishTargetFramework>
+    <XUnitRuntimeTargetFramework>netcoreapp2.0</XUnitRuntimeTargetFramework>
+    <XUnitRunnerVersion>2.4.1</XUnitRunnerVersion>
+    <XUnitArguments></XUnitArguments>
+    <XUnitWorkItemTimeout>00:30:00</XUnitWorkItemTimeout>
+  </PropertyGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -12,6 +12,7 @@
     "version": "3.1.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20116.1"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20116.1",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20116.1"
   }
 }

--- a/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/test/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -17,8 +17,4 @@
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -48,25 +48,31 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     return _fullTextInstalled.Value;
                 }
 
-                using (var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master")))
+                try
                 {
-                    sqlConnection.Open();
-
-                    using var command = new SqlCommand(
-                        "SELECT FULLTEXTSERVICEPROPERTY('IsFullTextInstalled')", sqlConnection);
-                    var result = (int)command.ExecuteScalar();
-
-                    _fullTextInstalled = result == 1;
-
-                    if (_fullTextInstalled.Value)
+                    using (var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master")))
                     {
-                        var flag = GetFlag("SupportsFullTextSearch");
+                        sqlConnection.Open();
 
-                        if (flag.HasValue)
+                        using var command = new SqlCommand(
+                            "SELECT FULLTEXTSERVICEPROPERTY('IsFullTextInstalled')", sqlConnection);
+                        var result = (int)command.ExecuteScalar();
+
+                        _fullTextInstalled = result == 1;
+
+                        if (_fullTextInstalled.Value)
                         {
-                            return flag.Value;
+                            var flag = GetFlag("SupportsFullTextSearch");
+
+                            if (flag.HasValue)
+                            {
+                                return flag.Value;
+                            }
                         }
                     }
+                }
+                catch (PlatformNotSupportedException)
+                {
                 }
 
                 _fullTextInstalled = false;


### PR DESCRIPTION
- Adds coverage for testing using
  - WindowsServer 2016-Datacenter with localdb
  - macOS 10.14
  - Ubuntu 18.04-LTS

- Currently tests are run separately based on OS type win/non-win due to #19964
- Uses anonymous auth from public build and access token from internal build
- Automatically adds all test projects from test folder
- All telemetry is enabled for reporting
  - EnableAzurePipelinesReporter
  - FailOnTestFailure
  - EnableXUnitReporter
  - FailOnMissionControlTestFailure
- Validated internal builds also uses helix for testing using HelixAccessToken
- Checking FullTextSearch on SqlServer has been put in try-catch (Helix run threw exception of localdb not found)


Resolves #19857
