### PR TITLE
[WIP] Fix/Suppress internal API usage in EFCore.Relational

### DIFF
--- a/src/EFCore.Relational/EFCore.Relational.csproj
+++ b/src/EFCore.Relational/EFCore.Relational.csproj
@@ -16,6 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EFCore\EFCore.csproj" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\EFCore.Analyzers\EFCore.Analyzers.csproj"
+                  ReferenceOutputAssembly="False"
+                  OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -203,8 +203,10 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(parameters, nameof(parameters));
 
             var facadeDependencies = GetFacadeDependencies(databaseFacade);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var concurrencyDetector = facadeDependencies.ConcurrencyDetector;
             var logger = facadeDependencies.CommandLogger;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             using (concurrencyDetector.EnterCriticalSection())
             {
@@ -218,7 +220,9 @@ namespace Microsoft.EntityFrameworkCore
                             facadeDependencies.RelationalConnection,
                             rawSqlCommand.ParameterValues,
                             null,
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             logger));
             }
         }
@@ -356,8 +360,10 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(parameters, nameof(parameters));
 
             var facadeDependencies = GetFacadeDependencies(databaseFacade);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var concurrencyDetector = facadeDependencies.ConcurrencyDetector;
             var logger = facadeDependencies.CommandLogger;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             using (concurrencyDetector.EnterCriticalSection())
             {
@@ -371,7 +377,9 @@ namespace Microsoft.EntityFrameworkCore
                             facadeDependencies.RelationalConnection,
                             rawSqlCommand.ParameterValues,
                             null,
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Context,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             logger),
                         cancellationToken);
             }
@@ -612,11 +620,15 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="databaseFacade"> The facade from <see cref="DbContext.Database" />. </param>
         /// <returns> True if a relational database provider is being used; false otherwise. </returns>
         public static bool IsRelational([NotNull] this DatabaseFacade databaseFacade)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => ((IDatabaseFacadeDependenciesAccessor)Check.NotNull(databaseFacade, nameof(databaseFacade))).Dependencies is IRelationalDatabaseFacadeDependencies;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         private static IRelationalDatabaseFacadeDependencies GetFacadeDependencies(DatabaseFacade databaseFacade)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var dependencies = ((IDatabaseFacadeDependenciesAccessor)databaseFacade).Dependencies;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             if (dependencies is IRelationalDatabaseFacadeDependencies relationalDependencies)
             {
@@ -640,6 +652,8 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static IDbContextTransactionManager GetTransactionManager([NotNull] this DatabaseFacade databaseFacade)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => ((IDatabaseFacadeDependenciesAccessor)Check.NotNull(databaseFacade, nameof(databaseFacade))).Dependencies.TransactionManager;
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -775,7 +775,9 @@ namespace Microsoft.EntityFrameworkCore
                     return null;
                 }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 principalProperty = linkingRelationship.PrincipalKey.Properties[linkingRelationship.Properties.IndexOf(principalProperty)];
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return principalProperty == property ? null : principalProperty;

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -54,6 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public static readonly IDictionary<Type, ServiceCharacteristics> RelationalServices
             = new Dictionary<Type, ServiceCharacteristics>
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 { typeof(IKeyValueIndexFactorySource), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IParameterNameGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IComparer<ModificationCommand>), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -91,6 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IMethodCallTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IMemberTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IRelationalParameterBasedQueryTranslationPostprocessorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) }
+#pragma warning restore EF1001 // Internal EF Core API usage.
             };
 
         /// <summary>
@@ -114,7 +116,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             return RelationalServices.TryGetValue(serviceType, out var characteristics)
                 ? characteristics
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : base.GetServiceCharacteristics(serviceType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         /// <summary>
@@ -171,6 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IRelationalQueryStringFactory, RelationalQueryStringFactory>();
 
             ServiceCollectionMap.GetInfrastructure()
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .AddDependencySingleton<RelationalSqlGenerationHelperDependencies>()
                 .AddDependencySingleton<RelationalTypeMappingSourceDependencies>()
                 .AddDependencySingleton<RelationalModelValidatorDependencies>()
@@ -201,6 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencyScoped<RelationalConnectionDependencies>()
                 .AddDependencyScoped<RelationalDatabaseDependencies>()
                 .AddDependencyScoped<RelationalQueryContextDependencies>();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return base.TryAddCoreServices();
         }

