### PR TITLE
WIP: Alternative fix for 17509. 

### DIFF
--- a/src/EFCore.Design/Design/ICSharpHelper.cs
+++ b/src/EFCore.Design/Design/ICSharpHelper.cs
@@ -212,8 +212,9 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     Generates a C# type reference.
         /// </summary>
         /// <param name="type"> The type to reference. </param>
+        /// <param name="useFullName"> whether to use the full or short type name in the reference. </param>
         /// <returns> The reference. </returns>
-        string Reference([NotNull] Type type);
+        string Reference([NotNull] Type type, bool useFullName = false);
 
         /// <summary>
         ///     Generates a literal for a type not known at compile time.

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -205,10 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string Reference(Type type)
-            => Reference(type, useFullName: false);
-
-        private string Reference(Type type, bool useFullName)
+        public virtual string Reference(Type type, bool useFullName = false)
         {
             Check.NotNull(type, nameof(type));
 

--- a/src/EFCore.Design/Migrations/Design/IMigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/IMigrationsCodeGenerator.cs
@@ -52,12 +52,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="contextType"> The model snapshot's <see cref="DbContext" /> type. </param>
         /// <param name="modelSnapshotName"> The model snapshot's name. </param>
         /// <param name="model"> The model. </param>
+        /// <param name="migrationName"> The name of the migration for which this is a snapshot. </param>
         /// <returns> The model snapshot code. </returns>
         string GenerateSnapshot(
             [NotNull] string modelSnapshotNamespace,
             [NotNull] Type contextType,
             [NotNull] string modelSnapshotName,
-            [NotNull] IModel model);
+            [NotNull] IModel model,
+            [CanBeNull] string migrationName);
 
         /// <summary>
         ///     Gets the file extension code files should use.

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -86,12 +86,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="contextType"> The model snapshot's <see cref="DbContext" /> type. </param>
         /// <param name="modelSnapshotName"> The model snapshot's name. </param>
         /// <param name="model"> The model. </param>
+        /// <param name="migrationName"> The name of the migration for which this is a snapshot. </param>
         /// <returns> The model snapshot code. </returns>
         public abstract string GenerateSnapshot(
             string modelSnapshotNamespace,
             Type contextType,
             string modelSnapshotName,
-            IModel model);
+            IModel model,
+            string migrationName);
 
         /// <summary>
         ///     Gets the namespaces required for a list of <see cref="MigrationOperation" /> objects.

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -170,7 +170,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 modelSnapshotNamespace,
                 _contextType,
                 modelSnapshotName,
-                Dependencies.Model);
+                Dependencies.Model,
+                migrationName);
 
             return new ScaffoldedMigration(
                 codeGenerator.FileExtension,
@@ -339,7 +340,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     modelSnapshotNamespace,
                     _contextType,
                     modelSnapshotName,
-                    model);
+                    model,
+                    null);
 
                 if (modelSnapshotFile == null)
                 {


### PR DESCRIPTION
Update DbContext attribute with namespace if needed.
@bricelam - this is the attempt to fix #17509 where we _only_ use the namespace in the `DbContext` attribute if it clashes with the migration's name. This does produce a number of updates to interfaces and the approach where we just put the namespace in all the time would not require those. So wanted to make sure you want to do that before adding tests etc.