### PR TITLE
Query: Introduce custom query roots

### DIFF
--- a/src/EFCore.Relational/Query/IFromSqlQueryable.cs
+++ b/src/EFCore.Relational/Query/IFromSqlQueryable.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    /// <summary>
+    ///     An interface to identify FromSql query roots in LINQ.
+    /// </summary>
+    public interface IFromSqlQueryable : IEntityQueryable
+    {
+        /// <summary>
+        ///     Return Sql used to get data for this query root.
+        /// </summary>
+        string Sql { get; }
+
+        /// <summary>
+        ///     Return arguments for the Sql.
+        /// </summary>
+        Expression Argument { get; }
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/CustomQueryableInjectingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CustomQueryableInjectingExpressionVisitor.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class CustomQueryableInjectingExpressionVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.DeclaringType == typeof(RelationalQueryableExtensions)
+                && methodCallExpression.Method.Name == nameof(RelationalQueryableExtensions.FromSqlOnQueryable))
+            {
+                var sql = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+                var entityType = ((IEntityQueryable)((ConstantExpression)methodCallExpression.Arguments[0]).Value).EntityType;
+
+                return CreateFromSqlQueryableExpression(entityType, sql, methodCallExpression.Arguments[2]);
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        private static ConstantExpression CreateFromSqlQueryableExpression(IEntityType entityType, string sql, Expression argument)
+        {
+            return Expression.Constant(
+                _createFromSqlQueryableMethod
+                    .MakeGenericMethod(entityType.ClrType)
+                    .Invoke(
+                        null, new object[] { NullAsyncQueryProvider.Instance, entityType, sql, argument }));
+        }
+
+        private static readonly MethodInfo _createFromSqlQueryableMethod
+            = typeof(CustomQueryableInjectingExpressionVisitor)
+                .GetTypeInfo().GetDeclaredMethod(nameof(CreateFromSqlQueryable));
+
+        [UsedImplicitly]
+        private static FromSqlQueryable<TResult> CreateFromSqlQueryable<TResult>(
+            IAsyncQueryProvider entityQueryProvider, IEntityType entityType, string sql, Expression argument)
+            => new FromSqlQueryable<TResult>(entityQueryProvider, entityType, sql, argument);
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryable`.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryable`.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class FromSqlQueryable<TResult> : EntityQueryable<TResult>, IFromSqlQueryable
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlQueryable(
+            [NotNull] IAsyncQueryProvider queryProvider, [NotNull] IEntityType entityType,
+            [NotNull] string sql, [NotNull] Expression argument)
+            : base(queryProvider, entityType)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(argument, nameof(argument));
+
+            Sql = sql;
+            Argument = argument;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string Sql { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Expression Argument { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override string ToString() => $"{base.ToString()}.FromSql(\"{Sql}\", {Argument.Print()}";
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -21,5 +23,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         protected virtual RelationalQueryTranslationPreprocessorDependencies RelationalDependencies { get; }
+
+        public override Expression NormalizeQueryableMethodCall(Expression expression)
+        {
+            expression = new CustomQueryableInjectingExpressionVisitor().Visit(expression);
+
+            return base.NormalizeQueryableMethodCall(expression);
+        }
     }
 }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -138,9 +139,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [Obsolete("Use constantExpression.Value is IEntityQueryable instead.")]
         public static bool IsEntityQueryable([NotNull] this ConstantExpression constantExpression)
-            => constantExpression.Type.IsGenericType
-                && constantExpression.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>);
+            => constantExpression.Value is IEntityQueryable;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using JetBrains.Annotations;

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -376,9 +376,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 printable.Print(this);
             }
-            else if (constantExpression.IsEntityQueryable())
+            else if (constantExpression.Value is IEntityQueryable entityQueryable)
             {
-                _stringBuilder.Append($"DbSet<{constantExpression.Type.GenericTypeArguments.First().ShortDisplayName()}>");
+                _stringBuilder.Append(entityQueryable.ToString());
             }
             else
             {

--- a/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -55,10 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             Check.NotNull(constantExpression, nameof(constantExpression));
 
-            return constantExpression.IsEntityQueryable()
-                ? new EntityReferenceExpression(
-                    constantExpression,
-                    ((IEntityQueryable)constantExpression.Value).EntityType)
+            return constantExpression.Value is IEntityQueryable entityQueryable
+                ? new EntityReferenceExpression(constantExpression, entityQueryable.EntityType)
                 : (Expression)constantExpression;
         }
 

