### PR TITLE
Remove Convert node over DbContext for queryable functions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -91,6 +91,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected virtual ShapedQueryExpression CreateShapedQueryExpression([NotNull] MethodCallExpression methodCallExpression)
         {
+            if (methodCallExpression.Object is UnaryExpression unaryExpression
+                && unaryExpression.NodeType == ExpressionType.Convert
+                && unaryExpression.Type.IsSubclassOf(typeof(DbContext)))
+            {
+                methodCallExpression = Expression.Call(
+                    unaryExpression.Operand,
+                    methodCallExpression.Method,
+                    methodCallExpression.Arguments);
+            }
+
             var sqlFuncExpression = _sqlTranslator.TranslateMethodCall(methodCallExpression) as SqlFunctionExpression;
 
             var elementType = methodCallExpression.Method.ReturnType.GetGenericArguments()[0];


### PR DESCRIPTION
While doing the tests for queryable functions, I ran into an issue: the Npgsql test suite has a subclass of UDFSqlContext because of some OnModelCreating stuff, and this causes a Convert node to be added over the DbContext object of the MethodCallExpression; this node isn't translated and the query fails. This PR removes the Convert node for that particular case.

/cc @smitpatel @pmiddleton 