### PR TITLE
Force use of common value generator for all derived types

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryTable.cs
@@ -31,6 +31,14 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        IEnumerable<object[]> Rows { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         void Create([NotNull] IUpdateEntry entry);
 
         /// <summary>
@@ -55,6 +63,31 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        InMemoryIntegerValueGenerator<TProperty> GetIntegerValueGenerator<TProperty>([NotNull] IProperty property);
+        InMemoryIntegerValueGenerator<TProperty> GetIntegerValueGenerator<TProperty>(
+            [NotNull] IProperty property, [NotNull] IReadOnlyList<IInMemoryTable> tables);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        void BumpValueGenerators([NotNull] object[] row);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IInMemoryTable BaseTable { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IEntityType EntityType { get; }
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryTableFactory.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryTableFactory.cs
@@ -20,6 +20,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IInMemoryTable Create([NotNull] IEntityType entityType);
+        IInMemoryTable Create([NotNull] IEntityType entityType, [CanBeNull] IInMemoryTable baseTable);
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTableFactory.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTableFactory.cs
@@ -24,8 +24,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
     {
         private readonly bool _sensitiveLoggingEnabled;
 
-        private readonly ConcurrentDictionary<IEntityType, Func<IInMemoryTable>> _factories
-            = new ConcurrentDictionary<IEntityType, Func<IInMemoryTable>>();
+        private readonly ConcurrentDictionary<(IEntityType EntityType, IInMemoryTable BaseTable), Func<IInMemoryTable>> _factories
+            = new ConcurrentDictionary<(IEntityType, IInMemoryTable), Func<IInMemoryTable>>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,17 +46,18 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IInMemoryTable Create(IEntityType entityType)
-            => _factories.GetOrAdd(entityType, CreateTable)();
+        public virtual IInMemoryTable Create(IEntityType entityType, IInMemoryTable baseTable)
+            => _factories.GetOrAdd((entityType, baseTable), e => CreateTable(e.EntityType, e.BaseTable))();
 
-        private Func<IInMemoryTable> CreateTable([NotNull] IEntityType entityType)
+        private Func<IInMemoryTable> CreateTable([NotNull] IEntityType entityType, IInMemoryTable baseTable)
             => (Func<IInMemoryTable>)typeof(InMemoryTableFactory).GetTypeInfo()
                 .GetDeclaredMethod(nameof(CreateFactory))
                 .MakeGenericMethod(GetKeyType(entityType.FindPrimaryKey()))
-                .Invoke(null, new object[] { entityType, _sensitiveLoggingEnabled });
+                .Invoke(null, new object[] { entityType, baseTable, _sensitiveLoggingEnabled });
 
         [UsedImplicitly]
-        private static Func<IInMemoryTable> CreateFactory<TKey>(IEntityType entityType, bool sensitiveLoggingEnabled)
-            => () => new InMemoryTable<TKey>(entityType, sensitiveLoggingEnabled);
+        private static Func<IInMemoryTable> CreateFactory<TKey>(
+            IEntityType entityType, IInMemoryTable baseTable, bool sensitiveLoggingEnabled)
+            => () => new InMemoryTable<TKey>(entityType, baseTable, sensitiveLoggingEnabled);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/IntegerValueGeneratorTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/IntegerValueGeneratorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -14,34 +15,34 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public void Each_property_gets_its_own_generator()
         {
-            var olives = new Olive[4];
+            var macs = new Mac[4];
             var toasts = new Toast[4];
 
             using (var context = new PetsContext("Dance"))
             {
-                olives[0] = context.Add(new Olive()).Entity;
+                macs[0] = context.Add(new Mac()).Entity;
                 toasts[0] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
 
-                olives[1] = context.Add(new Olive()).Entity;
+                macs[1] = context.Add(new Mac()).Entity;
                 toasts[1] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(2, olives[1].Id);
+                Assert.Equal(2, macs[1].Id);
                 Assert.Equal(2, toasts[1].Id);
 
                 context.SaveChanges();
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
-                Assert.Equal(2, olives[1].Id);
+                Assert.Equal(2, macs[1].Id);
                 Assert.Equal(2, toasts[1].Id);
 
-                olives[2] = context.Add(new Olive()).Entity;
+                macs[2] = context.Add(new Mac()).Entity;
                 toasts[2] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(3, olives[2].Id);
+                Assert.Equal(3, macs[2].Id);
                 Assert.Equal(3, toasts[2].Id);
 
                 context.SaveChanges();
@@ -49,23 +50,127 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new PetsContext("Dance"))
             {
-                olives[3] = context.Add(new Olive()).Entity;
+                macs[3] = context.Add(new Mac()).Entity;
                 toasts[3] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(4, olives[3].Id);
+                Assert.Equal(4, macs[3].Id);
                 Assert.Equal(4, toasts[3].Id);
 
                 context.SaveChanges();
             }
 
-            Assert.Equal(1, olives[0].Id);
+            Assert.Equal(1, macs[0].Id);
             Assert.Equal(1, toasts[0].Id);
-            Assert.Equal(2, olives[1].Id);
+            Assert.Equal(2, macs[1].Id);
             Assert.Equal(2, toasts[1].Id);
-            Assert.Equal(3, olives[2].Id);
+            Assert.Equal(3, macs[2].Id);
             Assert.Equal(3, toasts[2].Id);
-            Assert.Equal(4, olives[3].Id);
+            Assert.Equal(4, macs[3].Id);
             Assert.Equal(4, toasts[3].Id);
+
+            using (var context = new PetsContext("Dance"))
+            {
+                macs = context.Macs.OrderBy(e => e.Id).ToArray();
+                toasts = context.CookedBreads.OrderBy(e => e.Id).ToArray();
+            }
+
+            Assert.Equal(1, macs[0].Id);
+            Assert.Equal(1, toasts[0].Id);
+            Assert.Equal(2, macs[1].Id);
+            Assert.Equal(2, toasts[1].Id);
+            Assert.Equal(3, macs[2].Id);
+            Assert.Equal(3, toasts[2].Id);
+            Assert.Equal(4, macs[3].Id);
+            Assert.Equal(4, toasts[3].Id);
+        }
+
+        [ConditionalFact]
+        public void Each_property_gets_its_own_generator_with_seeding()
+        {
+            var macs = new Mac[4];
+            var toasts = new Toast[4];
+
+            using (var context = new PetsContextWithData("Pets II"))
+            {
+                context.Database.EnsureCreated();
+
+                var savedMacs = context.Macs.OrderBy(e => e.Id).ToList();
+                var savedToasts = context.CookedBreads.OrderBy(e => e.Id).ToList();
+
+                Assert.Equal(2, savedMacs.Count);
+                Assert.Single(savedToasts);
+
+                Assert.Equal(1, savedMacs[0].Id);
+                Assert.Equal(2, savedMacs[1].Id);
+                Assert.Equal(1, savedToasts[0].Id);
+            }
+
+            using (var context = new PetsContextWithData("Pets II"))
+            {
+                macs[0] = context.Add(new Mac()).Entity;
+                toasts[0] = context.Add(new Toast()).Entity;
+
+                Assert.Equal(3, macs[0].Id);
+                Assert.Equal(2, toasts[0].Id);
+
+                macs[1] = context.Add(new Mac()).Entity;
+                toasts[1] = context.Add(new Toast()).Entity;
+
+                Assert.Equal(4, macs[1].Id);
+                Assert.Equal(3, toasts[1].Id);
+
+                context.SaveChanges();
+
+                Assert.Equal(3, macs[0].Id);
+                Assert.Equal(2, toasts[0].Id);
+                Assert.Equal(4, macs[1].Id);
+                Assert.Equal(3, toasts[1].Id);
+
+                macs[2] = context.Add(new Mac()).Entity;
+                toasts[2] = context.Add(new Toast()).Entity;
+
+                Assert.Equal(5, macs[2].Id);
+                Assert.Equal(4, toasts[2].Id);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new PetsContextWithData("Pets II"))
+            {
+                macs[3] = context.Add(new Mac()).Entity;
+                toasts[3] = context.Add(new Toast()).Entity;
+
+                Assert.Equal(6, macs[3].Id);
+                Assert.Equal(5, toasts[3].Id);
+
+                context.SaveChanges();
+            }
+
+            Assert.Equal(3, macs[0].Id);
+            Assert.Equal(2, toasts[0].Id);
+            Assert.Equal(4, macs[1].Id);
+            Assert.Equal(3, toasts[1].Id);
+            Assert.Equal(5, macs[2].Id);
+            Assert.Equal(4, toasts[2].Id);
+            Assert.Equal(6, macs[3].Id);
+            Assert.Equal(5, toasts[3].Id);
+
+            using (var context = new PetsContextWithData("Pets II"))
+            {
+                var savedMacs = context.Macs.OrderBy(e => e.Id).ToList();
+                var savedToasts = context.CookedBreads.OrderBy(e => e.Id).ToList();
+
+                Assert.Equal(6, savedMacs.Count);
+                Assert.Equal(5, savedToasts.Count);
+
+                for (var i = 0; i < 5; i++)
+                {
+                    Assert.Equal(i + 1, savedMacs[i].Id);
+                    Assert.Equal(i + 1, savedToasts[i].Id);
+                }
+
+                Assert.Equal(6, savedMacs[5].Id);
+            }
         }
 
         [ConditionalFact]
@@ -81,15 +186,15 @@ namespace Microsoft.EntityFrameworkCore
 
             var root = new InMemoryDatabaseRoot();
 
-            var olives = new Olive[2];
+            var macs = new Mac[2];
             var toasts = new Toast[2];
 
             using (var context = new PetsContext("Drink", root, serviceProvider1))
             {
-                olives[0] = context.Add(new Olive()).Entity;
+                macs[0] = context.Add(new Mac()).Entity;
                 toasts[0] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
 
                 context.SaveChanges();
@@ -97,71 +202,71 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new PetsContext("Drink", root, serviceProvider2))
             {
-                olives[1] = context.Add(new Olive()).Entity;
+                macs[1] = context.Add(new Mac()).Entity;
                 toasts[1] = context.Add(new Toast()).Entity;
 
-                Assert.Equal(2, olives[1].Id);
+                Assert.Equal(2, macs[1].Id);
                 Assert.Equal(2, toasts[1].Id);
 
                 context.SaveChanges();
             }
 
-            Assert.Equal(1, olives[0].Id);
+            Assert.Equal(1, macs[0].Id);
             Assert.Equal(1, toasts[0].Id);
-            Assert.Equal(2, olives[1].Id);
+            Assert.Equal(2, macs[1].Id);
             Assert.Equal(2, toasts[1].Id);
         }
 
         [ConditionalFact]
         public void Mixing_explicit_values_with_generated_values_with_care_works()
         {
-            var olives = new Olive[4];
+            var macs = new Mac[4];
             var toasts = new Toast[4];
 
             using var context = new PetsContext("Wercs");
-            olives[0] = context.Add(new Olive { Id = 10 }).Entity;
+            macs[0] = context.Add(new Mac { Id = 10 }).Entity;
             toasts[0] = context.Add(new Toast { Id = 100 }).Entity;
 
             context.SaveChanges();
 
-            olives[1] = context.Add(new Olive()).Entity;
+            macs[1] = context.Add(new Mac()).Entity;
             toasts[1] = context.Add(new Toast()).Entity;
 
             context.SaveChanges();
 
-            Assert.Equal(10, olives[0].Id);
+            Assert.Equal(10, macs[0].Id);
             Assert.Equal(100, toasts[0].Id);
-            Assert.Equal(11, olives[1].Id);
+            Assert.Equal(11, macs[1].Id);
             Assert.Equal(101, toasts[1].Id);
 
-            olives[2] = context.Add(new Olive { Id = 20 }).Entity;
+            macs[2] = context.Add(new Mac { Id = 20 }).Entity;
             toasts[2] = context.Add(new Toast { Id = 200 }).Entity;
 
             context.SaveChanges();
 
-            olives[3] = context.Add(new Olive()).Entity;
+            macs[3] = context.Add(new Mac()).Entity;
             toasts[3] = context.Add(new Toast()).Entity;
 
             context.SaveChanges();
 
-            Assert.Equal(20, olives[2].Id);
+            Assert.Equal(20, macs[2].Id);
             Assert.Equal(200, toasts[2].Id);
-            Assert.Equal(21, olives[3].Id);
+            Assert.Equal(21, macs[3].Id);
             Assert.Equal(201, toasts[3].Id);
         }
 
         [ConditionalFact]
         public void Each_database_gets_its_own_generators()
         {
-            var olives = new List<Olive>();
+            var macs = new List<Mac>();
             var toasts = new List<Toast>();
 
             using (var context = new PetsContext("Nothing"))
             {
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
 
                 context.SaveChanges();
@@ -169,33 +274,33 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new PetsContext("Else"))
             {
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[1].Id);
+                Assert.Equal(1, macs[1].Id);
                 Assert.Equal(1, toasts[1].Id);
 
                 context.SaveChanges();
             }
 
-            Assert.Equal(1, olives[0].Id);
+            Assert.Equal(1, macs[0].Id);
             Assert.Equal(1, toasts[0].Id);
-            Assert.Equal(1, olives[1].Id);
+            Assert.Equal(1, macs[1].Id);
             Assert.Equal(1, toasts[1].Id);
         }
 
         [ConditionalFact]
         public void Each_root_gets_its_own_generators()
         {
-            var olives = new List<Olive>();
+            var macs = new List<Mac>();
             var toasts = new List<Toast>();
 
             using (var context = new PetsContext("To", new InMemoryDatabaseRoot()))
             {
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
 
                 context.SaveChanges();
@@ -203,33 +308,33 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new PetsContext("To", new InMemoryDatabaseRoot()))
             {
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[1].Id);
+                Assert.Equal(1, macs[1].Id);
                 Assert.Equal(1, toasts[1].Id);
 
                 context.SaveChanges();
             }
 
-            Assert.Equal(1, olives[0].Id);
+            Assert.Equal(1, macs[0].Id);
             Assert.Equal(1, toasts[0].Id);
-            Assert.Equal(1, olives[1].Id);
+            Assert.Equal(1, macs[1].Id);
             Assert.Equal(1, toasts[1].Id);
         }
 
         [ConditionalFact]
         public void EnsureDeleted_resets_generators()
         {
-            var olives = new List<Olive>();
+            var macs = new List<Mac>();
             var toasts = new List<Toast>();
 
             using (var context = new PetsContext("Do"))
             {
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[0].Id);
+                Assert.Equal(1, macs[0].Id);
                 Assert.Equal(1, toasts[0].Id);
 
                 context.SaveChanges();
@@ -239,18 +344,18 @@ namespace Microsoft.EntityFrameworkCore
             {
                 context.Database.EnsureDeleted();
 
-                olives.Add(context.Add(new Olive()).Entity);
+                macs.Add(context.Add(new Mac()).Entity);
                 toasts.Add(context.Add(new Toast()).Entity);
 
-                Assert.Equal(1, olives[1].Id);
+                Assert.Equal(1, macs[1].Id);
                 Assert.Equal(1, toasts[1].Id);
 
                 context.SaveChanges();
             }
 
-            Assert.Equal(1, olives[0].Id);
+            Assert.Equal(1, macs[0].Id);
             Assert.Equal(1, toasts[0].Id);
-            Assert.Equal(1, olives[1].Id);
+            Assert.Equal(1, macs[1].Id);
             Assert.Equal(1, toasts[1].Id);
         }
 
