### PR TITLE
Fix to #19900 - Query/Test: add automatic null propagation for AssertQuery baselines (part2)

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -1003,7 +1003,8 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 asyncQuery: ss => ss.Set<Customer>()
                     .AllAsync(
                         c1 => c1.CustomerID == "ALFKI"
-                            && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))));
+                            && ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID)),
+                        default));
 
             AssertSql(
                 @"SELECT c
@@ -1029,7 +1030,8 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                             && ss.Set<Customer>()
                                 .Any(
                                     c2 => ss.Set<Customer>()
-                                        .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
+                                        .Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID)),
+                                default));
 
             AssertSql(
                 @"SELECT c

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalFixtureBase.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ComplexNavigationsDefaultData(),
                 entitySorters,
                 entityAsserters,
-                CanExecuteQueryString);
+                CanExecuteQueryString,
+                CreateExpectedQueryRewritingVisitor());
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalQueryAsserter.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/RelationalQueryAsserter.cs
@@ -19,8 +19,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             ISetSource expectedData,
             Dictionary<Type, object> entitySorters,
             Dictionary<Type, object> entityAsserters,
-            bool canExecuteQueryString)
-            : base(contextCreator, expectedData, entitySorters, entityAsserters)
+            bool canExecuteQueryString,
+            ExpectedQueryRewritingVisitor expectedQueryRewritingVisitor = null)
+            : base(contextCreator, expectedData, entitySorters, entityAsserters, expectedQueryRewritingVisitor)
         {
             _canExecuteQueryString = canExecuteQueryString;
         }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -203,7 +204,80 @@ namespace Microsoft.EntityFrameworkCore.Query
                 CreateContext,
                 new ComplexNavigationsDefaultData(),
                 entitySorters,
-                entityAsserters);
+                entityAsserters,
+                CreateExpectedQueryRewritingVisitor());
+
+        private MemberInfo GetMemberInfo(Type sourceType, string name)
+            => sourceType.GetMember(name).Single();
+
+        protected virtual ExpectedQueryRewritingVisitor CreateExpectedQueryRewritingVisitor()
+            => new ExpectedQueryRewritingVisitor(new Dictionary<(Type, string), MemberInfo[]>
+                {
+                    {
+                        (typeof(Level1), "OneToMany_Optional_Self_Inverse1Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level1), "OneToMany_Optional_Self_Inverse1"),
+                            GetMemberInfo(typeof(Level1), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level1), "OneToOne_Optional_Self1Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level1), "OneToOne_Optional_Self1"),
+                            GetMemberInfo(typeof(Level1), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level2), "OneToMany_Optional_Self_Inverse2Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level2), "OneToMany_Optional_Self_Inverse2"),
+                            GetMemberInfo(typeof(Level2), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level2), "OneToOne_Optional_Self2Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level2), "OneToOne_Optional_Self2"),
+                            GetMemberInfo(typeof(Level2), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level3), "OneToMany_Optional_Self_Inverse3Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level3), "OneToMany_Optional_Self_Inverse3"),
+                            GetMemberInfo(typeof(Level3), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level3), "OneToOne_Optional_Self3Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level3), "OneToOne_Optional_Self3"),
+                            GetMemberInfo(typeof(Level3), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level4), "OneToMany_Optional_Self_Inverse4Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level4), "OneToMany_Optional_Self_Inverse4"),
+                            GetMemberInfo(typeof(Level4), "Id")
+                        }
+                    },
+                    {
+                        (typeof(Level4), "OneToOne_Optional_Self4Id"),
+                        new []
+                        {
+                            GetMemberInfo(typeof(Level4), "OneToOne_Optional_Self4"),
+                            GetMemberInfo(typeof(Level4), "Id")
+                        }
+                    },
+                });
 
         public QueryAsserterBase QueryAsserter { get; set; }
 

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -53,8 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Optional_FK1, "Id") == 0),
-                ss => ss.Set<Level1>().Where(l => l.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) == 0));
+                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Optional_FK1, "Id") == 0));
         }
 
         [ConditionalTheory]
@@ -63,8 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") > 7),
-                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) > 7));
+                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") > 7));
         }
 
         [ConditionalTheory]
@@ -73,8 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level2>().Where(l => EF.Property<int>(l.OneToOne_Required_FK_Inverse2, "Id") > 7),
-                ss => ss.Set<Level2>().Where(l => l.OneToOne_Required_FK_Inverse2.Id > 7));
+                ss => ss.Set<Level2>().Where(l => EF.Property<int>(l.OneToOne_Required_FK_Inverse2, "Id") > 7));
         }
 
         [ConditionalTheory]
@@ -83,8 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l => EF.Property<int>(EF.Property<Level2>(l, "OneToOne_Required_FK1"), "Id") == 7),
-                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => EF.Property<int>(EF.Property<Level2>(l, "OneToOne_Required_FK1"), "Id") == 7));
         }
 
         [ConditionalTheory]
@@ -93,8 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level2>().Where(l => EF.Property<int>(EF.Property<Level1>(l, "OneToOne_Required_FK_Inverse2"), "Id") == 7),
-                ss => ss.Set<Level2>().Where(l => l.OneToOne_Required_FK_Inverse2.Id == 7));
+                ss => ss.Set<Level2>().Where(l => EF.Property<int>(EF.Property<Level1>(l, "OneToOne_Required_FK_Inverse2"), "Id") == 7));
         }
 
         [ConditionalTheory]
@@ -103,8 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l => EF.Property<Level2>(l, "OneToOne_Required_FK1").Id == 7),
-                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => EF.Property<Level2>(l, "OneToOne_Required_FK1").Id == 7));
         }
 
         [ConditionalTheory]
@@ -113,8 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") == 7),
-                ss => ss.Set<Level1>().Where(l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 7));
+                ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Required_FK1, "Id") == 7));
         }
 
         [ConditionalTheory]
@@ -123,8 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level2>().Where(l => EF.Property<int>(l.OneToOne_Required_FK_Inverse2, "Id") == 7),
-                ss => ss.Set<Level2>().Where(l => l.OneToOne_Required_FK_Inverse2.Id == 7));
+                ss => ss.Set<Level2>().Where(l => EF.Property<int>(l.OneToOne_Required_FK_Inverse2, "Id") == 7));
         }
 
         [ConditionalTheory]
@@ -148,8 +140,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l => l.OneToOne_Required_FK1 == new Level2 { Id = 1 }
                         || l.OneToOne_Required_FK1 == new Level2 { Id = 2 }),
                 ss => ss.Set<Level1>().Where(
-                    l => l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 1
-                        || l.OneToOne_Required_FK1.MaybeScalar(x => x.Id) == 2));
+                    l => l.OneToOne_Required_FK1.Id == 1
+                        || l.OneToOne_Required_FK1.Id == 2));
         }
 
         [ConditionalTheory]
@@ -257,14 +249,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
+                      select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
 
@@ -274,14 +261,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Required_FK_Inverse2.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Required_FK_Inverse2.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Required_FK_Inverse2.Id
+                      select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
 
@@ -293,9 +275,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from e2 in ss.Set<Level2>()
                       where e2.OneToOne_Optional_PK_Inverse2.Id > 5
-                      select e2.Id,
-                ss => from e2 in ss.Set<Level2>()
-                      where e2.OneToOne_Optional_PK_Inverse2.MaybeScalar(x => x.Id) > 5
                       select e2.Id);
         }
 
@@ -346,11 +325,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level1>().GroupBy(
                         l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name,
                         l1 => new { Id = (int?)l1.OneToOne_Required_PK1.Id ?? 0 })
-                    .Where(g => g.Min(l1 => l1.Id) > 0)
-                    .Select(g => g.Count()),
-                ss => ss.Set<Level1>().GroupBy(
-                        l1 => l1.OneToOne_Required_PK1.OneToOne_Required_PK2.Name,
-                        l1 => new { Id = l1.OneToOne_Required_PK1.MaybeScalar(x => x.Id) ?? 0 })
                     .Where(g => g.Min(l1 => l1.Id) > 0)
                     .Select(g => g.Count()));
         }
@@ -422,9 +396,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from e1 in ss.Set<Level1>()
                       where EF.Property<string>(EF.Property<Level2>(e1, "OneToOne_Optional_FK1"), "Name") == "L2 01"
-                      select e1,
-                ss => from e1 in ss.Set<Level1>()
-                      where e1.OneToOne_Optional_FK1.Name == "L2 01"
                       select e1);
         }
 
@@ -451,9 +422,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from e1 in ss.Set<Level1>()
                       where e1.OneToOne_Optional_FK1.Name.StartsWith(e1.OneToOne_Optional_FK1.Name)
-                      select e1,
-                ss => from e1 in ss.Set<Level1>()
-                      where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith(x)) == true
                       select e1);
         }
 
@@ -512,14 +480,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1.Id equals e2.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) equals e2.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1.Id equals e2.Id
+                      select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
 
@@ -529,15 +492,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e3 in ss.Set<Level3>() on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id equals e3.Id
-                    select new { Id1 = e1.Id, Id3 = e3.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e3 in ss.Set<Level3>()
-                    on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) equals e3.Id
-                    select new { Id1 = e1.Id, Id3 = e3.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e3 in ss.Set<Level3>() on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id equals e3.Id
+                      select new { Id1 = e1.Id, Id3 = e3.Id },
                 e => (e.Id1, e.Id3));
         }
 
@@ -547,14 +504,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id equals e1.Id
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id) equals e1.Id
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
+                ss => from e3 in ss.Set<Level3>()
+                      join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id equals e1.Id
+                      select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id1, e.Id3));
         }
 
@@ -564,14 +516,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e2 in ss.Set<Level2>()
-                    join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.Id
-                    select new { Id2 = e2.Id, Id1 = e1.Id },
-                ss =>
-                    from e2 in ss.Set<Level2>()
-                    join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)
-                    select new { Id2 = e2.Id, Id1 = e1.Id },
+                ss => from e2 in ss.Set<Level2>()
+                      join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.Id
+                      select new { Id2 = e2.Id, Id1 = e1.Id },
                 e => (e.Id2, e.Id1));
         }
 
@@ -584,15 +531,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from e2 in ss.Set<Level2>()
                       join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.Id
                       join e3 in ss.Set<Level3>() on e2.Id equals e3.OneToOne_Optional_FK_Inverse3.Id
-                      select new
-                      {
-                          Id2 = e2.Id,
-                          Id1 = e1.Id,
-                          Id3 = e3.Id
-                      },
-                ss => from e2 in ss.Set<Level2>()
-                      join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)
-                      join e3 in ss.Set<Level3>() on e2.Id equals e3.OneToOne_Optional_FK_Inverse3.MaybeScalar(x => x.Id)
                       select new
                       {
                           Id2 = e2.Id,
@@ -646,14 +584,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1.Id
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id)
-                    select new { Id1 = e1.Id, Id2 = e2.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1.Id
+                      select new { Id1 = e1.Id, Id2 = e2.Id },
                 e => (e.Id1, e.Id2));
         }
 
