### PR TITLE
Fix for 9723. Allow namespaces to be specified.

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -71,7 +71,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            [CanBeNull] string entityNamespace,
+            [CanBeNull] string dbContextNamespace)
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -90,8 +92,11 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var scaffolder = services.GetRequiredService<IReverseEngineerScaffolder>();
 
-            var modelNamespace = GetNamespaceFromOutputPath(outputDir);
-            var contextNamespace = GetNamespaceFromOutputPath(outputContextDir);
+            var modelNamespace = entityNamespace ?? GetNamespaceFromOutputPath(outputDir);
+            var contextNamespace =
+                dbContextNamespace ??
+                entityNamespace ??
+                GetNamespaceFromOutputPath(outputContextDir);
 
             var scaffoldedModel = scaffolder.ScaffoldModel(
                 connectionString,

--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -69,11 +69,11 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [CanBeNull] string dbContextClassName,
             [NotNull] IEnumerable<string> schemas,
             [NotNull] IEnumerable<string> tables,
+            [CanBeNull] string modelNamespace,
+            [CanBeNull] string contextNamespace,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames,
-            [CanBeNull] string entityNamespace,
-            [CanBeNull] string dbContextNamespace)
+            bool useDatabaseNames)
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -92,10 +92,10 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var scaffolder = services.GetRequiredService<IReverseEngineerScaffolder>();
 
-            var modelNamespace = entityNamespace ?? GetNamespaceFromOutputPath(outputDir);
-            var contextNamespace =
-                dbContextNamespace ??
-                entityNamespace ??
+            var finalModelNamespace = modelNamespace ?? GetNamespaceFromOutputPath(outputDir);
+            var finalContextNamespace =
+                contextNamespace ??
+                modelNamespace ??
                 GetNamespaceFromOutputPath(outputContextDir);
 
             var scaffoldedModel = scaffolder.ScaffoldModel(
@@ -106,8 +106,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 {
                     UseDataAnnotations = useDataAnnotations,
                     RootNamespace = _rootNamespace,
-                    ModelNamespace = modelNamespace,
-                    ContextNamespace = contextNamespace,
+                    ModelNamespace = finalModelNamespace,
+                    ContextNamespace = finalContextNamespace,
                     Language = _language,
                     ContextDir = MakeDirRelative(outputDir, outputContextDir),
                     ContextName = dbContextClassName

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -104,9 +104,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var scaffolder = services.GetRequiredService<IMigrationsScaffolder>();
             var migration =
-                migrationNamespace == null
+                string.IsNullOrEmpty(migrationNamespace)
                 ? scaffolder.ScaffoldMigration(name, _rootNamespace, subNamespace, _language)
-                : scaffolder.ScaffoldMigration(name, migrationNamespace, null, _language);
+                : scaffolder.ScaffoldMigration(name, migrationNamespace, null, _language, true);
             var files = scaffolder.Save(_projectDir, migration, outputDir);
 
             return files;

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -78,7 +78,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         public virtual MigrationFiles AddMigration(
             [NotNull] string name,
             [CanBeNull] string outputDir,
-            [CanBeNull] string contextType)
+            [CanBeNull] string contextType,
+            [CanBeNull] string migrationNamespace)
         {
             Check.NotEmpty(name, nameof(name));
 
@@ -102,7 +103,10 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             EnsureMigrationsAssembly(services);
 
             var scaffolder = services.GetRequiredService<IMigrationsScaffolder>();
-            var migration = scaffolder.ScaffoldMigration(name, _rootNamespace, subNamespace, _language);
+            var migration =
+                migrationNamespace == null
+                ? scaffolder.ScaffoldMigration(name, _rootNamespace, subNamespace, _language)
+                : scaffolder.ScaffoldMigration(name, migrationNamespace, null, _language);
             var files = scaffolder.Save(_projectDir, migration, outputDir);
 
             return files;

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] string name,
             [CanBeNull] string outputDir,
             [CanBeNull] string contextType,
-            [CanBeNull] string migrationNamespace)
+            [CanBeNull] string @namespace)
         {
             Check.NotEmpty(name, nameof(name));
 
@@ -104,9 +104,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var scaffolder = services.GetRequiredService<IMigrationsScaffolder>();
             var migration =
-                string.IsNullOrEmpty(migrationNamespace)
+                string.IsNullOrEmpty(@namespace)
                 ? scaffolder.ScaffoldMigration(name, _rootNamespace, subNamespace, _language)
-                : scaffolder.ScaffoldMigration(name, migrationNamespace, null, _language, true);
+                : scaffolder.ScaffoldMigration(name, null, @namespace, _language);
             var files = scaffolder.Save(_projectDir, migration, outputDir);
 
             return files;

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -160,9 +160,9 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var name = (string)args["name"];
                 var outputDir = (string)args["outputDir"];
                 var contextType = (string)args["contextType"];
-                var migrationNamespace = (string)args["migrationNamespace"];
+                var @namespace = (string)args["namespace"];
 
-                Execute(() => executor.AddMigrationImpl(name, outputDir, contextType, migrationNamespace));
+                Execute(() => executor.AddMigrationImpl(name, outputDir, contextType, @namespace));
             }
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] string name,
             [CanBeNull] string outputDir,
             [CanBeNull] string contextType,
