### PR TITLE
Fix for 20281. Adding HasField() method and updating tests.

### DIFF
--- a/src/EFCore/Metadata/Builders/IConventionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionNavigationBuilder.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
     public interface IConventionNavigationBuilder : IConventionAnnotatableBuilder
@@ -9,6 +11,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     Gets the navigation being configured.
         /// </summary>
         new IConventionNavigation Metadata { get; }
+
+        /// <summary>
+        ///     Returns a value indicating whether the backing field can be set for this navigation
+        ///     from the given configuration source.
+        /// </summary>
+        /// <param name="fieldName"> The field name. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <c>true</c> if the backing field can be set for this property. </returns>
+        bool CanSetField([CanBeNull] string fieldName, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the backing field to use for this navigation.
+        /// </summary>
+        /// <param name="fieldName"> The field name. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <c>null</c> otherwise.
+        /// </returns>
+        IConventionNavigationBuilder HasField([CanBeNull] string fieldName, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns a value indicating whether the <see cref="PropertyAccessMode" /> can be set for this navigation

--- a/src/EFCore/Metadata/Builders/NavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/NavigationBuilder.cs
@@ -31,16 +31,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             Check.NotNull(navigationOrSkipNavigation, nameof(navigationOrSkipNavigation));
 
-            NavBuilder = (navigationOrSkipNavigation as Navigation)?.Builder;
-            SkipNavBuilder = (navigationOrSkipNavigation as SkipNavigation)?.Builder;
+            InternalNavigationBuilder = (navigationOrSkipNavigation as Navigation)?.Builder;
+            InternalSkipNavigationBuilder = (navigationOrSkipNavigation as SkipNavigation)?.Builder;
             Metadata = navigationOrSkipNavigation;
 
-            Check.DebugAssert(NavBuilder != null || SkipNavBuilder != null, "Expected either a Navigation or SkipNavigation");
+            Check.DebugAssert(InternalNavigationBuilder != null || InternalSkipNavigationBuilder != null, "Expected either a Navigation or SkipNavigation");
         }
 
-        private InternalNavigationBuilder NavBuilder { get; }
+        private InternalNavigationBuilder InternalNavigationBuilder { get; }
 
-        private InternalSkipNavigationBuilder SkipNavBuilder { get; }
+        private InternalSkipNavigationBuilder InternalSkipNavigationBuilder { get; }
 
         /// <summary>
         ///     The navigation being configured.
@@ -60,13 +60,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotEmpty(annotation, nameof(annotation));
             Check.NotNull(value, nameof(value));
 
-            if (NavBuilder != null)
+            if (InternalNavigationBuilder != null)
             {
-                NavBuilder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+                InternalNavigationBuilder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
             }
             else
             {
-                SkipNavBuilder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
+                InternalSkipNavigationBuilder.HasAnnotation(annotation, value, ConfigurationSource.Explicit);
             }
 
             return this;
@@ -91,13 +91,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual NavigationBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
         {
-            if (NavBuilder != null)
+            if (InternalNavigationBuilder != null)
             {
-                NavBuilder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
+                InternalNavigationBuilder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
             }
             else
             {
-                SkipNavBuilder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
+                InternalSkipNavigationBuilder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
             }
 
             return this;
@@ -112,21 +112,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual NavigationBuilder HasField([CanBeNull] string fieldName)
         {
-            if (NavBuilder != null)
+            if (InternalNavigationBuilder != null)
             {
-                NavBuilder.HasField(fieldName, ConfigurationSource.Explicit);
+                InternalNavigationBuilder.HasField(fieldName, ConfigurationSource.Explicit);
             }
             else
             {
-                SkipNavBuilder.HasField(fieldName, ConfigurationSource.Explicit);
+                InternalSkipNavigationBuilder.HasField(fieldName, ConfigurationSource.Explicit);
             }
 
             return this;
         }
 
-        IConventionSkipNavigationBuilder IInfrastructure<IConventionSkipNavigationBuilder>.Instance => SkipNavBuilder;
+        /// <summary>
+        ///     The internal builder being used to configure the skip navigation.
+        /// </summary>
+        IConventionSkipNavigationBuilder IInfrastructure<IConventionSkipNavigationBuilder>.Instance => InternalSkipNavigationBuilder;
 
-        IConventionNavigationBuilder IInfrastructure<IConventionNavigationBuilder>.Instance => NavBuilder;
+        /// <summary>
+        ///     The internal builder being used to configure the navigation.
+        /// </summary>
+        IConventionNavigationBuilder IInfrastructure<IConventionNavigationBuilder>.Instance => InternalNavigationBuilder;
 
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Builders/NavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/NavigationBuilder.cs
@@ -103,6 +103,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             return this;
         }
 
+        /// <summary>
+        ///     <para>
+        ///         Sets a backing field to use for this navigation property.
+        ///     </para>
+        /// </summary>
+        /// <param name="fieldName"> The name of the field to use for this navigation property. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual NavigationBuilder HasField([CanBeNull] string fieldName)
+        {
+            if (NavBuilder != null)
+            {
+                NavBuilder.HasField(fieldName, ConfigurationSource.Explicit);
+            }
+            else
+            {
+                SkipNavBuilder.HasField(fieldName, ConfigurationSource.Explicit);
+            }
+
+            return this;
+        }
+
         IConventionSkipNavigationBuilder IInfrastructure<IConventionSkipNavigationBuilder>.Instance => SkipNavBuilder;
 
         IConventionNavigationBuilder IInfrastructure<IConventionNavigationBuilder>.Instance => NavBuilder;

--- a/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
@@ -32,6 +32,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual new InternalNavigationBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+            => (InternalNavigationBuilder)base.HasField(fieldName, configurationSource);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual new InternalNavigationBuilder UsePropertyAccessMode(
             PropertyAccessMode? propertyAccessMode, ConfigurationSource configurationSource)
             => (InternalNavigationBuilder)base.UsePropertyAccessMode(propertyAccessMode, configurationSource);

--- a/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalNavigationBuilder.cs
@@ -77,5 +77,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             PropertyAccessMode? propertyAccessMode, bool fromDataAnnotation)
             => UsePropertyAccessMode(
                 propertyAccessMode, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        bool IConventionNavigationBuilder.CanSetField(string fieldName, bool fromDataAnnotation)
+            => CanSetField(
+                fieldName,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IConventionNavigationBuilder IConventionNavigationBuilder.HasField(string fieldName, bool fromDataAnnotation)
+            => HasField(
+                fieldName,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }
 }

--- a/src/EFCore/Metadata/Internal/InternalPropertyBaseBuilder`.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBaseBuilder`.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -23,6 +24,52 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public InternalPropertyBaseBuilder([NotNull] TPropertyBase metadata, [NotNull] InternalModelBuilder modelBuilder)
             : base(metadata, modelBuilder)
         {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalPropertyBaseBuilder<TPropertyBase> HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+        {
+            if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
+                || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                Metadata.SetFieldInfo(fieldName, configurationSource);
+
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                if (fieldName == null)
+                {
+                    return true;
+                }
+
+                var fieldInfo = PropertyBase.GetFieldInfo(
+                    fieldName, Metadata.DeclaringType, Metadata.Name,
+                    shouldThrow: false);
+                return fieldInfo != null
+                    && PropertyBase.IsCompatible(
+                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
+                        shouldThrow: false);
+            }
+
+            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -152,18 +152,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalPropertyBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
-        {
-            if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
-                || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
-            {
-                Metadata.SetFieldInfo(fieldName, configurationSource);
-
-                return this;
-            }
-
-            return null;
-        }
+        public virtual new InternalPropertyBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+            => (InternalPropertyBuilder)base.HasField(fieldName, configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -181,33 +171,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return null;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
-        {
-            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
-            {
-                if (fieldName == null)
-                {
-                    return true;
-                }
-
-                var fieldInfo = PropertyBase.GetFieldInfo(
-                    fieldName, Metadata.DeclaringType, Metadata.Name,
-                    shouldThrow: false);
-                return fieldInfo != null
-                    && PropertyBase.IsCompatible(
-                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
-                        shouldThrow: false);
-            }
-
-            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalSkipNavigationBuilder.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class InternalSkipNavigationBuilder : InternalModelItemBuilder<SkipNavigation>, IConventionSkipNavigationBuilder
+    public class InternalSkipNavigationBuilder : InternalPropertyBaseBuilder<SkipNavigation>, IConventionSkipNavigationBuilder
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -33,45 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalSkipNavigationBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
-        {
-            if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
-                || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
-            {
-                Metadata.SetFieldInfo(fieldName, configurationSource);
-
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual bool CanSetField([CanBeNull] string fieldName, ConfigurationSource? configurationSource)
-        {
-            if (configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
-            {
-                if (fieldName == null)
-                {
-                    return true;
-                }
-
-                var fieldInfo = PropertyBase.GetFieldInfo(
-                    fieldName, Metadata.DeclaringType, Metadata.Name,
-                    shouldThrow: false);
-                return fieldInfo != null
-                    && PropertyBase.IsCompatible(
-                        fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
-                        shouldThrow: false);
-            }
-
-            return Metadata.FieldInfo?.GetSimpleMemberName() == fieldName;
-        }
+        public virtual new InternalSkipNavigationBuilder HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+            => (InternalSkipNavigationBuilder)base.HasField(fieldName, configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -111,29 +74,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalSkipNavigationBuilder UsePropertyAccessMode(
+        public virtual new InternalSkipNavigationBuilder UsePropertyAccessMode(
             PropertyAccessMode? propertyAccessMode, ConfigurationSource configurationSource)
-        {
-            if (CanSetPropertyAccessMode(propertyAccessMode, configurationSource))
-            {
-                Metadata.SetPropertyAccessMode(propertyAccessMode, configurationSource);
-
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual bool CanSetPropertyAccessMode(
-            PropertyAccessMode? propertyAccessMode, ConfigurationSource? configurationSource)
-            => configurationSource.Overrides(Metadata.GetPropertyAccessModeConfigurationSource())
-                || ((ISkipNavigation)Metadata).GetPropertyAccessMode() == propertyAccessMode;
+            => (InternalSkipNavigationBuilder)base.UsePropertyAccessMode(propertyAccessMode, configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -169,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public virtual void Can_update_and_query_navigation_from_backing_field()
+        public virtual void Can_define_a_backing_field_for_a_navigation_and_query_and_update_it()
         {
             using (var context = CreateContext())
             {
@@ -183,9 +183,9 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.Equal("FirstName", dependentName);
 
-                // set the backing field directly
+                // use the backing field directly
                 var dependent2 = new NavDependent { Id = 2, Name = "SecondName", OneToOneFieldNavPrincipal = principal };
-                principal._dependent = dependent2;
+                principal._unconventionalDependent = dependent2;
                 context.SaveChanges();
 
                 dependentName =
@@ -1933,7 +1933,7 @@ namespace Microsoft.EntityFrameworkCore
             public int Id { get; set; }
             public string Name { get; set; }
 
-            public NavDependent _dependent;
+            public NavDependent _unconventionalDependent; // won't be picked up by convention
             public NavDependent Dependent
             {
                 get => throw new NotImplementedException("Invalid attempt to access Dependent getter");
@@ -1995,6 +1995,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 modelBuilder.Entity<OneToOneFieldNavPrincipal>()
                     .Navigation(e => e.Dependent)
+                    .HasField("_unconventionalDependent")
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
                 modelBuilder.Entity<NavDependent>();

--- a/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public class InternalNavigationBuilderTest
+    {
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_HasField()
+        {
+            var builder = CreateInternalNavigationBuilder();
+            var metadata = builder.Metadata;
+
+            Assert.NotNull(metadata.FieldInfo);
+            Assert.Equal(ConfigurationSource.Convention, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_details", ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField("_details", ConfigurationSource.DataAnnotation));
+
+            Assert.Equal("_details", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_details", ConfigurationSource.Convention));
+            Assert.False(builder.CanSetField("_otherDetails", ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasField("_details", ConfigurationSource.Convention));
+            Assert.Null(builder.HasField("_otherDetails", ConfigurationSource.Convention));
+
+            Assert.Equal("_details", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField("_otherDetails", ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField("_otherDetails", ConfigurationSource.DataAnnotation));
+
+            Assert.Equal("_otherDetails", metadata.FieldInfo?.Name);
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
+
+            Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+
+            Assert.Null(metadata.FieldInfo);
+            Assert.Null(metadata.GetFieldInfoConfigurationSource());
+        }
+
+        [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_PropertyAccessMode()
+        {
+            var builder = CreateInternalNavigationBuilder();
+            IConventionNavigation metadata = builder.Metadata;
+
+            Assert.Equal(PropertyAccessMode.PreferField, metadata.GetPropertyAccessMode());
+            Assert.Null(metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferProperty, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.Convention));
+            Assert.False(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.Convention));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferProperty, ConfigurationSource.Convention));
+            Assert.Null(builder.UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.Convention));
+
+            Assert.Equal(PropertyAccessMode.PreferProperty, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(PropertyAccessMode.PreferFieldDuringConstruction, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferFieldDuringConstruction, metadata.GetPropertyAccessMode());
+            Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetPropertyAccessModeConfigurationSource());
+
+            Assert.True(builder.CanSetPropertyAccessMode(null, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(builder.UsePropertyAccessMode(null, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(PropertyAccessMode.PreferField, metadata.GetPropertyAccessMode());
+            Assert.Null(metadata.GetPropertyAccessModeConfigurationSource());
+        }
+
+        private InternalNavigationBuilder CreateInternalNavigationBuilder()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
+            var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
+            var detailsEntityBuilder = modelBuilder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+            orderEntityBuilder
+                .HasRelationship(detailsEntityBuilder.Metadata, nameof(Order.Details), ConfigurationSource.Convention, targetIsPrincipal: false)
+                .IsUnique(false, ConfigurationSource.Convention);
+            var navigation = (Navigation)orderEntityBuilder.Navigation(nameof(Order.Details));
+
+            return new InternalNavigationBuilder(navigation, modelBuilder);
+        }
+
+        protected class Order
+        {
+            public int OrderId { get; set; }
+
+            private ICollection<OrderDetails> _details;
+            private readonly ICollection<OrderDetails> _otherDetails = new List<OrderDetails>();
+            public ICollection<OrderDetails> Details { get => _details; set => _details = value; }
+        }
+
+        protected class OrderDetails
+        {
+            public int Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #20281. `NavigationBuilder` now has a `HasField()` method on it allowing the user to specify the backing field explicitly.

(Note: avoiding duplication meant pushing this code down onto `InternalPropertyBaseBuilder` and updating some other classes to call it at the same time.)



