### PR TITLE
Add ability to configure the navigation on dependent side of Owned-types

### DIFF
--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder WithOne(
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => new ReferenceCollectionBuilder(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         [EntityFrameworkInternal]
         protected virtual InternalRelationshipBuilder WithOneBuilder(
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => WithOneBuilder(MemberIdentity.Create(navigationName), navigationConfiguration);
 
         /// <summary>
@@ -156,12 +156,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         [EntityFrameworkInternal]
         protected virtual InternalRelationshipBuilder WithOneBuilder(
             [CanBeNull] MemberInfo navigationMemberInfo,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => WithOneBuilder(MemberIdentity.Create(navigationMemberInfo), navigationConfiguration);
 
         private InternalRelationshipBuilder WithOneBuilder(
             MemberIdentity reference,
-            Action<NavigationBuilder> navigationConfiguration = null)
+            Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             if (SkipNavigation != null)
             {
@@ -201,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && withOneBuilder.Metadata.DependentToPrincipal != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(withOneBuilder.Metadata.DependentToPrincipal));
+                    new NavigationIdentityBuilder(withOneBuilder.Metadata.DependentToPrincipal));
             }
 
             return withOneBuilder;

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             return new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -221,6 +221,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     Check.NotEmpty(propertyName, nameof(propertyName)), ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure an existing navigation property of the entity type.
+        ///         It is an error for the navigation property not to exist.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationName"> The name of the navigation property to be configured. </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationIdentityBuilder Navigation([NotNull] string navigationName)
+            => new NavigationIdentityBuilder(
+                Builder.Navigation(
+                    Check.NotEmpty(navigationName, nameof(navigationName))).Metadata);
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     and navigations from the entity type that were added by convention.
         /// </summary>
@@ -582,7 +595,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -629,7 +642,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -668,7 +681,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotEmpty(navigationName, nameof(navigationName));
 
@@ -687,7 +700,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         protected virtual ForeignKey HasOneBuilder(
             MemberIdentity navigationId,
             [NotNull] EntityType relatedEntityType,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             ForeignKey foreignKey;
             if (navigationId.MemberInfo != null)
@@ -713,7 +726,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     : foreignKey.PrincipalToDependent;
 
                 navigationConfiguration(
-                    new NavigationBuilder(navigation));
+                    new NavigationIdentityBuilder(navigation));
             }
 
             return foreignKey;
@@ -744,7 +757,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -776,7 +789,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotEmpty(navigationName, nameof(navigationName));
 
@@ -831,7 +844,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionNavigationBuilder HasMany(
             [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -844,7 +857,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         private CollectionNavigationBuilder HasMany(
             string navigationName,
             EntityType relatedEntityType,
-            Action<NavigationBuilder> navigationConfiguration = null)
+            Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             var skipNavigation = navigationName != null ? Builder.Metadata.FindSkipNavigation(navigationName) : null;
 
@@ -861,7 +874,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey?.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new CollectionNavigationBuilder(

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -135,6 +135,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     .Metadata);
 
         /// <summary>
+        ///         Returns an object that can be used to configure an existing navigation property of the entity type.
+        ///         It is an error for the navigation property not to exist.
+        /// </summary>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the navigation property to be configured (
+        ///     <c>blog => blog.Posts</c>).
+        /// </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationIdentityBuilder Navigation<TNavigation>([NotNull] Expression<Func<TEntity, TNavigation>> navigationExpression)
+            => new NavigationIdentityBuilder(
+                Builder.Navigation(
+                        Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess())
+                    .Metadata);
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     or navigations from the entity type that were added by convention.
         /// </summary>
@@ -502,9 +517,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(string, Action{NavigationBuilder})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(string, Action{NavigationIdentityBuilder})" />
         ///         or
-        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(string, Action{NavigationBuilder})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(string, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -521,7 +536,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             where TRelatedEntity : class
         {
             var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationName);
@@ -548,10 +563,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}}, Action{NavigationBuilder})" />
+        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}}, Action{NavigationIdentityBuilder})" />
         ///         or
         ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationBuilder})" />