-            [CanBeNull] string migrationNamespace)
+            [CanBeNull] string @namespace)
         {
             Check.NotEmpty(name, nameof(name));
 
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 name,
                 outputDir,
                 contextType,
-                migrationNamespace);
+                @namespace);
 
             return new Hashtable
             {
@@ -446,6 +446,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             ///     <para><c>useDataAnnotations</c>--Use attributes to configure the model (where possible). If false, only the fluent API is used.</para>
             ///     <para><c>overwriteFiles</c>--Overwrite existing files.</para>
             ///     <para><c>useDatabaseNames</c>--Use table and column names directly from the database.</para>
+            ///     <para><c>modelNamespace</c>--Specify to override the namespace of the generated entity types.</para>
+            ///     <para><c>contextNamespace</c>--Specify to override the namespace of the generated DbContext class.</para>
             /// </summary>
             /// <param name="executor"> The operation executor. </param>
             /// <param name="resultHandler"> The <see cref="IOperationResultHandler" />. </param>
@@ -464,17 +466,17 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var dbContextClassName = (string)args["dbContextClassName"];
                 var schemaFilters = (IEnumerable<string>)args["schemaFilters"];
                 var tableFilters = (IEnumerable<string>)args["tableFilters"];
+                var modelNamespace = (string)args["modelNamespace"];
+                var contextNamespace = (string)args["contextNamespace"];
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
                 var useDatabaseNames = (bool)args["useDatabaseNames"];
-                var entityNamespace = (string)args["entityNamespace"];
-                var dbContextNamespace = (string)args["dbContextNamespace"];
 
                 Execute(
                     () => executor.ScaffoldContextImpl(
                         provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames,
-                        entityNamespace, dbContextNamespace));
+                        schemaFilters, tableFilters, modelNamespace, contextNamespace, useDataAnnotations,
+                        overwriteFiles, useDatabaseNames));
             }
         }
 
@@ -486,11 +488,11 @@ namespace Microsoft.EntityFrameworkCore.Design
             [CanBeNull] string dbContextClassName,
             [NotNull] IEnumerable<string> schemaFilters,
             [NotNull] IEnumerable<string> tableFilters,
+            [CanBeNull] string modelNamespace,
+            [CanBeNull] string contextNamespace,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames,
-            [CanBeNull] string entityNamespace,
-            [CanBeNull] string dbContextNamespace)
+            bool useDatabaseNames)
         {
             Check.NotNull(provider, nameof(provider));
             Check.NotNull(connectionString, nameof(connectionString));
@@ -499,8 +501,8 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = DatabaseOperations.ScaffoldContext(
                 provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames,
-                entityNamespace, dbContextNamespace);
+                schemaFilters, tableFilters, modelNamespace, contextNamespace, useDataAnnotations,
+                overwriteFiles, useDatabaseNames);
 
             return new Hashtable { ["ContextFile"] = files.ContextFile, ["EntityTypeFiles"] = files.AdditionalFiles.ToArray() };
         }

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -160,22 +160,25 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var name = (string)args["name"];
                 var outputDir = (string)args["outputDir"];
                 var contextType = (string)args["contextType"];
+                var migrationNamespace = (string)args["migrationNamespace"];
 
