### PR TITLE
Adding .WithPartitionKey()

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Cosmos DB specific extension methods for LINQ queries.
+    /// </summary>
+    public static class CosmosQueryableExtensions
+    {
+        internal static readonly MethodInfo WithPartitionKeyMethodInfo
+            = typeof(CosmosQueryableExtensions)
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(WithPartitionKey));
+
+        /// <summary>
+        ///     Specify the partition key for partition used for the query. Required when using
+        ///     a resource token that provides permission based on a partition key for authentication,  
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="partitionKey"> The partition key. </param>
+        /// <returns> A new query with the set partition key. </returns>
+        public static IQueryable<TEntity> WithPartitionKey<TEntity>(
+            [NotNull] this IQueryable<TEntity> source,
+            [NotNull] [NotParameterized] string partitionKey)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(partitionKey, nameof(partitionKey));
+
+            return
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: WithPartitionKeyMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                            source.Expression,
+                            Expression.Constant(partitionKey)))
+                    : source;
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, CosmosQueryableMethodTranslatingExpressionVisitorFactory>()
                 .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, CosmosShapedQueryCompilingExpressionVisitorFactory>()
                 .TryAdd<ISingletonOptions, ICosmosSingletonOptions>(p => p.GetService<ICosmosSingletonOptions>())
