### PR TITLE
Partial fix for 6674. 

### DIFF
--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -221,6 +221,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     Check.NotEmpty(propertyName, nameof(propertyName)), ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure an existing navigation property of the entity type.
+        ///         It is an error for the navigation property not to exist.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationName"> The name of the navigation property to be configured. </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationBuilder Navigation([NotNull] string navigationName)
+            => new NavigationBuilder(
+                Builder.Navigation(
+                    Check.NotEmpty(navigationName, nameof(navigationName))));
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     and navigations from the entity type that were added by convention.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -135,6 +135,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     .Metadata);
 
         /// <summary>
+        ///         Returns an object that can be used to configure an existing navigation property of the entity type.
+        ///         It is an error for the navigation property not to exist.
+        /// </summary>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the navigation property to be configured (
+        ///     <c>blog => blog.Posts</c>).
+        /// </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationBuilder Navigation<TNavigation>([NotNull] Expression<Func<TEntity, TNavigation>> navigationExpression)
+            => new NavigationBuilder(
+                Builder.Navigation(
+                        Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     or navigations from the entity type that were added by convention.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/NavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/NavigationBuilder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             NavBuilder = (navigationOrSkipNavigation as Navigation)?.Builder;
             SkipNavBuilder = (navigationOrSkipNavigation as SkipNavigation)?.Builder;
-            Metadata = (IMutableNavigationBase)NavBuilder?.Metadata ?? SkipNavBuilder?.Metadata;
+            Metadata = navigationOrSkipNavigation;
 
             Check.DebugAssert(NavBuilder != null || SkipNavBuilder != null, "Expected either a Navigation or SkipNavigation");
         }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -720,6 +720,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual IMutableNavigationBase Navigation([NotNull] MemberInfo memberInfo)
+            => Navigation(memberInfo.GetSimpleMemberName());
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IMutableNavigationBase Navigation([NotNull] string navigationName)
+        {
+            var existingNavigation = Metadata.FindNavigation(navigationName);
+            var existingSkipNavigation = Metadata.FindSkipNavigation(navigationName);
+            if (existingNavigation == null
+                && existingSkipNavigation == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.CanOnlyConfigureExistingNavigations(navigationName, Metadata.DisplayName()));
+            }
+
+            return ((IMutableNavigationBase)existingNavigation) ?? existingSkipNavigation;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual InternalServicePropertyBuilder ServiceProperty(
             [NotNull] MemberInfo memberInfo, ConfigurationSource? configurationSource)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2562,6 +2562,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("AttemptToCreateEntityTypeBasedOnProxyClass", nameof(typeName)),
                 typeName);
 
+        /// <summary>
+        ///     There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the model before configuring it.
+        /// </summary>
+        public static string CanOnlyConfigureExistingNavigations([CanBeNull] object navigationName, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("CanOnlyConfigureExistingNavigations", nameof(navigationName), nameof(entityType)),
+                navigationName, entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2563,7 +2563,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 typeName);
 
         /// <summary>
-        ///     There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the model before configuring it.
+        ///     There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the entity type before configuring it.
         /// </summary>
         public static string CanOnlyConfigureExistingNavigations([CanBeNull] object navigationName, [CanBeNull] object entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1358,6 +1358,6 @@
     <value>Cannot add an entity type with type '{typeName}'. That type is a dynamically-generated proxy type.</value>
   </data>
   <data name="CanOnlyConfigureExistingNavigations" xml:space="preserve">
-    <value>There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the model before configuring it.</value>
+    <value>There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the entity type before configuring it.</value>
   </data>
 </root>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1357,4 +1357,7 @@
   <data name="AttemptToCreateEntityTypeBasedOnProxyClass" xml:space="preserve">
     <value>Cannot add an entity type with type '{typeName}'. That type is a dynamically-generated proxy type.</value>
   </data>
+  <data name="CanOnlyConfigureExistingNavigations" xml:space="preserve">
+    <value>There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Please add the navigation to the model before configuring it.</value>
+  </data>
 </root>

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -2104,6 +2104,56 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .HasMany(e => e.Dependents)
+                    .WithOne(e => e.OneToManyPrincipal);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation(e => e.Dependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToManyPrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .HasMany<NavDependent>("Dependents")
+                    .WithOne("OneToManyPrincipal");
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation("Dependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToManyPrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
             public virtual void Access_mode_can_be_overridden_at_entity_and_navigation_property_levels()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -205,6 +205,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName)
                 => new GenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.IndexedProperty<TProperty>(propertyName));
 
+            public override TestNavigationBuilder Navigation<TNavigation>(Expression<Func<TEntity, TNavigation>> navigationExpression)
+                => new GenericTestNavigationBuilder(EntityTypeBuilder.Navigation(navigationExpression));
+
+            public override TestNavigationBuilder Navigation(string propertyName)
+                => new GenericTestNavigationBuilder(EntityTypeBuilder.Navigation(propertyName));
+
             public override TestEntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object>> propertyExpression)
                 => Wrap(EntityTypeBuilder.Ignore(propertyExpression));
 