-                Execute(() => executor.AddMigrationImpl(name, outputDir, contextType));
+                Execute(() => executor.AddMigrationImpl(name, outputDir, contextType, migrationNamespace));
             }
         }
 
         private IDictionary AddMigrationImpl(
             [NotNull] string name,
             [CanBeNull] string outputDir,
-            [CanBeNull] string contextType)
+            [CanBeNull] string contextType,
+            [CanBeNull] string migrationNamespace)
         {
             Check.NotEmpty(name, nameof(name));
 
             var files = MigrationsOperations.AddMigration(
                 name,
                 outputDir,
-                contextType);
+                contextType,
+                migrationNamespace);
 
             return new Hashtable
             {
@@ -464,11 +467,14 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
                 var useDatabaseNames = (bool)args["useDatabaseNames"];
+                var entityNamespace = (string)args["entityNamespace"];
+                var dbContextNamespace = (string)args["dbContextNamespace"];
 
                 Execute(
                     () => executor.ScaffoldContextImpl(
                         provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames));
+                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames,
+                        entityNamespace, dbContextNamespace));
             }
         }
 
@@ -482,7 +488,9 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            [CanBeNull] string entityNamespace,
+            [CanBeNull] string dbContextNamespace)
         {
             Check.NotNull(provider, nameof(provider));
             Check.NotNull(connectionString, nameof(connectionString));
@@ -491,7 +499,8 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = DatabaseOperations.ScaffoldContext(
                 provider, connectionString, outputDir, outputDbContextDir, dbContextClassName,
-                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames);
+                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames,
+                entityNamespace, dbContextNamespace);
 
             return new Hashtable { ["ContextFile"] = files.ContextFile, ["EntityTypeFiles"] = files.AdditionalFiles.ToArray() };
         }

--- a/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
@@ -17,14 +17,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="rootNamespace"> The project's root namespace. </param>
         /// <param name="subNamespace"> The migration's sub-namespace. </param>
         /// <param name="language"> The project's language. </param>
-        /// <param name="overrideNamespace"> Set to true to override all automatic namespace generation. </param>
         /// <returns> The scaffolded migration. </returns>
         ScaffoldedMigration ScaffoldMigration(
             [NotNull] string migrationName,
-            [NotNull] string rootNamespace,
+            [CanBeNull] string rootNamespace,
             [CanBeNull] string subNamespace = null,
-            [CanBeNull] string language = null,
-            bool overrideNamespace = false);
+            [CanBeNull] string language = null);
 
         /// <summary>
         ///     Removes the previous migration.

--- a/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/IMigrationsScaffolder.cs
@@ -17,12 +17,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="rootNamespace"> The project's root namespace. </param>
         /// <param name="subNamespace"> The migration's sub-namespace. </param>
         /// <param name="language"> The project's language. </param>
+        /// <param name="overrideNamespace"> Set to true to override all automatic namespace generation. </param>
         /// <returns> The scaffolded migration. </returns>
         ScaffoldedMigration ScaffoldMigration(
             [NotNull] string migrationName,
             [NotNull] string rootNamespace,
             [CanBeNull] string subNamespace = null,
-            [CanBeNull] string language = null);
+            [CanBeNull] string language = null,
+            bool overrideNamespace = false);
 
         /// <summary>
         ///     Removes the previous migration.

--- a/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs
@@ -78,7 +78,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             string language = null)
         {
             Check.NotEmpty(migrationName, nameof(migrationName));
-            Check.NotEmpty(string.Empty + rootNamespace + subNamespace, "rootNamespace + subNamespace");
 
             if (Dependencies.MigrationsAssembly.FindMigrationId(migrationName) != null)
             {

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.PS2.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.PS2.psm1
@@ -25,6 +25,9 @@ $versionErrorMessage = 'The Entity Framework Core Package Manager Console Tools 
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
+.PARAMETER Namespace
+    Specify to override the namespace for the migration.
+
 .LINK
     Remove-Migration
     Update-Database
@@ -35,7 +38,8 @@ function Add-Migration(
     $OutputDir,
     $Context,
     $Project,
-    $StartupProject)
+    $StartupProject,
+    $Namespace)
 {
     WarnIfEF6 'Add-Migration'
     throw $UpdatePowerShell
@@ -177,6 +181,12 @@ function Remove-Migration(
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
+.PARAMETER Namespace
+    Specify to override the namespace for the generated entity types.
+
+.PARAMETER ContextNamespace
+    Specify to override the namespace for the DbContext class.
+
 .LINK
     about_EntityFrameworkCore
 #>
@@ -192,7 +202,9 @@ function Scaffold-DbContext(
     [switch] $UseDatabaseNames,
     [switch] $Force,
     $Project,
-    $StartupProject)
+    $StartupProject,
+    $Namespace,
+    $ContextNamespace)
 {
     throw $UpdatePowerShell
 }

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -33,6 +33,9 @@ Register-TabExpansion Add-Migration @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
+.PARAMETER Namespace
+    Specify to override the namespace for the migration.
+
 .LINK
     Remove-Migration
     Update-Database
@@ -47,7 +50,8 @@ function Add-Migration
         [string] $OutputDir,
         [string] $Context,
         [string] $Project,
-        [string] $StartupProject)
+        [string] $StartupProject,
+        [string] $Namespace)
 
     WarnIfEF6 'Add-Migration'
 
