### PR TITLE
Test: Update Sql assertion in OwnedQuerySqlServerTest

### DIFF
--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -35,9 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IEntityType entityType,
             [NotNull] Expression valueBufferExpression,
             bool nullable,
-            [NotNull] LambdaExpression discriminatorCondition)
+            [CanBeNull] LambdaExpression materializationCondition)
             : base(entityType, valueBufferExpression, nullable,
-                  discriminatorCondition ?? GenerateMaterializationCondition(Check.NotNull(entityType, nameof(entityType)), nullable))
+                  materializationCondition ?? GenerateMaterializationCondition(Check.NotNull(entityType, nameof(entityType)), nullable))
         {
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(valueBufferExpression, nameof(valueBufferExpression));
 
             return valueBufferExpression != ValueBufferExpression
-                ? new RelationalEntityShaperExpression(EntityType, valueBufferExpression, IsNullable, DiscriminatorCondition)
+                ? new RelationalEntityShaperExpression(EntityType, valueBufferExpression, IsNullable, MaterializationCondition)
                 : this;
         }
     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2578,6 +2578,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("FunctionOnClient", nameof(methodName)),
                 methodName);
 
+        /// <summary>
+        ///     Materialization condition passed for entity shaper of entity type '{entityType}' is not of correct shape. Materialization condition must be LambdaExpression of 'Func&lt;ValueBuffer, IEntityType&gt;'
+        /// </summary>
+        public static string QueryEntityMaterializationConditionWrongShape([CanBeNull] object entityType)
+            => string.Format(
+                GetString("QueryEntityMaterializationConditionWrongShape", nameof(entityType)),
+                entityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1363,4 +1363,7 @@
   <data name="FunctionOnClient" xml:space="preserve">
     <value>The '{methodName}' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
+  <data name="QueryEntityMaterializationConditionWrongShape" xml:space="preserve">
+    <value>Materialization condition passed for entity shaper of entity type '{entityType}' is not of correct shape. Materialization condition must be LambdaExpression of 'Func&lt;ValueBuffer, IEntityType&gt;'</value>
+  </data>
 </root>

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -452,9 +452,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expressions.Add(
                     Expression.Assign(concreteEntityTypeVariable,
                         ReplacingExpressionVisitor.Replace(
-                            entityShaperExpression.DiscriminatorCondition.Parameters[0],
+                            entityShaperExpression.MaterializationCondition.Parameters[0],
                             valueBufferExpression,
-                            entityShaperExpression.DiscriminatorCondition.Body)));
+                            entityShaperExpression.MaterializationCondition.Body)));
 
                 var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToArray();
                 var discriminatorProperty = entityType.GetDiscriminatorProperty();
@@ -550,14 +550,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 return Expression.Block(blockExpressions);
             }
-
-            private static readonly MethodInfo _createUnableToDiscriminateException
-                = typeof(EntityMaterializerInjectingExpressionVisitor).GetTypeInfo()
-                    .GetDeclaredMethod(nameof(CreateUnableToDiscriminateException));
-
-            [UsedImplicitly]
-            private static Exception CreateUnableToDiscriminateException(IEntityType entityType, object discriminator)
-                => new InvalidOperationException(CoreStrings.UnableToDiscriminate(entityType.DisplayName(), discriminator?.ToString()));
         }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -479,10 +479,10 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
                                 ab.IndexedProperty<string>("AddressLine");
                                 ab.IndexedProperty(typeof(int), "ZipCode");
                                 ab.HasData(
-                                    new { OwnedPersonId = 1, AddressLine = "804 S. Lakeshore Road", ZipCode = 38654 },
-                                    new { OwnedPersonId = 2, AddressLine = "7 Church Dr.", ZipCode = 28655 },
-                                    new { OwnedPersonId = 3, AddressLine = "72 Hickory Rd.", ZipCode = 07728 },
-                                    new { OwnedPersonId = 4, AddressLine = "28 Strawberry St.", ZipCode = 19053 });
+                                    new { OwnedPersonId = 1, PlaceType = "Land", AddressLine = "804 S. Lakeshore Road", ZipCode = 38654 },
+                                    new { OwnedPersonId = 2, PlaceType = "Land", AddressLine = "7 Church Dr.", ZipCode = 28655 },
+                                    new { OwnedPersonId = 3, PlaceType = "Land", AddressLine = "72 Hickory Rd.", ZipCode = 07728 },
+                                    new { OwnedPersonId = 4, PlaceType = "Land", AddressLine = "28 Strawberry St.", ZipCode = 19053 });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -542,8 +542,10 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
                         eb.OwnsOne(
                             p => p.BranchAddress, ab =>
                             {
+                                ab.IndexedProperty<string>("BranchName");
                                 ab.HasData(
-                                    new { BranchId = 2 }, new { BranchId = 3 });
+                                    new { BranchId = 2, PlaceType = "Land", BranchName = "BranchA" },
+                                    new { BranchId = 3, PlaceType = "Land", BranchName = "BranchB" });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -574,8 +576,9 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
                         eb.OwnsOne(
                             p => p.LeafAAddress, ab =>
                             {
+                                ab.IndexedProperty<int>("LeafType");
                                 ab.HasData(
-                                    new { LeafAId = 3 });
+                                    new { LeafAId = 3, PlaceType = "Land", LeafType = 1 });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -600,8 +603,9 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
                         eb.OwnsOne(
                             p => p.LeafBAddress, ab =>
                             {
+                                ab.IndexedProperty<string>("LeafBType");
                                 ab.HasData(
-                                    new { LeafBId = 4 });
+                                    new { LeafBId = 4, PlaceType = "Land", LeafBType = "Green" });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>

--- a/test/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
@@ -28,6 +28,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                     entitySorters,
                     entityAsserters,
                     CanExecuteQueryString);
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+
+                // TODO: See issue#20334
+                //modelBuilder.Entity<OwnedPerson>().OwnsOne(e => e.PersonAddress).Property(e => e.PlaceType).HasColumnName("PlaceType");
+                //modelBuilder.Entity<Branch>().OwnsOne(e => e.BranchAddress).Property(e => e.PlaceType).HasColumnName("PlaceType");
+                //modelBuilder.Entity<LeafA>().OwnsOne(e => e.LeafAAddress).Property(e => e.PlaceType).HasColumnName("PlaceType");
+                //modelBuilder.Entity<LeafB>().OwnsOne(e => e.LeafBAddress).Property(e => e.PlaceType).HasColumnName("PlaceType");
+            }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Branch>());
         }
 
