### PR TITLE
Microsoft.Data.Sqlite: Default CommandText to an empty string

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Sqlite
 
         private readonly List<sqlite3_stmt> _preparedStatements = new List<sqlite3_stmt>();
         private SqliteConnection _connection;
-        private string _commandText;
+        private string _commandText = string.Empty;
         private bool _prepared;
 
         /// <summary>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -36,6 +36,14 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void CommandText_defaults_to_empty()
+        {
+            var command = new SqliteCommand();
+
+            Assert.Empty(command.CommandText);
+        }
+
+        [Fact]
         public void CommandText_throws_when_set_when_open_reader()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))


### PR DESCRIPTION
Fixes #19162

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


