### PR TITLE
Query: Make CreateReadValueExpression an extension method

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
                 var method = methodCallExpression.Method;
                 var genericMethod = method.IsGenericMethod ? method.GetGenericMethodDefinition() : null;
-                if (genericMethod == EntityMaterializerSource.TryReadValueMethod)
+                if (genericMethod == EntityFrameworkCore.Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod)
                 {
                     var property = (IProperty)((ConstantExpression)methodCallExpression.Arguments[2]).Value;
                     Expression innerExpression;

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using ExpressionExtensions = Microsoft.EntityFrameworkCore.Infrastructure.ExpressionExtensions;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
@@ -399,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
             if (methodCallExpression.Method.IsGenericMethod
-                && methodCallExpression.Method.GetGenericMethodDefinition() == EntityMaterializerSource.TryReadValueMethod)
+                && methodCallExpression.Method.GetGenericMethodDefinition() == ExpressionExtensions.ValueBufferTryReadValueMethod)
             {
                 return methodCallExpression;
             }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
                 if (methodCallExpression.Method.IsGenericMethod
-                    && methodCallExpression.Method.GetGenericMethodDefinition() == EntityMaterializerSource.TryReadValueMethod)
+                    && methodCallExpression.Method.GetGenericMethodDefinition() == Infrastructure.ExpressionExtensions.ValueBufferTryReadValueMethod)
                 {
                     var property = (IProperty)((ConstantExpression)methodCallExpression.Arguments[2]).Value;
                     var propertyProjectionMap = methodCallExpression.Arguments[0] is ProjectionBindingExpression projectionBindingExpression

--- a/src/EFCore/Metadata/PropertyParameterBinding.cs
+++ b/src/EFCore/Metadata/PropertyParameterBinding.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -33,11 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var property = ConsumedProperties[0];
 
-            return Expression.Call(
-                EntityMaterializerSource.TryReadValueMethod.MakeGenericMethod(property.ClrType),
-                Expression.Call(bindingInfo.MaterializationContextExpression, MaterializationContext.GetValueBufferMethod),
-                Expression.Constant(bindingInfo.GetValueBufferIndex(property)),
-                Expression.Constant(property, typeof(IPropertyBase)));
+            return Expression.Call(bindingInfo.MaterializationContextExpression, MaterializationContext.GetValueBufferMethod)
+                   .CreateValueBufferReadValueExpression(property.ClrType, bindingInfo.GetValueBufferIndex(property), property);
         }
     }
 }