-        [ConditionalTheory(Skip = "Issue#20336")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Query_for_branch_type_loads_all_owned_navs_tracking(bool async)
         {
@@ -408,7 +408,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "Issue#20336")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Unmapped_property_projection_loads_owned_navigations(bool async)
         {
@@ -750,6 +750,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 Assert.Equal(expectedAddress["AddressLine"], actualAddress["AddressLine"]);
                 Assert.Equal(expectedAddress["ZipCode"], actualAddress["ZipCode"]);
+                Assert.Equal(expectedAddress["BranchName"], actualAddress["BranchName"]);
+                Assert.Equal(expectedAddress["LeafType"], actualAddress["LeafType"]);
+                Assert.Equal(expectedAddress["LeafBType"], actualAddress["LeafBType"]);
+                Assert.Equal(expectedAddress.PlaceType, actualAddress.PlaceType);
                 Assert.Equal(expectedAddress.Country.PlanetId, actualAddress.Country.PlanetId);
                 Assert.Equal(expectedAddress.Country.Name, actualAddress.Country.Name);
             }
@@ -1042,10 +1046,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 ab.IndexedProperty<string>("AddressLine");
                                 ab.IndexedProperty(typeof(int), "ZipCode");
                                 ab.HasData(
-                                    new { OwnedPersonId = 1, AddressLine = "804 S. Lakeshore Road", ZipCode = 38654 },
-                                    new { OwnedPersonId = 2, AddressLine = "7 Church Dr.", ZipCode = 28655 },
-                                    new { OwnedPersonId = 3, AddressLine = "72 Hickory Rd.", ZipCode = 07728 },
-                                    new { OwnedPersonId = 4, AddressLine = "28 Strawberry St.", ZipCode = 19053 });
+                                    new { OwnedPersonId = 1, PlaceType = "Land", AddressLine = "804 S. Lakeshore Road", ZipCode = 38654 },
+                                    new { OwnedPersonId = 2, PlaceType = "Land", AddressLine = "7 Church Dr.", ZipCode = 28655 },
+                                    new { OwnedPersonId = 3, PlaceType = "Land", AddressLine = "72 Hickory Rd.", ZipCode = 07728 },
+                                    new { OwnedPersonId = 4, PlaceType = "Land", AddressLine = "28 Strawberry St.", ZipCode = 19053 });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -1103,8 +1107,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         eb.OwnsOne(
                             p => p.BranchAddress, ab =>
                             {
+                                ab.IndexedProperty<string>("BranchName");
                                 ab.HasData(
-                                    new { BranchId = 2 }, new { BranchId = 3 });
+                                    new { BranchId = 2, PlaceType = "Land", BranchName = "BranchA" },
+                                    new { BranchId = 3, PlaceType = "Land", BranchName = "BranchB" });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -1136,8 +1142,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         eb.OwnsOne(
                             p => p.LeafAAddress, ab =>
                             {
+                                ab.IndexedProperty<int>("LeafType");
+
                                 ab.HasData(
-                                    new { LeafAId = 3 });
+                                    new { LeafAId = 3, PlaceType = "Land", LeafType = 1 });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -1166,8 +1174,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                         eb.OwnsOne(
                             p => p.LeafBAddress, ab =>
                             {
+                                ab.IndexedProperty<string>("LeafBType");
                                 ab.HasData(
-                                    new { LeafBId = 4 });
+                                    new { LeafBId = 4, PlaceType = "Land", LeafBType = "Green" });
 
                                 ab.OwnsOne(
                                     a => a.Country, cb =>
@@ -1354,7 +1363,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             private static IReadOnlyList<OwnedPerson> CreateOwnedPeople()
             {
-                var personAddress1 = new OwnedAddress { Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
+                var personAddress1 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
                 personAddress1["AddressLine"] = "804 S. Lakeshore Road";
                 personAddress1["ZipCode"] = 38654;
                 var ownedPerson1 = new OwnedPerson
@@ -1364,37 +1373,46 @@ namespace Microsoft.EntityFrameworkCore.Query
                 };
                 ownedPerson1["Name"] = "Mona Cy";
 
-                var personAddress2 = new OwnedAddress { Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
+                var personAddress2 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
                 personAddress2["AddressLine"] = "7 Church Dr.";
                 personAddress2["ZipCode"] = 28655;
+                var branchAddress2 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } };
+                branchAddress2["BranchName"] = "BranchA";
+
                 var ownedPerson2 = new Branch
                 {
                     Id = 2,
                     PersonAddress = personAddress2,
-                    BranchAddress = new OwnedAddress { Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } }
+                    BranchAddress = branchAddress2
                 };
                 ownedPerson2["Name"] = "Antigonus Mitul";
 
-                var personAddress3 = new OwnedAddress { Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
+                var personAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
                 personAddress3["AddressLine"] = "72 Hickory Rd.";
                 personAddress3["ZipCode"] = 07728;
+                var branchAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } };
+                branchAddress3["BranchName"] = "BranchB";
+                var leafAAddress3 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Mexico", PlanetId = 1 } };
+                leafAAddress3["LeafType"] = 1;
                 var ownedPerson3 = new LeafA
                 {
                     Id = 3,
                     PersonAddress = personAddress3,
-                    BranchAddress = new OwnedAddress { Country = new OwnedCountry { Name = "Canada", PlanetId = 1 } },
-                    LeafAAddress = new OwnedAddress { Country = new OwnedCountry { Name = "Mexico", PlanetId = 1 } }
+                    BranchAddress = branchAddress3,
+                    LeafAAddress = leafAAddress3
                 };
                 ownedPerson3["Name"] = "Madalena Morana";
 
-                var personAddress4 = new OwnedAddress { Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
+                var personAddress4 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "USA", PlanetId = 1 } };
                 personAddress4["AddressLine"] = "28 Strawberry St.";
                 personAddress4["ZipCode"] = 19053;
+                var leafBAddress4 = new OwnedAddress { PlaceType = "Land", Country = new OwnedCountry { Name = "Panama", PlanetId = 1 } };
+                leafBAddress4["LeafBType"] = "Green";
                 var ownedPerson4 = new LeafB
                 {
                     Id = 4,
                     PersonAddress = personAddress4,
-                    LeafBAddress = new OwnedAddress { Country = new OwnedCountry { Name = "Panama", PlanetId = 1 } }
+                    LeafBAddress = leafBAddress4
                 };
                 ownedPerson4["Name"] = "Vanda Waldemar";
 
@@ -1474,37 +1492,50 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             private string _addressLine;
             private int _zipCode;
+            private string _branchName;
+            private int _leafAType;
+            private string _leafBType;
+
+            public string PlaceType { get; set; }
             public OwnedCountry Country { get; set; }
             public object this[string name]
             {
-                get
+                get => name switch
                 {
-                    if (string.Equals(name, "AddressLine", StringComparison.Ordinal))
-                    {
-                        return _addressLine;
-                    }
-
-                    if (string.Equals(name, "ZipCode", StringComparison.Ordinal))
-                    {
-                        return _zipCode;
-                    }
-
-                    throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}.");
-                }
+                    "AddressLine" => _addressLine,
+                    "ZipCode" => _zipCode,
+                    "BranchName" => _branchName,
+                    "LeafType" => _leafAType,
+                    "LeafBType" => _leafBType,
+                    _ => throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}."),
+                };
 
                 set
                 {
-                    if (string.Equals(name, "AddressLine", StringComparison.Ordinal))
+                    switch (name)
                     {
-                        _addressLine = (string)value;
-                    }
-                    else if (string.Equals(name, "ZipCode", StringComparison.Ordinal))
-                    {
-                        _zipCode = (int)value;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}.");
+                        case "AddressLine":
+                            _addressLine = (string)value;
+                            break;
+
+                        case "ZipCode":
+                            _zipCode = (int)value;
+                            break;
+
+                        case "BranchName":
+                            _branchName = (string)value;
+                            break;
+
+                        case "LeafType":
+                            _leafAType = (int)value;
+                            break;
+
+                        case "LeafBType":
+                            _leafBType = (string)value;
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}.");
                     }
                 }
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -20,54 +20,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             await base.Query_with_owned_entity_equality_operator(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t0].[Id], [t0].[PersonAddress_AddressLine], [t0].[PersonAddress_ZipCode], [t1].[Id], [t1].[PersonAddress_Country_Name], [t1].[PersonAddress_Country_PlanetId], [t3].[Id], [t4].[Id], [t4].[BranchAddress_Country_Name], [t4].[BranchAddress_Country_PlanetId], [t6].[Id], [t7].[Id], [t7].[LeafAAddress_Country_Name], [t7].[LeafAAddress_Country_PlanetId], [t].[Id], [o9].[ClientId], [o9].[Id], [o9].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [t].[Id], [o1].[ClientId], [o1].[Id], [o1].[OrderDate]
 FROM [OwnedPerson] AS [o]
 CROSS JOIN (
     SELECT [o0].[Id], [o0].[Discriminator], [o0].[Name]
     FROM [OwnedPerson] AS [o0]
     WHERE [o0].[Discriminator] = N'LeafB'
 ) AS [t]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [o].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t1] ON [t0].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t2].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t2] ON [o3].[Id] = [t2].[Id]
