### PR TITLE
Fixes #15393 Added test to check providers don't use internal APIs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,8 @@
     <MicrosoftAzureCosmosPackageVersion>3.7.0-preview</MicrosoftAzureCosmosPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>3.3.1</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.3.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesMSBuildPackageVersion>3.3.1</MicrosoftCodeAnalysisCSharpWorkspacesMSBuildPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <mod_spatialitePackageVersion>4.3.0.1</mod_spatialitePackageVersion>
     <NetTopologySuitePackageVersion>2.0.0</NetTopologySuitePackageVersion>
     <NetTopologySuiteIOSpatiaLitePackageVersion>2.0.0</NetTopologySuiteIOSpatiaLitePackageVersion>

--- a/test/EFCore.Cosmos.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Cosmos.Tests/ApiConsistencyTest.cs
@@ -25,5 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         protected override Assembly TargetAssembly => typeof(CosmosDatabaseWrapper).Assembly;
+
+        protected override bool IsProvider => true;
     }
 }

--- a/test/EFCore.InMemory.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.InMemory.Tests/ApiConsistencyTest.cs
@@ -27,5 +27,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override Assembly TargetAssembly => typeof(InMemoryDatabase).Assembly;
+
+        protected override bool IsProvider => true;
     }
 }

--- a/test/EFCore.SqlServer.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.SqlServer.Tests/ApiConsistencyTest.cs
@@ -32,5 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override Assembly TargetAssembly => typeof(SqlServerConnection).Assembly;
+
+        protected override bool IsProvider => true;
     }
 }

--- a/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
@@ -28,5 +28,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected override Assembly TargetAssembly => typeof(SqliteRelationalConnection).Assembly;
+
+        protected override bool IsProvider => true;
     }
 }

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -23,6 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesMSBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 


### PR DESCRIPTION
Summary of the changes
  - This is a first pass on adding a test to validate providers do not use internal APIs.
  - Most of the code is lifted from EFCore.Analyzers.InternalUsageDiagnosticAnalyzer
  - It has some fruity pathing in it to reach the All.sln file to read the projects. There is probably a better way to do this. Maybe read the information directly out of TargetAssembly?
  - For Roslyn to reflect on the source code, it needed access to the .net core path, I'm using MSBuildLocator for this but I'm not sure this is going to work everywhere. 
  - A bunch of providers fail right now with what looks like legit errors. Be good to review these and either put in exemptions for them or keep that as legit failures. Sqlite does pass with flying colours though! 🥇 

Fixes #15393


