### PR TITLE
[release/3.1] Fix dotnet-ef RuntimeFrameworkVersion

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
     <!-- Use the latest version instead of the one bundled with the SDK -->
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
       <LatestRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</LatestRuntimeFrameworkVersion>
-      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
+      <DefaultRuntimeFrameworkVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' And '$(TargetLatestDotNetRuntime)' != 'false'">$(MicrosoftNETCoreAppRuntimeVersion)</DefaultRuntimeFrameworkVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
     <KnownFrameworkReference Update="NETStandard.Library">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,7 @@
     <VersionPrefix>3.1.3</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+    <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->


### PR DESCRIPTION
### Description

The dotnet-ef global tool was built incorrectly:
* dotnet-ef 3.1.2 depends on runtime 3.1.2
* This fails on any machine with just 3.1 on it. This includes when the web tools try to load dotnet-ef from within VS.
* It should depend on 3.1.0

### Customer Impact

This will break common VS scenarios as well as people who install the latest tool on the command line.

### How found

CTI validation using VS following the patch release, and also customer-reported on the command line.

### Test coverage

We have done manual validation on the new PR and will validate again once it is in the build.

Going forward we need to make sure that we can reproduce this in the CTI validation _before_ the new packages are pushed to NuGet.

Also, since we knew about this before and thought it was fixed we will investigate what happened in the process that allowed this.

### Regression?

Yes, from 3.0.

### Risk

Low.

---

We had some dead code in the project files: (I'm not exactly sure what happened, but it looks like it broke while migrating to Arcade.)
``` xml
<!--
    This keeps dotnet-ef targeting the default version of .NET Core for netcoreapp3.1,
    which maximizes the machines on which this tool will be compatible.
-->
<TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
```

Fixes errors like:

> It was not possible to find any compatible framework version 
> The framework 'Microsoft.NETCore.App', version '3.1.2' was not found.

Verification:

Installed a local 3.1.3 build of dotnet-ef with only runtime 3.1.1 available and it worked where dotnet-ef 3.1.2 failed. Also verified that the runtimeconfig contains 3.1.0 instead of the latest patch version.

Fixes #20005