--- a/src/EFCore.Relational/Infrastructure/ModelSnapshot.cs
+++ b/src/EFCore.Relational/Infrastructure/ModelSnapshot.cs
@@ -16,8 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         private IModel CreateModel()
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             BuildModel(modelBuilder);
 

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -348,8 +348,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     {
                         var declaringType = tokenPair.Value.DeclaringEntityType;
                         if (!declaringType.IsAssignableFrom(entityType)
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             && !declaringType.IsInOwnershipPath(entityType)
                             && !entityType.IsInOwnershipPath(declaringType))
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         {
                             missingConcurrencyTokens.Add(tokenPair.Key);
                         }
@@ -373,7 +375,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     foreach (var missingColumn in missingConcurrencyTokens)
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         if (entityType.GetAllBaseTypes().SelectMany(t => t.GetDeclaredProperties())
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             .All(p => p.GetColumnName() != missingColumn))
                         {
                             throw new InvalidOperationException(
@@ -641,7 +645,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             foreach (var entityType in model.GetEntityTypes())
             {
                 if (entityType.BaseType != null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     && ((EntityType)entityType).FindAnnotation(RelationalAnnotationNames.TableName)?.GetConfigurationSource()
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         == ConfigurationSource.Explicit)
                 {
                     throw new InvalidOperationException(

--- a/src/EFCore.Relational/Internal/RelationalDatabaseFacadeDependencies.cs
+++ b/src/EFCore.Relational/Internal/RelationalDatabaseFacadeDependencies.cs
@@ -9,7 +9,9 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
     public class RelationalDatabaseFacadeDependencies : DatabaseFacadeDependencies, IRelationalDatabaseFacadeDependencies
+#pragma warning restore EF1001 // Internal EF Core API usage.
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -157,9 +157,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     continue;
                 }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 var identifyingMemberInfo = property.GetIdentifyingMemberInfo();
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 if (identifyingMemberInfo != null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     && identifyingMemberInfo.IsSameAs(otherProperty.GetIdentifyingMemberInfo()))
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
                     continue;
                 }

--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] ProviderConventionSetBuilderDependencies dependencies,
             [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _sets = dependencies.SetFinder.CreateClrTypeDbSetMapping(dependencies.ContextType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             Dependencies = dependencies;
         }
@@ -61,7 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 && entityType.ClrType != null
                 && _sets.ContainsKey(entityType.ClrType))
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 entityTypeBuilder.ToTable(_sets[entityType.ClrType].Name);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }
 
@@ -79,7 +83,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 && entityType.ClrType != null
                 && _sets.ContainsKey(entityType.ClrType))
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 entityTypeBuilder.ToTable(_sets[entityType.ClrType].Name);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }
 

--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -49,7 +49,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         IEnumerable<ICheckConstraint> CheckConstraints
             => EntityTypeMappings.SelectMany(m => CheckConstraint.GetCheckConstraints(m.EntityType))
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .Distinct((x, y) => x.Name == y.Name);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Gets the comment for this table.

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -146,7 +146,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _configurationSource = configurationSource.Max(_configurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         private static Dictionary<string, CheckConstraint> GetConstraintsDictionary(IEntityType entityType)

--- a/src/EFCore.Relational/Metadata/Internal/Column.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Column.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/ColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"Column: {column.Table.Name}.");
@@ -52,9 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             builder.Append(")");
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(column.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
@@ -52,7 +52,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         IColumnBase IColumnMappingBase.Column

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMappingExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"ColumnMapping: ");
@@ -41,9 +43,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             builder.Append(columnMapping.Column.Name);
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(columnMapping.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -273,7 +273,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => _configurationSource = configurationSource.Max(_configurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -299,7 +301,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _schemaConfigurationSource = schema == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_schemaConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return schema;
         }
@@ -336,7 +340,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _nameConfigurationSource = name == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_nameConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return name;
         }
@@ -373,7 +379,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _storeTypeConfigurationSource = storeType == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_storeTypeConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return storeType;
         }
@@ -411,7 +419,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _typeMappingConfigurationSource = typeMapping == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_typeMappingConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return typeMapping;
         }
@@ -461,7 +471,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _translationConfigurationSource = translation == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_translationConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return translation;
         }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