+        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -568,7 +583,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
             [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             where TRelatedEntity : class
         {
             var navigationMember = navigationExpression?.GetPropertyAccess();
@@ -596,7 +611,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see
-        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationBuilder})" />
+        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -613,7 +628,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             where TRelatedEntity : class
         {
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
@@ -634,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey?.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(
@@ -658,7 +673,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see
-        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationBuilder})" />
+        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -675,7 +690,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
             [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             where TRelatedEntity : class
         {
             var navigationMember = navigationExpression?.GetPropertyAccess();
@@ -695,7 +710,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey?.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(

--- a/src/EFCore/Metadata/Builders/NavigationIdentityBuilder.cs
+++ b/src/EFCore/Metadata/Builders/NavigationIdentityBuilder.cs
@@ -1,0 +1,132 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a <see cref="INavigation" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class NavigationIdentityBuilder
+    {
+        private readonly IMutableNavigationBase _navigationBase;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public NavigationIdentityBuilder([NotNull] IMutableNavigationBase navigationOrSkipNavigation)
+        {
+            Check.NotNull(navigationOrSkipNavigation, nameof(navigationOrSkipNavigation));
+
+            _navigationBase = navigationOrSkipNavigation;
+        }
+
+        /// <summary>
+        ///     Adds or updates an annotation on the navigation property. If an annotation
+        ///     with the key specified in <paramref name="annotation" /> already exists
+        ///     its value will be updated.
+        /// </summary>
+        /// <param name="annotation"> The key of the annotation to be added or updated. </param>
+        /// <param name="value"> The value to be stored in the annotation. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual NavigationIdentityBuilder HasAnnotation([NotNull] string annotation, [NotNull] object value)
+        {
+            Check.NotEmpty(annotation, nameof(annotation));
+            Check.NotNull(value, nameof(value));
+
+            var navigation = AsNavigation;
+            if (navigation != null)
+            {
+                new NavigationBuilder(navigation).HasAnnotation(annotation, value);
+            }
+            else
+            {
+                var skipNavigation = AsSkipNavigation;
+                Check.NotNull(skipNavigation, nameof(skipNavigation));
+                new SkipNavigationBuilder(skipNavigation).HasAnnotation(annotation, value);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Sets the <see cref="PropertyAccessMode" /> to use for this property.
+        ///     </para>
+        ///     <para>
+        ///         By default, the backing field, if one is found by convention or has been specified, is used when
+        ///         new objects are constructed, typically when entities are queried from the database.
+        ///         Properties are used for all other accesses.  Calling this method will change that behavior
+        ///         for this property as described in the <see cref="PropertyAccessMode" /> enum.
+        ///     </para>
+        ///     <para>
+        ///         Calling this method overrides for this property any access mode that was set on the
+        ///         entity type or model.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for this property. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual NavigationIdentityBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+        {
+            var navigation = AsNavigation;
+            if (navigation != null)
+            {
+                new NavigationBuilder(navigation).UsePropertyAccessMode(propertyAccessMode);
+            }
+            else
+            {
+                var skipNavigation = AsSkipNavigation;
+                Check.NotNull(skipNavigation, nameof(skipNavigation));
+                new SkipNavigationBuilder(skipNavigation).UsePropertyAccessMode(propertyAccessMode);
+            }
+
+            return this;
+        }
+
+        private IMutableNavigation AsNavigation => _navigationBase as IMutableNavigation;
+        private IMutableSkipNavigation AsSkipNavigation => _navigationBase as IMutableSkipNavigation;
+
+        #region Hidden System.Object members
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns> A string that represents the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns> true if the specified object is equal to the current object; otherwise, false. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectEqualsIsObjectEquals
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns> A hash code for the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
+    }
+}

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -235,6 +235,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     Check.NotEmpty(propertyName, nameof(propertyName)), ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure an existing navigation property
+        ///         from the owned type to its owner. It is an error for the navigation property
+        ///         not to exist.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationName"> The name of the navigation property to be configured. </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationIdentityBuilder Navigation([NotNull] string navigationName)
+            => new NavigationIdentityBuilder(
+                DependentEntityType.Builder.Navigation(
+                    Check.NotEmpty(navigationName, nameof(navigationName))).Metadata);
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     or navigations from the owned entity type that were added by convention.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -92,6 +92,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                         ConfigurationSource.Explicit).Metadata));
 
         /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure an existing navigation property
+        ///         from the owned type to its owner. It is an error for the navigation property
+        ///         not to exist.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the navigation property to be configured (
+        ///     <c>blog => blog.Posts</c>).
+        /// </param>
+        /// <returns> An object that can be used to configure the navigation property. </returns>
+        public virtual NavigationIdentityBuilder Navigation<TNavigation>(
+            [NotNull] Expression<Func<TDependentEntity, TNavigation>> navigationExpression)
+            => base.Navigation(
+                    Check.NotNull(navigationExpression, nameof(navigationExpression))
+                        .GetPropertyAccess().GetSimpleMemberName());
+
+        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     or navigations from the owned entity type that were added by convention.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -508,9 +508,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(string, Action{NavigationBuilder})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(string, Action{NavigationIdentityBuilder})" />
         ///         or
-        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(string, Action{NavigationBuilder})" />
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(string, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -550,10 +550,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}
-        /// .WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}}, Action{NavigationBuilder})" />
+        /// .WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}}, Action{NavigationIdentityBuilder})" />
         ///         or
         ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}
