### PR TITLE
[release/3.1] RevEng: Don't create navigations to keyless entity types

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -860,6 +860,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             foreignKey.HasDependentToPrincipal(dependentEndNavigationPropertyName);
 
+            if ((!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue18633", out var isEnabled)
+                    || !isEnabled)
+                && foreignKey.DeclaringEntityType.FindPrimaryKey() == null)
+            {
+                return;
+            }
+
             var principalEndExistingIdentifiers = ExistingIdentifiers(foreignKey.PrincipalEntityType);
             var principalEndNavigationPropertyCandidateName = foreignKey.IsSelfReferencing()
                 ? string.Format(

--- a/test/EFCore.Design.Tests/TestUtilities/DatabaseColumnRef.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/DatabaseColumnRef.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    class DatabaseColumnRef : DatabaseColumn
+    {
+        public DatabaseColumnRef(string name)
+        {
+            Name = name;
+        }
+
+        public override DatabaseTable Table
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override bool IsNullable
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override string StoreType
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override string DefaultValueSql
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override string ComputedColumnSql
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override string Comment
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override ValueGenerated? ValueGenerated
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/TestUtilities/DatabaseTableRef.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/DatabaseTableRef.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    class DatabaseTableRef : DatabaseTable
+    {
+        public DatabaseTableRef(string name, string schema = null)
+        {
+            Name = name;
+            Schema = schema;
+        }
+
+        public override DatabaseModel Database
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override string Comment
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override DatabasePrimaryKey PrimaryKey
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public override IList<DatabaseColumn> Columns
+             => throw new NotImplementedException();
+
+        public override IList<DatabaseUniqueConstraint> UniqueConstraints
+             => throw new NotImplementedException();
+
+        public override IList<DatabaseIndex> Indexes
+             => throw new NotImplementedException();
+
+        public override IList<DatabaseForeignKey> ForeignKeys
+             => throw new NotImplementedException();
+    }
+}

--- a/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -42,25 +44,50 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 if (table.PrimaryKey != null)
                 {
                     table.PrimaryKey.Table = table;
+                    FixupColumns(table, table.PrimaryKey.Columns);
                 }
 
                 foreach (var index in table.Indexes)
                 {
                     index.Table = table;
+                    FixupColumns(table, index.Columns);
                 }
 
                 foreach (var uniqueConstraints in table.UniqueConstraints)
                 {
                     uniqueConstraints.Table = table;
+                    FixupColumns(table, uniqueConstraints.Columns);
                 }
 
                 foreach (var foreignKey in table.ForeignKeys)
                 {
                     foreignKey.Table = table;
+                    FixupColumns(table, foreignKey.Columns);
+
+                    if (foreignKey.PrincipalTable is DatabaseTableRef tableRef)
+                    {
+                        foreignKey.PrincipalTable = databaseModel.Tables
+                            .First(t => t.Name == tableRef.Name && t.Schema == tableRef.Schema);
+                    }
+
+                    FixupColumns(foreignKey.PrincipalTable, foreignKey.PrincipalColumns);
                 }
             }
 
             return base.Create(databaseModel, useDatabaseNames);
+        }
+
+        private static void FixupColumns(DatabaseTable table, IList<DatabaseColumn> columns)
+        {
+            for (var i = 0; i < columns.Count; i++)
+            {
+                if (columns[i] is DatabaseColumnRef columnRef)
+                {
+                    columns[i] = table.Columns.First(c => c.Name == columnRef.Name);
+                }
+
+                columns[i].Table = table;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #18633

### Description

In 3.0, we started reverse engineering entity types for tables without a primary key. If the keyless table contained a foreign key, a bi-directional relationship was created for it; however navigation properties to a keyless entity type aren't allowed at runtime.

### Customer Impact

The code generated by `dotnet ef dbcontext scaffold` throws at runtime and needs to be updated manually before it will work.

### How found

Reported by multiple customers.

### Test coverage

Automated tests were added covering the various scenarios reported.

### Regression?

No.

### Risk

Low. Navigation properties to the keyless entity type are no longer created. An AppContext switch was added to enable reverting to the previous behavior.