@@ -663,14 +596,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
+                ss => from e3 in ss.Set<Level3>()
+                      join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
+                      select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id3, e.Id1));
         }
 
@@ -680,14 +608,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
-                ss =>
-                    from e3 in ss.Set<Level3>()
-                    join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
-                    select new { Id3 = e3.Id, Id1 = e1.Id },
+                ss => from e3 in ss.Set<Level3>()
+                      join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
+                      select new { Id3 = e3.Id, Id1 = e1.Id },
                 e => (e.Id3, e.Id1));
         }
 
@@ -835,13 +758,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
                     from l2 in groupJoin.DefaultIfEmpty()
 #pragma warning disable IDE0031 // Use null propagation
-                    select l2 == null ? null : l2.Name,
-#pragma warning restore IDE0031 // Use null propagation
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    join l2 in ss.Set<Level2>() on l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id) into groupJoin
-                    from l2 in groupJoin.DefaultIfEmpty()
-#pragma warning disable IDE0031 // Use null propagation
                     select l2 == null ? null : l2.Name);
 #pragma warning restore IDE0031 // Use null propagation
         }
@@ -852,8 +768,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Id),
-                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)));
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Id));
         }
 
         [ConditionalTheory]
@@ -864,10 +779,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into groupJoin
-                      from l2 in groupJoin.DefaultIfEmpty()
-                      select l2 == null ? null : (int?)l2.Id,
-                ss => from l1 in ss.Set<Level1>()
-                      join l2 in ss.Set<Level2>() on l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id) into groupJoin
                       from l2 in groupJoin.DefaultIfEmpty()
                       select l2 == null ? null : (int?)l2.Id);
         }
@@ -943,8 +854,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id),
-                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)));
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id));
         }
 
         [ConditionalTheory]
@@ -1034,8 +944,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id),
-                ss => ss.Set<Level1>().Select(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2.MaybeScalar(x => x.Id)));
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Required_FK1.OneToOne_Required_FK2.Id));
         }
 
         [ConditionalTheory]
@@ -1054,9 +963,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQueryScalar(
                 async,
                 ss => from l1 in ss.Set<Level1>()
-                      select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id,
-                ss => from l1 in ss.Set<Level1>()
-                      select l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.MaybeScalar(x => x.Id));
+                      select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id);
         }
 
         [ConditionalTheory]
@@ -1104,7 +1011,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     from l2 in ss.Set<Level2>()
-                    where l1.Id == l2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
+                    where l1.Id == l2.OneToOne_Optional_FK_Inverse2.Id
                     select new { Id1 = l1.Id, Id2 = l2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -1123,7 +1030,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss =>
                     from l1 in ss.Set<Level1>()
                     from l2 in ss.Set<Level2>()
-                    where l1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) == l2.Id
+                    where l1.OneToOne_Optional_FK1.Id == l2.Id
                     select new { Id1 = l1.Id, Id2 = l2.Id },
                 e => (e.Id1, e.Id2));
         }
@@ -1186,10 +1093,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
                         && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id != 7)
                     .Select(e => new { e.Name, Id = (int?)e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id }),
-                ss => ss.Set<Level1>()
-                    .Where(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
-                        && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) != 7)
-                    .Select(e => new { e.Name, Id = e.OneToOne_Required_FK1.OneToOne_Optional_FK2.MaybeScalar(x => x.Id) }),
                 elementSorter: e => (e.Name, e.Id));
         }
 
@@ -1199,23 +1102,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e in ss.Set<Level3>()
-                    where e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2
-                        == e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2
-                        && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id != 7
-                    select new { e.Name, Id = (int?)e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id },
-                ss =>
-                    from e in ss.Set<Level3>()
-                    where e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2
-                        == e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2
-                        && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
-                        != 7
-                    select new
-                    {
-                        e.Name,
-                        Id = e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
-                    },
+                ss => from e in ss.Set<Level3>()
+                      where e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2
+                          == e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2
+                          && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id != 7
+                      select new { e.Name, Id = (int?)e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id },
                 e => (e.Name, e.Id));
         }
 
@@ -1339,10 +1230,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertAverage(
                 async,
                 ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id),
-                ss => ss.Set<Level1>().Select(
-                    e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id)),
-                actualSelector: e => e,
-                expectedSelector: e => e);
+                selector: e => e);
         }
 
         [ConditionalTheory]
@@ -1351,8 +1239,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertAverage(
                 async,
-                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id),
-                ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id)));
+                ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id));
         }
 
         [ConditionalTheory]
@@ -1658,16 +1545,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
-                    where ss.Set<Level2>().Any(l2 => l2.Level1_Required_Id == e1.Id)
-                    select new { Name1 = e1.Name, Id2 = e2.Id },
-                ss =>
-                    from e1 in ss.Set<Level1>()
-                    join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.MaybeScalar(x => x.Id)
-                    where ss.Set<Level2>().Any(l2 => l2.Level1_Required_Id == e1.Id)
-                    select new { Name1 = e1.Name, Id2 = e2.Id },
+                ss => from e1 in ss.Set<Level1>()
+                      join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
+                      where ss.Set<Level2>().Any(l2 => l2.Level1_Required_Id == e1.Id)
+                      select new { Name1 = e1.Name, Id2 = e2.Id },
                 e => (e.Name1, e.Id2));
         }
 
@@ -1722,7 +1603,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level3>().OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id)
                     .Select(l3 => EF.Property<Level2>(l3, "OneToOne_Required_FK_Inverse3")),
-                ss => ss.Set<Level3>().OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id).Select(l3 => l3.OneToOne_Required_FK_Inverse3),
                 elementAsserter: (e, a) => AssertEqual(e, a),
                 assertOrder: true);
         }
@@ -1735,7 +1615,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level3>().OrderBy(l3 => EF.Property<Level2>(l3, "OneToOne_Required_FK_Inverse3").Id)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3),
-                ss => ss.Set<Level3>().OrderBy(l3 => l3.OneToOne_Required_FK_Inverse3.Id).Select(l3 => l3.OneToOne_Required_FK_Inverse3),
                 elementAsserter: (e, a) => AssertEqual(e, a),
                 assertOrder: true);
         }
@@ -1791,11 +1670,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => (int?)l2.Id)
-                    .Take(10)
-                    .Select(l2 => l2.OneToOne_Optional_FK2.Name),
-                ss => ss.Set<Level1>()
-                    .Select(l1 => l1.OneToOne_Optional_FK1)
-                    .OrderBy(l2 => l2.MaybeScalar(x => x.Id))
                     .Take(10)
                     .Select(l2 => l2.OneToOne_Optional_FK2.Name),
                 assertOrder: true);
@@ -2273,7 +2147,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where l3 != null
                       select l1,
                 ss => from l1 in ss.Set<Level1>()
-                      from l3 in l1.OneToOne_Required_FK1.OneToMany_Optional2.MaybeDefaultIfEmpty() ?? new List<Level3>()
+                      from l3 in l1.OneToOne_Required_FK1.OneToMany_Optional2.DefaultIfEmpty() ?? new List<Level3>()
                       where l3 != null
                       select l1);
         }
@@ -2347,11 +2221,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                                   .DefaultIfEmpty())
                           on l1.Id equals l2.Level1_Optional_Id
                       select new { l1, l2 },
-               ss => from l1 in ss.Set<Level1>()
-                     join l2 in ss.Set<Level4>().SelectMany(
-                             l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty()) on
-                         l1.Id equals l2.MaybeScalar(x => x.Level1_Optional_Id)
-                     select new { l1, l2 },
                 elementSorter: e => (e.l1?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -2366,16 +2235,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss
-                    => from l2 in ss.Set<Level4>().SelectMany(
-                           l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.DefaultIfEmpty())
-                       join l1 in ss.Set<Level1>() on l2.Level1_Optional_Id equals l1.Id
-                       select new { l2, l1 },
-                ss
-                    => from l2 in ss.Set<Level4>().SelectMany(
-                           l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
-                       join l1 in ss.Set<Level1>() on l2.MaybeScalar(x => x.Level1_Optional_Id) equals l1.Id
-                       select new { l2, l1 },
+                ss => from l2 in ss.Set<Level4>().SelectMany(
+                          l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.DefaultIfEmpty())
+                      join l1 in ss.Set<Level1>() on l2.Level1_Optional_Id equals l1.Id
+                      select new { l2, l1 },
                 elementSorter: e => (e.l2?.Id, e.l1?.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -2386,18 +2249,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany3(
-            bool async)
+        public virtual Task SelectMany_with_nested_navigations_explicit_DefaultIfEmpty_and_additional_joins_outside_of_SelectMany3(bool async)
         {
             return AssertQuery(
                 async,
                 ss => from l4 in ss.Set<Level1>().SelectMany(
                           l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
                       join l2 in ss.Set<Level2>() on l4.Id equals l2.Id
-                      select new { l4, l2 },
-                ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
-                      join l2 in ss.Set<Level2>() on l4.MaybeScalar(x => x.Id) equals l2.Id
                       select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
@@ -2414,18 +2272,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss
-                    => from l4 in ss.Set<Level1>().SelectMany(
-                           l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                       join l2 in ss.Set<Level2>() on l4.Id equals l2.Id into grouping
-                       from l2 in grouping.DefaultIfEmpty()
-                       select new { l4, l2 },
-                ss
-                    => from l4 in ss.Set<Level1>().SelectMany(
-                           l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
-                       join l2 in ss.Set<Level2>() on l4.MaybeScalar(x => x.Id) equals l2.Id into grouping
-                       from l2 in grouping.DefaultIfEmpty()
-                       select new { l4, l2 },
+                ss => from l4 in ss.Set<Level1>().SelectMany(
+                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
+                      join l2 in ss.Set<Level2>() on l4.Id equals l2.Id into grouping
+                      from l2 in grouping.DefaultIfEmpty()
+                      select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -2447,12 +2298,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                                   .DefaultIfEmpty())
                           on l4.Id equals l2.Id
                       select new { l4, l2 },
-                ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
-                      join l2 in ss.Set<Level4>().SelectMany(
-                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
-                          on l4.MaybeScalar(x => x.Id) equals l2.MaybeScalar(x => x.Id)
-                      select new { l4, l2 },
                 elementSorter: e => (e.l4?.Id, e.l2?.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -2469,9 +2314,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l3 in ss.Set<Level4>().SelectMany(
                           l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty())
-                      select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2,
-                ss => from l3 in ss.Set<Level4>().SelectMany(
-                          l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.MaybeDefaultIfEmpty())
                       select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2);
         }
 
@@ -2484,8 +2326,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.DefaultIfEmpty())
-                      select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2,
-                ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeDefaultIfEmpty())
                       select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2);
         }
 
@@ -2515,13 +2355,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                           Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
                       },
                 ss => from l4 in ss.Set<Level1>().SelectMany(
-                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.MaybeDefaultIfEmpty())
+                          l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
                       join l2 in ss.Set<Level4>().SelectMany(
-                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.MaybeDefaultIfEmpty())
-                          on l4.MaybeScalar(x => x.Id) equals l2.MaybeScalar(x => x.Id)
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2
+                                  .DefaultIfEmpty())
+                          on l4.Id equals l2.Id
                       join l3 in ss.Set<Level4>().SelectMany(
-                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.MaybeDefaultIfEmpty())
-                          on l2.MaybeScalar(x => x.Id) equals l3.MaybeScalar(x => x.Id) into grouping
+                              l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty())
+                          on l2.Id equals l3.Id into grouping
                       from l3 in grouping.DefaultIfEmpty()
                       where l4.OneToMany_Optional_Inverse4.Name != "Foo"
                       orderby l2.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
@@ -2608,7 +2449,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)),
                 ss => ss.Set<Level1>().Where(
-                    l1 => l1.OneToOne_Optional_FK1.MaybeScalar(x => x.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(1)) == true));
+                    l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeScalar(x => x.Distinct().Select(l3 => l3.Id).Contains(1)) == true));
         }
 
         [ConditionalTheory]