@@ -86,7 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         private void UpdateStoreTypeConfigurationSource(ConfigurationSource configurationSource)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => _storeTypeConfigurationSource = configurationSource.Max(_storeTypeConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -125,7 +127,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private void UpdateTypeMappingConfigurationSource(ConfigurationSource configurationSource)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => _typeMappingConfigurationSource = configurationSource.Max(_typeMappingConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraint.cs
@@ -47,7 +47,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public virtual SortedSet<IForeignKey> MappedForeignKeys { get; } = new SortedSet<IForeignKey>(ForeignKeyComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -105,6 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintExtensions.cs
@@ -32,7 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = new StringBuilder();
 
             builder.Append(indent);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append("ForeignKey: ");
@@ -57,9 +59,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(foreignKey.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -382,25 +382,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     if (foreignKey.IsUnique
                         && foreignKey.PrincipalKey.IsPrimaryKey()
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         && !foreignKey.IsIntraHierarchical()
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         && ((ITableBase)table).EntityTypeMappings.Any(m => m.EntityType == foreignKey.PrincipalEntityType))
                     {
                         if (internalForeignKeys == null)
                         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             internalForeignKeys = new SortedSet<IForeignKey>(ForeignKeyComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         }
                         internalForeignKeys.Add(foreignKey);
 
                         if (referencingInternalForeignKeyMap == null)
                         {
                             referencingInternalForeignKeyMap =
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                 new SortedDictionary<IEntityType, IEnumerable<IForeignKey>>(EntityTypePathComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         }
 
                         var principalEntityType = foreignKey.PrincipalEntityType;
                         if (!referencingInternalForeignKeyMap.TryGetValue(principalEntityType, out var internalReferencingForeignKeys))
                         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             internalReferencingForeignKeys = new SortedSet<IForeignKey>(ForeignKeyComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             referencingInternalForeignKeyMap[principalEntityType] = internalReferencingForeignKeys;
                         }
                         ((SortedSet<IForeignKey>)internalReferencingForeignKeys).Add(foreignKey);
@@ -412,7 +420,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (internalForeignKeyMap == null)
                     {
                         internalForeignKeyMap =
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             new SortedDictionary<IEntityType, IEnumerable<IForeignKey>>(EntityTypePathComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         table.InternalForeignKeys = internalForeignKeyMap;
                     }
 
@@ -420,7 +430,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 if (internalForeignKeys == null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     && ((ITableBase)table).EntityTypeMappings.Any(m => !m.EntityType.IsSameHierarchy(entityType)))
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
                     table.IsSplit = true;
                 }

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -263,7 +263,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _startValueConfigurationSource = startValue == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_startValueConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return startValue;
         }
@@ -301,7 +303,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _incrementByConfigurationSource = incrementBy == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_incrementByConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return incrementBy;
         }
@@ -339,7 +343,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _minValueConfigurationSource = minValue == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_minValueConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return minValue;
         }
@@ -377,7 +383,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _maxValueConfigurationSource = maxValue == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_maxValueConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return maxValue;
         }
@@ -430,7 +438,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _clrTypeConfigurationSource = clrType == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_clrTypeConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return clrType;
         }
@@ -468,7 +478,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             _isCyclicConfigurationSource = cyclic == null
                 ? (ConfigurationSource?)null
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 : configurationSource.Max(_isCyclicConfigurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return cyclic;
         }
@@ -498,7 +510,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => _configurationSource = _configurationSource.Max(configurationSource);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/Table.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Table.cs
@@ -85,7 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         IEnumerable<IColumnBase> ITableBase.Columns

--- a/src/EFCore.Relational/Metadata/Internal/TableExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableExtensions.cs
@@ -47,7 +47,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" NonMigratable");
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 var mappings = table.EntityTypeMappings.ToList();
                 if (mappings.Count != 0)