-        /// .WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationBuilder})" />
+        /// .WithOne(Expression{Func{TRelatedEntity,TEntity}}, Action{NavigationIdentityBuilder})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder WithMany(
             [CanBeNull] string collection = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             var foreignKey = WithManyBuilder(Check.NullButNotEmpty(collection, nameof(collection))).Metadata;
 
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new ReferenceCollectionBuilder(
@@ -231,7 +231,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceReferenceBuilder WithOne(
             [CanBeNull] string reference = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => new ReferenceReferenceBuilder(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -248,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         [EntityFrameworkInternal]
         protected virtual InternalRelationshipBuilder WithOneBuilder(
             [CanBeNull] string navigationName,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => WithOneBuilder(MemberIdentity.Create(navigationName), navigationConfiguration);
 
         /// <summary>
@@ -260,12 +260,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         [EntityFrameworkInternal]
         protected virtual InternalRelationshipBuilder WithOneBuilder(
             [CanBeNull] MemberInfo navigationMemberInfo,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => WithOneBuilder(MemberIdentity.Create(navigationMemberInfo), navigationConfiguration);
 
         private InternalRelationshipBuilder WithOneBuilder(
             MemberIdentity reference,
-            Action<NavigationBuilder> navigationConfiguration = null)
+            Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             var referenceName = reference.Name;
             if (!Builder.Metadata.IsUnique
@@ -338,12 +338,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 if (pointsToPrincipal)
                 {
                     navigationConfiguration(
-                        new NavigationBuilder(withOneBuilder.Metadata.DependentToPrincipal));
+                        new NavigationIdentityBuilder(withOneBuilder.Metadata.DependentToPrincipal));
                 }
                else
                 {
                     navigationConfiguration(
-                        new NavigationBuilder(withOneBuilder.Metadata.PrincipalToDependent));
+                        new NavigationIdentityBuilder(withOneBuilder.Metadata.PrincipalToDependent));
                 }
             }
 

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             var foreignKey = WithManyBuilder(
                 Check.NullButNotEmpty(navigationName, nameof(navigationName))).Metadata;
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
             [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
         {
             var navigationMember = navigationExpression?.GetPropertyAccess();
             var foreignKey = WithManyBuilder(navigationMember).Metadata;
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && foreignKey.PrincipalToDependent != null)
             {
                 navigationConfiguration(
-                    new NavigationBuilder(foreignKey.PrincipalToDependent));
+                    new NavigationIdentityBuilder(foreignKey.PrincipalToDependent));
             }
 
             return new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] string navigationName = null,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
             [CanBeNull] Expression<Func<TRelatedEntity, TEntity>> navigationExpression,
-            [CanBeNull] Action<NavigationBuilder> navigationConfiguration = null)
+            [CanBeNull] Action<NavigationIdentityBuilder> navigationConfiguration = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/SkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/SkipNavigationBuilder.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a <see cref="ISkipNavigation" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class SkipNavigationBuilder : IInfrastructure<IConventionSkipNavigationBuilder>
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public SkipNavigationBuilder([NotNull] IMutableSkipNavigation skipNavigation)
+        {
+            Check.NotNull(skipNavigation, nameof(skipNavigation));
+
+            Builder = ((SkipNavigation)skipNavigation).Builder;
+        }
+
+        /// <summary>
+        ///     The internal builder being used to configure the skip navigation property.
+        /// </summary>
+        IConventionSkipNavigationBuilder IInfrastructure<IConventionSkipNavigationBuilder>.Instance => Builder;
+
+        /// <summary>
+        ///     The skip navigation being configured.
+        /// </summary>
+        public virtual IMutableSkipNavigation Metadata => Builder.Metadata;
+
+        /// <summary>
+        ///     Adds or updates an annotation on the skip navigation property. If an annotation
+        ///     with the key specified in <paramref name="annotation" /> already exists
+        ///     its value will be updated.
+        /// </summary>
+        /// <param name="annotation"> The key of the annotation to be added or updated. </param>
+        /// <param name="value"> The value to be stored in the annotation. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual SkipNavigationBuilder HasAnnotation([NotNull] string annotation, [NotNull] object value)
+        {
+            Check.NotEmpty(annotation, nameof(annotation));
+            Check.NotNull(value, nameof(value));
+
+            Builder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Sets the <see cref="PropertyAccessMode" /> to use for this skip navigation property.
+        ///     </para>
+        ///     <para>
+        ///         By default, the backing field, if one is found by convention or has been specified, is used when
+        ///         new objects are constructed, typically when entities are queried from the database.
+        ///         Properties are used for all other accesses.  Calling this method will change that behavior
+        ///         for this skip navigation property as described in the <see cref="PropertyAccessMode" /> enum.
+        ///     </para>
+        ///     <para>
+        ///         Calling this method overrides for this skip navigation property any access mode that was set on the
+        ///         entity type or model.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for this property. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual SkipNavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+        {
+            Builder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        private InternalSkipNavigationBuilder Builder { get; }
+
+        #region Hidden System.Object members
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns> A string that represents the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns> true if the specified object is equal to the current object; otherwise, false. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectEqualsIsObjectEquals
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns> A hash code for the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
+    }
+}

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -720,6 +720,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual InternalNavigationIdentityBuilder Navigation([NotNull] MemberInfo memberInfo)
+            => Navigation(memberInfo.GetSimpleMemberName());
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalNavigationIdentityBuilder Navigation([NotNull] string navigationName)
+        {
+            var existingNavigation = Metadata.FindNavigation(navigationName);
+            var existingSkipNavigation = Metadata.FindSkipNavigation(navigationName);
+            if (existingNavigation == null
+                && existingSkipNavigation == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.CanOnlyConfigureExistingNavigations(navigationName, Metadata.DisplayName()));
+            }
+
+            return existingNavigation != null
+                ? new InternalNavigationIdentityBuilder(
+                    existingNavigation,
+                    existingNavigation.Builder.ModelBuilder)
+                : new InternalNavigationIdentityBuilder(
+                    existingSkipNavigation,
+                    existingSkipNavigation.Builder.ModelBuilder);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual InternalServicePropertyBuilder ServiceProperty(
             [NotNull] MemberInfo memberInfo, ConfigurationSource? configurationSource)
         {

--- a/src/EFCore/Metadata/Internal/InternalNavigationIdentityBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalNavigationIdentityBuilder.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class InternalNavigationIdentityBuilder
+    {
+        private readonly InternalNavigationBuilder _internalNavigationBuilder;
+        private readonly InternalSkipNavigationBuilder _internalSkipNavigationBuilder;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public InternalNavigationIdentityBuilder(
+            [NotNull] IMutableNavigationBase navigationBase,
+            [NotNull] InternalModelBuilder modelBuilder)
+        {
+            Check.NotNull(navigationBase, nameof(navigationBase));
+
+            Metadata = navigationBase;
+            var navigation = Metadata as Navigation;
+            if (navigation != null)
+            {
+                _internalNavigationBuilder = new InternalNavigationBuilder(navigation, modelBuilder);
+            }
+            else
+            {
+                var skipNavigation = Metadata as SkipNavigation;
+                Check.NotNull(skipNavigation, nameof(skipNavigation));
+                _internalSkipNavigationBuilder = new InternalSkipNavigationBuilder(skipNavigation, modelBuilder);
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IMutableNavigationBase Metadata { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalNavigationIdentityBuilder UsePropertyAccessMode(
+            PropertyAccessMode? propertyAccessMode, ConfigurationSource configurationSource)
+        {
+            if (_internalNavigationBuilder != null)
+            {
+                _internalNavigationBuilder.UsePropertyAccessMode(propertyAccessMode, configurationSource);
+            }
+            else
+            {
+                _internalSkipNavigationBuilder.UsePropertyAccessMode(propertyAccessMode, configurationSource);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetPropertyAccessMode(PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
+        {
+            return _internalNavigationBuilder != null
+                ? _internalNavigationBuilder.CanSetPropertyAccessMode(
+                    propertyAccessMode,
+                    fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention)
+                : _internalSkipNavigationBuilder.CanSetPropertyAccessMode(
+                    propertyAccessMode,
+                    fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+        }
+    }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2562,6 +2562,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("AttemptToCreateEntityTypeBasedOnProxyClass", nameof(typeName)),
                 typeName);
 
+        /// <summary>
+        ///     There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Only pre-existing navigations can be configured.
+        /// </summary>
+        public static string CanOnlyConfigureExistingNavigations([CanBeNull] object navigationName, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("CanOnlyConfigureExistingNavigations", nameof(navigationName), nameof(entityType)),
+                navigationName, entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1357,4 +1357,7 @@
   <data name="AttemptToCreateEntityTypeBasedOnProxyClass" xml:space="preserve">
     <value>Cannot add an entity type with type '{typeName}'. That type is a dynamically-generated proxy type.</value>
   </data>
+  <data name="CanOnlyConfigureExistingNavigations" xml:space="preserve">
+    <value>There is no navigation property with name '{navigationName}' on entity type '{entityType}'. Only pre-existing navigations can be configured.</value>
+  </data>
 </root>

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -2104,6 +2104,56 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .HasMany(e => e.Dependents)
+                    .WithOne(e => e.OneToManyPrincipal);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation(e => e.Dependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToManyPrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .HasMany<NavDependent>("Dependents")
+                    .WithOne("OneToManyPrincipal");
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation("Dependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToManyPrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
             public virtual void Access_mode_can_be_overridden_at_entity_and_navigation_property_levels()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne<TRelatedEntity>(
                         navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName(),
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany<TRelatedEntity>(
                         navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName(),
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericStringTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
@@ -163,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(navigationExpression, navigationConfiguration));
         }
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(navigationExpression, navigationConfiguration));
         }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -226,6 +226,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
                 => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsOne<TRelatedEntity>(navigationName));
 
+            public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                => Wrap(
+                    EntityTypeBuilder.OwnsOne<TRelatedEntity>(
+                        navigationName,
+                        r => buildAction(new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
+
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsOne(navigationExpression));
@@ -241,6 +249,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
                 => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsMany<TRelatedEntity>(navigationName));
+            public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                => Wrap(
+                    EntityTypeBuilder.OwnsMany<TRelatedEntity>(
+                        navigationName,
+                        r => buildAction(new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
@@ -728,6 +743,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> Property<TProperty>(
                 Expression<Func<TDependentEntity, TProperty>> propertyExpression)
                 => new GenericTestPropertyBuilder<TProperty>(OwnedNavigationBuilder.Property(propertyExpression));
+
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(string navigationName)
+                => new GenericTestNavigationIdentityBuilder(OwnedNavigationBuilder.Navigation(navigationName));
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(
+                Expression<Func<TDependentEntity, TNavigation>> navigationExpression)
+                => new GenericTestNavigationIdentityBuilder(OwnedNavigationBuilder.Navigation(navigationExpression));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(string propertyName)
                 => Wrap(OwnedNavigationBuilder.Ignore(propertyName));

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -205,6 +205,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName)
                 => new GenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.IndexedProperty<TProperty>(propertyName));
 
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(Expression<Func<TEntity, TNavigation>> navigationExpression)
+                => new GenericTestNavigationIdentityBuilder(EntityTypeBuilder.Navigation(navigationExpression));
+
+            public override TestNavigationIdentityBuilder Navigation(string propertyName)
+                => new GenericTestNavigationIdentityBuilder(EntityTypeBuilder.Navigation(propertyName));
+
             public override TestEntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object>> propertyExpression)
                 => Wrap(EntityTypeBuilder.Ignore(propertyExpression));
 
@@ -216,6 +222,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.HasIndex(propertyNames));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsOne<TRelatedEntity>(navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
@@ -229,9 +238,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         navigationExpression,
                         r => buildAction(new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany<TRelatedEntity>(navigationName));
+
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
-                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.OwnsMany(navigationExpression));
+                => new GenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany(navigationExpression));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
@@ -243,24 +257,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne<TRelatedEntity>(navigationName, navigationConfiguration));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(navigationExpression, navigationConfiguration));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany<TRelatedEntity>(navigationName, navigationConfiguration));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(navigationExpression, navigationConfiguration));
 
             public override TestEntityTypeBuilder<TEntity> HasQueryFilter(Expression<Func<TEntity, bool>> filter)
@@ -418,6 +432,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             PropertyBuilder<TProperty> IInfrastructure<PropertyBuilder<TProperty>>.Instance => PropertyBuilder;
         }
 
+        protected class GenericTestNavigationIdentityBuilder : TestNavigationIdentityBuilder
+        {
+            public GenericTestNavigationIdentityBuilder(NavigationIdentityBuilder navigationIdentityBuilder)
+            {
+                NavigationIdentityBuilder = navigationIdentityBuilder;
+            }
+
+            private NavigationIdentityBuilder NavigationIdentityBuilder { get; }
+
+            public override TestNavigationIdentityBuilder HasAnnotation(string annotation, object value)
+                => new GenericTestNavigationIdentityBuilder(NavigationIdentityBuilder.HasAnnotation(annotation, value));
+
+            public override TestNavigationIdentityBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+                => new GenericTestNavigationIdentityBuilder(NavigationIdentityBuilder.UsePropertyAccessMode(propertyAccessMode));
+        }
+
         protected class
             GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
@@ -432,25 +462,25 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(navigationName, navigationConfiguration));
 
             public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(navigationExpression, navigationConfiguration));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(navigationName, navigationConfiguration));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(navigationExpression, navigationConfiguration));
         }