@@ -2666,12 +2507,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Level2>()
                     .Where(l2o => l2o.Id == 7)
-                    .Where(
-                        l1 => EF.Property<string>(ss.Set<Level2>().OrderBy(l2i => l2i.Id).First().OneToOne_Required_FK_Inverse2, "Name")
-                            == "L1 02"),
-                ss => ss.Set<Level2>()
-                    .Where(l2o => l2o.Id == 7)
-                    .Where(l1 => ss.Set<Level2>().OrderBy(l2i => l2i.Id).First().OneToOne_Required_FK_Inverse2.Name == "L1 02"));
+                    .Where(l1 => EF.Property<string>(
+                        ss.Set<Level2>().OrderBy(l2i => l2i.Id).First().OneToOne_Required_FK_Inverse2, "Name") == "L1 02"));
         }
 
         [ConditionalTheory]
@@ -2693,16 +2530,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1)
-                    join l2 in ss.Set<Level2>() on l2_nav.Level1_Required_Id equals l2.Id into grouping
-                    from l2 in grouping.DefaultIfEmpty()
-                    select new { Id1 = (int?)l2_nav.Id, Id2 = (int?)l2.Id },
-                ss =>
-                    from l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1)
-                    join l2 in ss.Set<Level2>() on l2_nav.MaybeScalar(x => x.Level1_Required_Id) equals l2.Id into grouping
-                    from l2 in grouping.DefaultIfEmpty()
-                    select new { Id1 = l2_nav.MaybeScalar(x => x.Id), Id2 = l2.MaybeScalar(x => x.Id) },
+                ss => from l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1)
+                      join l2 in ss.Set<Level2>() on l2_nav.Level1_Required_Id equals l2.Id into grouping
+                      from l2 in grouping.DefaultIfEmpty()
+                      select new { Id1 = (int?)l2_nav.Id, Id2 = (int?)l2.Id },
                 elementSorter: e => e.Id1);
         }
 
@@ -2712,16 +2543,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l3 in ss.Set<Level3>()
-                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.Id into grouping
-                    from l2_nav in grouping.DefaultIfEmpty()
-                    select new { Name1 = l3.Name, Name2 = l2_nav.Name },
-                ss =>
-                    from l3 in ss.Set<Level3>()
-                    join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.MaybeScalar(x => x.Id) into grouping
-                    from l2_nav in grouping.DefaultIfEmpty()
-                    select new { Name1 = l3.Name, Name2 = l2_nav.Name },
+                ss => from l3 in ss.Set<Level3>()
+                      join l2_nav in ss.Set<Level1>().Select(ll => ll.OneToOne_Optional_FK1) on l3.Level2_Required_Id equals l2_nav.Id into grouping
+                      from l2_nav in grouping.DefaultIfEmpty()
+                      select new { Name1 = l3.Name, Name2 = l2_nav.Name },
                 elementSorter: e => (e.Name1, e.Name2));
         }
 
@@ -2739,15 +2564,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l3.Level2_Required_Id equals l2_outer.Id into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select l2_outer.Name,
-                ss => from l3 in ss.Set<Level3>()
-                      join l2_outer in
-                          from l1_inner in ss.Set<Level1>()
-                          join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
-                          from l2_inner in grouping_inner.DefaultIfEmpty()
-                          select l2_inner
-                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
-                      from l2_outer in grouping_outer.DefaultIfEmpty()
                       select l2_outer.Name);
         }
 
@@ -2764,15 +2580,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                           from l2_inner in grouping_inner.DefaultIfEmpty()
                           select l2_inner
                           on l3.Level2_Required_Id equals l2_outer.Id into grouping_outer
-                      from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select new { entity = l2_outer, property = l2_outer.Name },
-                ss => from l3 in ss.Set<Level3>()
-                      join l2_outer in
-                          from l1_inner in ss.Set<Level1>()
-                          join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
-                          from l2_inner in grouping_inner.DefaultIfEmpty()
-                          select l2_inner
-                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
                       select new { entity = l2_outer, property = l2_outer.Name },
                 elementSorter: e => e.property,
@@ -2802,15 +2609,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l3.Level2_Required_Id equals l2_outer.Id into grouping_outer
                       from l2_outer in grouping_outer.DefaultIfEmpty()
-                      select ClientMethodReturnSelf(l2_outer.Name),
-                ss => from l3 in ss.Set<Level3>()
-                      join l2_outer in
-                          from l1_inner in ss.Set<Level1>()
-                          join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
-                          from l2_inner in grouping_inner.DefaultIfEmpty()
-                          select l2_inner
-                          on l3.Level2_Required_Id equals l2_outer.MaybeScalar(x => x.Id) into grouping_outer
-                      from l2_outer in grouping_outer.DefaultIfEmpty()
                       select ClientMethodReturnSelf(l2_outer.Name));
         }
 
@@ -2827,15 +2625,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select (int?)subquery.Id,
-                ss => from l1_outer in ss.Set<Level1>()
-                      join subquery in
-                          from l2_inner in ss.Set<Level2>()
-                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
-                          select l2_inner
-                          on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                      from subquery in grouping.DefaultIfEmpty()
-                      select subquery.MaybeScalar(x => x.Id));
+                      select (int?)subquery.Id);
         }
 
         [ConditionalTheory]
@@ -2851,15 +2641,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select subquery != null ? (int?)subquery.Id : null,
-                ss => from l1_outer in ss.Set<Level1>()
-                      join subquery in
-                          from l2_inner in ss.Set<Level2>()
-                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id
-                          select l2_inner
-                          on l1_outer.Id equals subquery.Level1_Optional_Id into grouping
-                      from subquery in grouping.DefaultIfEmpty()
-                      select subquery.MaybeScalar(x => x.Id));
+                      select subquery != null ? (int?)subquery.Id : null);
         }
 
         [ConditionalTheory]
@@ -2876,16 +2658,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                           select l2_inner
                           on l1_outer.Id equals subquery.Level1_Required_Id into grouping
                       from subquery in grouping.DefaultIfEmpty()
-                      select (int?)subquery.Id,
-                ss => from l1_outer in ss.Set<Level1>()
-                      join subquery in
-                          from l2_inner in ss.Set<Level2>()
-                          join l1_inner in ss.Set<Level1>() on l2_inner.Level1_Required_Id equals l1_inner.Id into grouping_inner
-                          from l1_inner in grouping_inner.DefaultIfEmpty()
-                          select l2_inner
-                          on l1_outer.Id equals subquery.MaybeScalar(x => x.Level1_Required_Id) into grouping
-                      from subquery in grouping.DefaultIfEmpty()
-                      select subquery.MaybeScalar(x => x.Id));
+                      select (int?)subquery.Id);
         }
 
         [ConditionalTheory]
@@ -2954,16 +2727,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                          select l2).Take(2)
                     join l1_outer in ss.Set<Level1>() on x.Level1_Optional_Id equals l1_outer.Id into grouping_outer
                     from l1_outer in grouping_outer.DefaultIfEmpty()
-                    select l1_outer.Name,
-                ss =>
-                    from x in
-                        (from l1 in ss.Set<Level1>()
-                         join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id into grouping
-                         from l2 in grouping.DefaultIfEmpty()
-                         orderby l1.Id
-                         select l2).Take(2)
-                    join l1_outer in ss.Set<Level1>() on x.MaybeScalar(xx => xx.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
-                    from l1_outer in grouping_outer.DefaultIfEmpty()
                     select l1_outer.Name);
         }
 
@@ -2982,16 +2745,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                          orderby l1.Id
                          select l2).Take(2)
                     join l1_outer in ss.Set<Level1>() on x.Level1_Optional_Id equals l1_outer.Id into grouping_outer
-                    from l1_outer in grouping_outer.DefaultIfEmpty()
-                    select l1_outer.Name,
-                ss =>
-                    from x in
-                        (from l1 in ss.Set<Level1>()
-                         join l2 in ss.Set<Level2>().OrderBy(ee => ee.Date) on l1.Id equals l2.Level1_Optional_Id into grouping
-                         from l2 in grouping.DefaultIfEmpty()
-                         orderby l1.Id
-                         select l2).Take(2)
-                    join l1_outer in ss.Set<Level1>() on x.MaybeScalar(xx => xx.Level1_Optional_Id) equals l1_outer.Id into grouping_outer
                     from l1_outer in grouping_outer.DefaultIfEmpty()
                     select l1_outer.Name);
         }
@@ -3313,18 +3066,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    join l2 in ss.Set<Level2>()
-                        on new { A = EF.Property<int?>(l1, "OneToMany_Optional_Self_Inverse1Id") }
-                        equals new { A = EF.Property<int?>(l2, "Level1_Optional_Id") }
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    join l2 in ss.Set<Level2>()
-                        on new { A = l1.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id) }
-                        equals new { A = l2.Level1_Optional_Id }
-                    select l1);
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>()
+                          on new { A = EF.Property<int?>(l1, "OneToMany_Optional_Self_Inverse1Id") }
+                          equals new { A = EF.Property<int?>(l2, "Level1_Optional_Id") }
+                      select l1);
         }
 
         [ConditionalTheory]