-) AS [t3] ON [o].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t4] ON [t3].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t5].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafA'
-    ) AS [t5] ON [o6].[Id] = [t5].[Id]
-) AS [t6] ON [o].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafAAddress_Country_Name], [o8].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t7] ON [t6].[Id] = [t7].[Id]
-LEFT JOIN [Order] AS [o9] ON [o].[Id] = [o9].[ClientId]
+LEFT JOIN [Order] AS [o1] ON [o].[Id] = [o1].[ClientId]
 WHERE 0 = 1
-ORDER BY [o].[Id], [t].[Id], [o9].[ClientId], [o9].[Id]");
+ORDER BY [o].[Id], [t].[Id], [o1].[ClientId], [o1].[Id]");
         }
 
         public override async Task Query_for_base_type_loads_all_owned_navs(bool async)
@@ -76,62 +38,10 @@ ORDER BY [o].[Id], [t].[Id], [o9].[ClientId], [o9].[Id]");
 
             // See issue #10067
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
-ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task No_ignored_include_warning_when_implicit_load(bool async)
@@ -148,49 +58,11 @@ FROM [OwnedPerson] AS [o]");
             await base.Query_for_branch_type_loads_all_owned_navs(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafAAddress_Country_Name], [t6].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id], [o8].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafA'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Query_for_branch_type_loads_all_owned_navs_tracking(bool async)