--- a/src/EFCore/Query/Internal/EntityQueryable`.cs
+++ b/src/EFCore/Query/Internal/EntityQueryable`.cs
@@ -156,5 +156,38 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual QueryDebugView DebugView => new QueryDebugView(() => Expression.Print(), this.ToQueryString);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override bool Equals(object obj)
+            => obj != null
+                && (ReferenceEquals(this, obj)
+                    || obj is IEntityQueryable entityQueryable
+                        && entityQueryable.EntityType == _entityType);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override int GetHashCode() => _entityType?.GetHashCode() ?? 0;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override string ToString()
+            => _entityType != null
+            ? (_entityType.IsSharedType
+                ? $"DbSet<{_entityType.ClrType.ShortDisplayName()}>(\"{_entityType.Name}\")"
+                : $"DbSet<{_entityType.ClrType.ShortDisplayName()}>()")
+            : base.ToString();
     }
 }

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -421,8 +421,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 => a.Value == b.Value
                     || (a.Value != null
                         && b.Value != null
-                        && (a.IsEntityQueryable() && b.IsEntityQueryable() && a.Value.GetType() == b.Value.GetType()
-                            || Equals(a.Value, b.Value)));
+                        && (Equals(a.Value, b.Value)));
 
             private bool CompareGoto(GotoExpression a, GotoExpression b)
                 => a.Kind == b.Kind

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -682,12 +682,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 Check.NotNull(constantExpression, nameof(constantExpression));
 
-                if (constantExpression.IsEntityQueryable())
+                if (constantExpression.Value is IEntityQueryable entityQueryable)
                 {
-                    var entityType = ((IEntityQueryable)constantExpression.Value).EntityType;
-                    if (entityType == _entityType)
+                    if (entityQueryable.EntityType == _entityType)
                     {
-                        return _navigationExpandingExpressionVisitor.CreateNavigationExpansionExpression(constantExpression, entityType);
+                        return _navigationExpandingExpressionVisitor.CreateNavigationExpansionExpression(constantExpression, _entityType);
                     }
                 }
 

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -37,8 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(constantExpression, nameof(constantExpression));
 
-            return constantExpression.IsEntityQueryable()
-                ? CreateShapedQueryExpression(((IEntityQueryable)constantExpression.Value).EntityType)
+            return constantExpression.Value is IEntityQueryable entityQueryable
+                ? CreateShapedQueryExpression(entityQueryable.EntityType)
                 : base.VisitConstant(constantExpression);
         }
 

--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -227,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore
                 ExistingTestStore = Fixture.CreateTestStore(SqlServerTestStoreFactory.Instance, StoreName, Seed);
             }
 