@@ -59,6 +63,11 @@ function Add-Migration
     if ($OutputDir)
     {
         $params += '--output-dir', $OutputDir
+    }
+
+    if ($Namespace)
+    {
+        $params += '--namespace', $Namespace
     }
 
     $params += GetParams $Context
@@ -305,6 +314,12 @@ Register-TabExpansion Scaffold-DbContext @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
+.PARAMETER Namespace
+    Specify to override the namespace for the generated entity types.
+
+.PARAMETER ContextNamespace
+    Specify to override the namespace for the DbContext class.
+
 .LINK
     about_EntityFrameworkCore
 #>
@@ -325,7 +340,9 @@ function Scaffold-DbContext
         [switch] $UseDatabaseNames,
         [switch] $Force,
         [string] $Project,
-        [string] $StartupProject)
+        [string] $StartupProject,
+        [string] $Namespace,
+        [string] $ContextNamespace)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -345,6 +362,16 @@ function Scaffold-DbContext
     if ($Context)
     {
         $params += '--context', $Context
+    }
+
+    if ($Namespace)
+    {
+        $params += '--namespace', $Namespace
+    }
+
+    if ($ContextNamespace)
+    {
+        $params += '--context-namespace', $ContextNamespace
     }
 
     $params += $Schemas | %{ '--schema', $_ }

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -452,6 +452,24 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string DbContextConnectionDescription
             => GetString("DbContextConnectionDescription");
 