@@ -198,49 +70,11 @@ ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
             await base.Query_for_branch_type_loads_all_owned_navs_tracking(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafAAddress_Country_Name], [t6].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id], [o8].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafA'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Query_for_leaf_type_loads_all_owned_navs(bool async)
@@ -248,49 +82,11 @@ ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
             await base.Query_for_leaf_type_loads_all_owned_navs(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafAAddress_Country_Name], [t6].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id], [o8].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafA'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Query_when_subquery(bool async)
@@ -300,74 +96,17 @@ ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
             AssertSql(
                 @"@__p_0='5'
 
-SELECT [t0].[Id], [t0].[Discriminator], [t0].[Name], [t2].[Id], [t2].[PersonAddress_AddressLine], [t2].[PersonAddress_ZipCode], [t3].[Id], [t3].[PersonAddress_Country_Name], [t3].[PersonAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[BranchAddress_Country_Name], [t6].[BranchAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafBAddress_Country_Name], [t9].[LeafBAddress_Country_PlanetId], [t11].[Id], [t12].[Id], [t12].[LeafAAddress_Country_Name], [t12].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[PersonAddress_AddressLine], [t0].[PersonAddress_PlaceType], [t0].[PersonAddress_ZipCode], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t0].[BranchAddress_BranchName], [t0].[BranchAddress_PlaceType], [t0].[BranchAddress_Country_Name], [t0].[BranchAddress_Country_PlanetId], [t0].[LeafBAddress_LeafBType], [t0].[LeafBAddress_PlaceType], [t0].[Id0], [t0].[LeafBAddress_Country_Name], [t0].[LeafBAddress_Country_PlanetId], [t0].[LeafAAddress_LeafType], [t0].[LeafAAddress_PlaceType], [t0].[LeafAAddress_Country_Name], [t0].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [t].[Id], [t].[Discriminator], [t].[Name]
+    SELECT TOP(@__p_0) [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId]
     FROM (
-        SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name]
+        SELECT DISTINCT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
         FROM [OwnedPerson] AS [o]
     ) AS [t]
     ORDER BY [t].[Id]
 ) AS [t0]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t0].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t2] ON [t0].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t4] ON [o3].[Id] = [t4].[Id]
-) AS [t5] ON [t0].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t7] ON [o6].[Id] = [t7].[Id]
-) AS [t8] ON [t0].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t10].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t10] ON [o9].[Id] = [t10].[Id]
-) AS [t11] ON [t0].[Id] = [t11].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t12] ON [t11].[Id] = [t12].[Id]
-LEFT JOIN [Order] AS [o12] ON [t0].[Id] = [o12].[ClientId]
-ORDER BY [t0].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t0].[Id] = [o0].[ClientId]
+ORDER BY [t0].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool async)
@@ -375,19 +114,9 @@ ORDER BY [t0].[Id], [o12].[ClientId], [o12].[Id]");
             await base.Navigation_rewrite_on_owned_reference_projecting_scalar(async);
 
             AssertSql(
-                @"SELECT [t0].[PersonAddress_Country_Name]
+                @"SELECT [o].[PersonAddress_Country_Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-WHERE [t0].[PersonAddress_Country_Name] = N'USA'");
+WHERE [o].[PersonAddress_Country_Name] = N'USA'");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_projecting_entity(bool async)
@@ -395,63 +124,11 @@ WHERE [t0].[PersonAddress_Country_Name] = N'USA'");
             await base.Navigation_rewrite_on_owned_reference_projecting_entity(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
-WHERE [t0].[PersonAddress_Country_Name] = N'USA'
-ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+WHERE [o].[PersonAddress_Country_Name] = N'USA'
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_collection(bool async)
@@ -492,22 +169,12 @@ ORDER BY [o0].[Id]");
 
             AssertSql(
                 @"SELECT (
-    SELECT TOP(1) [t0].[PersonAddress_Country_Name]
+    SELECT TOP(1) [o0].[PersonAddress_Country_Name]
     FROM [Order] AS [o]
     LEFT JOIN [OwnedPerson] AS [o0] ON [o].[ClientId] = [o0].[Id]
-    LEFT JOIN (
-        SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-    LEFT JOIN (
-        SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] AS [o2]
-        WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-    ) AS [t0] ON [t].[Id] = [t0].[Id]
-    WHERE [o3].[Id] = [o].[ClientId]
+    WHERE [o1].[Id] = [o].[ClientId]
     ORDER BY [o].[Id])
-FROM [OwnedPerson] AS [o3]");
+FROM [OwnedPerson] AS [o1]");
         }
 
         public override async Task SelectMany_on_owned_collection(bool async)
