### PR TITLE
Query: Improve parameterization of queryable functions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalEvaluatableExpressionFilter.cs
+++ b/src/EFCore.Relational/Query/RelationalEvaluatableExpressionFilter.cs
@@ -59,16 +59,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(model, nameof(model));
 
             if (expression is MethodCallExpression methodCallExpression
-                && model.FindDbFunction(methodCallExpression.Method) is IDbFunction func)
+                && model.FindDbFunction(methodCallExpression.Method) != null)
             {
-                return func?.IsQueryable ?? true;
+                // Never evaluate DbFunction
+                // If it is inside lambda then we will have whole method call
+                // If it is outside of lambda then it will be evaluated for queryable function already.
+                return false;
             }
 
             return base.IsEvaluatableExpression(expression, model);
         }
-
-        public override bool IsQueryableFunction(Expression expression, IModel model) =>
-            expression is MethodCallExpression methodCallExpression
-               && model.FindDbFunction(methodCallExpression.Method)?.IsQueryable == true;
     }
 }

--- a/src/EFCore/Query/EvaluatableExpressionFilterBase.cs
+++ b/src/EFCore/Query/EvaluatableExpressionFilterBase.cs
@@ -68,7 +68,5 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return true;
         }
-
-        public virtual bool IsQueryableFunction(Expression expression, IModel model) => false;
     }
 }

--- a/src/EFCore/Query/IEvaluatableExpressionFilter.cs
+++ b/src/EFCore/Query/IEvaluatableExpressionFilter.cs
@@ -27,13 +27,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="model"> The model. </param>
         /// <returns> True if the expression can be evaluated; false otherwise. </returns>
         bool IsEvaluatableExpression([NotNull] Expression expression, [NotNull] IModel model);
-
-        /// <summary>
-        ///     Checks whether the given expression is a queryable function
-        /// </summary>
-        /// <param name="expression"> The expression. </param>
-        /// <param name="model"> The model. </param>
-        /// <returns> True if the expression is a queryable function </returns>
-        bool IsQueryableFunction([NotNull] Expression expression, [NotNull] IModel model);
     }
 }

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -552,12 +552,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
             {
-                if (_evaluatableExpressionFilter.IsQueryableFunction(methodCallExpression, _model)
-                        && !_inLambda)
-                {
-                    _evaluatable = false;
-                }
-
                 Visit(methodCallExpression.Object);
                 var parameterInfos = methodCallExpression.Method.GetParameters();
                 for (var i = 0; i < methodCallExpression.Arguments.Count; i++)

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -1545,7 +1545,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue#20184")]
         public virtual void QF_Select_Direct_In_Anonymous()
         {
             using (var context = CreateContext())
@@ -1640,7 +1640,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "Issue#20184")]
         public virtual void QF_Select_Correlated_Subquery_In_Anonymous_Nested()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -639,11 +639,9 @@ ORDER BY [o].[Count] DESC, [o].[Year] DESC");
             base.QF_CrossJoin_Not_Correlated();
 
             AssertSql(
-                @"@__customerId_1='2'
-
-SELECT [c].[Id], [c].[LastName], [o].[Year], [o].[Count]
+                @"SELECT [c].[Id], [c].[LastName], [o].[Year], [o].[Count]
 FROM [Customers] AS [c]
-CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@__customerId_1) AS [o]
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear](2) AS [o]
 WHERE [c].[Id] = 2
 ORDER BY [o].[Count]");
         }
@@ -653,13 +651,12 @@ ORDER BY [o].[Count]");
             base.QF_CrossJoin_Parameter();
 
             AssertSql(
-                @"@__customerId_1='2'
-@__custId_2='2'
+                @"@__custId_1='2'
 
 SELECT [c].[Id], [c].[LastName], [o].[Year], [o].[Count]
 FROM [Customers] AS [c]
-CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@__customerId_1) AS [o]
-WHERE [c].[Id] = @__custId_2
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@__custId_1) AS [o]
+WHERE [c].[Id] = @__custId_1
 ORDER BY [o].[Count]");
         }
 


### PR DESCRIPTION
Resolves #20162

- Never evaluate DbFunction
  - If it is inside lambda then we will have whole method call
  - If it is outside of lambda then it will be evaluated by compiler alread