+        /// <summary>
+        ///     Specify to override the namespace for the generated entity types.
+        /// </summary>
+        public static string NamespaceDescription
+            => GetString("NamespaceDescription");
+
+        /// <summary>
+        ///     Specify to override the namespace for the DbContext class.
+        /// </summary>
+        public static string ContextNamespaceDescription
+            => GetString("ContextNamespaceDescription");
+
+        /// <summary>
+        ///     Specify to override the namespace for the migration.
+        /// </summary>
+        public static string MigrationsNamespaceDescription
+            => GetString("MigrationsNamespaceDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -321,4 +321,13 @@
   <data name="DbContextConnectionDescription" xml:space="preserve">
     <value>The connection string to the database. Defaults to the one specified in AddDbContext or OnConfiguring.</value>
   </data>
+  <data name="NamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the generated entity types.</value>
+  </data>
+  <data name="ContextNamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the DbContext class.</value>
+  </data>
+  <data name="MigrationsNamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the migration.</value>
+  </data>
 </root>

--- a/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
@@ -19,6 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandOption _tables;
         private CommandOption _useDatabaseNames;
         private CommandOption _json;
+        private CommandOption _namespace;
+        private CommandOption _contextNamespace;
 
         public override void Configure(CommandLineApplication command)
         {
@@ -36,6 +38,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             _tables = command.Option("-t|--table <TABLE_NAME>...", Resources.TablesDescription);
             _useDatabaseNames = command.Option("--use-database-names", Resources.UseDatabaseNamesDescription);
             _json = Json.ConfigureOption(command);
+            _namespace = command.Option("-n|--namespace <NAMESPACE>", Resources.NamespaceDescription);
+            _contextNamespace = command.Option("--context-namespace <NAMESPACE>", Resources.ContextNamespaceDescription);
 
             base.Configure(command);
         }

--- a/src/ef/Commands/DbContextScaffoldCommand.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.cs
@@ -37,7 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 _tables.Values,
                 _dataAnnotations.HasValue(),
                 _force.HasValue(),
-                _useDatabaseNames.HasValue());
+                _useDatabaseNames.HasValue(),
+                _namespace.Value(),
+                _contextNamespace.Value());
             if (_json.HasValue())
             {
                 ReportJsonResults(result);

--- a/src/ef/Commands/MigrationsAddCommand.Configure.cs
+++ b/src/ef/Commands/MigrationsAddCommand.Configure.cs
@@ -11,6 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandArgument _name;
         private CommandOption _outputDir;
         private CommandOption _json;
+        private CommandOption _namespace;
 
         public override void Configure(CommandLineApplication command)
         {
@@ -20,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
 
             _outputDir = command.Option("-o|--output-dir <PATH>", Resources.MigrationsOutputDirDescription);
             _json = Json.ConfigureOption(command);
+            _namespace = command.Option("-n|--namespace <NAMESPACE>", Resources.MigrationsNamespaceDescription);
 
             base.Configure(command);
         }

--- a/src/ef/Commands/MigrationsAddCommand.cs
+++ b/src/ef/Commands/MigrationsAddCommand.cs
@@ -21,7 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
 
         protected override int Execute()
         {
-            var files = CreateExecutor().AddMigration(_name.Value, _outputDir.Value(), Context.Value());
+            var files = CreateExecutor().AddMigration(
+                _name.Value, _outputDir.Value(), Context.Value(), _namespace.Value());
 
             if (_json.HasValue())
             {

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
 {
     internal interface IOperationExecutor : IDisposable
     {
-        IDictionary AddMigration(string name, string outputDir, string contextType);
+        IDictionary AddMigration(string name, string outputDir, string contextType, string migrationNamespace);
         IDictionary RemoveMigration(string contextType, bool force);
         IEnumerable<IDictionary> GetMigrations(string contextType);
         void DropDatabase(string contextType);
@@ -27,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames);
+            bool useDatabaseNames,
+            string entityNamespace,
+            string dbContextNamespace);
 
         string ScriptMigration(string fromMigration, string toMigration, bool idempotent, string contextType);
 

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -82,10 +82,16 @@ namespace Microsoft.EntityFrameworkCore.Tools
             return resultHandler.Result;
         }
 
-        public IDictionary AddMigration(string name, string outputDir, string contextType)
+        public IDictionary AddMigration(string name, string outputDir, string contextType, string migrationNamespace)
             => InvokeOperation<IDictionary>(
                 "AddMigration",
-                new Dictionary<string, string> { ["name"] = name, ["outputDir"] = outputDir, ["contextType"] = contextType });
+                new Dictionary<string, string>
+                {
+                    ["name"] = name,
+                    ["outputDir"] = outputDir,
+                    ["contextType"] = contextType,
+                    ["migrationNamespace"] = migrationNamespace
+                });
 
         public IDictionary RemoveMigration(string contextType, bool force)
             => InvokeOperation<IDictionary>(
@@ -130,7 +136,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            string entityNamespace,
+            string dbContextNamespace)
             => InvokeOperation<IDictionary>(
                 "ScaffoldContext",
                 new Dictionary<string, object>
@@ -144,7 +152,9 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["tableFilters"] = tableFilters,
                     ["useDataAnnotations"] = useDataAnnotations,
                     ["overwriteFiles"] = overwriteFiles,
-                    ["useDatabaseNames"] = useDatabaseNames
+                    ["useDatabaseNames"] = useDatabaseNames,
+                    ["entityNamespace"] = entityNamespace,
+                    ["dbContextNamespace"] = dbContextNamespace
                 });
 
         public string ScriptMigration(

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             return resultHandler.Result;
         }
 
-        public IDictionary AddMigration(string name, string outputDir, string contextType, string migrationNamespace)
+        public IDictionary AddMigration(string name, string outputDir, string contextType, string @namespace)
             => InvokeOperation<IDictionary>(
                 "AddMigration",
                 new Dictionary<string, string>
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["name"] = name,
                     ["outputDir"] = outputDir,
                     ["contextType"] = contextType,
-                    ["migrationNamespace"] = migrationNamespace
+                    ["namespace"] = @namespace
                 });
 
         public IDictionary RemoveMigration(string contextType, bool force)
@@ -137,8 +137,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             bool useDataAnnotations,
             bool overwriteFiles,
             bool useDatabaseNames,
