### PR TITLE
Introduce KeylessAttribute

### DIFF
--- a/src/EFCore.Abstractions/KeylessAttribute.cs
+++ b/src/EFCore.Abstractions/KeylessAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Marks a type as keyless entity.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class KeylessAttribute : Attribute
+    {
+    }
+}

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -457,9 +457,12 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             if (key == null)
             {
-                var line = new List<string> { $".{nameof(EntityTypeBuilder.HasNoKey)}()" };
+                if (!useDataAnnotations)
+                {
+                    var line = new List<string> { $".{nameof(EntityTypeBuilder.HasNoKey)}()" };
 
-                AppendMultiLineFluentApi(entityType, line);
+                    AppendMultiLineFluentApi(entityType, line);
+                }
 
                 return;
             }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -66,6 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 _sb.AppendLine("using System.ComponentModel.DataAnnotations;");
                 _sb.AppendLine("using System.ComponentModel.DataAnnotations.Schema;");
+                _sb.AppendLine("using Microsoft.EntityFrameworkCore;"); // For attributes coming out of Abstractions
             }
 
             foreach (var ns in entityType.GetProperties()
@@ -132,7 +133,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(entityType, nameof(entityType));
 
+            GenerateKeylessAttribute(entityType);
             GenerateTableAttribute(entityType);
+        }
+
+        private void GenerateKeylessAttribute(IEntityType entityType)
+        {
+            if (entityType.FindPrimaryKey() == null)
+            {
+                _sb.AppendLine(new AttributeWriter(nameof(KeylessAttribute)));
+            }
         }
 
         private void GenerateTableAttribute(IEntityType entityType)
@@ -156,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     tableAttribute.AddParameter($"{nameof(TableAttribute.Schema)} = {_code.Literal(schema)}");
                 }
 
-                _sb.AppendLine(tableAttribute.ToString());
+                _sb.AppendLine(tableAttribute);
             }
         }
 
@@ -278,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                 lengthAttribute.AddParameter(_code.Literal(maxLength.Value));
 
-                _sb.AppendLine(lengthAttribute.ToString());
+                _sb.AppendLine(lengthAttribute);
             }
         }
 
@@ -288,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 && property.ClrType.IsNullableType()
                 && !property.IsPrimaryKey())
             {
-                _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)).ToString());
+                _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)));
             }
         }
 
@@ -351,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
                     }
 
-                    _sb.AppendLine(foreignKeyAttribute.ToString());
+                    _sb.AppendLine(foreignKeyAttribute);
                 }
             }
         }
@@ -372,7 +382,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
                             : _code.Literal(inverseNavigation.Name));
 
-                    _sb.AppendLine(inversePropertyAttribute.ToString());
+                    _sb.AppendLine(inversePropertyAttribute);
                 }
             }
         }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -64,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
 
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(Dependencies));
+            conventionSet.EntityTypeAddedConventions.Add(new KeylessEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new BaseTypeDiscoveryConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/KeylessEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeylessEntityTypeAttributeConvention.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that ignores entity types that have the <see cref="KeylessAttribute" />.
+    /// </summary>
+    public class KeylessEntityTypeAttributeConvention : EntityTypeAttributeConventionBase<KeylessAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="KeylessEntityTypeAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public KeylessEntityTypeAttributeConvention([NotNull] ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after an entity type is added to the model if it has an attribute.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="attribute"> The attribute. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        protected override void ProcessEntityTypeAdded(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            KeylessAttribute attribute,
+            IConventionContext<IConventionEntityTypeBuilder> context)
+        {
+            entityTypeBuilder.HasNoKey(fromDataAnnotation: true);
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -37,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
@@ -58,7 +59,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code);
+                        postFile.Code, ignoreLineEndingDifferences: true);
                 },
                 model =>
                 {
@@ -97,6 +98,7 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
@@ -112,7 +114,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code);
+                        postFile.Code, ignoreLineEndingDifferences: true);
                 },
                 model =>
                 {
@@ -152,6 +154,7 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
@@ -167,7 +170,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code);
+                        postFile.Code, ignoreLineEndingDifferences: true);
                 },
                 model =>
                 {
@@ -208,6 +211,7 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
@@ -227,7 +231,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code);
+                        postFile.Code, ignoreLineEndingDifferences: true);
                 },
                 model =>
                 {
@@ -275,6 +279,7 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace TestNamespace
 {
@@ -287,7 +292,7 @@ namespace TestNamespace
     }
 }
 ",