@@ -527,17 +194,7 @@ INNER JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]");
             AssertSql(
                 @"SELECT [p].[Id], [p].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]");
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]");
         }
 
         public override async Task Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(bool async)
@@ -545,22 +202,12 @@ LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]");
             await base.Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o2].[ClientId], [o2].[Id], [o2].[OrderDate]
+                @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o2] ON [o].[Id] = [o2].[ClientId]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE ([p].[Id] <> 42) OR [p].[Id] IS NULL
-ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Project_multiple_owned_navigations(bool async)
@@ -568,21 +215,11 @@ ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
             await base.Project_multiple_owned_navigations(async);
 
             AssertSql(
-                @"SELECT [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o].[Id], [o2].[ClientId], [o2].[Id], [o2].[OrderDate]
+                @"SELECT [o].[Id], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [p].[Id], [p].[StarId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN [Order] AS [o2] ON [o].[Id] = [o2].[ClientId]
-ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Project_multiple_owned_navigations_with_expansion_on_owned_collections(bool async)
@@ -590,36 +227,16 @@ ORDER BY [o].[Id], [o2].[ClientId], [o2].[Id]");
             await base.Project_multiple_owned_navigations_with_expansion_on_owned_collections(async);
 
             AssertSql(
-    @"SELECT (
+                @"SELECT (
     SELECT COUNT(*)
     FROM [Order] AS [o]
     LEFT JOIN [OwnedPerson] AS [o0] ON [o].[ClientId] = [o0].[Id]
-    LEFT JOIN (
-        SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-        FROM [OwnedPerson] AS [o1]
-        WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-    ) AS [t] ON [o0].[Id] = [t].[Id]
-    LEFT JOIN (
-        SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] AS [o2]
-        WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-    ) AS [t0] ON [t].[Id] = [t0].[Id]
-    LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+    LEFT JOIN [Planet] AS [p] ON [o0].[PersonAddress_Country_PlanetId] = [p].[Id]
     LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
-    WHERE ([o3].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
-FROM [OwnedPerson] AS [o3]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[PersonAddress_AddressLine], [o4].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [o3].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[PersonAddress_Country_Name], [o5].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN [Planet] AS [p0] ON [t2].[PersonAddress_Country_PlanetId] = [p0].[Id]
-ORDER BY [o3].[Id]");
+    WHERE ([o1].[Id] = [o].[ClientId]) AND (([s].[Id] <> 42) OR [s].[Id] IS NULL)) AS [Count], [p0].[Id], [p0].[StarId]
+FROM [OwnedPerson] AS [o1]
+LEFT JOIN [Planet] AS [p0] ON [o1].[PersonAddress_Country_PlanetId] = [p0].[Id]
+ORDER BY [o1].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(bool async)
@@ -627,64 +244,12 @@ ORDER BY [o3].[Id]");
             await base.Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE ([p].[Id] <> 7) OR [p].[Id] IS NULL
-ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool async)
@@ -694,17 +259,7 @@ ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
             AssertSql(
                 @"SELECT [p].[Id]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]");
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
@@ -714,17 +269,7 @@ LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]");
             AssertSql(
                 @"SELECT [o].[Id], [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
 ORDER BY [o].[Id], [m].[Id]");
         }
@@ -736,17 +281,7 @@ ORDER BY [o].[Id], [m].[Id]");
             AssertSql(
                 @"SELECT [m].[Id], [m].[Diameter], [m].[PlanetId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 INNER JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]");
         }
 
@@ -757,17 +292,7 @@ INNER JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]");
             AssertSql(
                 @"SELECT [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 INNER JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]");
         }
@@ -779,17 +304,7 @@ INNER JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 ORDER BY [o].[Id], [e].[Id]");
@@ -803,17 +318,7 @@ ORDER BY [o].[Id], [e].[Id]");
             AssertSql(
                 @"SELECT [s].[Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]");
         }
 