-            string entityNamespace,
-            string dbContextNamespace)
+            string modelNamespace,
+            string contextNamespace)
             => InvokeOperation<IDictionary>(
                 "ScaffoldContext",
                 new Dictionary<string, object>
@@ -153,8 +153,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["useDataAnnotations"] = useDataAnnotations,
                     ["overwriteFiles"] = overwriteFiles,
                     ["useDatabaseNames"] = useDatabaseNames,
-                    ["entityNamespace"] = entityNamespace,
-                    ["dbContextNamespace"] = dbContextNamespace
+                    ["modelNamespace"] = modelNamespace,
+                    ["contextNamespace"] = contextNamespace
                 });
 
         public string ScriptMigration(

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -496,6 +496,24 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string DbContextConnectionDescription
             => GetString("DbContextConnectionDescription");
 
+        /// <summary>
+        ///     Specify to override the namespace for the generated entity types.
+        /// </summary>
+        public static string NamespaceDescription
+            => GetString("NamespaceDescription");
+
+        /// <summary>
+        ///     Specify to override the namespace for the DbContext class.
+        /// </summary>
+        public static string ContextNamespaceDescription
+            => GetString("ContextNamespaceDescription");
+
+        /// <summary>
+        ///     Specify to override the namespace for the migration.
+        /// </summary>
+        public static string MigrationsNamespaceDescription
+            => GetString("MigrationsNamespaceDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -333,4 +333,13 @@
   <data name="DbContextConnectionDescription" xml:space="preserve">
     <value>The connection string to the database. Defaults to the one specified in AddDbContext or OnConfiguring.</value>
   </data>
+  <data name="NamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the generated entity types.</value>
+  </data>
+  <data name="ContextNamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the DbContext class.</value>
+  </data>
+  <data name="MigrationsNamespaceDescription" xml:space="preserve">
+    <value>Specify to override the namespace for the migration.</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,6 +47,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var migration = scaffolder.ScaffoldMigration("EmptyMigration", "WebApplication1");
 
             Assert.Equal("GenericContextModelSnapshot", migration.SnapshotName);
+        }
+
+        [ConditionalFact]
+        public void ScaffoldMigration_can_override_namespace()
+        {
+            var scaffolder = CreateMigrationScaffolder<ContextWithSnapshot>();
+
+            var migration = scaffolder.ScaffoldMigration("EmptyMigration", "OverrideNamespace", "OverrideSubNamespace", overrideNamespace: true);
+
+            Assert.Contains("namespace OverrideNamespace.OverrideSubNamespace", migration.MigrationCode);
+            Assert.Equal("OverrideSubNamespace", migration.MigrationSubNamespace);
+
+            Assert.Contains("namespace OverrideNamespace.OverrideSubNamespace", migration.SnapshotCode);
+            Assert.Equal("OverrideSubNamespace", migration.SnapshotSubnamespace);
         }
 
         private IMigrationsScaffolder CreateMigrationScaffolder<TContext>()

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -54,13 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         {
             var scaffolder = CreateMigrationScaffolder<ContextWithSnapshot>();
 
-            var migration = scaffolder.ScaffoldMigration("EmptyMigration", "OverrideNamespace", "OverrideSubNamespace", overrideNamespace: true);
+            var migration = scaffolder.ScaffoldMigration("EmptyMigration", null, "OverrideNamespace.OverrideSubNamespace");
 
             Assert.Contains("namespace OverrideNamespace.OverrideSubNamespace", migration.MigrationCode);
-            Assert.Equal("OverrideSubNamespace", migration.MigrationSubNamespace);
+            Assert.Equal("OverrideNamespace.OverrideSubNamespace", migration.MigrationSubNamespace);
 
             Assert.Contains("namespace OverrideNamespace.OverrideSubNamespace", migration.SnapshotCode);
-            Assert.Equal("OverrideSubNamespace", migration.SnapshotSubnamespace);
+            Assert.Equal("OverrideNamespace.OverrideSubNamespace", migration.SnapshotSubnamespace);
         }
 
         private IMigrationsScaffolder CreateMigrationScaffolder<TContext>()


### PR DESCRIPTION
Fixes #9723 

Add the ability to override the namespaces of
- the migration in Add-Migration
- the entity classes generated by Scaffold-DbContext
- and separately the DbContext class generated by Scaffold-DbContext

Updates to dotnet-ef, ef and Powershell all included.