@@ -3346,20 +3092,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                             A = EF.Property<int?>(l2, "Level1_Optional_Id"),
                             B = EF.Property<int?>(l2, "OneToMany_Optional_Self_Inverse2Id")
                         }
-                    select l1,
-                ss =>
-                    from l1 in ss.Set<Level1>()
-                    join l2 in ss.Set<Level2>()
-                        on new
-                        {
-                            A = l1.OneToMany_Optional_Self_Inverse1.MaybeScalar(x => x.Id),
-                            B = l1.OneToOne_Optional_Self1.MaybeScalar(x => x.Id)
-                        }
-                        equals new
-                        {
-                            A = l2.Level1_Optional_Id,
-                            B = l2.OneToMany_Optional_Self_Inverse2.MaybeScalar(x => x.Id)
-                        }
                     select l1);
         }
 
@@ -3377,18 +3109,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                          from l2_inner in grouping_inner.DefaultIfEmpty()
                          select l2_inner).Take(2)
                     join l2_outer in ss.Set<Level2>() on l1_outer.Id equals l2_outer.Level1_Optional_Id into grouping_outer
-                    from l2_outer in grouping_outer.DefaultIfEmpty()
-                    select l2_outer.Name,
-                ss =>
-                    from l1_outer in
-                        (from l1_inner in ss.Set<Level1>()
-                         orderby l1_inner.Id
-                         join l2_inner in ss.Set<Level2>() on l1_inner.Id equals l2_inner.Level1_Optional_Id into grouping_inner
-                         from l2_inner in grouping_inner.DefaultIfEmpty()
-                         select l2_inner).Take(2)
-                    join l2_outer in ss.Set<Level2>() on l1_outer.MaybeScalar(x => x.Id) equals l2_outer.Level1_Optional_Id
-                        into
-                        grouping_outer
                     from l2_outer in grouping_outer.DefaultIfEmpty()
                     select l2_outer.Name);
         }
@@ -3471,9 +3191,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                           .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Required_FK2).Any()
                       select l2.Name,
                 ss => from l2 in ss.Set<Level2>()
-                      where l2.OneToOne_Required_FK2.MaybeScalar(
-                          x => x.OneToMany_Optional3.MaybeScalar(
-                              xx => xx.Select(i => i.OneToOne_Optional_PK_Inverse4 == x).Any())) == true
+                      where l2.OneToOne_Required_FK2.OneToMany_Optional3.MaybeScalar(
+                              x => x.Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Required_FK2).Any()) == true
                       select l2.Name);
         }
 
@@ -3488,9 +3207,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                           .Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any()
                       select l2.Name,
                 ss => from l2 in ss.Set<Level2>()
-                      where l2.OneToOne_Required_FK2.MaybeScalar(
-                          x => x.OneToMany_Optional3.MaybeScalar(
-                              xx => xx.Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any())) == true
+                      where l2.OneToOne_Required_FK2.OneToMany_Optional3.MaybeScalar(
+                              x => x.Select(i => i.OneToOne_Optional_PK_Inverse4 == l2.OneToOne_Optional_PK2).Any()) == true
                       select l2.Name);
         }
 
@@ -3632,10 +3350,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                               l1,
                               "OneToOne_Optional_FK1"),
                           "OneToMany_Optional2"),
-                ss => from l1 in ss.Set<Level1>()
-                      select l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>(),
-                elementSorter: e => e.Count,
-                elementAsserter: (e, a) => AssertCollection(e, a));
+                elementSorter: e => e?.Count ?? 0,
+                elementAsserter: (e, a) => AssertCollection(e ?? new List<Level3>(), a));
         }
 
         [ConditionalTheory]
@@ -3646,17 +3362,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       select new { l1.Id, l1.OneToOne_Optional_FK1.OneToMany_Optional2 },
-                ss => from l1 in ss.Set<Level1>()
-                      select new
-                      {
-                          l1.Id,
-                          OneToMany_Optional2 = l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()
-                      },
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    AssertCollection(e.OneToMany_Optional2, a.OneToMany_Optional2);
+                    AssertCollection(e.OneToMany_Optional2 ?? new List<Level3>(), a.OneToMany_Optional2);
                 });
         }
 
@@ -3730,17 +3440,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from l1 in ss.Set<Level1>()
                       select new { l1.OneToOne_Optional_FK1, l1.OneToOne_Optional_FK1.OneToMany_Optional2 },
-                ss => from l1 in ss.Set<Level1>()
-                      select new
-                      {
-                          l1.OneToOne_Optional_FK1,
-                          OneToMany_Optional2 = l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()
-                      },
                 elementSorter: e => e.OneToOne_Optional_FK1?.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.OneToOne_Optional_FK1?.Id, a.OneToOne_Optional_FK1?.Id);
-                    AssertCollection(e.OneToMany_Optional2, a.OneToMany_Optional2);
+                    AssertCollection(e.OneToMany_Optional2 ?? new List<Level3>(), a.OneToMany_Optional2);
                 });
         }
 
@@ -3793,9 +3497,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => EF.Property<int>(l2, "Level1_Required_Id"))
-                    .ThenBy(l2 => l2.Name),
-                ss => ss.Set<Level2>()
-                    .OrderBy(l2 => l2.Level1_Required_Id)
                     .ThenBy(l2 => l2.Name),
                 new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional2") },
                 assertOrder: true);
@@ -4075,9 +3776,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1.Id),
-                ss => ss.Set<Level1>()
-                    .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                    .OrderBy(l1 => l1.OneToOne_Optional_FK1.MaybeScalar(x => x.Id)),
                 expectedIncludes: new List<IExpectedInclude>
                 {
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1, "OneToOne_Optional_FK1"),
@@ -5132,9 +4830,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Where(w => w.Id == w.OneToOne_Optional_FK1.Id as int?),
-                ss => ss.Set<Level1>()
-                    .Where(w => w.Id == (w.OneToOne_Optional_FK1.MaybeScalar(x => x.Id) as int?)));
+                ss => ss.Set<Level1>().Where(w => w.Id == w.OneToOne_Optional_FK1.Id as int?));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -29,15 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("a_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -51,9 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("_Ba_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -80,16 +74,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm1 = "%B";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm1)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm2)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName));
 
             var prm3 = (string)null;
             await AssertQuery(
@@ -106,9 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm5 = "_Ba_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm5)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
@@ -141,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.Contains(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true),
+                    .Where(r => r.ln == "" || r.fn.Contains(r.ln)),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -169,15 +157,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("a_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("a_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -191,9 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("_Ba_")) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -220,15 +202,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm1 = "%B";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true)
-                    .Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName));
 
             var prm3 = (string)null;
             await AssertQuery(
@@ -245,8 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm5 = "_Ba_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm5)) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
@@ -273,42 +251,34 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("[")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[[a^")) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")));
 
             var prm1 = "[";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)));
 
             var prm2 = "B[";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)));
 
             var prm3 = "B[[a^";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm3)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)),
-                ss => ss.Set<FunkyCustomer>().Where(
-                    c => c.LastName != null && c.FirstName.MaybeScalar(x => x.StartsWith(c.LastName)) == true));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)));
         }
 
         [ConditionalTheory]
@@ -322,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.StartsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true),
+                    .Where(r => r.ln == "" || r.fn.StartsWith(r.ln)),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -351,13 +321,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("%B")) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%B")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("a_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("a_")) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("a_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -371,8 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_Ba_")).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("_Ba_")) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_Ba_")).Select(c => c.FirstName));
 
             await AssertQuery(
                 async,
@@ -397,14 +364,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm1 = "%B";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm1)) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName));
 
             var prm2 = "a_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm2)) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName));
 
             var prm3 = (string)null;
             await AssertQuery(
@@ -421,8 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var prm5 = "_Ba_";
             await AssertQuery(
                 async,
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName),
-                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm5)) == true).Select(c => c.FirstName));
+                ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName));
 
             var prm6 = "%B%a%r";
             await AssertQuery(
@@ -454,7 +418,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.EndsWith(r.ln)),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
+                    .Where(r => r.ln == "" || r.fn.EndsWith(r.ln)),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -488,10 +452,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(r => r.fn.EndsWith(r.ln) ? true : false),
                 ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                     .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                    .Where(
-                        r => r.ln == "" || r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true
-                            ? true
-                            : false),
+                    .Where(r => r.ln == "" || r.fn.EndsWith(r.ln) ? true : false),
                 elementSorter: e => (e.fn, e.ln),
                 elementAsserter: (e, a) =>
                 {
@@ -525,9 +486,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                     .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value),
-                ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                    .Where(r => r.c1.FirstName.MaybeScalar(x => r.c2.LastName.MaybeScalar(xx => x.EndsWith(xx))) == true
-                        == r.c1.NullableBool.MaybeScalar(x => x.Value)),
                 elementSorter: e => (e.c1.Id, e.c2.Id),
                 elementAsserter: (e, a) =>
                 {
@@ -544,9 +502,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                     .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value),
-                ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                    .Where(r => r.c1.FirstName.MaybeScalar(x => r.c2.LastName.MaybeScalar(xx => x.EndsWith(xx))) == true
-                        != r.c1.NullableBool.MaybeScalar(x => x.Value)),
                 elementSorter: e => (e.c1.Id, e.c2.Id),
                 elementAsserter: (e, a) =>
                 {

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -950,8 +950,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Where(
-                    g => (null == EF.Property<string>(g, "LeaderNickname") ? (int?)null : g.LeaderNickname.Length) == 5 == (bool?)true),
-                ss => ss.Set<Gear>().Where(g => (null == g.LeaderNickname ? (int?)null : g.LeaderNickname.Length) == 5 == (bool?)true));
+                    g => (null == EF.Property<string>(g, "LeaderNickname") ? (int?)null : g.LeaderNickname.Length) == 5 == (bool?)true));
         }
 
         [ConditionalTheory]
@@ -963,9 +962,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Where(
                     g => (null != g.LeaderNickname ? (int?)(EF.Property<string>(g, "LeaderNickname").Length) : (int?)null)
                         == 5
-                        == (bool?)true),
-                ss => ss.Set<Gear>().Where(
-                    g => (null != g.LeaderNickname ? (int?)(g.LeaderNickname.Length) : (int?)null) == 5 == (bool?)true));
+                        == (bool?)true));
         }
 
         [ConditionalTheory]
@@ -977,9 +974,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Where(
                     g => (null != g.LeaderNickname ? (int?)EF.Property<string>(g, "LeaderNickname").Length : (int?)null)
                         == 5
-                        == (bool?)true),
-                ss => ss.Set<Gear>().Where(
-                    g => (null != g.LeaderNickname ? (int?)g.LeaderNickname.Length : (int?)null) == 5 == (bool?)true));
+                        == (bool?)true));
         }
 
         [ConditionalTheory]