@@ -826,17 +331,7 @@ LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]");
             AssertSql(
                 @"SELECT [s].[Id], [s].[Name], [o].[Id], [e].[Id], [e].[Name], [e].[StarId]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN [Planet] AS [p] ON [t0].[PersonAddress_Country_PlanetId] = [p].[Id]
+LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [s].[Name] = N'Sol'
@@ -848,49 +343,11 @@ ORDER BY [o].[Id], [e].[Id]");
             await base.Query_with_OfType_eagerly_loads_correct_owned_navigations(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafAAddress_Country_Name], [t6].[LeafAAddress_Country_PlanetId], [o8].[ClientId], [o8].[Id], [o8].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[Id], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafA'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [o8].[ClientId], [o8].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Preserve_includes_when_applying_skip_take_after_anonymous_type_select(bool async)
@@ -904,72 +361,15 @@ FROM [OwnedPerson] AS [o]",
                 @"@__p_1='0'
 @__p_2='100'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
     OFFSET @__p_1 ROWS FETCH NEXT @__p_2 ROWS ONLY
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Unmapped_property_projection_loads_owned_navigations(bool async)
@@ -977,63 +377,11 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
             await base.Unmapped_property_projection_loads_owned_navigations(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Id] = 1
-ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_skip_loads_owned_navigations(bool async)
@@ -1043,72 +391,15 @@ ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
             AssertSql(
                 @"@__p_0='1'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
     OFFSET @__p_0 ROWS
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_take_loads_owned_navigations(bool async)
@@ -1118,71 +409,14 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_skip_take_loads_owned_navigations(bool async)
@@ -1193,72 +427,15 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
                 @"@__p_0='1'
 @__p_1='2'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_skip_loads_owned_navigations_variation_2(bool async)
@@ -1268,72 +445,15 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
             AssertSql(
                 @"@__p_0='1'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
     OFFSET @__p_0 ROWS
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_take_loads_owned_navigations_variation_2(bool async)
@@ -1343,71 +463,14 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
             AssertSql(
                 @"@__p_0='2'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT TOP(@__p_0) [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Client_method_skip_take_loads_owned_navigations_variation_2(bool async)
@@ -1418,72 +481,15 @@ ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
                 @"@__p_0='1'
 @__p_1='2'
 
-SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t1].[Id], [t1].[PersonAddress_AddressLine], [t1].[PersonAddress_ZipCode], [t2].[Id], [t2].[PersonAddress_Country_Name], [t2].[PersonAddress_Country_PlanetId], [t4].[Id], [t5].[Id], [t5].[BranchAddress_Country_Name], [t5].[BranchAddress_Country_PlanetId], [t7].[Id], [t8].[Id], [t8].[LeafBAddress_Country_Name], [t8].[LeafBAddress_Country_PlanetId], [t10].[Id], [t11].[Id], [t11].[LeafAAddress_Country_Name], [t11].[LeafAAddress_Country_PlanetId], [o12].[ClientId], [o12].[Id], [o12].[OrderDate]
+SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[PersonAddress_AddressLine], [t].[PersonAddress_PlaceType], [t].[PersonAddress_ZipCode], [t].[PersonAddress_Country_Name], [t].[PersonAddress_Country_PlanetId], [t].[BranchAddress_BranchName], [t].[BranchAddress_PlaceType], [t].[BranchAddress_Country_Name], [t].[BranchAddress_Country_PlanetId], [t].[LeafBAddress_LeafBType], [t].[LeafBAddress_PlaceType], [t].[Id0], [t].[LeafBAddress_Country_Name], [t].[LeafBAddress_Country_PlanetId], [t].[LeafAAddress_LeafType], [t].[LeafAAddress_PlaceType], [t].[LeafAAddress_Country_Name], [t].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM (
-    SELECT [o].[Id], [o].[Discriminator], [o].[Name]
+    SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id] AS [Id0], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId]
     FROM [OwnedPerson] AS [o]
     ORDER BY [o].[Id]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t1] ON [t].[Id] = [t1].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o2]
-    WHERE [o2].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o3].[Id], [t3].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o3]
-    INNER JOIN (
-        SELECT [o4].[Id], [o4].[Discriminator], [o4].[Name]
-        FROM [OwnedPerson] AS [o4]
-        WHERE [o4].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t3] ON [o3].[Id] = [t3].[Id]
-) AS [t4] ON [t].[Id] = [t4].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [o5].[BranchAddress_Country_Name], [o5].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o5]
-    WHERE [o5].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t5] ON [t4].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o6].[Id], [t6].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o6]
-    INNER JOIN (
-        SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name]
-        FROM [OwnedPerson] AS [o7]
-        WHERE [o7].[Discriminator] = N'LeafB'
-    ) AS [t6] ON [o6].[Id] = [t6].[Id]
-) AS [t7] ON [t].[Id] = [t7].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [o8].[LeafBAddress_Country_Name], [o8].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o8]
-    WHERE [o8].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t8] ON [t7].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o9].[Id], [t9].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o9]
-    INNER JOIN (
-        SELECT [o10].[Id], [o10].[Discriminator], [o10].[Name]
-        FROM [OwnedPerson] AS [o10]
-        WHERE [o10].[Discriminator] = N'LeafA'
-    ) AS [t9] ON [o9].[Id] = [t9].[Id]
-) AS [t10] ON [t].[Id] = [t10].[Id]
-LEFT JOIN (
-    SELECT [o11].[Id], [o11].[LeafAAddress_Country_Name], [o11].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o11]
-    WHERE [o11].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t11] ON [t10].[Id] = [t11].[Id]
-LEFT JOIN [Order] AS [o12] ON [t].[Id] = [o12].[ClientId]
-ORDER BY [t].[Id], [o12].[ClientId], [o12].[Id]");
+LEFT JOIN [Order] AS [o0] ON [t].[Id] = [o0].[ClientId]
+ORDER BY [t].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Where_owned_collection_navigation_ToList_Count(bool async)
@@ -1558,63 +564,11 @@ ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
             await base.Can_query_on_indexer_properties(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 WHERE [o].[Name] = N'Mona Cy'
-ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Can_query_on_owned_indexer_properties(bool async)
@@ -1624,12 +578,7 @@ ORDER BY [o].[Id], [o11].[ClientId], [o11].[Id]");
             AssertSql(
                 @"SELECT [o].[Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-WHERE [t].[PersonAddress_ZipCode] = 38654");
+WHERE [o].[PersonAddress_ZipCode] = 38654");
         }
 
         public override async Task Can_query_on_indexer_property_when_property_name_from_closure(bool async)