@@ -284,18 +389,66 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Cat>();
+                modelBuilder.Entity<Dog>();
+            }
+
             public DbSet<Toast> CookedBreads { get; set; }
             public DbSet<Olive> Olives { get; set; }
+            public DbSet<Mac> Macs { get; set; }
+            public DbSet<Smokey> Smokeys { get; set; }
+            public DbSet<Alice> Alices { get; set; }
         }
 
-        private class Toast
+        private class PetsContextWithData : PetsContext
+        {
+            public PetsContextWithData(
+                string databaseName,
+                InMemoryDatabaseRoot root = null,
+                IServiceProvider internalServiceProvider = null)
+                : base(databaseName, root, internalServiceProvider)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Toast>().HasData(new Toast { Id = 1 });
+                modelBuilder.Entity<Mac>().HasData(new Mac { Id = 1 }, new Mac { Id = 2 });
+            }
+        }
+
+        private class Dog
         {
             public int Id { get; set; }
         }
 
-        private class Olive
+        private class Toast : Dog
+        {
+        }
+
+        private class Olive : Dog
+        {
+        }
+
+        private class Cat
         {
             public int Id { get; set; }
+        }
+
+        private class Mac: Cat
+        {
+        }
+
+        private class Smokey: Cat
+        {
+        }
+
+        private class Alice: Cat
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes #19854

Because in-memory isn't "TPH" and so derived types have their own "table" but the value generator is stored on the "table" that the property is defined in.