@@ -1082,9 +1077,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Gear>().Select(
                     g => null != g.LeaderNickname
                         ? EF.Property<string>(g, "LeaderNickname").Length != EF.Property<string>(g, "LeaderNickname").Length
-                        : (bool?)null),
-                ss => ss.Set<Gear>().Select(
-                    g => null != g.LeaderNickname ? g.LeaderNickname.Length != g.LeaderNickname.Length : (bool?)null));
+                        : (bool?)null));
         }
 
         [ConditionalTheory]
@@ -1137,10 +1130,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => from t in ss.Set<CogTag>()
                       select EF.Property<City>(EF.Property<CogTag>(t.Gear, "Tag").Gear, "AssignedCity") != null
                           ? EF.Property<string>(EF.Property<Gear>(t.Gear.Tag, "Gear").AssignedCity, "Name")
-                          : null,
-                ss => from t in ss.Set<CogTag>()
-                      select t.Gear.Tag.Gear.AssignedCity != null
-                          ? t.Gear.Tag.Gear.AssignedCity.Name
                           : null);
         }
 
@@ -1308,9 +1297,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertFirst(
                 async,
                 ss => ss.Set<Weapon>().OrderBy(w => w.Id).Select(
-                    w => new Weapon { IsAutomatic = (bool?)w.SynergyWith.IsAutomatic ?? false }),
-                ss => ss.Set<Weapon>().OrderBy(w => w.Id).Select(
-                    w => new Weapon { IsAutomatic = w.SynergyWith.MaybeScalar(x => x.IsAutomatic) ?? false }));
+                    w => new Weapon { IsAutomatic = (bool?)w.SynergyWith.IsAutomatic ?? false }));
         }
 
         [ConditionalTheory]
@@ -2126,9 +2113,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 // ReSharper disable once RedundantTernaryExpression
-                ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch ? true : false),
-                // ReSharper disable once RedundantTernaryExpression
-                ss => ss.Set<CogTag>().Where(t => (t.Gear.MaybeScalar(x => x.HasSoulPatch) == true) ? true : false));
+                ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch ? true : false));
         }
 
         [ConditionalTheory]
@@ -2137,8 +2122,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch || t.Note.Contains("Cole")),
-                ss => ss.Set<CogTag>().Where(t => t.Gear.MaybeScalar(x => x.HasSoulPatch) == true || t.Note.Contains("Cole")));
+                ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch || t.Note.Contains("Cole")));
         }
 
         [ConditionalTheory]
@@ -2147,9 +2131,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<CogTag>().Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")),
-                ss => ss.Set<CogTag>().Select(
-                    t => t.Gear.MaybeScalar(x => x.HasSoulPatch) == true && t.Note.Contains("Cole")));
+                ss => ss.Set<CogTag>().Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")));
         }
 
         [ConditionalTheory]
@@ -2750,14 +2732,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.Rank)
                     .Include(g => g.Tag)
                     .Where(g => g.HasSoulPatch)
-                    .Select(
-                        g => new { FullName = EF.Property<string>(g, "FullName") }),
-                ss => ss.Set<Gear>()
-                    .OrderBy(g => g.Rank)
-                    .Include(g => g.Tag)
-                    .Where(g => g.HasSoulPatch)
-                    .Select(
-                        g => new { g.FullName }),
+                    .Select(g => new { FullName = EF.Property<string>(g, "FullName") }),
                 assertOrder: true);
         }
 
@@ -3011,9 +2986,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                     async,
                     ss => from g in ss.Set<Gear>()
                           where !g.HasSoulPatch && FavoriteWeapon(EF.Property<List<Weapon>>(g, "Weapons")).Name == "Cole's Gnasher"
-                          select g.Nickname,
-                    ss => from g in ss.Set<Gear>()
-                          where !g.HasSoulPatch && FavoriteWeapon(g.Weapons).Name == "Cole's Gnasher"
                           select g.Nickname));
         }
 
@@ -3128,11 +3100,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                           Name = EF.Property<string>(horde, "Name"),
                           Eradicated = EF.Property<bool>((LocustHorde)f, "Eradicated")
                       },
-                ss => from f in ss.Set<Faction>()
-                      where f is LocustHorde
-                      let horde = (LocustHorde)f
-                      orderby f.Name
-                      select new { horde.Name, Eradicated = (bool)((LocustHorde)f).Eradicated },
                 assertOrder: true);
         }
 
@@ -3183,10 +3150,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where f is LocustHorde
                       orderby f.Name
                       select new { f.Name, Threat = EF.Property<LocustCommander>((LocustHorde)f, "Commander").ThreatLevel },
-                ss => from f in ss.Set<Faction>()
-                      where f is LocustHorde
-                      orderby f.Name
-                      select new { f.Name, Threat = ((LocustHorde)f).Commander.ThreatLevel },
                 assertOrder: true);
         }
 
@@ -3358,10 +3321,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Faction>()
                     .Where(f => f is LocustHorde)
-                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).CommanderName : null),
-                ss => ss.Set<Faction>()
-                    .Where(f => f is LocustHorde)
-                    .Select(f => ((LocustHorde)f).CommanderName != null ? ((LocustHorde)f).CommanderName : null));
+                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).CommanderName : null));
         }
 
         [ConditionalTheory]
@@ -3372,10 +3332,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Faction>()
                     .Where(f => f is LocustHorde)
-                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).Eradicated : null),
-                ss => ss.Set<Faction>()
-                    .Where(f => f is LocustHorde)
-                    .Select(f => ((LocustHorde)f).CommanderName != null ? ((LocustHorde)f).Eradicated : null));
+                    .Select(f => EF.Property<string>((LocustHorde)f, "CommanderName") != null ? ((LocustHorde)f).Eradicated : null));
         }
 
         [ConditionalTheory]
@@ -3387,9 +3344,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Faction>().OfType<LocustHorde>()
                     .Select(
                         h => new { h.Id, Leaders = EF.Property<ICollection<LocustLeader>>(h.Commander.CommandingFaction, "Leaders") }),
-                ss => ss.Set<Faction>().OfType<LocustHorde>()
-                    .Select(
-                        h => new { h.Id, Leaders = (ICollection<LocustLeader>)h.Commander.CommandingFaction.Leaders }),
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
@@ -3407,9 +3361,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Faction>().OfType<LocustHorde>()
                     .Select(
                         h => new { h.Id, Gears = EF.Property<ICollection<Gear>>((Officer)h.Commander.DefeatedBy, "Reports") }),
-                ss => ss.Set<Faction>().OfType<LocustHorde>()
-                    .Select(
-                        h => new { h.Id, Gears = ((Officer)h.Commander.DefeatedBy).Reports }),
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
@@ -3431,14 +3382,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         {
                             f.Id,
                             Gears = EF.Property<ICollection<Gear>>((Officer)((LocustHorde)f).Commander.DefeatedBy, "Reports")
-                        }),
-                ss => ss.Set<Faction>()
-                    .Where(f => f is LocustHorde)
-                    .Select(
-                        f => new
-                        {
-                            f.Id,
-                            Gears = ((Officer)((LocustHorde)f).Commander.DefeatedBy).Reports
                         }),
                 elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
@@ -4818,13 +4761,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         grouping
                     from h in grouping.DefaultIfEmpty()
                     where h.Eradicated != true
-                    select h,
-                ss =>
-                    from ll in ss.Set<LocustLeader>()
-                    join h in ss.Set<Faction>().OfType<LocustHorde>().Where(f => f.Name == "Swarm") on ll.Name equals h.CommanderName into
-                        grouping
-                    from h in grouping.DefaultIfEmpty()
-                    where h.MaybeScalar(x => x.Eradicated) != true
                     select h);
         }
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1324,7 +1324,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertSingleResult(
                 async,
                 syncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).Contains("ALFKI"),
-                asyncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).ContainsAsync("ALFKI"));
+                asyncQuery: ss => ss.Set<Customer>().Select(c => c.CustomerID).ContainsAsync("ALFKI", default));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2198,7 +2198,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertSingleResult(
                 async,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Count(),
-                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync());
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync(default));
         }
 
         [ConditionalTheory(Skip = "Issue #18836")]
@@ -2214,7 +2214,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => (from o in ss.Set<Order>()
                        group o by new { o.CustomerID }
                        into g
-                       select g.Where(e => e.OrderID < 10300).Count()).LongCountAsync());
+                       select g.Where(e => e.OrderID < 10300).Count()).LongCountAsync(default));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -1093,7 +1093,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 syncQuery: ss => ss.Set<Customer>().All(
                     c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))),
                 asyncQuery: ss => ss.Set<Customer>().AllAsync(
-                    c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID))));
+                    c1 => ss.Set<Customer>().Any(c2 => ss.Set<Customer>().Any(c3 => c1.CustomerID == c3.CustomerID)),
+                    default));
         }
 
         [ConditionalTheory]
@@ -1107,7 +1108,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         c2 => ss.Set<Customer>().Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))),
                 asyncQuery: ss => ss.Set<Customer>().AllAsync(
                     c1 => ss.Set<Customer>().Any(
-                        c2 => ss.Set<Customer>().Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID))));
+                        c2 => ss.Set<Customer>().Any(c3 => EF.Property<string>(c1, "CustomerID") == c3.CustomerID)),
+                    default));
         }
 
         [ConditionalTheory]
@@ -4409,7 +4411,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 syncQuery: ss => ss.Set<Customer>().Select(
                     c => new { c.CustomerID }).Distinct().Count(n => n.CustomerID.StartsWith("A")),
                 asyncQuery: ss => ss.Set<Customer>().Select(
-                    c => new { c.CustomerID }).Distinct().CountAsync(n => n.CustomerID.StartsWith("A")));
+                    c => new { c.CustomerID }).Distinct().CountAsync(n => n.CustomerID.StartsWith("A"), default));
         }
 
         [ConditionalTheory]
@@ -4441,7 +4443,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 syncQuery: ss => ss.Set<Customer>().Select(c => new { A = c.CustomerID + c.City }).Distinct()
                     .Count(n => n.A.StartsWith("A")),
                 asyncQuery: ss
-                    => ss.Set<Customer>().Select(c => new { A = c.CustomerID + c.City }).Distinct().CountAsync(n => n.A.StartsWith("A")));
+                    => ss.Set<Customer>().Select(c => new { A = c.CustomerID + c.City }).Distinct().CountAsync(n => n.A.StartsWith("A"), default));
         }
 
         [ConditionalTheory]