@@ -1656,13 +605,8 @@ FROM [OwnedPerson] AS [o]");
             await base.Can_project_owned_indexer_properties(async);
 
             AssertSql(
-                @"SELECT [t].[PersonAddress_AddressLine]
-FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]");
+                @"SELECT [o].[PersonAddress_AddressLine]
+FROM [OwnedPerson] AS [o]");
         }
 
         public override async Task Can_project_indexer_properties_converted(bool async)
@@ -1679,13 +623,8 @@ FROM [OwnedPerson] AS [o]");
             await base.Can_project_owned_indexer_properties_converted(async);
 
             AssertSql(
-                @"SELECT [t].[PersonAddress_AddressLine]
-FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]");
+                @"SELECT [o].[PersonAddress_AddressLine]
+FROM [OwnedPerson] AS [o]");
         }
 
         public override async Task Can_OrderBy_indexer_properties(bool async)
@@ -1693,62 +632,10 @@ LEFT JOIN (
             await base.Can_OrderBy_indexer_properties(async);
 
             AssertSql(
-                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [t].[Id], [t].[PersonAddress_AddressLine], [t].[PersonAddress_ZipCode], [t0].[Id], [t0].[PersonAddress_Country_Name], [t0].[PersonAddress_Country_PlanetId], [t2].[Id], [t3].[Id], [t3].[BranchAddress_Country_Name], [t3].[BranchAddress_Country_PlanetId], [t5].[Id], [t6].[Id], [t6].[LeafBAddress_Country_Name], [t6].[LeafBAddress_Country_PlanetId], [t8].[Id], [t9].[Id], [t9].[LeafAAddress_Country_Name], [t9].[LeafAAddress_Country_PlanetId], [o11].[ClientId], [o11].[Id], [o11].[OrderDate]
+                @"SELECT [o].[Id], [o].[Discriminator], [o].[Name], [o].[PersonAddress_AddressLine], [o].[PersonAddress_PlaceType], [o].[PersonAddress_ZipCode], [o].[PersonAddress_Country_Name], [o].[PersonAddress_Country_PlanetId], [o].[BranchAddress_BranchName], [o].[BranchAddress_PlaceType], [o].[BranchAddress_Country_Name], [o].[BranchAddress_Country_PlanetId], [o].[LeafBAddress_LeafBType], [o].[LeafBAddress_PlaceType], [o].[Id], [o].[LeafBAddress_Country_Name], [o].[LeafBAddress_Country_PlanetId], [o].[LeafAAddress_LeafType], [o].[LeafAAddress_PlaceType], [o].[LeafAAddress_Country_Name], [o].[LeafAAddress_Country_PlanetId], [o0].[ClientId], [o0].[Id], [o0].[OrderDate]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-LEFT JOIN (
-    SELECT [o1].[Id], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o1]
-    WHERE [o1].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t0] ON [t].[Id] = [t0].[Id]
-LEFT JOIN (
-    SELECT [o2].[Id], [t1].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o2]
-    INNER JOIN (
-        SELECT [o3].[Id], [o3].[Discriminator], [o3].[Name]
-        FROM [OwnedPerson] AS [o3]
-        WHERE [o3].[Discriminator] IN (N'Branch', N'LeafA')
-    ) AS [t1] ON [o2].[Id] = [t1].[Id]
-) AS [t2] ON [o].[Id] = [t2].[Id]
-LEFT JOIN (
-    SELECT [o4].[Id], [o4].[BranchAddress_Country_Name], [o4].[BranchAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o4]
-    WHERE [o4].[BranchAddress_Country_PlanetId] IS NOT NULL
-) AS [t3] ON [t2].[Id] = [t3].[Id]
-LEFT JOIN (
-    SELECT [o5].[Id], [t4].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o5]
-    INNER JOIN (
-        SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name]
-        FROM [OwnedPerson] AS [o6]
-        WHERE [o6].[Discriminator] = N'LeafB'
-    ) AS [t4] ON [o5].[Id] = [t4].[Id]
-) AS [t5] ON [o].[Id] = [t5].[Id]
-LEFT JOIN (
-    SELECT [o7].[Id], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o7]
-    WHERE [o7].[LeafBAddress_Country_PlanetId] IS NOT NULL
-) AS [t6] ON [t5].[Id] = [t6].[Id]
-LEFT JOIN (
-    SELECT [o8].[Id], [t7].[Id] AS [Id0]
-    FROM [OwnedPerson] AS [o8]
-    INNER JOIN (
-        SELECT [o9].[Id], [o9].[Discriminator], [o9].[Name]
-        FROM [OwnedPerson] AS [o9]
-        WHERE [o9].[Discriminator] = N'LeafA'
-    ) AS [t7] ON [o8].[Id] = [t7].[Id]
-) AS [t8] ON [o].[Id] = [t8].[Id]
-LEFT JOIN (
-    SELECT [o10].[Id], [o10].[LeafAAddress_Country_Name], [o10].[LeafAAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o10]
-    WHERE [o10].[LeafAAddress_Country_PlanetId] IS NOT NULL
-) AS [t9] ON [t8].[Id] = [t9].[Id]
-LEFT JOIN [Order] AS [o11] ON [o].[Id] = [o11].[ClientId]
-ORDER BY [o].[Name], [o].[Id], [o11].[ClientId], [o11].[Id]");
+LEFT JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
+ORDER BY [o].[Name], [o].[Id], [o0].[ClientId], [o0].[Id]");
         }
 
         public override async Task Can_OrderBy_indexer_properties_converted(bool async)