@@ -469,15 +499,20 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(navigationName, navigationConfiguration));
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(navigationExpression, navigationConfiguration));
+
+            public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName)
+                => new GenericTestCollectionCollectionBuilder<TRelatedEntity, TEntity>(
+                    CollectionNavigationBuilder.WithMany(navigationName));
 
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
@@ -706,6 +741,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(Expression<Func<TDependentEntity, object>> indexExpression)
                 => new TestIndexBuilder(OwnedNavigationBuilder.HasIndex(indexExpression));
+
+            public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference)
+                => new GenericTestOwnershipBuilder<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.WithOwner(ownerReference));
 
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression = null)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(
                         typeof(TRelatedEntity).FullName,
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany(
                         typeof(TRelatedEntity).FullName,
@@ -174,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -173,6 +173,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsOne(typeof(TRelatedEntity), navigationName));
+            public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                => Wrap(
+                    EntityTypeBuilder.OwnsOne(
+                        typeof(TRelatedEntity),
+                        navigationName,
+                        r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
@@ -191,6 +199,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsMany(typeof(TRelatedEntity), navigationName));
+            public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                => Wrap(
+                    EntityTypeBuilder.OwnsMany(
+                        typeof(TRelatedEntity),
+                        navigationName,
+                        r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
@@ -724,6 +740,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 return new NonGenericTestPropertyBuilder<TProperty>(
                     OwnedNavigationBuilder.Property(propertyInfo.PropertyType, propertyInfo.GetSimpleMemberName()));
             }
+
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(string navigationName)
+                => new NonGenericTestNavigationIdentityBuilder(OwnedNavigationBuilder.Navigation(navigationName));
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(
+                Expression<Func<TDependentEntity, TNavigation>> navigationExpression)
+                => new NonGenericTestNavigationIdentityBuilder(
+                    OwnedNavigationBuilder.Navigation(navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(string propertyName)
                 => Wrap<TEntity, TDependentEntity>(OwnedNavigationBuilder.Ignore(propertyName));

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -147,6 +147,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName)
                 => new NonGenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.IndexedProperty<TProperty>(propertyName));
 
+            public override TestNavigationIdentityBuilder Navigation<TNavigation>(Expression<Func<TEntity, TNavigation>> navigationExpression)
+            {
+                var navigationInfo = navigationExpression.GetPropertyAccess();
+                return new NonGenericTestNavigationIdentityBuilder(
+                    EntityTypeBuilder.Navigation(navigationInfo.GetSimpleMemberName()));
+            }
+
+            public override TestNavigationIdentityBuilder Navigation(string propertyName)
+                => new NonGenericTestNavigationIdentityBuilder(EntityTypeBuilder.Navigation(propertyName));
+
             public override TestEntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object>> propertyExpression)
                 => Wrap(EntityTypeBuilder.Ignore(propertyExpression.GetPropertyAccess().GetSimpleMemberName()));
 
@@ -159,6 +169,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestIndexBuilder HasIndex(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.HasIndex(propertyNames));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsOne(typeof(TRelatedEntity), navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
@@ -173,6 +187,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         typeof(TRelatedEntity),
                         navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
+
+            public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
+                    EntityTypeBuilder.OwnsMany(typeof(TRelatedEntity), navigationName));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
@@ -190,13 +208,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(navigationName, navigationConfiguration));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(
                         typeof(TRelatedEntity),
@@ -205,13 +223,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany(typeof(TRelatedEntity), navigationName, navigationConfiguration));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany(
                         typeof(TRelatedEntity),
@@ -387,6 +405,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             PropertyBuilder IInfrastructure<PropertyBuilder>.Instance => PropertyBuilder;
         }
 
+        protected class NonGenericTestNavigationIdentityBuilder : TestNavigationIdentityBuilder
+        {
+            public NonGenericTestNavigationIdentityBuilder(NavigationIdentityBuilder navigationIdentityBuilder)
+            {
+                NavigationIdentityBuilder = navigationIdentityBuilder;
+            }
+
+            private NavigationIdentityBuilder NavigationIdentityBuilder { get; }
+
+            public override TestNavigationIdentityBuilder HasAnnotation(string annotation, object value)
+                => new NonGenericTestNavigationIdentityBuilder(NavigationIdentityBuilder.HasAnnotation(annotation, value));
+
+            public override TestNavigationIdentityBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+                => new NonGenericTestNavigationIdentityBuilder(NavigationIdentityBuilder.UsePropertyAccessMode(propertyAccessMode));
+        }
+
         protected class
             NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : TestReferenceNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
@@ -401,13 +435,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(navigationName, navigationConfiguration));
 
             public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