@@ -69,9 +71,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     builder.Append(table.AnnotationsToDebugString(indent: indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
             }
 

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -44,7 +44,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public virtual SortedSet<IIndex> MappedIndexes { get; } = new SortedSet<IIndex>(IndexComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -83,6 +85,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/TableIndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndexExtensions.cs
@@ -29,7 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = new StringBuilder();
 
             builder.Append(indent);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append("Index: ");
@@ -53,9 +55,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(index.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -55,7 +55,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         ITableBase ITableMappingBase.Table

--- a/src/EFCore.Relational/Metadata/Internal/TableMappingComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMappingComparer.cs
@@ -36,7 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public int Compare(ITableMapping x, ITableMapping y)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var result = EntityTypePathComparer.Instance.Compare(x.EntityType, y.EntityType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (result != 0)
             {
                 return result;
@@ -91,7 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public int GetHashCode(ITableMapping obj)
         {
             var hashCode = new HashCode();
+#pragma warning disable EF1001 // Internal EF Core API usage.
             hashCode.Add(obj.EntityType, EntityTypePathComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             hashCode.Add(obj.Table.Name);
             hashCode.Add(obj.Table.Schema);
             foreach (var columnMapping in obj.ColumnMappings)

--- a/src/EFCore.Relational/Metadata/Internal/TableMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMappingExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"TableMapping: ");
@@ -46,9 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(tableMapping.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/UniqueConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/UniqueConstraint.cs
@@ -45,7 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public virtual SortedSet<IKey> MappedKeys { get; } = new SortedSet<IKey>(KeyComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -78,6 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/UniqueConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/UniqueConstraintExtensions.cs
@@ -29,7 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = new StringBuilder();
 
             builder.Append(indent);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append("Key: ");
@@ -46,9 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(uniqueConstraint.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/View.cs
+++ b/src/EFCore.Relational/Metadata/Internal/View.cs
@@ -61,7 +61,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         IEnumerable<IViewColumnMapping> IViewColumn.PropertyMappings

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumnExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"Column: {column.Table.Name}.");
@@ -52,9 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             builder.Append(")");
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(column.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumnMapping.cs
@@ -52,7 +52,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         IColumnBase IColumnMappingBase.Column

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumnMappingExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"ViewColumnMapping: ");
@@ -41,9 +43,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             builder.Append(columnMapping.Column.Name);
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(columnMapping.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Metadata/Internal/ViewExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewExtensions.cs
@@ -42,7 +42,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(view.Name);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 var mappings = view.EntityTypeMappings.ToList();
                 if (mappings.Count != 0)
@@ -64,9 +66,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     builder.Append(view.AnnotationsToDebugString(indent: indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
             }
 

--- a/src/EFCore.Relational/Metadata/Internal/ViewMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewMapping.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <inheritdoc/>
         ITableBase ITableMappingBase.Table

--- a/src/EFCore.Relational/Metadata/Internal/ViewMappingComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewMappingComparer.cs
@@ -36,7 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public int Compare(IViewMapping x, IViewMapping y)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var result = EntityTypePathComparer.Instance.Compare(x.EntityType, y.EntityType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (result != 0)
             {
                 return result;
@@ -91,7 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public int GetHashCode(IViewMapping obj)
         {
             var hashCode = new HashCode();
+#pragma warning disable EF1001 // Internal EF Core API usage.
             hashCode.Add(obj.EntityType, EntityTypePathComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             hashCode.Add(obj.View.Name);
             hashCode.Add(obj.View.Schema);
             foreach (var columnMapping in obj.ColumnMappings)

--- a/src/EFCore.Relational/Metadata/Internal/ViewMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewMappingExtensions.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(indent);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var singleLine = (options & MetadataDebugStringOptions.SingleLine) != 0;
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (singleLine)
             {
                 builder.Append($"ViewMapping: ");
@@ -46,9 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             if (!singleLine &&
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 (options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 builder.Append(viewMapping.AnnotationsToDebugString(indent + "  "));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             return builder.ToString();

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -275,8 +275,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 }
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var createTableGraph = new Multigraph<CreateTableOperation, AddForeignKeyOperation>();
             createTableGraph.AddVertices(createTableOperations);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             foreach (var createTableOperation in createTableOperations)
             {
                 foreach (var addForeignKeyOperation in createTableOperation.ForeignKeys)
@@ -292,12 +294,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             && o.Schema == addForeignKeyOperation.PrincipalSchema);
                     if (principalCreateTableOperation != null)
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         createTableGraph.AddEdge(principalCreateTableOperation, createTableOperation, addForeignKeyOperation);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
                 }
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             createTableOperations = createTableGraph.TopologicalSort(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 (principalCreateTableOperation, createTableOperation, cyclicAddForeignKeyOperations) =>
                 {
                     foreach (var cyclicAddForeignKeyOperation in cyclicAddForeignKeyOperations)
@@ -309,8 +315,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     return true;
                 }).ToList();
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var dropTableGraph = new Multigraph<DropTableOperation, IForeignKey>();
             dropTableGraph.AddVertices(dropTableOperations);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             foreach (var dropTableOperation in dropTableOperations)
             {
                 var table = diffContext.FindTable(dropTableOperation);
@@ -321,13 +329,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     if (principalDropTableOperation != null
                         && principalDropTableOperation != dropTableOperation)
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         dropTableGraph.AddEdge(dropTableOperation, principalDropTableOperation, foreignKey);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
                 }
             }
 
             var newDiffContext = new DiffContext(null, null);
+#pragma warning disable EF1001 // Internal EF Core API usage.
             dropTableOperations = dropTableGraph.TopologicalSort(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 (dropTableOperation, principalDropTableOperation, foreignKeys) =>
                 {
                     dropForeignKeyOperations.AddRange(foreignKeys.SelectMany(c => Remove(c, newDiffContext)));
@@ -686,7 +698,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         private static IEnumerable<IProperty> GetSortedProperties(ITable table)
             => GetSortedProperties(GetRootType(table))
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .Distinct((x, y) => x.GetColumnName() == y.GetColumnName());
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         private static IEnumerable<IProperty> GetSortedProperties(IEntityType entityType)
         {
@@ -720,7 +734,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }
 
                     clrProperty = foreignKey.DependentToPrincipal.PropertyInfo;
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     var groupIndex = foreignKey.Properties.IndexOf(property);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                     unorderedGroups.GetOrAddNew(clrProperty).Add(groupIndex, property);
                 }
@@ -737,7 +753,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                 var clrType = clrProperty.DeclaringType;
                 var index = clrType.GetTypeInfo().DeclaredProperties
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     .IndexOf(clrProperty, PropertyInfoEqualityComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                 Check.DebugAssert(clrType != null, "clrType is null");
                 types.GetOrAddNew(clrType)[index] = clrProperty;
@@ -773,14 +791,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                 var clrType = clrProperty.DeclaringType;
                 var index = clrType.GetTypeInfo().DeclaredProperties
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     .IndexOf(clrProperty, PropertyInfoEqualityComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                 Check.DebugAssert(clrType != null, "clrType is null");
                 types.GetOrAddNew(clrType)[index] = clrProperty;
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var graph = new Multigraph<Type, object>();
             graph.AddVertices(types.Keys);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             foreach (var left in types.Keys)
             {
@@ -791,7 +813,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         if (right == baseType)
                         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             graph.AddEdge(right, left, null);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             found = true;
 
                             break;
@@ -805,7 +829,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 }
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var sortedPropertyInfos = graph.TopologicalSort().SelectMany(e => types[e].Values).ToList();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return sortedPropertyInfos
                 .Select(pi => primaryKeyPropertyGroups.ContainsKey(pi) ? primaryKeyPropertyGroups[pi] : null)
@@ -911,7 +937,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 return entityType.DefiningNavigationName;
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var primaryKey = entityType.FindDeclaredPrimaryKey();
+#pragma warning restore EF1001 // Internal EF Core API usage.
             if (primaryKey != null)
             {
                 var definingForeignKey = entityType
@@ -2179,7 +2207,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected virtual IEnumerable<string> GetSchemas([NotNull] IModel model)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => model.GetRootEntityTypes().Where(t => !t.IsIgnoredByMigrations()).Select(t => t.GetSchema())
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 .Concat(model.GetSequences().Select(s => s.Schema))
                 .Where(s => !string.IsNullOrEmpty(s))
                 .Distinct();
@@ -2239,15 +2269,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         private static IEnumerable<IKey> GetKeys(ITable table)
             => table.EntityTypeMappings.SelectMany(m => m.EntityType.GetDeclaredKeys())
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .Distinct((x, y) => x.GetName() == y.GetName());
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         private static IEnumerable<IIndex> GetIndexes(ITable table)
             => table.EntityTypeMappings.SelectMany(m => m.EntityType.GetDeclaredIndexes())
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .Distinct((x, y) => x.GetName() == y.GetName());
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         private static IEnumerable<IForeignKey> GetForeignKeys(ITable table)
             => table.EntityTypeMappings.SelectMany(m => m.EntityType.GetDeclaredForeignKeys())
+#pragma warning disable EF1001 // Internal EF Core API usage.
                    .Distinct((x, y) => x.GetConstraintName() == y.GetConstraintName())
+#pragma warning restore EF1001 // Internal EF Core API usage.
                    .Where(fk => !fk.PrincipalKey.Properties
                        .Select(p => p.GetTableColumnMappings().Select(m => m.Column).SingleOrDefault(m => m.Table == table))
                            .SequenceEqual(fk.Properties.

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -318,6 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 out var migrationsToRevert,
                 out var actualTargetMigration);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var builder = new IndentedStringBuilder();
 
             if (fromMigration == Migration.InitialDatabase
@@ -383,6 +384,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             }
 
             return builder.ToString();
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Migrations/Migration.cs
+++ b/src/EFCore.Relational/Migrations/Migration.cs
@@ -33,11 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 IModel Create()
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     var model = new Model();
                     var modelBuilder = new ModelBuilder(model);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     BuildTargetModel(modelBuilder);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     return model.FinalizeModel();
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 return _targetModel ??= Create();

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -99,7 +99,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <summary>
         ///     Gets a comparer that can be used to compare two product versions.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         protected virtual IComparer<string> VersionComparer { get; } = new SemanticVersionComparer();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Generates commands from a list of operations.
@@ -1665,7 +1667,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <returns> True if the version could be retrieved. </returns>
         protected virtual bool TryGetVersion([CanBeNull] IModel model, out string version)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             if (!(model?[CoreAnnotationNames.ProductVersion] is string versionString))
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 version = null;
 

--- a/src/EFCore.Relational/Query/FromSqlParameterApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/FromSqlParameterApplyingExpressionVisitor.cs
@@ -17,7 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query
     public class FromSqlParameterApplyingExpressionVisitor : ExpressionVisitor
     {
         private readonly IDictionary<FromSqlExpression, Expression> _visitedFromSqlExpressions
+#pragma warning disable EF1001 // Internal EF Core API usage.
             = new Dictionary<FromSqlExpression, Expression>(ReferenceEqualityComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
         private readonly ParameterNameGenerator _parameterNameGenerator;

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
@@ -64,9 +64,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private bool Equals(FromSqlQueryRootExpression queryRootExpression)
             => base.Equals(queryRootExpression)
                 && string.Equals(Sql, queryRootExpression.Sql, StringComparison.OrdinalIgnoreCase)
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 && ExpressionEqualityComparer.Instance.Equals(Argument, queryRootExpression.Argument);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         public override int GetHashCode()
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => HashCode.Combine(base.GetHashCode(), Sql, ExpressionEqualityComparer.Instance.GetHashCode(Argument));
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Query/Internal/QueryableFunctionQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryableFunctionQueryRootExpression.cs
@@ -62,7 +62,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private bool Equals(QueryableFunctionQueryRootExpression queryRootExpression)
             => base.Equals(queryRootExpression)
                 && Equals(Function, queryRootExpression.Function)
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 && Arguments.SequenceEqual(queryRootExpression.Arguments, ExpressionEqualityComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         public override int GetHashCode()
         {

--- a/src/EFCore.Relational/Query/Internal/TableAliasUniquifyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/TableAliasUniquifyingExpressionVisitor.cs
@@ -15,7 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly ISet<string> _usedAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         private readonly ISet<TableExpressionBase> _visitedTableExpressionBases
+#pragma warning disable EF1001 // Internal EF Core API usage.
             = new HashSet<TableExpressionBase>(ReferenceEqualityComparer.Instance);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         protected override Expression VisitExtension(Expression extensionExpression)
         {

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -49,7 +49,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                         body = Condition(
                             requiredNonPkProperties
                                 .Select(p => NotEqual(
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                     valueBufferParameter.CreateValueBufferReadValueExpression(typeof(object), p.GetIndex(), p),
+#pragma warning restore EF1001 // Internal EF Core API usage.
                                     Constant(null)))
                                 .Aggregate((a, b) => AndAlso(a, b)),
                             body,
@@ -63,7 +65,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                             body = Condition(
                                 allNonPkProperties
                                     .Select(p => NotEqual(
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                         valueBufferParameter.CreateValueBufferReadValueExpression(typeof(object), p.GetIndex(), p),
+#pragma warning restore EF1001 // Internal EF Core API usage.
                                         Constant(null)))
                                     .Aggregate((a, b) => OrElse(a, b)),
                                 body,

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -682,7 +682,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return source;
                 }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 var baseType = entityType.GetAllBaseTypes().SingleOrDefault(et => et.ClrType == resultType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 if (baseType != null)
                 {
                     return source.UpdateShaperExpression(entityShaperExpression.WithEntityType(baseType));
@@ -1186,12 +1188,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     var innerSequenceType = innerShapedQuery.Type.TryGetSequenceType();
                     var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     var outerKey = entityShaperExpression.CreateKeyAccessExpression(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         navigation.IsOnDependent
                             ? foreignKey.Properties
                             : foreignKey.PrincipalKey.Properties,
                         makeNullable);
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     var innerKey = correlationPredicateParameter.CreateKeyAccessExpression(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         navigation.IsOnDependent
                             ? foreignKey.PrincipalKey.Properties
                             : foreignKey.Properties,
@@ -1247,12 +1253,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .Select(p => p.ClrType)
                             .Any(t => t.IsNullableType());
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         var outerKey = entityShaperExpression.CreateKeyAccessExpression(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             navigation.IsOnDependent
                                 ? foreignKey.Properties
                                 : foreignKey.PrincipalKey.Properties,
                             makeNullable);
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         var innerKey = innerShapedQuery.ShaperExpression.CreateKeyAccessExpression(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             navigation.IsOnDependent
                                 ? foreignKey.PrincipalKey.Properties
                                 : foreignKey.Properties,
@@ -1306,7 +1316,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 IEntityType entityType, TableExpression table, bool nullable)
             {
                 var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 foreach (var property in entityType.GetTypesInHierarchy().SelectMany(EntityTypeExtensions.GetDeclaredProperties))
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
                     propertyExpressions[property] = new ColumnExpression(property, table, nullable || !property.IsPrimaryKey());
                 }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -234,7 +234,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (node is SqlExpression sqlExpression
                     && !(node is SqlFragmentExpression)
                     && !(node is SqlFunctionExpression sqlFunctionExpression
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         && sqlFunctionExpression.Type.IsQueryableType()))
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 {
                     if (sqlExpression.TypeMapping == null)
                     {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -143,7 +143,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         private static IEnumerable<IProperty> GetAllPropertiesInHierarchy(IEntityType entityType)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => entityType.GetTypesInHierarchy().SelectMany(EntityTypeExtensions.GetDeclaredProperties);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         public void ReplaceProjectionMapping([NotNull] IDictionary<ProjectionMember, Expression> projectionMapping)
         {
@@ -819,7 +821,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
                 var newEntityProjection = new EntityProjectionExpression(entityProjection.EntityType, propertyExpressions);
                 // Also lift nested entity projections
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 foreach (var navigation in entityProjection.EntityType.GetTypesInHierarchy()
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     .SelectMany(EntityTypeExtensions.GetDeclaredNavigations))
                 {
                     var boundEntityShaperExpression = entityProjection.BindNavigation(navigation);

--- a/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
+++ b/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
@@ -32,7 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             bool logParameterValues)
             => parameters
                 .Cast<DbParameter>()
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 .Select(p => FormatParameter(p, logParameterValues)).Join();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
@@ -20,7 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public class RelationalCommandBuilder : IRelationalCommandBuilder
     {
         private readonly List<IRelationalParameter> _parameters = new List<IRelationalParameter>();
+#pragma warning disable EF1001 // Internal EF Core API usage.
         private readonly IndentedStringBuilder _commandTextBuilder = new IndentedStringBuilder();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     <para>
@@ -55,12 +57,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <returns> The newly created command. </returns>
         public virtual IRelationalCommand Build()
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => new RelationalCommand(Dependencies, _commandTextBuilder.ToString(), Parameters);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Gets the command text.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public override string ToString() => _commandTextBuilder.ToString();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     The collection of parameters.
@@ -90,7 +96,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(value, nameof(value));
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _commandTextBuilder.Append(value);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return this;
         }
@@ -101,7 +109,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual IRelationalCommandBuilder AppendLine()
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _commandTextBuilder.AppendLine();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return this;
         }
@@ -112,7 +122,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual IRelationalCommandBuilder IncrementIndent()
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _commandTextBuilder.IncrementIndent();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return this;
         }
@@ -123,7 +135,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual IRelationalCommandBuilder DecrementIndent()
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _commandTextBuilder.DecrementIndent();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             return this;
         }
@@ -131,6 +145,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the length of the command text.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public virtual int CommandTextLength => _commandTextBuilder.Length;
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
+++ b/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
@@ -53,7 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     current database provider.
         /// </summary>
         protected virtual IExecutionStrategy CreateDefaultStrategy([NotNull] ExecutionStrategyDependencies dependencies)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => new NoopExecutionStrategy(Dependencies);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Creates an <see cref="IExecutionStrategy" /> for the current database provider.

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -25,7 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="property"> The property for which mapping is needed. </param>
         public RelationalTypeMappingInfo([NotNull] IProperty property)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             : this(property.FindPrincipals())
+#pragma warning restore EF1001 // Internal EF Core API usage.
         {
         }
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -204,7 +204,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 return mapping;
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var principals = property.FindPrincipals();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             string storeTypeName = null;
             bool? isFixedLength = null;

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -273,6 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         /// </summary>
         protected virtual IReadOnlyList<List<ModificationCommand>> TopologicalSort([NotNull] IEnumerable<ModificationCommand> commands)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             var modificationCommandGraph = new Multigraph<ModificationCommand, IAnnotatable>();
             modificationCommandGraph.AddVertices(commands);
 
@@ -283,6 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             AddUniqueValueEdges(modificationCommandGraph);
 
             return modificationCommandGraph.BatchingTopologicalSort(FormatCycle);
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         private string FormatCycle(IReadOnlyList<Tuple<ModificationCommand, ModificationCommand, IEnumerable<IAnnotatable>>> data)
@@ -458,7 +460,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             Graph<ModificationCommand> commandGraph)
         {
             var predecessorsMap = new Dictionary<IKeyValueIndex, List<ModificationCommand>>();
+#pragma warning disable EF1001 // Internal EF Core API usage.
             foreach (var command in commandGraph.Vertices)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 var columnModifications = command.ColumnModifications;
                 if (command.EntityState == EntityState.Modified
@@ -543,7 +547,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             Multigraph<ModificationCommand, IAnnotatable> commandGraph,
             Dictionary<IKeyValueIndex, List<ModificationCommand>> predecessorsMap)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             foreach (var command in commandGraph.Vertices)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 switch (command.EntityState)
                 {
@@ -609,7 +615,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 {
                     if (predecessor != command)
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         commandGraph.AddEdge(predecessor, command, foreignKey);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
                 }
             }
@@ -618,7 +626,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         private void AddUniqueValueEdges(Multigraph<ModificationCommand, IAnnotatable> commandGraph)
         {
             Dictionary<IIndex, Dictionary<object[], ModificationCommand>> predecessorsMap = null;
+#pragma warning disable EF1001 // Internal EF Core API usage.
             foreach (var command in commandGraph.Vertices)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 if (command.EntityState != EntityState.Modified
                     && command.EntityState != EntityState.Deleted)
@@ -653,15 +663,19 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             }
                         }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         var valueFactory = index.GetNullableValueFactory<object[]>();
                         if (valueFactory.TryCreateFromOriginalValues(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                             (InternalEntityEntry)entry, out var indexValue))
                         {
                             predecessorsMap ??= new Dictionary<IIndex, Dictionary<object[], ModificationCommand>>();
                             if (!predecessorsMap.TryGetValue(index, out var predecessorCommands))
                             {
                                 predecessorCommands =
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                     new Dictionary<object[], ModificationCommand>(valueFactory.EqualityComparer);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                                 predecessorsMap.Add(index, predecessorCommands);
                             }
 
@@ -679,7 +693,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 return;
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             foreach (var command in commandGraph.Vertices)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             {
                 if (command.EntityState == EntityState.Modified
                     || command.EntityState == EntityState.Added)
@@ -696,13 +712,17 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             if (command.EntityState == EntityState.Added
                                 || indexColumnModifications.Any())
                             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                 var valueFactory = index.GetNullableValueFactory<object[]>();
                                 if (valueFactory.TryCreateFromCurrentValues((InternalEntityEntry)entry, out var indexValue)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                                     && predecessorsMap.TryGetValue(index, out var predecessorCommands)
                                     && predecessorCommands.TryGetValue(indexValue, out var predecessor)
                                     && predecessor != command)
                                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                     commandGraph.AddEdge(predecessor, command, index);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                                 }
                             }
                         }

--- a/src/EFCore.Relational/Update/Internal/KeyValueIndexFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/KeyValueIndexFactory.cs
@@ -36,8 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         public virtual IKeyValueIndex CreatePrincipalKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
             => new KeyValueIndex<TKey>(
                 foreignKey,
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 _principalKeyValueFactory.CreateFromCurrentValues(entry),
                 _principalKeyValueFactory.EqualityComparer,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 fromOriginalValues: false);
 
         /// <summary>
@@ -49,8 +51,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         public virtual IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
             => new KeyValueIndex<TKey>(
                 foreignKey,
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 _principalKeyValueFactory.CreateFromOriginalValues(entry),
                 _principalKeyValueFactory.EqualityComparer,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 fromOriginalValues: true);
 
         /// <summary>
@@ -60,8 +64,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IKeyValueIndex CreateDependentKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => foreignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromCurrentValues(entry, out var keyValue)
                 ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: false)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 : null;
 
         /// <summary>
@@ -71,8 +77,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IKeyValueIndex CreateDependentKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => foreignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromOriginalValues(entry, out var keyValue)
                 ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: true)
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 : null;
     }
 }

--- a/src/EFCore.Relational/Update/Internal/KeyValueIndexFactorySource.cs
+++ b/src/EFCore.Relational/Update/Internal/KeyValueIndexFactorySource.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
     ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
     ///     </para>
     /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
     public class KeyValueIndexFactorySource : IdentityMapFactoryFactoryBase, IKeyValueIndexFactorySource
+#pragma warning restore EF1001 // Internal EF Core API usage.
     {
         private readonly ConcurrentDictionary<IKey, IKeyValueIndexFactory> _factories
             = new ConcurrentDictionary<IKey, IKeyValueIndexFactory>();
@@ -52,6 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
         [UsedImplicitly]
         private static IKeyValueIndexFactory CreateFactory<TKey>(IKey key)
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => new KeyValueIndexFactory<TKey>(key.GetPrincipalKeyValueFactory<TKey>());
+#pragma warning restore EF1001 // Internal EF Core API usage.
     }
 }

--- a/src/EFCore.Relational/Update/Internal/ModificationCommandComparer.cs
+++ b/src/EFCore.Relational/Update/Internal/ModificationCommandComparer.cs
@@ -98,7 +98,9 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 {
                     var xKeyProperty = xKey.Properties[i];
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     result = xKeyProperty.GetCurrentValueComparer().Compare(xEntry, yEntry);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     if (0 != result)
                     {
                         return result;

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -119,7 +119,9 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     The list of <see cref="ColumnModification" />s needed to perform the insert, update, or delete.
         /// </summary>
         public virtual IReadOnlyList<ColumnModification> ColumnModifications
+#pragma warning disable EF1001 // Internal EF Core API usage.
             => NonCapturingLazyInitializer.EnsureInitialized(
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 ref _columnModifications, this, command => command.GenerateColumnModifications());
 
         /// <summary>
@@ -401,6 +403,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 }
             }
 
+#pragma warning disable EF1001 // Internal EF Core API usage.
             public bool TryPropagate(IProperty property, InternalEntityEntry entry)
             {
                 if (_write
@@ -415,6 +418,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
                 return _write;
             }
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
     }
 }

--- a/src/EFCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/EFCore.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -28,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
     public class RelationalValueGeneratorSelector : ValueGeneratorSelector
     {
         private readonly TemporaryNumberValueGeneratorFactory _numberFactory
+#pragma warning disable EF1001 // Internal EF Core API usage.
             = new TemporaryNumberValueGeneratorFactory();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="RelationalValueGeneratorSelector" /> class.
@@ -62,17 +64,23 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
                     || propertyType == typeof(float)
                     || propertyType == typeof(double))
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     return _numberFactory.Create(property);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 if (propertyType == typeof(DateTime))
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     return new TemporaryDateTimeValueGenerator();
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 if (propertyType == typeof(DateTimeOffset))
                 {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     return new TemporaryDateTimeOffsetValueGenerator();
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 if (property.GetDefaultValueSql() != null)
@@ -84,12 +92,16 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
 
                     if (propertyType == typeof(string))
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         return new StringValueGenerator(generateTemporaryValues: true);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
 
                     if (propertyType == typeof(byte[]))
                     {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         return new BinaryValueGenerator(generateTemporaryValues: true);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
                 }
             }


### PR DESCRIPTION
Major points I found
- IndentedStringBuilder
- ExpressionEqualityComparer
- MultiGraph
- Metadata printing
- DatabaseFacadeDependencies is seriously complicated
- ValueGeneratorSelector