@@ -1768,12 +655,7 @@ ORDER BY [o].[Name], [o].[Id]");
             AssertSql(
                 @"SELECT [o].[Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-ORDER BY [t].[PersonAddress_ZipCode], [o].[Id]");
+ORDER BY [o].[PersonAddress_ZipCode], [o].[Id]");
         }
 
         public override async Task Can_OrderBy_owened_indexer_properties_converted(bool async)
@@ -1783,12 +665,7 @@ ORDER BY [t].[PersonAddress_ZipCode], [o].[Id]");
             AssertSql(
                 @"SELECT [o].[Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-ORDER BY [t].[PersonAddress_ZipCode], [o].[Id]");
+ORDER BY [o].[PersonAddress_ZipCode], [o].[Id]");
         }
 
         public override async Task Can_group_by_indexer_property(bool isAsync)
@@ -1818,12 +695,7 @@ GROUP BY [o].[Name]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-GROUP BY [t].[PersonAddress_ZipCode]");
+GROUP BY [o].[PersonAddress_ZipCode]");
         }
 
         public override async Task Can_group_by_converted_owned_indexer_property(bool isAsync)
@@ -1833,12 +705,7 @@ GROUP BY [t].[PersonAddress_ZipCode]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-GROUP BY [t].[PersonAddress_ZipCode]");
+GROUP BY [o].[PersonAddress_ZipCode]");
         }
 
         public override async Task Can_join_on_indexer_property_on_query(bool isAsync)
@@ -1846,27 +713,9 @@ GROUP BY [t].[PersonAddress_ZipCode]");
             await base.Can_join_on_indexer_property_on_query(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Id], [t2].[PersonAddress_Country_Name] AS [Name]
+                @"SELECT [o].[Id], [o0].[PersonAddress_Country_Name] AS [Name]
 FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]
-INNER JOIN (
-    SELECT [o1].[Id], [o1].[Discriminator], [o1].[Name], [t0].[Id] AS [Id0], [t0].[PersonAddress_AddressLine], [t0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o1]
-    LEFT JOIN (
-        SELECT [o2].[Id], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_ZipCode]
-        FROM [OwnedPerson] AS [o2]
-        WHERE [o2].[PersonAddress_ZipCode] IS NOT NULL
-    ) AS [t0] ON [o1].[Id] = [t0].[Id]
-) AS [t1] ON [t].[PersonAddress_ZipCode] = [t1].[PersonAddress_ZipCode]
-LEFT JOIN (
-    SELECT [o3].[Id], [o3].[PersonAddress_Country_Name], [o3].[PersonAddress_Country_PlanetId]
-    FROM [OwnedPerson] AS [o3]
-    WHERE [o3].[PersonAddress_Country_PlanetId] IS NOT NULL
-) AS [t2] ON [t1].[Id0] = [t2].[Id]");
+INNER JOIN [OwnedPerson] AS [o0] ON [o].[PersonAddress_ZipCode] = [o0].[PersonAddress_ZipCode]");
         }
 
         public override async Task Projecting_indexer_property_ignores_include(bool isAsync)
@@ -1874,13 +723,8 @@ LEFT JOIN (
             await base.Projecting_indexer_property_ignores_include(isAsync);
 
             AssertSql(
-                @"SELECT [t].[PersonAddress_ZipCode] AS [Nation]
-FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]");
+                @"SELECT [o].[PersonAddress_ZipCode] AS [Nation]
+FROM [OwnedPerson] AS [o]");
         }
 
         public override async Task Projecting_indexer_property_ignores_include_converted(bool isAsync)
@@ -1888,13 +732,8 @@ LEFT JOIN (
             await base.Projecting_indexer_property_ignores_include_converted(isAsync);
 
             AssertSql(
-                @"SELECT [t].[PersonAddress_ZipCode] AS [Nation]
-FROM [OwnedPerson] AS [o]
-LEFT JOIN (
-    SELECT [o0].[Id], [o0].[PersonAddress_AddressLine], [o0].[PersonAddress_ZipCode]
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o0].[PersonAddress_ZipCode] IS NOT NULL
-) AS [t] ON [o].[Id] = [t].[Id]");
+                @"SELECT [o].[PersonAddress_ZipCode] AS [Nation]
+FROM [OwnedPerson] AS [o]");
         }
 
         public override async Task Indexer_property_is_pushdown_into_subquery(bool isAsync)
@@ -1924,7 +763,7 @@ WHERE (
         }
 
         private void AssertSql(params string[] expected)
-        { }//=> Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
         public class OwnedQuerySqlServerFixture : RelationalOwnedQueryFixture
         {


### PR DESCRIPTION
- Also add at least one additional property in each owned type. If there no columns other than shared PK then it is required dependent.
- Add a property in owned type which would be sharing column for hierarchy. Currently disabled due to #20334

Resolves #20343
Resolves #20336
Finishes left over test work from #20345