@@ -4524,7 +4526,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 syncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID }).Distinct().Count(n => n.Property.StartsWith("A")),
                 asyncQuery: ss => ss.Set<Customer>().Select(
-                    c => new DTO<string> { Property = c.CustomerID }).Distinct().CountAsync(n => n.Property.StartsWith("A")));
+                    c => new DTO<string> { Property = c.CustomerID }).Distinct().CountAsync(n => n.Property.StartsWith("A"), default));
         }
 
         [ConditionalTheory]
@@ -4560,7 +4562,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 syncQuery: ss => ss.Set<Customer>().Select(
                     c => new DTO<string> { Property = c.CustomerID + c.City }).Distinct().Count(n => n.Property.StartsWith("A")),
                 asyncQuery: ss => ss.Set<Customer>().Select(
-                    c => new DTO<string> { Property = c.CustomerID + c.City }).Distinct().CountAsync(n => n.Property.StartsWith("A")));
+                    c => new DTO<string> { Property = c.CustomerID + c.City }).Distinct().CountAsync(n => n.Property.StartsWith("A"), default));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -123,8 +123,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected Task AssertSingleResult<TResult>(
             bool async,
-            Func<ISetSource, TResult> syncQuery,
-            Func<ISetSource, Task<TResult>> asyncQuery,
+            Expression<Func<ISetSource, TResult>> syncQuery,
+            Expression<Func<ISetSource, Task<TResult>>> asyncQuery,
             Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             [CallerMemberName] string testMethodName = null)
@@ -132,9 +132,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected Task AssertSingleResult<TResult>(
             bool async,
-            Func<ISetSource, TResult> actualSyncQuery,
-            Func<ISetSource, Task<TResult>> actualAsyncQuery,
-            Func<ISetSource, TResult> expectedQuery,
+            Expression<Func<ISetSource, TResult>> actualSyncQuery,
+            Expression<Func<ISetSource, Task<TResult>>> actualAsyncQuery,
+            Expression<Func<ISetSource, TResult>> expectedQuery,
             Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             [CallerMemberName] string testMethodName = null)

--- a/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ExpectedQueryRewritingVisitor.cs
@@ -2,15 +2,62 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class ExpectedQueryRewritingVisitor : ExpressionVisitor
     {
+        private static readonly MethodInfo _maybeDefaultIfEmpty
+            = typeof(QueryTestExtensions).GetMethod(nameof(QueryTestExtensions.MaybeDefaultIfEmpty));
+
         private static readonly MethodInfo _maybeMethod
             = typeof(QueryTestExtensions).GetMethod(nameof(QueryTestExtensions.Maybe));
+
+        private static readonly MethodInfo _containsMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) });
+
+        private static readonly MethodInfo _startsWithMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) });
+
+        private static readonly MethodInfo _endsWithMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) });
+
+        private static readonly MethodInfo _maybeScalarNullableMethod;
+        private static readonly MethodInfo _maybeScalarNonNullableMethod;
+
+        /// <summary>
+        /// used to map shadow property to a series of non-shadow member expressions,
+        /// e.g. order.CustomerId -> order.Customer + customer.Id
+        /// key: source type + shadow property name
+        /// value: list of MemberInfos that should be used during rewrite
+        /// </summary>
+        private readonly Dictionary<(Type type, string name), MemberInfo[]> _efPropertyMemberInfoMappings;
+
+        private bool _negated = false;
+
+        static ExpectedQueryRewritingVisitor()
+        {
+            var maybeScalarMethods = typeof(QueryTestExtensions).GetMethods()
+                .Where(m => m.Name == nameof(QueryTestExtensions.MaybeScalar))
+                .Select(m => new
+                {
+                    method = m,
+                    argument = m.GetParameters()[1].ParameterType.GetGenericArguments()[1]
+                });
+
+            _maybeScalarNullableMethod = maybeScalarMethods.Single(x => x.argument.IsNullableValueType()).method;
+            _maybeScalarNonNullableMethod = maybeScalarMethods.Single(x => !x.argument.IsNullableValueType()).method;
+        }
+
+        public ExpectedQueryRewritingVisitor(Dictionary<(Type type, string name), MemberInfo[]> efPropertyMemberInfoMappings = null)
+        {
+            _efPropertyMemberInfoMappings = efPropertyMemberInfoMappings ?? new Dictionary<(Type type, string name), MemberInfo[]>();
+        }
 
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
@@ -27,7 +74,308 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 return Expression.Call(method, expression, lambda);
             }
 