@@ -216,6 +222,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.HasIndex(propertyNames));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsOne<TRelatedEntity>(navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
@@ -229,9 +238,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         navigationExpression,
                         r => buildAction(new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany<TRelatedEntity>(navigationName));
+
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
-                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsMany(navigationExpression));
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany(navigationExpression));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
@@ -418,6 +432,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             PropertyBuilder<TProperty> IInfrastructure<PropertyBuilder<TProperty>>.Instance => PropertyBuilder;
         }
 
+        protected class GenericTestNavigationBuilder : TestNavigationBuilder
+        {
+            public GenericTestNavigationBuilder(NavigationBuilder navigationBuilder)
+            {
+                NavigationBuilder = navigationBuilder;
+            }
+
+            private NavigationBuilder NavigationBuilder { get; }
+
+            public override TestNavigationBuilder HasAnnotation(string annotation, object value)
+                => new GenericTestNavigationBuilder(NavigationBuilder.HasAnnotation(annotation, value));
+
+            public override TestNavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+                => new GenericTestNavigationBuilder(NavigationBuilder.UsePropertyAccessMode(propertyAccessMode));
+        }
+
         protected class
             GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
@@ -478,6 +508,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Action<NavigationBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(navigationExpression, navigationConfiguration));
+
+            public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName)
+                => new GenericTestCollectionCollectionBuilder<TRelatedEntity, TEntity>(
+                    CollectionNavigationBuilder.WithMany(navigationName));
 
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
@@ -706,6 +741,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(Expression<Func<TDependentEntity, object>> indexExpression)
                 => new TestIndexBuilder(OwnedNavigationBuilder.HasIndex(indexExpression));
+
+            public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference)
+                => new GenericTestOwnershipBuilder<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.WithOwner(ownerReference));
 
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression = null)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -147,6 +147,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName)
                 => new NonGenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.IndexedProperty<TProperty>(propertyName));
 
+            public override TestNavigationBuilder Navigation<TNavigation>(Expression<Func<TEntity, TNavigation>> navigationExpression)
+            {
+                var navigationInfo = navigationExpression.GetPropertyAccess();
+                return new NonGenericTestNavigationBuilder(
+                    EntityTypeBuilder.Navigation(navigationInfo.GetSimpleMemberName()));
+            }
+
+            public override TestNavigationBuilder Navigation(string propertyName)
+                => new NonGenericTestNavigationBuilder(EntityTypeBuilder.Navigation(propertyName));
+
             public override TestEntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object>> propertyExpression)
                 => Wrap(EntityTypeBuilder.Ignore(propertyExpression.GetPropertyAccess().GetSimpleMemberName()));
 
@@ -159,6 +169,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.HasIndex(propertyNames));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsOne(typeof(TRelatedEntity), navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
@@ -173,6 +187,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         typeof(TRelatedEntity),
                         navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany(typeof(TRelatedEntity), navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
@@ -387,6 +405,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             PropertyBuilder IInfrastructure<PropertyBuilder>.Instance => PropertyBuilder;
         }
 
+        protected class NonGenericTestNavigationBuilder : TestNavigationBuilder
+        {
+            public NonGenericTestNavigationBuilder(NavigationBuilder navigationIdentityBuilder)
+            {
+                NavigationIdentityBuilder = navigationIdentityBuilder;
+            }
+
+            private NavigationBuilder NavigationIdentityBuilder { get; }
+
+            public override TestNavigationBuilder HasAnnotation(string annotation, object value)
+                => new NonGenericTestNavigationBuilder(NavigationIdentityBuilder.HasAnnotation(annotation, value));
+
+            public override TestNavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+                => new NonGenericTestNavigationBuilder(NavigationIdentityBuilder.UsePropertyAccessMode(propertyAccessMode));
+        }
+
         protected class
             NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
@@ -453,6 +487,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     CollectionNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
                         navigationConfiguration));
+
+            public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName)
+                => new NonGenericTestCollectionCollectionBuilder<TRelatedEntity, TEntity>(
+                    CollectionNavigationBuilder.WithMany(navigationName));
 
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
@@ -701,6 +740,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new TestIndexBuilder(
                     OwnedNavigationBuilder.HasIndex(
                         indexExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+
+            public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference)
+                => new NonGenericTestOwnershipBuilder<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.WithOwner(ownerReference));
 
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -194,6 +194,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName);
             public abstract TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName);
 
+            public abstract TestNavigationBuilder Navigation<TNavigation>(
+                Expression<Func<TEntity, TNavigation>> propertyExpression);
+            public abstract TestNavigationBuilder Navigation(string propertyName);
+
             public abstract TestEntityTypeBuilder<TEntity> Ignore(
                 Expression<Func<TEntity, object>> propertyExpression);
 
@@ -202,6 +206,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestIndexBuilder HasIndex(Expression<Func<TEntity, object>> indexExpression);
             public abstract TestIndexBuilder HasIndex(params string[] propertyNames);
 
