### PR TITLE
#18132 Added regression tests for concatenating int and strings together

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -3514,6 +3514,43 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Concat_string_int(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Order>().Select(o => o.OrderID + o.CustomerID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Concat_int_string(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Order>().Select(o => o.CustomerID + o.OrderID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Concat_parameter_string_int(bool isAsync)
+        {
+            var parameter = "-";
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Order>().Select(o => parameter + o.OrderID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Concat_constant_string_int(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Order>().Select(o => "-" + o.OrderID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task String_concat_with_navigation1(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -2768,6 +2768,44 @@ FROM [Customers] AS [c]
 WHERE (@__NewLine_0 = N'') OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
         }
 
+        public override async Task Concat_string_int(bool async)
+        {
+            await base.Concat_string_int(async);
+
+            AssertSql(
+                @"SELECT CAST([o].[OrderID] AS nchar(5)) + [o].[CustomerID]
+FROM [Orders] AS [o]");
+        }
+
+        public override async Task Concat_int_string(bool async)
+        {
+            await base.Concat_int_string(async);
+
+            AssertSql(
+                @"SELECT COALESCE([o].[CustomerID], N'') + CAST([o].[OrderID] AS nchar(5))
+FROM [Orders] AS [o]");
+        }
+
+        public override async Task Concat_parameter_string_int(bool async)
+        {
+            await base.Concat_parameter_string_int(async);
+
+            AssertSql(
+                @"@__parameter_0='-' (Size = 4000)
+
+SELECT @__parameter_0 + CAST([o].[OrderID] AS nvarchar(max))
+FROM [Orders] AS [o]");
+        }
+
+        public override async Task Concat_constant_string_int(bool async)
+        {
+            await base.Concat_constant_string_int(async);
+
+            AssertSql(
+                @"SELECT N'-' + CAST([o].[OrderID] AS nvarchar(max))
+FROM [Orders] AS [o]");
+        }
+
         public override async Task String_concat_with_navigation1(bool async)
         {
             await base.String_concat_with_navigation1(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -242,6 +242,41 @@ FROM (
 
         public override Task AsQueryable_in_query_server_evals(bool async) => null;
 
+        [ConditionalTheory(Skip = "Issue #19990")]
+        public override async Task Concat_string_int(bool async)
+        {
+            await base.Concat_string_int(async);
+        }
+
+        public override async Task Concat_int_string(bool async)
+        {
+            await base.Concat_int_string(async);
+
+            AssertSql(
+                @"SELECT COALESCE(""o"".""CustomerID"", '') || CAST(""o"".""OrderID"" AS TEXT)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override async Task Concat_parameter_string_int(bool async)
+        {
+            await base.Concat_parameter_string_int(async);
+
+            AssertSql(
+                @"@__parameter_0='-' (Size = 1)
+
+SELECT @__parameter_0 || CAST(""o"".""OrderID"" AS TEXT)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override async Task Concat_constant_string_int(bool async)
+        {
+            await base.Concat_constant_string_int(async);
+
+            AssertSql(
+                @"SELECT '-' || CAST(""o"".""OrderID"" AS TEXT)
+FROM ""Orders"" AS ""o""");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Summary of the changes
  - Added regression test to verify concatenating int and strings together doesn't fail with "Null TypeMapping in Sql Tree"
  - I rolled the code back to the 3.1 release branch and verified the tests failed on that branch.

Fixes #18132