### PR TITLE
Adding a BackingField attribute

### DIFF
--- a/src/EFCore.Abstractions/BackingFieldAttribute.cs
+++ b/src/EFCore.Abstractions/BackingFieldAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Initializes a new instance of the <see cref="BackingFieldAttribute" /> class.
         /// </summary>
-        /// <param name="name">The name of the backing field.</param>
+        /// <param name="name"> The name of the backing field. </param>
         public BackingFieldAttribute([NotNull] string name)
         {
             Check.NotEmpty(name, nameof(name));

--- a/src/EFCore.Abstractions/BackingFieldAttribute.cs
+++ b/src/EFCore.Abstractions/BackingFieldAttribute.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Names the backing field associated with this property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class BackingFieldAttribute : Attribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BackingFieldAttribute" /> class.
+        /// </summary>
+        /// <param name="name">The name of the backing field.</param>
+        public BackingFieldAttribute([NotNull] string name)
+        {
+            Check.NotEmpty(name, nameof(name));
+
+            Name = name;
+        }
+
+        /// <summary>
+        ///     The name of the backing field.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/BackingFieldAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/BackingFieldAttributeConvention.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures a property as having a backing field
+    ///     based on the <see cref="BackingFieldAttribute"/> attribute.
+    /// </summary>
+    public class BackingFieldAttributeConvention : PropertyAttributeConventionBase<BackingFieldAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="BackingFieldAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public BackingFieldAttributeConvention([NotNull] ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after a property is added to the entity type with an attribute on the associated CLR property or field.
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property. </param>
+        /// <param name="attribute"> The attribute. </param>
+        /// <param name="clrMember"> The member that has the attribute. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        protected override void ProcessPropertyAdded(
+            IConventionPropertyBuilder propertyBuilder,
+            BackingFieldAttribute attribute,
+            MemberInfo clrMember,
+            IConventionContext context)
+        {
+            propertyBuilder.HasField(attribute.Name, fromDataAnnotation: true);
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -109,6 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var maxLengthAttributeConvention = new MaxLengthAttributeConvention(Dependencies);
             var stringLengthAttributeConvention = new StringLengthAttributeConvention(Dependencies);
             var timestampAttributeConvention = new TimestampAttributeConvention(Dependencies);
+            var backingFieldAttributeConvention = new BackingFieldAttributeConvention(Dependencies);
 
             conventionSet.PropertyAddedConventions.Add(backingFieldConvention);
             conventionSet.PropertyAddedConventions.Add(concurrencyCheckAttributeConvention);
@@ -118,6 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyAddedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(timestampAttributeConvention);
+            conventionSet.PropertyAddedConventions.Add(backingFieldAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
@@ -210,6 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyFieldChangedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(timestampAttributeConvention);
+            conventionSet.PropertyFieldChangedConventions.Add(backingFieldAttributeConvention);
 
             return conventionSet;
         }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -212,7 +212,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyFieldChangedConventions.Add(maxLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(stringLengthAttributeConvention);
             conventionSet.PropertyFieldChangedConventions.Add(timestampAttributeConvention);
-            conventionSet.PropertyFieldChangedConventions.Add(backingFieldAttributeConvention);
 
             return conventionSet;
         }


### PR DESCRIPTION
Fixes #6266. Adding a `BackingField` attribute which does the same as the `HasField()` fluent API.

