### PR TITLE
Add [NotParameterized] to FreeText's argument

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbFunctionsExtensions.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.SqlServer.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
@@ -33,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             [NotNull] string propertyReference,
             [NotNull] string freeText,
-            int languageTerm)
+            [NotParameterized] int languageTerm)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(FreeText)));
 
         /// <summary>
@@ -71,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] this DbFunctions _,
             [NotNull] string propertyReference,
             [NotNull] string searchCondition,
-            int languageTerm)
+            [NotParameterized] int languageTerm)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Contains)));
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindDbFunctionsQuerySqlServerTest.cs
@@ -112,6 +112,22 @@ WHERE FREETEXT([e].[Title], N'President', LANGUAGE 1033)");
 
         [ConditionalFact]
         [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void FreeText_with_non_literal_language_term()
+        {
+            int language = 1033;
+            using var context = CreateContext();
+            var result = context.Employees.SingleOrDefault(c => EF.Functions.FreeText(c.Title, "President", language));
+
+            Assert.Equal(2u, result.EmployeeID);
+
+            AssertSql(
+                @"SELECT TOP(2) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE FREETEXT([e].[Title], N'President', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
         public void FreeText_with_multiple_words_and_language_term()
         {
             using var context = CreateContext();
@@ -300,6 +316,22 @@ WHERE CONTAINS([e].[Title], N'Representative')");
         {
             using var context = CreateContext();
             var result = context.Employees.SingleOrDefault(c => EF.Functions.Contains(c.Title, "President", 1033));
+
+            Assert.Equal(2u, result.EmployeeID);
+
+            AssertSql(
+                @"SELECT TOP(2) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE CONTAINS([e].[Title], N'President', LANGUAGE 1033)");
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
+        public void Contains_with_non_literal_language_term()
+        {
+            int language = 1033;
+            using var context = CreateContext();
+            var result = context.Employees.SingleOrDefault(c => EF.Functions.Contains(c.Title, "President", language));
 
             Assert.Equal(2u, result.EmployeeID);
 


### PR DESCRIPTION
To support non-literal value for the argument

Fixes #13315