### PR TITLE
Fix to #19825 - Query: incorrectly generating JOIN rather than APPLY for subqueries with outside references to a joined table

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -938,7 +938,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             }
 
             var joinPredicate = TryExtractJoinKey(innerSelectExpression);
-            var containsOuterReference = new SelectExpressionCorrelationFindingExpressionVisitor(Tables)
+            var containsOuterReference = new SelectExpressionCorrelationFindingExpressionVisitor(this)
                 .ContainsOuterReference(innerSelectExpression);
             if (containsOuterReference && joinPredicate != null)
             {
@@ -1226,12 +1226,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         private sealed class SelectExpressionCorrelationFindingExpressionVisitor : ExpressionVisitor
         {
-            private readonly IReadOnlyList<TableExpressionBase> _tables;
+            private readonly SelectExpression _outerSelectExpression;
             private bool _containsOuterReference;
 
-            public SelectExpressionCorrelationFindingExpressionVisitor(IReadOnlyList<TableExpressionBase> tables)
+            public SelectExpressionCorrelationFindingExpressionVisitor(SelectExpression outerSelectExpression)
             {
-                _tables = tables;
+                _outerSelectExpression = outerSelectExpression;
             }
 
             public bool ContainsOuterReference(SelectExpression selectExpression)
@@ -1251,7 +1251,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 }
 
                 if (expression is ColumnExpression columnExpression
-                    && _tables.Contains(columnExpression.Table))
+                    && _outerSelectExpression.ContainsTableReference(columnExpression.Table))
                 {
                     _containsOuterReference = true;
 
@@ -1304,7 +1304,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 joinPredicate = TryExtractJoinKey(innerSelectExpression);
                 if (joinPredicate != null)
                 {
-                    var containsOuterReference = new SelectExpressionCorrelationFindingExpressionVisitor(Tables)
+                    var containsOuterReference = new SelectExpressionCorrelationFindingExpressionVisitor(this)
                         .ContainsOuterReference(innerSelectExpression);
                     if (containsOuterReference)
                     {

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
@@ -71,5 +71,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Select_subquery_single_nested_subquery2(async);
         }
+
+        [ConditionalTheory(Skip = "issue #19967")]
+        public override Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async)
+        {
+            return base.SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(async);
+        }
+
+        [ConditionalTheory(Skip = "issue #19967")]
+        public override Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async)
+        {
+            return base.Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(async);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4398,6 +4398,31 @@ LEFT JOIN (
 ORDER BY [l].[Id], [t1].[Id], [t1].[Id0]");
         }
 
+        public override async Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async)
+        {
+            await base.SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+FROM [LevelOne] AS [l]
+INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
+INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
+INNER JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
+OUTER APPLY (
+    SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id]
+    FROM [LevelOne] AS [l3]
+    WHERE ([l3].[Id] <= [l0].[Id]) AND (([l2].[Name] = [l3].[Name]) OR ([l2].[Name] IS NULL AND [l3].[Name] IS NULL))
+) AS [t]");
+        }
+
+        public override async Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async)
+        {
+            await base.Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(async);
+
+            AssertSql(
+                @"");
+        }
+
         private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -30,5 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Include_inside_subquery(async);
         }
+
+        // Sqlite does not support cross/outer apply
+        public override Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async) => null;
+        public override Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async) => null;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
@@ -25,5 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Project_collection_navigation_nested_with_take(async);
         }
+
+        // Sqlite does not support cross/outer apply
+        public override Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async) => null;
+        public override Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async) => null;
     }
 }


### PR DESCRIPTION
During translation, when we decide whether we can apply JOIN or APPLY we visit inner SelectExpression looking for references to tables in the outer SelectExpression.
Problem was that we were using Contains method, which would not match cases where the outer table was in the form of JoinExpressionBase.
Fix is to use ContainsTableReference method which matches different types of tables.

Resolves #19825 