### PR TITLE
[release/3.1] Query: Match memberInfo in hierarchy for reducing MemberInitExpression

### DIFF
--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -109,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (innerExpression is MemberInitExpression memberInitExpression
                 && memberInitExpression.Bindings.SingleOrDefault(
-                    mb => mb.Member == memberExpression.Member) is MemberAssignment memberAssignment)
+                    mb => mb.Member.IsSameAs(memberExpression.Member)) is MemberAssignment memberAssignment)
             {
                 return memberAssignment.Expression;
             }

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -31,16 +31,5 @@ namespace System.Reflection
             var index = name.LastIndexOf('.');
             return index >= 0 ? name.Substring(index + 1) : name;
         }
-
-        private class MemberInfoComparer : IEqualityComparer<MemberInfo>
-        {
-            public static readonly MemberInfoComparer Instance = new MemberInfoComparer();
-
-            public bool Equals(MemberInfo x, MemberInfo y)
-                => x.IsSameAs(y);
-
-            public int GetHashCode(MemberInfo obj)
-                => obj.GetHashCode();
-        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -502,6 +502,17 @@ FROM (
 WHERE CAST(0 AS bit) = CAST(1 AS bit)");
         }
 
+        public override void Member_access_on_intermediate_type_works()
+        {
+            base.Member_access_on_intermediate_type_works();
+
+            AssertSql(
+                @"SELECT [a].[Name]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = N'Kiwi'
+ORDER BY [a].[Name]");
+        }
+
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 


### PR DESCRIPTION
**Description**
Issue: For compiler generated trees the MemberInfos always in sync. But for manually generated trees, if derived type parameter is used then the MemberInfo.ReflectedType is different. Which throws off ReplacingExpressionVisitor when comparing MemberInfo.
Fix: Use helper method IsSameAs which compare memberInfos which refer to same member access in given hierarchy

Resolves #19087

**Customer Impact**
In dynamic query generation if hierarchies are involved then it could throw translation failure error. It is hard to figure out the root cause for such cases.

**How found**
Multiple customer reported.

**Test coverage**
We have added test to cover this scenario.

**Regression?**
Yes, from 2.x

**Risk**
Low.