-            [ConditionalFact]
+            [ConditionalFact(Skip = "#18682")]
             public async Task Can_use_one_context_nested_inside_another_of_a_different_type()
             {
                 var inMemoryServiceProvider = InMemoryFixture.DefaultServiceProvider;

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Assert.Equal(
                 CoreStrings.TranslationFailed(
-                    @"DbSet<Bird>
+                    @"DbSet<Bird>()
     .Select(b => InheritanceInMemoryFixture.MaterializeView(b))
     .OrderBy(a => a.CountryId)"),
                 message);

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -570,7 +570,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             Assert.Equal(
-                @"The LINQ expression 'DbSet<CollectionScalar>    .Where(c => c.Tags        .Any())' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                @"The LINQ expression 'DbSet<CollectionScalar>()    .Where(c => c.Tags        .Any())' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
                 Assert.Throws<InvalidOperationException>(
                     () => context.Set<CollectionScalar>().Where(e => e.Tags.Any()).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));
@@ -581,7 +581,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             Assert.Equal(
-                @"The LINQ expression 'DbSet<CollectionScalar>    .Where(c => c.Tags.Count == 2)' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                @"The LINQ expression 'DbSet<CollectionScalar>()    .Where(c => c.Tags.Count == 2)' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
                 Assert.Throws<InvalidOperationException>(
                     () => context.Set<CollectionScalar>().Where(e => e.Tags.Count == 2).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));
@@ -599,7 +599,7 @@ namespace Microsoft.EntityFrameworkCore
             using var context = CreateContext();
             var sameRole = Roles.Seller;
             Assert.Equal(
-                @"The LINQ expression 'DbSet<CollectionEnum>    .Where(c => c.Roles.Contains(__sameRole_0))' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                @"The LINQ expression 'DbSet<CollectionEnum>()    .Where(c => c.Roles.Contains(__sameRole_0))' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
                 Assert.Throws<InvalidOperationException>(
                     () => context.Set<CollectionEnum>().Where(e => e.Roles.Contains(sameRole)).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1504,7 +1504,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     @"(MaterializeCollectionNavigation(
     navigation: Navigation: Gear.Weapons,
     subquery: (NavigationExpansionExpression
-        Source: DbSet<Weapon>
+        Source: DbSet<Weapon>()
             .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
         PendingSelector: w => (NavigationTreeExpression
             Value: (EntityReference: Weapon)
@@ -1519,7 +1519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     .Concat((MaterializeCollectionNavigation(
         navigation: Navigation: Gear.Weapons,
         subquery: (NavigationExpansionExpression
-            Source: DbSet<Weapon>
+            Source: DbSet<Weapon>()
                 .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
             PendingSelector: w0 => (NavigationTreeExpression
                 Value: (EntityReference: Weapon)
@@ -1547,7 +1547,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     @"(MaterializeCollectionNavigation(
     navigation: Navigation: Gear.Weapons,
     subquery: (NavigationExpansionExpression
-        Source: DbSet<Weapon>
+        Source: DbSet<Weapon>()
             .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
         PendingSelector: w => (NavigationTreeExpression
             Value: (EntityReference: Weapon)
@@ -1562,7 +1562,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     .Union((MaterializeCollectionNavigation(
         navigation: Navigation: Gear.Weapons,
         subquery: (NavigationExpansionExpression
-            Source: DbSet<Weapon>
+            Source: DbSet<Weapon>()
                 .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
             PendingSelector: w0 => (NavigationTreeExpression
                 Value: (EntityReference: Weapon)

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Client_eval()
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Product>    .Where(p => NorthwindContext.ClientMethod(p))"),
+                CoreStrings.TranslationFailed("DbSet<Product>()    .Where(p => NorthwindContext.ClientMethod(p))"),
                 RemoveNewLines(
                     Assert.Throws<InvalidOperationException>(
                         () => _context.Products.ToList()).Message));
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Included_one_to_many_query_with_client_eval()
         {
             Assert.Equal(
-                CoreStrings.TranslationFailed("DbSet<Product>    .Where(p => NorthwindContext.ClientMethod(p))"),
+                CoreStrings.TranslationFailed("DbSet<Product>()    .Where(p => NorthwindContext.ClientMethod(p))"),
                 RemoveNewLines(
                     Assert.Throws<InvalidOperationException>(
                         () => _context.Products.Include(p => p.OrderDetails).ToList()).Message));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -6767,7 +6767,7 @@ FROM [MockEntities] AS [m]");
                 () => queryBase.Cast<IDummyEntity>().FirstOrDefault(x => x.Id == id)).Message;
 
             Assert.Equal(
-                CoreStrings.TranslationFailed(@"DbSet<MockEntity>    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
+                CoreStrings.TranslationFailed(@"DbSet<MockEntity>()    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
                 message.Replace("\r", "").Replace("\n", ""));
         }
 


### PR DESCRIPTION
This change introduces derived types of EntityQueryable<T> to be processed as query root in core pipeline.
Currently FromSql and Queryable functions generate a method call in query pipeline which would be mapped to a query root. This means that any visitor which need to detect query root, they have to have special code to handle this.
With this change, any provider bringing custom query roots can inject custom query root for relevant subtree in the query and it would be processed transparently through the stack. Only during translation, once the custom query root needs to be intercepted to generate correct SQL.

Converted FromSql in this PR.
Will submit another PR to convert queryable functions.

Custom query roots can be generated during query construction itself (before it reaches EF), such query root requires
- Overriden Equals/GetHashCode methods so we differentiate them during query caching.
- Optional ToString method for debugging print out.
- Conversion to such custom roots in QueryFilter if needed.
- Components of custom root cannot be parameterized in ParameterExtractingExpressionVisitor

Part of #18923