-                        postFile.Code);
+                        postFile.Code, ignoreLineEndingDifferences: true);
                 },
                 model =>
                 {
@@ -302,14 +307,104 @@ namespace TestNamespace
             Test(
                 modelBuilder => modelBuilder.Entity("Vista").ToView("Vistas", "dbo"),
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code => Assert.DoesNotContain(
-                    "[Table(",
-                    code.AdditionalFiles.First(f => f.Path == "Vista.cs").Code),
+                code =>
+                {
+                    var vistaFile = code.AdditionalFiles.First(f => f.Path == "Vista.cs");
+                    Assert.Equal(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace TestNamespace
+{
+    [Keyless]
+    public partial class Vista
+    {
+    }
+}
+",
+                        vistaFile.Code, ignoreLineEndingDifferences: true);
+                },
                 model =>
                 {
                     var entityType = model.FindEntityType("TestNamespace.Vista");
                     Assert.Equal("Vistas", entityType.GetTableName());
                     Assert.Equal("dbo", entityType.GetSchema());
+                });
+        }
+
+        [ConditionalFact]
+        public void Keyless_entity_generates_KeylesssAttribute()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Vista").HasNoKey(),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    var vistaFile = code.AdditionalFiles.First(f => f.Path == "Vista.cs");
+                    Assert.Equal(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace TestNamespace
+{
+    [Keyless]
+    public partial class Vista
+    {
+    }
+}
+",
+                        vistaFile.Code, ignoreLineEndingDifferences: true);
+
+                    Assert.Equal(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Vista> Vista { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile.Code, ignoreLineEndingDifferences: true);
+                },
+                model =>
+                {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+                    Assert.Null(entityType.FindPrimaryKey());
                 });
         }
     }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -49,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 References =
                 {
+                    BuildReference.ByName("Microsoft.EntityFrameworkCore.Abstractions"),
                     BuildReference.ByName("Microsoft.EntityFrameworkCore"),
                     BuildReference.ByName("Microsoft.EntityFrameworkCore.Relational"),
                     BuildReference.ByName("Microsoft.EntityFrameworkCore.SqlServer")

--- a/test/EFCore.Tests/Metadata/Conventions/EntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityTypeAttributeConventionTest.cs
@@ -1,7 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -54,11 +59,90 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         #endregion
 
+        #region OwnedAttribute
+
+        [ConditionalFact]
+        public void OwnedAttribute_configures_entity_as_owned()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            modelBuilder.Entity<Customer>();
+
+            Assert.Equal(2, modelBuilder.Model.GetEntityTypes().Count());
+            Assert.True(modelBuilder.Model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Address)).ForeignKey.IsOwnership);
+        }
+
+        [ConditionalFact]
+        public void Entity_marked_with_OwnedAttribute_cannot_be_configured_as_regular_entity()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            Assert.Equal(
+                CoreStrings.ClashingOwnedEntityType(nameof(Address)),
+                Assert.Throws<InvalidOperationException>(
+                    () => modelBuilder.Entity<Customer>().HasOne(e => e.Address).WithOne(e => e.Customer)).Message);
+        }
+
+        #endregion
+
+        #region KeylessAttribute
+
+        [ConditionalFact]
+        public void KeylessAttribute_overrides_configuration_from_convention()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+
+            var entityBuilder = modelBuilder.Entity(typeof(KeylessEntity), ConfigurationSource.Convention);
+            entityBuilder.Property("Id", ConfigurationSource.Convention);
+            entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
+
+            Assert.NotNull(entityBuilder.Metadata.FindPrimaryKey());
+
+            RunConvention(entityBuilder);
+
+            Assert.Null(entityBuilder.Metadata.FindPrimaryKey());
+            Assert.True(entityBuilder.Metadata.IsKeyless);
+        }
+
+        [ConditionalFact]
+        public void KeylessAttribute_can_be_overriden_using_explicit_configuration()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            var entityBuilder = modelBuilder.Entity<KeylessEntity>();
+
+            Assert.True(entityBuilder.Metadata.IsKeyless);
+
+            entityBuilder.HasKey(e => e.Id);
+
+            Assert.False(entityBuilder.Metadata.IsKeyless);
+            Assert.NotNull(entityBuilder.Metadata.FindPrimaryKey());
+        }
+
+        [ConditionalFact]
+        public void KeyAttribute_overrides_keyless_attribute()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            var entityBuilder = modelBuilder.Entity<KeyClash>();
+
+            Assert.False(entityBuilder.Metadata.IsKeyless);
+            Assert.NotNull(entityBuilder.Metadata.FindPrimaryKey());
+        }
+
+        #endregion
+
         private void RunConvention(InternalEntityTypeBuilder entityTypeBuilder)
         {
             var context = new ConventionContext<IConventionEntityTypeBuilder>(entityTypeBuilder.Metadata.Model.ConventionDispatcher);
 
             new NotMappedEntityTypeAttributeConvention(CreateDependencies())
+                .ProcessEntityTypeAdded(entityTypeBuilder, context);
+
+            new OwnedEntityTypeAttributeConvention(CreateDependencies())
+                .ProcessEntityTypeAdded(entityTypeBuilder, context);
+
+            new KeylessEntityTypeAttributeConvention(CreateDependencies())
                 .ProcessEntityTypeAdded(entityTypeBuilder, context);
         }
 
