### PR TITLE
[release/3.1] Query: Map projection properly when joining 2 tables

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -921,5 +921,11 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         {
             return base.LastOrDefault_member_access_in_projection_translates_to_server(isAsync);
         }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task Projecting_multiple_collection_with_same_constant_works(bool async)
+        {
+            return base.Projecting_multiple_collection_with_same_constant_works(async);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1492,5 +1492,25 @@ namespace Microsoft.EntityFrameworkCore.Query
             public string City { get; set; }
             public Customer Customer { get; }
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_multiple_collection_with_same_constant_works(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
+                    .Select(c => new
+                    {
+                        O1 = c.Orders.Select(e => new { Value = 1 }),
+                        O2 = c.Orders.Select(e => new { AnotherValue = 1 })
+                    }),
+                assertOrder: true, //single element
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e.O1, a.O1, ordered: true);
+                    AssertCollection(e.O2, a.O2, ordered: true);
+                });
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -1227,5 +1227,18 @@ WHERE [c].[CustomerID] LIKE N'A%'");
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A%'");
         }
+
+        public override async Task Projecting_multiple_collection_with_same_constant_works(bool async)
+        {
+            await base.Projecting_multiple_collection_with_same_constant_works(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], 1, [o].[OrderID], [o0].[OrderID]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+        }
     }
 }


### PR DESCRIPTION
When joining 2 tables in relational, we lift the table from inner select expression and copy over projections. If one of this projection is same as any outer projection then we reuse the same projection. That means the associated indexes in inner shaper will go to different indexes rather than in linear fashion.

Fix is to remember which index each projection went and use that rather than applying an offset.

Resolves #19616

### Description

Inside Select, if subquery Select contains a constant/parameter, which is in parent Select or other subquery's Select then we project it only once in SQL causing projection indexes mismatch.

### Customer Impact

Problematic queries throws exception.

### How found

Reported by multiple customers.

### Test coverage

Added regression test for scenario in which projection indexes would become non-linear.

### Regression?

Yes. From 2.2 to 3.0

### Risk

Low. The modified codepath is being used in more than 15,000 tests. It properly takes care of existing working scenarios.