@@ -415,13 +449,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(navigationName, navigationConfiguration));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
@@ -442,17 +476,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(navigationName, navigationConfiguration));
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
                         navigationConfiguration));
+
+            public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName)
+                => new NonGenericTestCollectionCollectionBuilder<TRelatedEntity, TEntity>(
+                    CollectionNavigationBuilder.WithMany(navigationName));
 
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
@@ -701,6 +740,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new TestIndexBuilder(
                     OwnedNavigationBuilder.HasIndex(
                         indexExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+
+            public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference)
+                => new NonGenericTestOwnershipBuilder<TEntity, TDependentEntity>(
+                    OwnedNavigationBuilder.WithOwner(ownerReference));
 
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
             {
                 var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
 
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
             {
                 var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
 
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 => new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
                         navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -208,6 +208,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
                 where TRelatedEntity : class;
+            public abstract TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                where TRelatedEntity : class;
+
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 where TRelatedEntity : class;
@@ -219,6 +224,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
                 where TRelatedEntity : class;
+            public abstract TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
+                string navigationName,
+                Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
+                where TRelatedEntity : class;
+
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
                 where TRelatedEntity : class;
@@ -520,6 +530,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public abstract TestPropertyBuilder<TProperty> Property<TProperty>(
                 Expression<Func<TDependentEntity, TProperty>> propertyExpression);
+
+            public abstract TestNavigationIdentityBuilder Navigation<TNavigation>(string navigationName);
+            public abstract TestNavigationIdentityBuilder Navigation<TNavigation>(
+                Expression<Func<TDependentEntity, TNavigation>> navigationExpression);
 
             public abstract TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(string propertyName);
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -194,6 +194,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName);
             public abstract TestPropertyBuilder<TProperty> IndexedProperty<TProperty>(string propertyName);
 
+            public abstract TestNavigationIdentityBuilder Navigation<TNavigation>(
+                Expression<Func<TEntity, TNavigation>> propertyExpression);
+            public abstract TestNavigationIdentityBuilder Navigation(string propertyName);
+
             public abstract TestEntityTypeBuilder<TEntity> Ignore(
                 Expression<Func<TEntity, object>> propertyExpression);
 
@@ -202,6 +206,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestIndexBuilder HasIndex(Expression<Func<TEntity, object>> indexExpression);
             public abstract TestIndexBuilder HasIndex(params string[] propertyNames);
 
+            public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)
+                where TRelatedEntity : class;
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 where TRelatedEntity : class;
@@ -211,6 +217,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
                 where TRelatedEntity : class;
 
+            public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
+                where TRelatedEntity : class;
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
                 where TRelatedEntity : class;
@@ -222,22 +230,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public abstract TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 where TRelatedEntity : class;
 
             public abstract TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 where TRelatedEntity : class;
 
             public abstract TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 where TRelatedEntity : class;
 
             public abstract TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null)