+            if (memberExpression.Type == typeof(bool)
+                && !_negated
+                && memberExpression.Expression != null)
+            {
+                var expression = Visit(memberExpression.Expression);
+
+                var lambdaParameter = Expression.Parameter(expression.Type, "x");
+                var lambda = Expression.Lambda(memberExpression.Update(lambdaParameter), lambdaParameter);
+                var method = _maybeScalarNonNullableMethod.MakeGenericMethod(expression.Type, memberExpression.Type);
+
+                return Expression.Equal(
+                    Expression.Call(method, expression, lambda),
+                    Expression.Constant(true, typeof(bool?)));
+            }
+
             return base.VisitMember(memberExpression);
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.DeclaringType == typeof(Queryable)
+                && methodCallExpression.Method.IsGenericMethod
+                && (methodCallExpression.Method.GetGenericMethodDefinition() == QueryableMethods.Join
+                    || methodCallExpression.Method.GetGenericMethodDefinition() == QueryableMethods.GroupJoin))
+            {
+                return RewriteJoinGroupJoin(methodCallExpression);
+            }
+
+            if (Infrastructure.MethodInfoExtensions.IsEFPropertyMethod(methodCallExpression.Method))
+            {
+                var rewritten = TryConvertEFPropertyToMemberAccess(methodCallExpression);
+
+                return Visit(rewritten);
+            }
+
+            if (!_negated
+                && (methodCallExpression.Method == _containsMethodInfo
+                    || methodCallExpression.Method == _startsWithMethodInfo
+                    || methodCallExpression.Method == _endsWithMethodInfo))
+            {
+                return RewriteStartsWithEndsWithContains(methodCallExpression);
+            }
+
+            if (methodCallExpression.Method.IsGenericMethod
+                && methodCallExpression.Method.GetGenericMethodDefinition() == EnumerableMethods.DefaultIfEmptyWithoutArgument)
+            {
+                var source = Visit(methodCallExpression.Arguments[0]);
+
+                return Expression.Call(
+                    _maybeDefaultIfEmpty.MakeGenericMethod(
+                        methodCallExpression.Method.GetGenericArguments()[0]),
+                    source);
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        private Expression RewriteJoinGroupJoin(MethodCallExpression methodCallExpression)
+        {
+            //outer.Join<TOuter, TInner, int, Anonymous<...>(inner, ok => ok.Id, ik => i.Fk, (o, i) => new { o, i })
+            //gets converted to:
+            //outer.Join<TOuter, TInner, int?, Anonymous<...>(inner,
+            //  ok => ok.MaybeScalar(x => x.Id),
+            //  ik => i.MaybeScalar(x.Fk),
+            //  (o, i) => new { o, i })
+            var outer = Visit(methodCallExpression.Arguments[0]);
+            var inner = Visit(methodCallExpression.Arguments[1]);
+            var resultSelector = Visit(methodCallExpression.Arguments[4]);
+
+            var originalLeftKeySelectorLambda = methodCallExpression.Arguments[2].UnwrapLambdaFromQuote();
+            var originalRightKeySelectorLambda = methodCallExpression.Arguments[3].UnwrapLambdaFromQuote();
+            var leftKeySelectorBody = AddNullProtectionForNonNullableMemberAccess(originalLeftKeySelectorLambda.Body);
+            var rightKeySelectorBody = AddNullProtectionForNonNullableMemberAccess(originalRightKeySelectorLambda.Body);
+
+            if (leftKeySelectorBody.Type.IsNullableValueType()
+                && rightKeySelectorBody.Type.IsValueType
+                && leftKeySelectorBody.Type.UnwrapNullableType() == rightKeySelectorBody.Type)
+            {
+                rightKeySelectorBody = Expression.Convert(rightKeySelectorBody, leftKeySelectorBody.Type);
+            }
+
+            if (rightKeySelectorBody.Type.IsNullableValueType()
+                && leftKeySelectorBody.Type.IsValueType
+                && rightKeySelectorBody.Type.UnwrapNullableType() == leftKeySelectorBody.Type)
+            {
+                leftKeySelectorBody = Expression.Convert(leftKeySelectorBody, rightKeySelectorBody.Type);
+            }
+
+            var keySelectorTypeChanged = false;
+            var joinMethodInfo = methodCallExpression.Method;
+            var joinMethodInfoGenericArguments = methodCallExpression.Method.GetGenericArguments();
+
+            if ((leftKeySelectorBody.Type != methodCallExpression.Arguments[2].UnwrapLambdaFromQuote().Body.Type)
+                || (rightKeySelectorBody.Type != methodCallExpression.Arguments[3].UnwrapLambdaFromQuote().Body.Type))
+            {
+                joinMethodInfoGenericArguments[2] = leftKeySelectorBody.Type;
+                joinMethodInfo = joinMethodInfo.GetGenericMethodDefinition().MakeGenericMethod(joinMethodInfoGenericArguments);
+                keySelectorTypeChanged = true;
+            }
+
+            var leftKeySelector = keySelectorTypeChanged
+                ? Expression.Lambda(
+                    leftKeySelectorBody,
+                    methodCallExpression.Arguments[2].UnwrapLambdaFromQuote().Parameters)
+                : Expression.Lambda(
+                    originalLeftKeySelectorLambda.Type,
+                    leftKeySelectorBody,
+                    methodCallExpression.Arguments[2].UnwrapLambdaFromQuote().Parameters);
+
+            var rightKeySelector = keySelectorTypeChanged
+                ? Expression.Lambda(
+                    rightKeySelectorBody,
+                    methodCallExpression.Arguments[3].UnwrapLambdaFromQuote().Parameters)
+                : Expression.Lambda(
+                    originalRightKeySelectorLambda.Type,
+                    rightKeySelectorBody,
+                    methodCallExpression.Arguments[3].UnwrapLambdaFromQuote().Parameters);
+
+            return Expression.Call(
+                joinMethodInfo,
+                outer,
+                inner,
+                leftKeySelector,
+                rightKeySelector,
+                resultSelector);
+        }
+
+        private Expression RewriteStartsWithEndsWithContains(MethodCallExpression methodCallExpression)
+        {
+            // c.FirstName.StartsWith(c.Nickname)
+            // gets converted to:
+            // c.Maybe(x => x.FirstName).MaybeScalar(x => c.Maybe(xx => xx.Nickname).MaybeScalar(xx => x.StartsWith(xx)))
+            var caller = Visit(methodCallExpression.Object);
+            var argument = Visit(methodCallExpression.Arguments[0]);
+            var outerMaybeScalarMethod = _maybeScalarNullableMethod.MakeGenericMethod(typeof(string), typeof(bool));
+            var innerMaybeScalarMethod = _maybeScalarNonNullableMethod.MakeGenericMethod(typeof(string), typeof(bool));
+
+            var outerMaybeScalarLambdaParameter = Expression.Parameter(typeof(string), "x");
+            var innerMaybeScalarLambdaParameter = Expression.Parameter(typeof(string), "xx");
+            var innerMaybeScalarLambda = Expression.Lambda(
+                methodCallExpression.Update(
+                    outerMaybeScalarLambdaParameter,
+                    new[] { innerMaybeScalarLambdaParameter }),
+                innerMaybeScalarLambdaParameter);
+
+            var innerMaybeScalar = Expression.Call(
+                innerMaybeScalarMethod,
+                argument,
+                innerMaybeScalarLambda);
+
+            var outerMaybeScalarLambda = Expression.Lambda(
+                innerMaybeScalar,
+                outerMaybeScalarLambdaParameter);
+
+            var outerMaybeScalar = Expression.Call(
+                outerMaybeScalarMethod,
+                caller,
+                outerMaybeScalarLambda);
+
+            return Expression.Equal(outerMaybeScalar, Expression.Constant(true, typeof(bool?)));
+        }
+
+        private Expression TryConvertEFPropertyToMemberAccess(Expression expression)
+        {
+            if (expression is MethodCallExpression methodCallExpression
+                && Infrastructure.MethodInfoExtensions.IsEFPropertyMethod(methodCallExpression.Method))
+            {
+                var caller = RemoveConvertToObject(methodCallExpression.Arguments[0]);
+                var propertyName = (methodCallExpression.Arguments[1] as ConstantExpression)?.Value as string
+                    ?? Expression.Lambda<Func<string>>(methodCallExpression.Arguments[1]).Compile().Invoke();
+
+                if (propertyName != null)
+                {
+                    var efPropertyMemberInfoMapping = _efPropertyMemberInfoMappings
+                        .Where(m => m.Key.type == caller.Type && m.Key.name == propertyName)
+                        .Select(m => m.Value).SingleOrDefault();
+
+                    var result = default(Expression);
+                    if (efPropertyMemberInfoMapping != null)
+                    {
+                        result = caller;
+                        foreach (var targetMemberInfo in efPropertyMemberInfoMapping)
+                        {
+                            result = Expression.MakeMemberAccess(result, targetMemberInfo);
+                        }
+                    }
+                    else if (caller.Type.GetMembers().Where(m => m.Name == propertyName).SingleOrDefault() is MemberInfo matchingMember)
+                    {
+                        result = Expression.Property(caller, propertyName);
+                    }
+
+                    if (result != null)
+                    {
+                        // in case type argument on EF property overrides actual type of the member that is accessed, e.g.
+                        // EF.Property<bool>(e, "MyNullableBool")
+                        return result.Type != expression.Type
+                            ? Expression.Convert(result, expression.Type)
+                            : result;
+                    }
+                }
+
+                throw new InvalidOperationException($"Couldn't convert EF.Property() method. Caller type: '{caller.Type.Name}'. Property name: '{propertyName}'.");
+            }
+
+            return expression;
+
+            static Expression RemoveConvertToObject(Expression expression)
+                => expression is UnaryExpression unaryExpression
+                    && (expression.NodeType == ExpressionType.Convert
+                        || expression.NodeType == ExpressionType.ConvertChecked)
+                    && expression.Type == typeof(object)
+                    ? RemoveConvertToObject(unaryExpression.Operand)
+                    : expression;
+        }
+
+        private Expression AddNullProtectionForNonNullableMemberAccess(Expression expression)
+        {
+            expression = TryConvertEFPropertyToMemberAccess(expression);
+
+            if (expression is MemberExpression memberExpression
+                && (memberExpression.Type.IsValueType || memberExpression.Type.IsNullableValueType())
+                && memberExpression.Expression != null)
+            {
+                var instance = Visit(memberExpression.Expression);
+                var maybeLambdaParameter = Expression.Parameter(instance.Type, "x");
+                var maybeLambda = Expression.Lambda(memberExpression.Update(maybeLambdaParameter), maybeLambdaParameter);
+
+                var methodInfo = (memberExpression.Type.IsNullableValueType()
+                    ? _maybeScalarNullableMethod
+                    : _maybeScalarNonNullableMethod).MakeGenericMethod(
+                        instance.Type,
+                        memberExpression.Type.UnwrapNullableType());
+
+                return Expression.Call(methodInfo, instance, maybeLambda);
+            }
+
+            return Visit(expression);
+        }
+
+        protected override Expression VisitUnary(UnaryExpression unaryExpression)
+        {
+            if ((unaryExpression.NodeType == ExpressionType.Convert || unaryExpression.NodeType == ExpressionType.ConvertChecked || unaryExpression.NodeType == ExpressionType.TypeAs)
+                && unaryExpression.Operand is MemberExpression memberOperand
+                && memberOperand.Type.IsValueType
+                && !memberOperand.Type.IsNullableValueType()
+                && memberOperand.Expression != null
+                && unaryExpression.Type.IsNullableValueType()
+                && unaryExpression.Type.UnwrapNullableType() == memberOperand.Type)
+            {
+                var expression = Visit(memberOperand.Expression);
+
+                var lambdaParameter = Expression.Parameter(expression.Type, "x");
+                var lambda = Expression.Lambda(memberOperand.Update(lambdaParameter), lambdaParameter);
+                var method = _maybeScalarNonNullableMethod.MakeGenericMethod(expression.Type, memberOperand.Type);
+
+                return unaryExpression.Update(
+                    Expression.Call(method, expression, lambda));
+            }
+
+            if (unaryExpression.NodeType == ExpressionType.Not)
+            {
+                var negated = _negated;
+                _negated = true;
+                var operand = Visit(unaryExpression.Operand);
+                _negated = negated;
+
+                return unaryExpression.Update(operand);
+            }
+
+            return base.VisitUnary(unaryExpression);
+        }
+
+        protected override Expression VisitBinary(BinaryExpression binaryExpression)
+        {
+            if (binaryExpression.NodeType == ExpressionType.Equal
+                || binaryExpression.NodeType == ExpressionType.NotEqual
+                || binaryExpression.NodeType == ExpressionType.GreaterThan
+                || binaryExpression.NodeType == ExpressionType.GreaterThanOrEqual
+                || binaryExpression.NodeType == ExpressionType.LessThan
+                || binaryExpression.NodeType == ExpressionType.LessThanOrEqual)
+            {
+                var left = AddNullProtectionForNonNullableMemberAccess(binaryExpression.Left);
+                var right = AddNullProtectionForNonNullableMemberAccess(binaryExpression.Right);
+
+                if (left.Type.IsNullableValueType()
+                    && right.Type.IsValueType
+                    && left.Type.UnwrapNullableType() == right.Type)
+                {
+                    right = Expression.Convert(right, left.Type);
+                }
+
+                if (right.Type.IsNullableValueType()
+                    && left.Type.IsValueType
+                    && right.Type.UnwrapNullableType() == left.Type)
+                {
+                    left = Expression.Convert(left, right.Type);
+                }
+
+                return binaryExpression.Update(left, binaryExpression.Conversion, right);
+            }
+
+            return base.VisitBinary(binaryExpression);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private readonly Dictionary<Type, object> _entitySorters;
         private readonly Dictionary<Type, object> _entityAsserters;
         private readonly IncludeQueryResultAsserter _includeResultAsserter;
+        private readonly ExpectedQueryRewritingVisitor _expectedQueryRewritingVisitor;
 
         private const bool ProceduralQueryGeneration = false;
 
@@ -25,10 +26,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<TContext> contextCreator,
             ISetSource expectedData,
             Dictionary<Type, object> entitySorters,
-            Dictionary<Type, object> entityAsserters)
+            Dictionary<Type, object> entityAsserters,
+            ExpectedQueryRewritingVisitor expectedQueryRewritingVisitor = null)
         {
             _contextCreator = contextCreator;
             ExpectedData = expectedData;
+            _expectedQueryRewritingVisitor = expectedQueryRewritingVisitor ?? new ExpectedQueryRewritingVisitor();
             _entitySorters = entitySorters ?? new Dictionary<Type, object>();
             _entityAsserters = entityAsserters ?? new Dictionary<Type, object>();
 
@@ -41,9 +44,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         public override async Task AssertSingleResultTyped<TResult>(
-            Func<ISetSource, TResult> actualSyncQuery,
-            Func<ISetSource, Task<TResult>> actualAsyncQuery,
-            Func<ISetSource, TResult> expectedQuery,
+            Expression<Func<ISetSource, TResult>> actualSyncQuery,
+            Expression<Func<ISetSource, Task<TResult>>> actualAsyncQuery,
+            Expression<Func<ISetSource, TResult>> expectedQuery,
             Action<TResult, TResult> asserter,
             int entryCount,
             bool async,
@@ -54,27 +57,27 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             if (async)
             {
-                actual = await actualAsyncQuery(SetSourceCreator(context));
+                actual = await actualAsyncQuery.Compile()(SetSourceCreator(context));
             }
             else
             {
-                actual = actualSyncQuery(SetSourceCreator(context));
+                actual = actualSyncQuery.Compile()(SetSourceCreator(context));
             }
 
-            var expected = expectedQuery(ExpectedData);
+            var rewrittenExpectedQueryExpression = (Expression<Func<ISetSource, TResult>>)_expectedQueryRewritingVisitor.Visit(expectedQuery);
+            var expected = rewrittenExpectedQueryExpression.Compile()(ExpectedData);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
         }
 
-        private IList<TResult> GetExpectedResults<TResult>(Func<ISetSource, IQueryable<TResult>> expectedQueryFunc)
+        private IQueryable<TResult> GetExpectedResults<TResult>(Func<ISetSource, IQueryable<TResult>> expectedQueryFunc)
         {
             var expectedQuery = expectedQueryFunc(ExpectedData);
             var expectedQueryExpression = expectedQuery.Expression;
-            var rewrittenExpectedQueryExpression = new ExpectedQueryRewritingVisitor().Visit(expectedQueryExpression);
-            var newExpectedQuery = expectedQuery.Provider.CreateQuery<TResult>(rewrittenExpectedQueryExpression);
+            var rewrittenExpectedQueryExpression = _expectedQueryRewritingVisitor.Visit(expectedQueryExpression);
 
-            return newExpectedQuery.ToList();
+            return expectedQuery.Provider.CreateQuery<TResult>(rewrittenExpectedQueryExpression);
         }
 
         public override async Task AssertQuery<TResult>(
@@ -104,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             AssertRogueExecution(actual.Count, query);
 
-            var expected = GetExpectedResults(expectedQuery);
+            var expected = GetExpectedResults(expectedQuery).ToList();
 
             if (!assertOrder
                 && elementSorter == null)
@@ -174,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             AssertRogueExecution(actual.Count, query);
 
-            var expected = GetExpectedResults(expectedQuery);
+            var expected = GetExpectedResults(expectedQuery).ToList();
 
             TestHelpers.AssertResults(
                 expected,
@@ -209,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             AssertRogueExecution(actual.Count, query);
 
-            var expected = GetExpectedResults(expectedQuery);
+            var expected = GetExpectedResults(expectedQuery).ToList();
 
             TestHelpers.AssertResults(
                 expected,
@@ -247,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             AssertRogueExecution(actual.Count, query);
 
-            var expected = GetExpectedResults(expectedQuery);
+            var expected = GetExpectedResults(expectedQuery).ToList();
 
             if (!assertOrder
                 && elementSorter == null)
@@ -294,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AnyAsync()
                 : actualQuery(SetSourceCreator(context)).Any();
 
-            var expected = expectedQuery(ExpectedData).Any();
+            var expected = GetExpectedResults(expectedQuery).Any();
 
             Assert.Equal(expected, actual);
         }
@@ -312,7 +315,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     ? await actualQuery(SetSourceCreator(context)).AnyAsync(actualPredicate)
                     : actualQuery(SetSourceCreator(context)).Any(actualPredicate);
 
-                var expected = expectedQuery(ExpectedData).Any(expectedPredicate);
+                var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+                var expected = GetExpectedResults(expectedQuery).Any(rewrittenExpectedPredicate);
 
                 Assert.Equal(expected, actual);
             }
@@ -341,7 +345,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AllAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).All(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).All(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).All(rewrittenExpectedPredicate);
 
             Assert.Equal(expected, actual);
         }