--- a/src/EFCore/Query/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/EntityMaterializerSource.cs
@@ -34,26 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        public virtual Expression CreateReadValueExpression(
-            Expression valueBufferExpression,
-            Type type,
-            int index,
-            IPropertyBase property)
-            => Expression.Call(
-                TryReadValueMethod.MakeGenericMethod(type),
-                valueBufferExpression,
-                Expression.Constant(index),
-                Expression.Constant(property, typeof(IPropertyBase)));
-
-        public static readonly MethodInfo TryReadValueMethod
-            = typeof(EntityMaterializerSource).GetTypeInfo()
-                .GetDeclaredMethod(nameof(TryReadValue));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static TValue TryReadValue<TValue>(
-            in ValueBuffer valueBuffer, int index, IPropertyBase property)
-            => valueBuffer[index] is TValue value ? value : default;
-
         public virtual Expression CreateMaterializeExpression(
             IEntityType entityType,
             string entityInstanceName,
@@ -127,8 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var readValueExpression
                     = property is IServiceProperty serviceProperty
                         ? serviceProperty.GetParameterBinding().BindToParameter(bindingInfo)
-                        : CreateReadValueExpression(
-                            valueBufferExpression,
+                        : valueBufferExpression.CreateValueBufferReadValueExpression(
                             memberInfo.GetMemberType(),
                             property.GetIndex(),
                             property);

--- a/src/EFCore/Query/IEntityMaterializerSource.cs
+++ b/src/EFCore/Query/IEntityMaterializerSource.cs
@@ -29,26 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         /// <summary>
         ///     <para>
-        ///         Creates an <see cref="Expression" /> tree representing reading a value from a <see cref="ValueBuffer" />
-        ///     </para>
-        ///     <para>
-        ///         This method is typically used by database providers (and other extensions). It is generally
-        ///         not used in application code.
-        ///     </para>
-        /// </summary>
-        /// <param name="valueBuffer"> The expression that exposes the <see cref="ValueBuffer" />. </param>
-        /// <param name="type"> The type to read. </param>
-        /// <param name="index"> The index in the buffer to read from. </param>
-        /// <param name="property"> The IPropertyBase being read if any. </param>
-        /// <returns> An expression to read the value. </returns>
-        Expression CreateReadValueExpression(
-            [NotNull] Expression valueBuffer,
-            [NotNull] Type type,
-            int index,
-            [CanBeNull] IPropertyBase property);
-
-        /// <summary>
-        ///     <para>
         ///         Creates an <see cref="Expression" /> tree representing creating an entity instance.
         ///     </para>
         ///     <para>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -372,8 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     typeof(object),
                                     primaryKey.Properties
                                         .Select(
-                                            p => _entityMaterializerSource.CreateReadValueExpression(
-                                                valueBufferExpression,
+                                            p => valueBufferExpression.CreateValueBufferReadValueExpression(
                                                 typeof(object),
                                                 p.GetIndex(),
                                                 p))),
@@ -407,8 +407,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         expressions.Add(Expression.IfThen(
                             primaryKey.Properties.Select(
                                 p => Expression.NotEqual(
-                                        _entityMaterializerSource.CreateReadValueExpression(
-                                            valueBufferExpression, typeof(object), p.GetIndex(), p),
+                                        valueBufferExpression.CreateValueBufferReadValueExpression(typeof(object), p.GetIndex(), p),
                                         Expression.Constant(null)))
                                 .Aggregate((a, b) => Expression.AndAlso(a, b)),
                             MaterializeEntity(
@@ -424,8 +423,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                         .Select(
                                             p =>
                                                 Expression.NotEqual(
-                                                    _entityMaterializerSource.CreateReadValueExpression(
-                                                        valueBufferExpression,
+                                                    valueBufferExpression.CreateValueBufferReadValueExpression(
                                                         typeof(object),
                                                         p.GetIndex(),
                                                         p),
@@ -486,8 +484,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     expressions.Add(
                         Expression.Assign(
                             discriminatorValueVariable,
-                            _entityMaterializerSource.CreateReadValueExpression(
-                                valueBufferExpression,
+                            valueBufferExpression.CreateValueBufferReadValueExpression(
                                 discriminatorProperty.ClrType,
                                 discriminatorProperty.GetIndex(),
                                 discriminatorProperty)));
@@ -578,11 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 Expression.NewArrayInit(
                                     typeof(object),
                                     shadowProperties.Select(
-                                        p => _entityMaterializerSource.CreateReadValueExpression(
-                                            valueBufferExpression,
-                                            typeof(object),
-                                            p.GetIndex(),
-                                            p))))));
+                                        p => valueBufferExpression.CreateValueBufferReadValueExpression(typeof(object), p.GetIndex(), p))))));
                 }
 
                 materializer = materializer.Type == returnType


### PR DESCRIPTION
This method is to read a particular index from valueBuffer for a property.
It was in EntityMaterializerSource as an instance method in order for provider to influence how values are read from valueBuffer.
In new query pipeline, providers are supposed to convert valueBuffer read to their database object read. Further, even if they want to create a ValueBuffer for read, the valueBuffer should have values after all custom processing.
Hence there is no particular need to make this overridable behavior. Making it extension method simplify quite a lot of things.

(note: functionality to use this was available anyway since the method it invoke was also publicly exposed as static.