+                .TryAdd<IQueryTranslationPreprocessorFactory, CosmosQueryTranslationPreprocessorFactory>()
+                .TryAdd<IQueryCompilationContextFactory, CosmosQueryCompilationContextFactory>()
                 .TryAddProviderSpecificServices(
                     b => b
                         .TryAddSingleton<ICosmosSingletonOptions, CosmosSingletonOptions>()

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContext.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContext.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    public class CosmosQueryCompilationContext : QueryCompilationContext
+    {
+        public virtual string PartitionKey { get; internal set; }
+
+        public CosmosQueryCompilationContext(
+            [NotNull] QueryCompilationContextDependencies dependencies, bool async)
+            : base(dependencies, async)
+        {
+
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContextFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryCompilationContextFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         A factory for creating <see cref="CosmosQueryCompilationContext" /> instances.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
+    ///         <see cref="DbContext" /> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
+    ///     </para>
+    /// </summary>
+    public class CosmosQueryCompilationContextFactory : IQueryCompilationContextFactory
+    {
+        private readonly QueryCompilationContextDependencies _dependencies;
+
+        public CosmosQueryCompilationContextFactory([NotNull] QueryCompilationContextDependencies dependencies)
+        {
+            Check.NotNull(dependencies, nameof(dependencies));
+            _dependencies = dependencies;
+        }
+
+        public virtual QueryCompilationContext Create(bool async)
+            => new CosmosQueryCompilationContext(_dependencies, async);
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryContext.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryContext.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
@@ -26,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             [NotNull] CosmosClientWrapper cosmosClient)
             : base(dependencies)
         {
+            Check.NotNull(cosmosClient, nameof(cosmosClient));
             CosmosClient = cosmosClient;
         }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryContextFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryContextFactory.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
@@ -28,6 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             [NotNull] QueryContextDependencies dependencies,
             [NotNull] CosmosClientWrapper cosmosClient)
         {
+            Check.NotNull(dependencies, nameof(dependencies));
+            Check.NotNull(cosmosClient, nameof(cosmosClient));
+
             _dependencies = dependencies;
             _cosmosClient = cosmosClient;
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryMetadataExtractingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryMetadataExtractingExpressionVisitor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    public class CosmosQueryMetadataExtractingExpressionVisitor : ExpressionVisitor
+    {
+        private readonly CosmosQueryCompilationContext _cosmosQueryCompilationContext;
+
+        public CosmosQueryMetadataExtractingExpressionVisitor([NotNull] CosmosQueryCompilationContext cosmosQueryCompilationContext)
+        {
+            Check.NotNull(cosmosQueryCompilationContext, nameof(cosmosQueryCompilationContext));
+            _cosmosQueryCompilationContext = cosmosQueryCompilationContext;
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.IsGenericMethod
+                && methodCallExpression.Method.GetGenericMethodDefinition() == CosmosQueryableExtensions.WithPartitionKeyMethodInfo)
+            {
+                var innerQueryable = Visit(methodCallExpression.Arguments[0]);
+
+                _cosmosQueryCompilationContext.PartitionKey = (string)((ConstantExpression)methodCallExpression.Arguments[1]).Value;
+
+                return innerQueryable;
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessor.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    public class CosmosQueryTranslationPreprocessor : QueryTranslationPreprocessor
+    {
+
+        private readonly CosmosQueryCompilationContext _queryCompilationContext;
+
+        public CosmosQueryTranslationPreprocessor(
+            [NotNull] QueryTranslationPreprocessorDependencies dependencies,
+            [NotNull] CosmosQueryCompilationContext cosmosQueryCompilationContext)
+            : base(dependencies, cosmosQueryCompilationContext)
+        {
+            _queryCompilationContext = cosmosQueryCompilationContext;
+        }
+
+        public override Expression NormalizeQueryableMethodCall(Expression query)
+        {
+            query = base.NormalizeQueryableMethodCall(query);
+
+            query = new CosmosQueryMetadataExtractingExpressionVisitor(_queryCompilationContext).Visit(query);
+
+            return query;
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPreprocessorFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         A factory for creating <see cref="CosmosQueryTranslationPreprocessor" /> instances.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance
+    ///         is used by many <see cref="DbContext" /> instances. The implementation must be thread-safe.
+    ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
+    ///     </para>
+    /// </summary>
+    public class CosmosQueryTranslationPreprocessorFactory : IQueryTranslationPreprocessorFactory
+    {
+        private readonly QueryTranslationPreprocessorDependencies _dependencies;
+
+        public CosmosQueryTranslationPreprocessorFactory(
+            [NotNull] QueryTranslationPreprocessorDependencies dependencies)
+        {
+            Check.NotNull(dependencies, nameof(dependencies));
+            _dependencies = dependencies;
+        }
+
+        public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
+            => new CosmosQueryTranslationPreprocessor(_dependencies,  (CosmosQueryCompilationContext)queryCompilationContext);
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             private readonly Func<QueryContext, JObject, T> _shaper;
             private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
             private readonly Type _contextType;
+            private readonly string _partitionKey;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
             public QueryingEnumerable(
@@ -39,6 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 SelectExpression selectExpression,
                 Func<QueryContext, JObject, T> shaper,
                 Type contextType,
+                string partitionKey,
                 IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             {
                 _cosmosQueryContext = cosmosQueryContext;
@@ -47,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 _selectExpression = selectExpression;
                 _shaper = shaper;
                 _contextType = contextType;
+                _partitionKey = partitionKey;
                 _logger = logger;
             }
 
@@ -113,6 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                                 _enumerator = _queryingEnumerable._cosmosQueryContext.CosmosClient
                                     .ExecuteSqlQuery(
                                         _queryingEnumerable._selectExpression.Container,
+                                        _queryingEnumerable._partitionKey,
                                         sqlQuery)
                                     .GetEnumerator();
                             }
@@ -153,6 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 private readonly ISqlExpressionFactory _sqlExpressionFactory;
                 private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
                 private readonly Type _contextType;
+                private readonly string _partitionKey;
                 private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
                 private readonly CancellationToken _cancellationToken;
 
@@ -164,6 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     _sqlExpressionFactory = queryingEnumerable._sqlExpressionFactory;
                     _querySqlGeneratorFactory = queryingEnumerable._querySqlGeneratorFactory;
                     _contextType = queryingEnumerable._contextType;
+                    _partitionKey = queryingEnumerable._partitionKey;
                     _logger = queryingEnumerable._logger;
                     _cancellationToken = cancellationToken;
                 }
@@ -184,6 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                                 _enumerator = _cosmosQueryContext.CosmosClient
                                     .ExecuteSqlQueryAsync(
                                         _selectExpression.Container,
+                                        _partitionKey,
                                         _querySqlGeneratorFactory.Create().GetSqlQuery(
                                             selectExpression, _cosmosQueryContext.ParameterValues))
                                     .GetAsyncEnumerator(_cancellationToken);

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly string _partitionKey;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -32,15 +33,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         public CosmosShapedQueryCompilingExpressionVisitor(
             [NotNull] ShapedQueryCompilingExpressionVisitorDependencies dependencies,
-            [NotNull] QueryCompilationContext queryCompilationContext,
+            [NotNull] CosmosQueryCompilationContext cosmosQueryCompilationContext,
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
             [NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory)
-            : base(dependencies, queryCompilationContext)
+            : base(dependencies, cosmosQueryCompilationContext)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
             _querySqlGeneratorFactory = querySqlGeneratorFactory;
-            _contextType = queryCompilationContext.ContextType;
-            _logger = queryCompilationContext.Logger;
+            _contextType = cosmosQueryCompilationContext.ContextType;
+            _logger = cosmosQueryCompilationContext.Logger;
+            _partitionKey = cosmosQueryCompilationContext.PartitionKey;
         }
 
         /// <summary>
@@ -77,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 Expression.Constant(selectExpression),
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
+                Expression.Constant(_partitionKey, typeof(string)),
                 Expression.Constant(_logger));
         }
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitorFactory.cs
@@ -30,6 +30,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
             [NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory)
         {
+            Check.NotNull(dependencies, nameof(dependencies));
+            Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
+            Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory));
+
             _dependencies = dependencies;
             _sqlExpressionFactory = sqlExpressionFactory;
             _querySqlGeneratorFactory = querySqlGeneratorFactory;
@@ -47,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             return new CosmosShapedQueryCompilingExpressionVisitor(
                 _dependencies,
-                queryCompilationContext,
+                (CosmosQueryCompilationContext)queryCompilationContext,
                 _sqlExpressionFactory,
                 _querySqlGeneratorFactory);
         }

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -274,6 +274,91 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
+        [ConditionalFact]
+        public async Task Can_add_update_delete_end_to_end_with_withpartitionkey_extension()
+        {
+            var options = Fixture.CreateOptions();
+            const int pk1 = 1;
+            const int pk2 = 2;
+
+            var customer = new Customer
+            {
+                Id = 42,
+                Name = "Theon",
+                PartitionKey = pk1
+            };
+
+            using (var context = new PartitionKeyContext(options))
+            {
+                await context.Database.EnsureCreatedAsync();
+
+                context.Add(customer);
+                context.Add(
+                    new Customer
+                    {
+                        Id = 42,
+                        Name = "Theon Twin",
+                        PartitionKey = pk2
+                    });
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new PartitionKeyContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>()
+                    .WithPartitionKey(partitionKey:pk1.ToString())
+                    .FirstAsync();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
+                Assert.Equal(pk1, customerFromStore.PartitionKey);
+
+                customerFromStore.Name = "Theon Greyjoy";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new PartitionKeyContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>()
+                    .WithPartitionKey(partitionKey:pk1.ToString())
+                    .FirstAsync();
+
+                customerFromStore.PartitionKey = pk2;
+
+                Assert.Equal(
+                    CoreStrings.KeyReadOnly(nameof(Customer.PartitionKey), nameof(Customer)),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+
+            using (var context = new PartitionKeyContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>()
+                    .WithPartitionKey(partitionKey: pk1.ToString())
+                    .FirstAsync();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+                Assert.Equal(pk1, customerFromStore.PartitionKey);
+
+                context.Remove(customerFromStore);
+
+                context.Remove(await context.Set<Customer>()
+                    .WithPartitionKey(pk2.ToString())
+                    .LastAsync());
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new PartitionKeyContext(options))
+            {
+                Assert.Empty(await context.Set<Customer>()
+                    .WithPartitionKey(partitionKey: pk2.ToString())
+                    .ToListAsync());
+            }
+        }
+
         private class PartitionKeyContext : DbContext
         {
             public PartitionKeyContext(DbContextOptions dbContextOptions)


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #20221
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

Adding `.WithPartitionKey()`  `IQueryable` extension method.

Needed when using resource tokens for secure authentication when permissions are grated based on partition keys. #20221