+                Action<NavigationIdentityBuilder> navigationConfiguration = null)
                 where TRelatedEntity : class;
 
             public abstract TestEntityTypeBuilder<TEntity> HasQueryFilter(Expression<Func<TEntity, bool>> filter);
@@ -350,17 +358,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestPropertyBuilder<TProperty> HasConversion(ValueConverter converter);
         }
 
+        public abstract class TestNavigationIdentityBuilder
+        {
+            public abstract TestNavigationIdentityBuilder HasAnnotation(string annotation, object value);
+            public abstract TestNavigationIdentityBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode);
+        }
+
         public abstract class TestCollectionNavigationBuilder<TEntity, TRelatedEntity>
             where TEntity : class
             where TRelatedEntity : class
         {
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
 
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
+
+            public abstract TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
+                string navigationName);
 
             public abstract TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression);
@@ -372,19 +389,19 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public abstract TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
 
             public abstract TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 string navigationName,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null,
-                Action<NavigationBuilder> navigationConfiguration = null);
+                Action<NavigationIdentityBuilder> navigationConfiguration = null);
         }
 
         public abstract class TestReferenceCollectionBuilder<TEntity, TRelatedEntity>
@@ -512,6 +529,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestIndexBuilder HasIndex(params string[] propertyNames);
             public abstract TestIndexBuilder HasIndex(Expression<Func<TDependentEntity, object>> indexExpression);
 
