### PR TITLE
Query: Print better expression trees

### DIFF
--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -933,9 +933,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (extensionExpression is IPrintableExpression printable)
             {
-                _stringBuilder.Append("(");
                 printable.Print(this);
-                _stringBuilder.Append(")");
             }
             else
             {

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -486,7 +486,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             // DefaultIfEmpty with argument
                             // Index based lambda overloads of Where, SkipWhile, TakeWhile, Select, SelectMany
                             // IEqualityComparer overloads of Distinct, Contains, Join, Except, Intersect, Union, OrderBy, ThenBy, OrderByDescending, ThenByDescending, GroupBy
-                            throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
+                            throw new InvalidOperationException(CoreStrings.TranslationFailed(
+                                _reducingExpressionVisitor.Visit(methodCallExpression).Print()));
                     }
                 }
 

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1501,35 +1501,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Assert.Equal(
                 CoreStrings.TranslationFailed(
-                    @"(MaterializeCollectionNavigation(
+                    @"MaterializeCollectionNavigation(
     navigation: Navigation: Gear.Weapons,
-    subquery: (NavigationExpansionExpression
-        Source: DbSet<Weapon>
-            .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
-        PendingSelector: w => (NavigationTreeExpression
-            Value: (EntityReference: Weapon)
-            Expression: w)
-    )
-        .Where(i => EF.Property<string>((NavigationTreeExpression
-            Value: (EntityReference: Gear)
-            Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
-            Value: (EntityReference: Gear)
-            Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))
+    subquery: DbSet<Weapon>
+        .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
+        .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))
     .AsQueryable()
-    .Concat((MaterializeCollectionNavigation(
+    .Concat(MaterializeCollectionNavigation(
         navigation: Navigation: Gear.Weapons,
-        subquery: (NavigationExpansionExpression
-            Source: DbSet<Weapon>
-                .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
-            PendingSelector: w0 => (NavigationTreeExpression
-                Value: (EntityReference: Weapon)
-                Expression: w0)
-        )
-            .Where(i => EF.Property<string>((NavigationTreeExpression
-                Value: (EntityReference: Gear)
-                Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
-                Value: (EntityReference: Gear)
-                Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))))"),
+        subquery: DbSet<Weapon>
+            .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
+            .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))"),
                 message, ignoreLineEndingDifferences: true);
         }
 
@@ -1544,35 +1526,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Assert.Equal(
                 CoreStrings.TranslationFailed(
-                    @"(MaterializeCollectionNavigation(
+                    @"MaterializeCollectionNavigation(
     navigation: Navigation: Gear.Weapons,
-    subquery: (NavigationExpansionExpression
-        Source: DbSet<Weapon>
-            .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
-        PendingSelector: w => (NavigationTreeExpression
-            Value: (EntityReference: Weapon)
-            Expression: w)
-    )
-        .Where(i => EF.Property<string>((NavigationTreeExpression
-            Value: (EntityReference: Gear)
-            Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
-            Value: (EntityReference: Gear)
-            Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))
+    subquery: DbSet<Weapon>
+        .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
+        .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))
     .AsQueryable()
-    .Union((MaterializeCollectionNavigation(
+    .Union(MaterializeCollectionNavigation(
         navigation: Navigation: Gear.Weapons,
-        subquery: (NavigationExpansionExpression
-            Source: DbSet<Weapon>
-                .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
-            PendingSelector: w0 => (NavigationTreeExpression
-                Value: (EntityReference: Weapon)
-                Expression: w0)
-        )
-            .Where(i => EF.Property<string>((NavigationTreeExpression
-                Value: (EntityReference: Gear)
-                Expression: g), ""FullName"") != null && EF.Property<string>((NavigationTreeExpression
-                Value: (EntityReference: Gear)
-                Expression: g), ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))))"),
+        subquery: DbSet<Weapon>
+            .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
+            .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))"),
                 message, ignoreLineEndingDifferences: true);
         }
 


### PR DESCRIPTION
- Removed parenthesis around IPrintableExpression since it was making printing of query roots bad.
  - Individual expression should decide if it wants to add parenthesis around it.
- Reduce the expression tree before printing in Navigation expansion for more human readable form.

Required for #20146