### PR TITLE
Ignore line ending differences in tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,14 +198,14 @@ stages:
                 value: $(_BuildConfig)
               - ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: Windows.10.Amd64.Open
+                  value: Windows.10.Amd64.Open;Ubuntu.1804.Amd64.Open;OSX.1014.Amd64.Open
                 - name: Creator
                   value: efcore
                 - name: _HelixAccessToken
                   value: '' # Needed for public queues
               - ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 - name: HelixTargetQueues
-                  value: Windows.10.Amd64
+                  value: Windows.10.Amd64;Ubuntu.1804.Amd64;OSX.1014.Amd64
                 - name: _HelixAccessToken
                   value: $(HelixApiAccessToken) # Needed for internal queues
             steps:
@@ -226,41 +226,6 @@ stages:
               - script: restore.cmd -ci /p:configuration=$(_BuildConfig)
                 displayName: Restore packages
               - script: .dotnet\dotnet msbuild eng\helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
-                displayName: Send job to helix
-                env:
-                  HelixAccessToken: $(_HelixAccessToken)
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-
-          - job: Helix_Linux
-            pool:
-              vmImage: ubuntu-16.04
-            variables:
-              - name: _HelixBuildConfig
-                value: $(_BuildConfig)
-              - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                - name: HelixTargetQueues
-                  value: Ubuntu.1804.Amd64.Open;OSX.1014.Amd64.Open
-                - name: Creator
-                  value: efcore
-                - name: _HelixAccessToken
-                  value: '' # Needed for public queues
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - name: HelixTargetQueues
-                  value: Ubuntu.1804.Amd64;OSX.1014.Amd64
-                - name: _HelixAccessToken
-                  value: $(HelixApiAccessToken) # Needed for internal queues
-            steps:
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: Bash@3
-                  displayName: Setup Private Feeds Credentials
-                  inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                    arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: ./restore.sh --restore -ci /p:configuration=$(_BuildConfig)
-                displayName: Restore packages
-              - script: .dotnet/dotnet msbuild eng/helix.proj /restore /t:Test /p:configuration=$(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
                 displayName: Send job to helix
                 env:
                   HelixAccessToken: $(_HelixAccessToken)

--- a/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
+++ b/test/EFCore.CrossStore.FunctionalTests/ConfigurationPatternsTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "#18682")]
         public void Can_select_appropriate_provider_when_multiple_registered()
         {
             var serviceProvider

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -246,8 +247,7 @@ namespace TestNamespace
                 new ModelCodeGenerationOptions(),
                 code =>
                 {
-                    Assert.Contains(@"Property(e => e.ValueGeneratedOnAdd)
-                    .ValueGeneratedOnAdd()", code.ContextFile.Code);
+                    Assert.Contains(@$"Property(e => e.ValueGeneratedOnAdd){Environment.NewLine}                    .ValueGeneratedOnAdd()", code.ContextFile.Code);
                     Assert.Contains("Property(e => e.ValueGeneratedOnAddOrUpdate).ValueGeneratedOnAddOrUpdate()", code.ContextFile.Code);
                     Assert.Contains("Property(e => e.ConcurrencyToken).IsConcurrencyToken()", code.ContextFile.Code);
                     Assert.Contains("Property(e => e.ValueGeneratedOnUpdate).ValueGeneratedOnUpdate()", code.ContextFile.Code);

--- a/test/EFCore.InMemory.FunctionalTests/Query/CompleteMappingInheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/CompleteMappingInheritanceInMemoryTest.cs
@@ -24,7 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     @"DbSet<Bird>()
     .Select(b => InheritanceInMemoryFixture.MaterializeView(b))
     .OrderBy(a => a.CountryId)"),
-                message);
+                message,
+                ignoreLineEndingDifferences: true);
         }
 
         protected override bool EnforcesFkConstraints => false;

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
@@ -26,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     @"DbSet<Bird>()
     .Select(b => InheritanceInMemoryFixture.MaterializeView(b))
     .OrderBy(a => a.CountryId)"),
-                message);
+                message,
+                ignoreLineEndingDifferences: true);
         }
 
         protected override bool EnforcesFkConstraints => false;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/FromSqlQuerySqliteTest.cs
@@ -27,7 +27,7 @@ FROM (
 ) AS ""c""
 WHERE ('z' = '') OR (instr(""c"".""ContactName"", 'z') > 0)";
 
-            Assert.Equal(expected, queryString);
+            Assert.Equal(expected, queryString, ignoreLineEndingDifferences: true);
 
             return null;
         }
@@ -43,7 +43,7 @@ SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyN
 FROM (
     SELECT * FROM ""Customers"" WHERE ""City"" = @p0
 ) AS ""c""
-WHERE ""c"".""ContactTitle"" = @__contactTitle_1", queryString);
+WHERE ""c"".""ContactTitle"" = @__contactTitle_1", queryString, ignoreLineEndingDifferences: true);
 
             return null;
         }

--- a/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionPrinterTest.cs
@@ -173,7 +173,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         Expression.Constant("Foobar"),
                         typeof(string).GetMethods().Single(m => m.Name == nameof(string.Substring) && m.GetParameters().Count() == 2),
                         Expression.Constant(0),
-                        Expression.Constant(4))));
+                        Expression.Constant(4))),
+                ignoreLineEndingDifferences: true);
         }
 
         [ConditionalFact]
@@ -193,7 +194,8 @@ namespace Microsoft.EntityFrameworkCore.Query
     .Select(x => x.ToString())
     .AsEnumerable()
     .Where(x => x.Length > 1)",
-                _expressionPrinter.Print(expr.Body));
+                _expressionPrinter.Print(expr.Body),
+                ignoreLineEndingDifferences: true);
         }
     }
 }


### PR DESCRIPTION
Use single build to run helix tests across different OS.

Resolves #19964