+            public abstract TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference);
             public abstract TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression = null);
 

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2733,6 +2733,94 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
             }
 
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToManyPrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation(e => e.Dependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne<OneToManyNavPrincipal>("OneToManyPrincipal")
+                    .WithMany("Dependents");
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToManyPrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToManyNavPrincipal>()
+                    .Navigation("Dependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Attempt_to_configure_non_existent_Navigation_property_throws()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                Assert.Equal(
+                    CoreStrings.CanOnlyConfigureExistingNavigations("NonExistent", "NavDependent"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<NavDependent>()
+                        .Navigation("NonExistent")
+                        .UsePropertyAccessMode(PropertyAccessMode.Property)
+                        ).Message);
+            }
+
+            [ConditionalFact]
+            public virtual void Attempt_to_configure_Navigation_property_which_is_actually_a_Property_throws()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToManyPrincipal)
+                    .WithMany(e => e.Dependents);
+
+                Assert.Equal(
+                    CoreStrings.CanOnlyConfigureExistingNavigations("Name", "NavDependent"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<NavDependent>()
+                        .Navigation(e => e.Name)
+                        .UsePropertyAccessMode(PropertyAccessMode.Property)
+                        ).Message);
+            }
+
             private static void AssertGraph(
                 ModifierGroupHeader parent,
                 ModifierGroupHeader child1,

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4405,6 +4405,56 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
             }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne(e => e.OneToOnePrincipal)
+                    .WithOne(e => e.Dependent);
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation(e => e.OneToOnePrincipal)
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToOneNavPrincipal>()
+                    .Navigation(e => e.Dependent)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Navigation_properties_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<NavDependent>()
+                    .HasOne<OneToOneNavPrincipal>("OneToOnePrincipal")
+                    .WithOne("Dependent");
+
+                modelBuilder.Entity<NavDependent>()
+                    .Navigation("OneToOnePrincipal")
+                    .UsePropertyAccessMode(PropertyAccessMode.Property);
+
+                modelBuilder.Entity<OneToOneNavPrincipal>()
+                    .Navigation("Dependent")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal));
+                var dependent = (IEntityType)model.FindEntityType(typeof(NavDependent));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1329,6 +1329,80 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal(4, model.GetEntityTypes().Count());
             }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .OwnsOne(e => e.OwnedDependent)
+                    .WithOwner(e => e.OneToOneOwner);
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .Navigation(e => e.OwnedDependent)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .OwnsOne<OwnedNavDependent>("OwnedDependent")
+                    .WithOwner("OneToOneOwner");
+
+                modelBuilder.Entity<OneToOneNavPrincipalOwner>()
+                    .Navigation("OwnedDependent")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_expressions()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .OwnsMany(e => e.OwnedDependents);
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .Navigation(e => e.OwnedDependents)
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+            }
+
+            [ConditionalFact]
+            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_navigation_names()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .OwnsMany<OwnedOneToManyNavDependent>("OwnedDependents");
+
+                modelBuilder.Entity<OneToManyNavPrincipalOwner>()
+                    .Navigation("OwnedDependents")
+                    .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+                var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+
+                Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -1331,77 +1331,111 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_expressions()
+            public virtual void Navigations_to_OneToOne_Owned_types_can_set_access_mode_using_expressions()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
                 modelBuilder.Entity<OneToOneNavPrincipalOwner>()