@@ -78,6 +162,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public int Id { get; set; }
 
             public virtual A NavToA { get; set; }
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public Address Address { get; set; }
+        }
+
+        [Owned]
+        private class Address
+        {
+            public int Id { get; set; }
+            public Customer Customer { get; set; }
+        }
+
+        [Keyless]
+        private class KeylessEntity
+        {
+            public int Id { get; set; }
+        }
+
+        [Keyless]
+        private class KeyClash
+        {
+            [Key]
+            public int MyId { get; set; }
         }
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
@@ -509,6 +509,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.True(entityTypeBuilder.Property<byte[]>(nameof(F.Timestamp)).Metadata.IsConcurrencyToken);
         }
 
+        #endregion
+
+        #region BackingFieldAttribute
+
         [ConditionalFact]
         public void BackingFieldAttribute_overrides_configuration_from_convention_source()
         {
@@ -574,13 +578,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             new DatabaseGeneratedAttributeConvention(dependencies)
                 .ProcessPropertyAdded(propertyBuilder, context);
 
-            new KeyAttributeConvention(dependencies)
+            new RequiredPropertyAttributeConvention(dependencies)
                 .ProcessPropertyAdded(propertyBuilder, context);
 
             new MaxLengthAttributeConvention(dependencies)
-                .ProcessPropertyAdded(propertyBuilder, context);
-
-            new RequiredPropertyAttributeConvention(dependencies)
                 .ProcessPropertyAdded(propertyBuilder, context);
 
             new StringLengthAttributeConvention(dependencies)
@@ -590,6 +591,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .ProcessPropertyAdded(propertyBuilder, context);
 
             new BackingFieldAttributeConvention(dependencies)
+                .ProcessPropertyAdded(propertyBuilder, context);
+
+            new KeyAttributeConvention(dependencies)
                 .ProcessPropertyAdded(propertyBuilder, context);
         }
 


### PR DESCRIPTION
Resolves #19246
Also related #19964

- Add KeylessAttribute in Abstractions packge
- Add convention to detect KeylessAttribute and configure the entityType to be keyless
- Scaffolding when using data annotations
  - Generate KeylessAttribute over entity class
  - Skip HasNoKey from fluent API configuration

Tests:
- Add tests for OwnedAttribute
- Add tests for KeylessAttribute
- Add test for scaffolding to verify behavior with data annotations