+            public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                where TRelatedEntity : class;
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 where TRelatedEntity : class;
@@ -211,6 +217,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
                 where TRelatedEntity : class;
 
+            public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                where TRelatedEntity : class;
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
                 where TRelatedEntity : class;
@@ -350,6 +358,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestPropertyBuilder<TProperty> HasConversion(ValueConverter converter);
         }
 
+        public abstract class TestNavigationBuilder
+        {
+            public abstract TestNavigationBuilder HasAnnotation(string annotation, object value);
+            public abstract TestNavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode);
+        }
+
         public abstract class TestCollectionNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
             where TRelatedEntity : class
@@ -361,6 +375,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
                 Action<NavigationBuilder> navigationConfiguration = null);
+
+            public abstract TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName);
 
             public abstract TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression);
@@ -512,6 +529,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestIndexBuilder HasIndex(params string[] propertyNames);
             public abstract TestIndexBuilder HasIndex(Expression<Func<TDependentEntity, object>> indexExpression);
 
+            public abstract TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference);
             public abstract TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression = null);
 

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2733,6 +2733,94 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
             }
 
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToManyPrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation(e => e.Dependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne<OneToManyNavPrincipal>("OneToManyPrincipal")
+                    .WithMany("Dependents");
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToManyPrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation("Dependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Attempt_to_configure_non_existent_Navigation_property_throws()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                Assert.Equal(
+                    CoreStrings.CanOnlyConfigureExistingNavigations("NonExistent", "NavDependent"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<NavDependent>()
+                        .Navigation("NonExistent")
+                        .UsePropertyAccessMode(PropertyAccessMode.Property)
+                        ).Message);
+            }
+
+            [ConditionalFact]
+            public virtual void Attempt_to_configure_Navigation_property_which_is_actually_a_Property_throws()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                Assert.Equal(
+                    CoreStrings.CanOnlyConfigureExistingNavigations("Name", "NavDependent"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<NavDependent>()
+                        .Navigation(e => e.Name)
+                        .UsePropertyAccessMode(PropertyAccessMode.Property)
+                        ).Message);
+            }
+
             private static void AssertGraph(
                 ModifierGroupHeader parent,
                 ModifierGroupHeader child1,

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4405,6 +4405,56 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
             }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToOnePrincipal)
+                    .WithOne(e => e.Dependent);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToOnePrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToOneNavPrincipal>()
+                    .Navigation(e => e.Dependent)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne<OneToOneNavPrincipal>("OneToOnePrincipal")
+                    .WithOne("Dependent");
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToOnePrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToOneNavPrincipal>()
+                    .Navigation("Dependent")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1329,6 +1329,80 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(4, model.GetEntityTypes().Count());
             }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .OwnsOne(e => e.OwnedDependent)
+                    .WithOwner(e => e.OneToOneOwner);
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .Navigation(e => e.OwnedDependent)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .OwnsOne<OwnedNavDependent>("OwnedDependent")
+                    .WithOwner("OneToOneOwner");
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .Navigation("OwnedDependent")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .OwnsMany(e => e.OwnedDependents);
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .Navigation(e => e.OwnedDependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .OwnsMany<OwnedOneToManyNavDependent>("OwnedDependents");
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .Navigation("OwnedDependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -866,6 +866,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public NavDependent Dependent { get; set; }
         }
 
+        private class ManyToManyNavPrincipal
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public List<NavDependent> Dependents { get; set; }
+        }
+
         private class NavDependent
         {
             public int Id { get; set; }
@@ -873,6 +881,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public OneToManyNavPrincipal OneToManyPrincipal { get; set; }
             public OneToOneNavPrincipal OneToOnePrincipal { get; set; }
+            public List<ManyToManyNavPrincipal> ManyToManyPrincipals { get; set; }
         }
 
         private class OneToManyNavPrincipalOwner
@@ -880,7 +889,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int Id { get; set; }
             public string Description { get; set; }
 
-            public List<OwnedNavDependent> OwnedDependents { get; set; }
+            public List<OwnedOneToManyNavDependent> OwnedDependents { get; set; }
         }
 
         private class OneToOneNavPrincipalOwner
@@ -895,6 +904,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public string FirstName { get; set; }
             public string LastName { get; set; }
+
+            public OneToOneNavPrincipalOwner OneToOneOwner { get; set; }
+        }
+
+        private class OwnedOneToManyNavDependent
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+
+            public OneToManyNavPrincipalOwner OneToManyOwner { get; set; }
         }
     }
 }


### PR DESCRIPTION
Partial fix for #6674

Created new Navigation() calls directly on EntityBuilder. Added tests for OneToMany, ManyToOne, ManyToMany, OneToOne and principal side of the Owned Type.

#### Things remaining:
- The additions to `WithOwner()` to allow configuring a navigation on the dependent side of an Owned Type.
- Removing the old way of doing it (see #20195).