### PR TITLE
Partial fix for 6674. Can configure navigations between owner and owned types.

### DIFF
--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -811,6 +811,46 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     <para>
+        ///         Used to configure the navigation property from owner to owned type.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationConfiguration">
+        ///     An action which configures the navigation property from owner to owned type.
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual OwnedNavigationBuilder OwnerToOwnedNavigation(
+            [NotNull] Action<NavigationBuilder> navigationConfiguration)
+        {
+            if (Metadata.PrincipalToDependent != null)
+            {
+                navigationConfiguration(new NavigationBuilder(Metadata.PrincipalToDependent));
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Used to configure the navigation property from the owned type to its owner.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationConfiguration">
+        ///     An action which configures the navigation property from the owned type to its owner.
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual OwnedNavigationBuilder OwnedToOwnerNavigation(
+            [NotNull] Action<NavigationBuilder> navigationConfiguration)
+        {
+            if (Metadata.DependentToPrincipal != null)
+            {
+                navigationConfiguration(new NavigationBuilder(Metadata.DependentToPrincipal));
+            }
+
+            return this;
+        }
+
+        /// <summary>
         ///     Configures this entity to have seed data. It is used to generate data motion migrations.
         /// </summary>
         /// <param name="data">

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -115,6 +115,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                         .GetPropertyAccess().GetSimpleMemberName());
 
         /// <summary>
+        ///     <para>
+        ///         Used to configure the navigation property from owner to owned type.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationConfiguration">
+        ///     An action which configures the navigation property from owner to owned type.
+        /// </param>
+        public new virtual OwnedNavigationBuilder<TEntity, TDependentEntity> OwnerToOwnedNavigation(
+            [NotNull] Action<NavigationBuilder> navigationConfiguration)
+            => (OwnedNavigationBuilder<TEntity, TDependentEntity>)
+                base.OwnerToOwnedNavigation(
+                    Check.NotNull(navigationConfiguration, nameof(navigationConfiguration)));
+
+        /// <summary>
+        ///     <para>
+        ///         Used to configure the navigation property from the owned type to its owner.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationConfiguration">
+        ///     An action which configures the navigation property from the owned type to its owner.
+        /// </param>
+        public new virtual OwnedNavigationBuilder<TEntity, TDependentEntity> OwnedToOwnerNavigation(
+            [NotNull] Action<NavigationBuilder> navigationConfiguration)
+            => (OwnedNavigationBuilder<TEntity, TDependentEntity>)
+                base.OwnedToOwnerNavigation(
+                    Check.NotNull(navigationConfiguration, nameof(navigationConfiguration)));
+
+        /// <summary>
         ///     Configures an index on the specified properties. If there is an existing index on the given
         ///     set of properties, then the existing index will be returned for configuration.
         /// </summary>

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -701,6 +701,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TDependentEntity, object>> propertyExpression)
                 => Wrap(OwnedNavigationBuilder.Ignore(propertyExpression));
 
+            public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnerToOwnedNavigation(
+                Action<NavigationBuilder> navigationConfiguration)
+                => Wrap(OwnedNavigationBuilder.OwnerToOwnedNavigation(navigationConfiguration));
+
+            public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnedToOwnerNavigation(
+                Action<NavigationBuilder> navigationConfiguration)
+                => Wrap(OwnedNavigationBuilder.OwnedToOwnerNavigation(navigationConfiguration));
+
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(OwnedNavigationBuilder.HasIndex(propertyNames));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -694,6 +694,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap<TEntity, TDependentEntity>(
                     OwnedNavigationBuilder.Ignore(propertyExpression.GetPropertyAccess().GetSimpleMemberName()));
 
+            public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnerToOwnedNavigation(
+                Action<NavigationBuilder> navigationConfiguration)
+                => Wrap<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.OwnerToOwnedNavigation(navigationConfiguration));
+
+            public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnedToOwnerNavigation(
+                Action<NavigationBuilder> navigationConfiguration)
+                => Wrap<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.OwnedToOwnerNavigation(navigationConfiguration));
+
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(OwnedNavigationBuilder.HasIndex(propertyNames));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -509,6 +509,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(
                 Expression<Func<TDependentEntity, object>> propertyExpression);
 
+            public abstract TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnerToOwnedNavigation(
+                Action<NavigationBuilder> navigationConfiguration);
+            public abstract TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnedToOwnerNavigation(
+                Action<NavigationBuilder> navigationConfiguration);
+
             public abstract TestIndexBuilder HasIndex(params string[] propertyNames);
             public abstract TestIndexBuilder HasIndex(Expression<Func<TDependentEntity, object>> indexExpression);
 

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -117,6 +117,49 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Can_configure_owned_type_navigation_properties_for_OwnsOne()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<Order>()
+                    .OwnsOne(o => o.Details,
+                        a =>
+                        {
+                            a.OwnerToOwnedNavigation(nb => nb.UsePropertyAccessMode(PropertyAccessMode.Field));
+                            a.OwnedToOwnerNavigation(nb => nb.UsePropertyAccessMode(PropertyAccessMode.Property));
+                        });
+
+                var model = modelBuilder.FinalizeModel();
+
+                var owner = model.FindEntityType(typeof(Order));
+                var foreignKey = owner.FindNavigation(nameof(Order.Details)).ForeignKey;
+                Assert.Equal(PropertyAccessMode.Field, foreignKey.PrincipalToDependent.GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, foreignKey.DependentToPrincipal.GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Can_configure_owned_type_navigation_properties_for_OwnsMany()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<OrderDetails>().Ignore(od => od.Order);
+                modelBuilder.Entity<Customer>()
+                    .OwnsMany(c => c.Orders,
+                        a =>
+                        {
+                            a.OwnerToOwnedNavigation(nb => nb.UsePropertyAccessMode(PropertyAccessMode.Field));
+                            a.OwnedToOwnerNavigation(nb => nb.UsePropertyAccessMode(PropertyAccessMode.Property));
+                        });
+
+                var model = modelBuilder.FinalizeModel();
+
+                var owner = model.FindEntityType(typeof(Customer));
+                var foreignKey = owner.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                Assert.Equal(PropertyAccessMode.Field, foreignKey.PrincipalToDependent.GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, foreignKey.DependentToPrincipal.GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
             public virtual void Can_configure_owned_type_key()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Partial fix for #6674. Adds the ability to configure navigations between owner and owned types.