@@ -358,7 +363,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).FirstAsync()
                 : actualQuery(SetSourceCreator(context)).First();
 
-            var expected = expectedQuery(ExpectedData).First();
+            var expected = GetExpectedResults(expectedQuery).First();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -367,18 +372,19 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public override async Task AssertFirst<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualFirstPredicate,
-            Expression<Func<TResult, bool>> expectedFirstPredicate,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
             Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool async = false)
         {
             using var context = _contextCreator();
             var actual = async
-                ? await actualQuery(SetSourceCreator(context)).FirstAsync(actualFirstPredicate)
-                : actualQuery(SetSourceCreator(context)).First(actualFirstPredicate);
+                ? await actualQuery(SetSourceCreator(context)).FirstAsync(actualPredicate)
+                : actualQuery(SetSourceCreator(context)).First(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).First(expectedFirstPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).First(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -396,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).FirstOrDefaultAsync()
                 : actualQuery(SetSourceCreator(context)).FirstOrDefault();
 
-            var expected = expectedQuery(ExpectedData).FirstOrDefault();
+            var expected = GetExpectedResults(expectedQuery).FirstOrDefault();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -416,7 +422,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).FirstOrDefaultAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).FirstOrDefault(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).FirstOrDefault(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).FirstOrDefault(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -434,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SingleAsync()
                 : actualQuery(SetSourceCreator(context)).Single();
 
-            var expected = expectedQuery(ExpectedData).Single();
+            var expected = GetExpectedResults(expectedQuery).Single();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -443,18 +450,19 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public override async Task AssertSingle<TResult>(
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            Expression<Func<TResult, bool>> actualFirstPredicate,
-            Expression<Func<TResult, bool>> expectedFirstPredicate,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate,
             Action<TResult, TResult> asserter = null,
             int entryCount = 0,
             bool async = false)
         {
             using var context = _contextCreator();
             var actual = async
-                ? await actualQuery(SetSourceCreator(context)).SingleAsync(actualFirstPredicate)
-                : actualQuery(SetSourceCreator(context)).Single(actualFirstPredicate);
+                ? await actualQuery(SetSourceCreator(context)).SingleAsync(actualPredicate)
+                : actualQuery(SetSourceCreator(context)).Single(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).Single(expectedFirstPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).Single(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -472,7 +480,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SingleOrDefaultAsync()
                 : actualQuery(SetSourceCreator(context)).SingleOrDefault();
 
-            var expected = expectedQuery(ExpectedData).SingleOrDefault();
+            var expected = GetExpectedResults(expectedQuery).SingleOrDefault();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -492,7 +500,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SingleOrDefaultAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).SingleOrDefault(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).SingleOrDefault(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).SingleOrDefault(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -510,7 +519,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LastAsync()
                 : actualQuery(SetSourceCreator(context)).Last();
 
-            var expected = expectedQuery(ExpectedData).Last();
+            var expected = GetExpectedResults(expectedQuery).Last();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -530,7 +539,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LastAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).Last(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).Last(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).Last(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -548,7 +558,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LastOrDefaultAsync()
                 : actualQuery(SetSourceCreator(context)).LastOrDefault();
 
-            var expected = expectedQuery(ExpectedData).LastOrDefault();
+            var expected = GetExpectedResults(expectedQuery).LastOrDefault();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -568,7 +578,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LastOrDefaultAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).LastOrDefault(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).LastOrDefault(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).LastOrDefault(rewrittenExpectedPredicate);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -584,7 +595,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).CountAsync()
                 : actualQuery(SetSourceCreator(context)).Count();
 
-            var expected = expectedQuery(ExpectedData).Count();
+            var expected = GetExpectedResults(expectedQuery).Count();
 
             Assert.Equal(expected, actual);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -602,7 +613,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).CountAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).Count(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).Count(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).Count(rewrittenExpectedPredicate);
 
             Assert.Equal(expected, actual);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -618,7 +630,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LongCountAsync()
                 : actualQuery(SetSourceCreator(context)).LongCount();
 
-            var expected = expectedQuery(ExpectedData).LongCount();
+            var expected = GetExpectedResults(expectedQuery).LongCount();
 
             Assert.Equal(expected, actual);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -636,7 +648,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).LongCountAsync(actualPredicate)
                 : actualQuery(SetSourceCreator(context)).LongCount(actualPredicate);
 
-            var expected = expectedQuery(ExpectedData).LongCount(expectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = GetExpectedResults(expectedQuery).LongCount(rewrittenExpectedPredicate);
 
             Assert.Equal(expected, actual);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -654,7 +667,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).MinAsync()
                 : actualQuery(SetSourceCreator(context)).Min();
 
-            var expected = expectedQuery(ExpectedData).Min();
+            var expected = GetExpectedResults(expectedQuery).Min();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -674,7 +687,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).MinAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Min(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Min(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, TSelector>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Min(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -692,7 +706,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).MaxAsync()
                 : actualQuery(SetSourceCreator(context)).Max();
 
-            var expected = expectedQuery(ExpectedData).Max();
+            var expected = GetExpectedResults(expectedQuery).Max();
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -712,7 +726,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).MaxAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Max(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Max(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, TSelector>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Max(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
@@ -729,7 +744,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -746,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -763,7 +778,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -780,7 +795,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -797,7 +812,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -814,7 +829,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -831,7 +846,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -848,7 +863,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -865,7 +880,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -882,7 +897,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync()
                 : actualQuery(SetSourceCreator(context)).Sum();
 
-            var expected = expectedQuery(ExpectedData).Sum();
+            var expected = GetExpectedResults(expectedQuery).Sum();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -901,7 +916,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, int>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -920,7 +936,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, int?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -939,7 +956,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, long>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -958,7 +976,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, long?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -977,7 +996,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, decimal>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -996,7 +1016,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, decimal?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1015,7 +1036,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, float>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1034,7 +1056,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, float?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1053,7 +1076,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, double>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1072,7 +1096,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).SumAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Sum(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Sum(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, double?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Sum(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1089,7 +1114,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1106,7 +1131,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1123,7 +1148,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1140,7 +1165,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1157,7 +1182,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1174,7 +1199,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1191,7 +1216,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1208,7 +1233,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1225,7 +1250,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1242,7 +1267,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync()
                 : actualQuery(SetSourceCreator(context)).Average();
 
-            var expected = expectedQuery(ExpectedData).Average();
+            var expected = GetExpectedResults(expectedQuery).Average();
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1261,7 +1286,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, int>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1280,7 +1306,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, int?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1299,7 +1326,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, long>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1318,7 +1346,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, long?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1337,7 +1366,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, decimal>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1356,7 +1386,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, decimal?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1375,7 +1406,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, float>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1394,7 +1426,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, float?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1413,7 +1446,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, double>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());
@@ -1432,7 +1466,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ? await actualQuery(SetSourceCreator(context)).AverageAsync(actualSelector)
                 : actualQuery(SetSourceCreator(context)).Average(actualSelector);
 
-            var expected = expectedQuery(ExpectedData).Average(expectedSelector);
+            var rewrittenExpectedSelector = (Expression<Func<TResult, double?>>)new ExpectedQueryRewritingVisitor().Visit(expectedSelector);
+            var expected = GetExpectedResults(expectedQuery).Average(rewrittenExpectedSelector);
 
             AssertEqual(expected, actual, asserter);
             Assert.Empty(context.ChangeTracker.Entries());

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -16,9 +16,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public virtual ISetSource ExpectedData { get; set; }
 
         public abstract Task AssertSingleResultTyped<TResult>(
-            Func<ISetSource, TResult> actualSyncQuery,
-            Func<ISetSource, Task<TResult>> actualAsyncQuery,
-            Func<ISetSource, TResult> expectedQuery,
+            Expression<Func<ISetSource, TResult>> actualSyncQuery,
+            Expression<Func<ISetSource, Task<TResult>>> actualAsyncQuery,
+            Expression<Func<ISetSource, TResult>> expectedQuery,
             Action<TResult, TResult> asserter,
             int entryCount,
             bool async,


### PR DESCRIPTION
- converting EF.Property to member access,
- adding complex EF.Property rewrite, e.g. EF.Property(entity, "CustomerId") -> entity.Customer.Id
- adding null safety to non-nullable member access in Join/GroupJoin key selectors,
- adding null safety to non-nullable member access in binary,
- adding null safety to non-nullable member access wrapped in cast to nullable,
- adding null safety to member access returning bool,
- adding null safety for string related methods: StartsWith, EndsWith, Contains,
- adding expected query rewrite for methods returning a single element.

Resolves #19900