-                    .OwnsOne(e => e.OwnedDependent)
-                    .WithOwner(e => e.OneToOneOwner);
+                    .OwnsOne(
+                        e => e.OwnedDependent,
+                        a =>
+                        {
+                            a.WithOwner(e => e.OneToOneOwner);
+                            a.Navigation(owned => owned.OneToOneOwner)
+                                .UsePropertyAccessMode(PropertyAccessMode.Property);
+                        });
 
                 modelBuilder.Entity<OneToOneNavPrincipalOwner>()
                     .Navigation(e => e.OwnedDependent)
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
                 var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+                var dependent = (IEntityType)model.FindEntityType(typeof(OwnedNavDependent));
 
                 Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOneOwner").GetPropertyAccessMode());
             }
 
             [ConditionalFact]
-            public virtual void Principal_end_of_navigations_to_OneToOne_Owned_types_can_set_access_mode_using_navigation_names()
+            public virtual void Navigations_to_OneToOne_Owned_types_can_set_access_mode_using_navigation_names()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
                 modelBuilder.Entity<OneToOneNavPrincipalOwner>()
-                    .OwnsOne<OwnedNavDependent>("OwnedDependent")
-                    .WithOwner("OneToOneOwner");
+                    .OwnsOne<OwnedNavDependent>(
+                        "OwnedDependent",
+                        a =>
+                        {
+                            a.WithOwner("OneToOneOwner");
+                            a.Navigation<OneToOneNavPrincipalOwner>("OneToOneOwner")
+                                .UsePropertyAccessMode(PropertyAccessMode.Property);
+                        });
 
                 modelBuilder.Entity<OneToOneNavPrincipalOwner>()
                     .Navigation("OwnedDependent")
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
                 var principal = (IEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
+                var dependent = (IEntityType)model.FindEntityType(typeof(OwnedNavDependent));
 
                 Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOneOwner").GetPropertyAccessMode());
             }
 
             [ConditionalFact]
-            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_expressions()
+            public virtual void Navigations_to_OneToMany_Owned_types_can_set_access_mode_using_expressions()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
                 modelBuilder.Entity<OneToManyNavPrincipalOwner>()
-                    .OwnsMany(e => e.OwnedDependents);
+                    .OwnsMany(
+                        e => e.OwnedDependents,
+                        a =>
+                        {
+                            a.WithOwner(e => e.OneToManyOwner);
+                            a.Navigation(owned => owned.OneToManyOwner)
+                                .UsePropertyAccessMode(PropertyAccessMode.Property);
+                        });
 
                 modelBuilder.Entity<OneToManyNavPrincipalOwner>()
                     .Navigation(e => e.OwnedDependents)
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
                 var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+                var dependent = (IEntityType)model.FindEntityType(typeof(OwnedOneToManyNavDependent));
 
                 Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyOwner").GetPropertyAccessMode());
             }
 
             [ConditionalFact]
-            public virtual void Principal_end_of_navigations_to_OneToMany_Owned_types_can_set_access_mode_using_navigation_names()
+            public virtual void Navigations_to_OneToMany_Owned_types_can_set_access_mode_using_navigation_names()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
                 modelBuilder.Entity<OneToManyNavPrincipalOwner>()
-                    .OwnsMany<OwnedOneToManyNavDependent>("OwnedDependents");
+                    .OwnsMany<OwnedOneToManyNavDependent>(
+                    "OwnedDependents",
+                    a =>
+                    {
+                        a.WithOwner("OneToManyOwner");
+                        a.Navigation<OneToManyNavPrincipalOwner>("OneToManyOwner")
+                            .UsePropertyAccessMode(PropertyAccessMode.Property);
+                    });
 
                 modelBuilder.Entity<OneToManyNavPrincipalOwner>()
                     .Navigation("OwnedDependents")
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
                 var principal = (IEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
+                var dependent = (IEntityType)model.FindEntityType(typeof(OwnedOneToManyNavDependent));
 
                 Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
+                Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyOwner").GetPropertyAccessMode());
             }
         }
     }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -866,6 +866,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public NavDependent Dependent { get; set; }
         }
 
+        private class ManyToManyNavPrincipal
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public List<NavDependent> Dependents { get; set; }
+        }
+
         private class NavDependent
         {
             public int Id { get; set; }
@@ -873,6 +881,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public OneToManyNavPrincipal OneToManyPrincipal { get; set; }
             public OneToOneNavPrincipal OneToOnePrincipal { get; set; }
+            public List<ManyToManyNavPrincipal> ManyToManyPrincipals { get; set; }
         }
 
         private class OneToManyNavPrincipalOwner
@@ -880,7 +889,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int Id { get; set; }
             public string Description { get; set; }
 
-            public List<OwnedNavDependent> OwnedDependents { get; set; }
+            public List<OwnedOneToManyNavDependent> OwnedDependents { get; set; }
         }
 
         private class OneToOneNavPrincipalOwner
@@ -895,6 +904,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public string FirstName { get; set; }
             public string LastName { get; set; }
+
+            public OneToOneNavPrincipalOwner OneToOneOwner { get; set; }
+        }
+
+        private class OwnedOneToManyNavDependent
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+
+            public OneToManyNavPrincipalOwner OneToManyOwner { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fix for #6674 . Based on PR #20271 

This adds the last part - being able to configure the dependent side navigation of an Owned-type relationship.

(This PR will need to be merged with the work in #20271 before committing).