### PR TITLE
[release/3.1] Microsoft.Data.Sqlite: Set temp and data directory on UWP

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Properties/Microsoft.Data.Sqlite.rd.xml
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Microsoft.Data.Sqlite.rd.xml
@@ -1,0 +1,10 @@
+<!--
+    This file contains Runtime Directives used by .NET Native.
+-->
+
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library>
+    <Type Name="Windows.Storage.ApplicationData" Dynamic="Required All" />
+    <Type Name="Windows.Storage.StorageFolder" Dynamic="Required All" />
+  </Library>
+</Directives>

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Data.Sqlite.Utilities
+{
+    internal class ApplicationDataHelper
+    {
+        private static object _appData;
+        private static string _localFolder;
+        private static string _tempFolder;
+
+        public static object CurrentApplicationData
+            => _appData ??= LoadAppData();
+
+        public static string TemporaryFolderPath
+            => _tempFolder ??= GetFolderPath("TemporaryFolder");
+
+        public static string LocalFolderPath
+            => _localFolder ??= GetFolderPath("LocalFolder");
+
+        private static object LoadAppData()
+        {
+            try
+            {
+                return Type.GetType("Windows.Storage.ApplicationData, Windows, ContentType=WindowsRuntime")
+                    ?.GetRuntimeProperty("Current").GetValue(null);
+            }
+            catch
+            {
+                // Ignore "The process has no package identity."
+                return null;
+            }
+        }
+
+        private static string GetFolderPath(string propertyName)
+        {
+            var appDataType = CurrentApplicationData?.GetType();
+            var temporaryFolder = appDataType?.GetRuntimeProperty(propertyName).GetValue(CurrentApplicationData);
+
+            return temporaryFolder?.GetType().GetRuntimeProperty("Path").GetValue(temporaryFolder) as string;
+        }
+    }
+}

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
@@ -1,26 +1,48 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Reflection;
+
+using static SQLitePCL.raw;
 
 namespace Microsoft.Data.Sqlite.Utilities
 {
     internal static class BundleInitializer
     {
+        private const int SQLITE_WIN32_DATA_DIRECTORY_TYPE = 1;
+        private const int SQLITE_WIN32_TEMP_DIRECTORY_TYPE = 2;
+
         public static void Initialize()
         {
-            Assembly assembly;
+            Assembly assembly = null;
             try
             {
                 assembly = Assembly.Load(new AssemblyName("SQLitePCLRaw.batteries_v2"));
             }
             catch
             {
-                return;
             }
 
-            assembly.GetType("SQLitePCL.Batteries_V2").GetTypeInfo().GetDeclaredMethod("Init")
-                .Invoke(null, null);
+            if (assembly != null)
+            {
+                assembly.GetType("SQLitePCL.Batteries_V2").GetTypeInfo().GetDeclaredMethod("Init")
+                    .Invoke(null, null);
+            }
+
+            if ((!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue19754", out var isEnabled) || !isEnabled)
+                && ApplicationDataHelper.CurrentApplicationData != null)
+            {
+                var rc = sqlite3_win32_set_directory(
+                    SQLITE_WIN32_DATA_DIRECTORY_TYPE,
+                    ApplicationDataHelper.LocalFolderPath);
+                SqliteException.ThrowExceptionForRC(rc, db: null);
+
+                rc = sqlite3_win32_set_directory(
+                    SQLITE_WIN32_TEMP_DIRECTORY_TYPE,
+                    ApplicationDataHelper.TemporaryFolderPath);
+                SqliteException.ThrowExceptionForRC(rc, db: null);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #19754

### Description

The native SQLite interop library we depend on (SQLitePCL.raw) made a breaking change to stop setting the temp and data directories on UWP. Our guidance was for users to manually set these in their application. If users don't set these and specify a relative database file in their connection string, they'll get a SQLite error:

> unable to open database file

### Customer Impact

Several customers are encountering the error without understanding why or how to fix it.

By reintroducing code to set these directories automatically for the user, it will lower the barrier to get started using Microsoft.Data.Sqlite and EF Core on UWP.

### How found

Reported by multiple customers.

### Test coverage

Manually verified that this works on UWP using both the version of SQLite that we include and winsqlite3.dll. Also verified that it works on .NET Native.

### Regression?

Yes, from 2.2 to 3.0

### Risk

Low. This is a no-op on all platforms besides UWP. There is a flag to disable the new behavior if it proves to be problematic.