### PR TITLE
[3.1] Fix to #12729 - Flatten Case expression

### DIFF
--- a/src/EFCore.Relational/Query/Internal/CaseWhenFlatteningExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CaseWhenFlatteningExpressionVisitor.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    public class CaseWhenFlatteningExpressionVisitor : ExpressionVisitor
+    {
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        public CaseWhenFlatteningExpressionVisitor(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        protected override Expression VisitExtension(Expression node)
+        {
+            // Only applies to 'CASE WHEN condition...' not 'CASE operand WHEN...'
+            if (node is CaseExpression caseExpression && caseExpression.Operand == null)
+            {
+                if (caseExpression.ElseResult is CaseExpression nestedCaseExpression && nestedCaseExpression.Operand == null)
+                {
+                    return VisitExtension(_sqlExpressionFactory.Case(
+                        caseExpression.WhenClauses.Union(nestedCaseExpression.WhenClauses).ToList(),
+                        nestedCaseExpression.ElseResult));
+                }
+            }
+            return base.VisitExtension(node);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -36,6 +37,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             query = new SelectExpressionProjectionApplyingExpressionVisitor().Visit(query);
             query = new CollectionJoinApplyingExpressionVisitor().Visit(query);
             query = new TableAliasUniquifyingExpressionVisitor().Visit(query);
+
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue12729", out var enabled) && enabled))
+            {
+                query = new CaseWhenFlatteningExpressionVisitor(SqlExpressionFactory).Visit(query);
+            }
 
             if (!UseRelationalNulls)
             {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1482,6 +1482,39 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => Assert.Equal(e.Customer, a.Customer));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_over_10_nested_ternary_condition(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                os => from c in os.Set<Customer>()
+                      select
+                      c.CustomerID == "1"
+                        ? "01"
+                        : c.CustomerID == "2"
+                            ? "02"
+                            : c.CustomerID == "3"
+                                ? "03"
+                                : c.CustomerID == "4"
+                                    ? "04"
+                                    : c.CustomerID == "5"
+                                        ? "05"
+                                        : c.CustomerID == "6"
+                                            ? "06"
+                                            : c.CustomerID == "7"
+                                                ? "07"
+                                                : c.CustomerID == "8"
+                                                    ? "08"
+                                                    : c.CustomerID == "9"
+                                                        ? "09"
+                                                        : c.CustomerID == "10"
+                                                            ? "10"
+                                                            : c.CustomerID == "11"
+                                                                ? "11"
+                                                                : null);
+        }
+
         private class CustomerWrapper2
         {
             public CustomerWrapper2(Customer customer)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4363,10 +4363,8 @@ LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
 LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 WHERE CASE
     WHEN [l0].[Id] IS NULL THEN NULL
-    ELSE CASE
-        WHEN [l1].[Id] IS NULL THEN NULL
-        ELSE [l2].[Name]
-    END
+    WHEN [l1].[Id] IS NULL THEN NULL
+    ELSE [l2].[Name]
 END = N'L4 01'");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -1240,5 +1240,27 @@ LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
+
+        public override async Task Select_over_10_nested_ternary_condition(bool isAsync)
+        {
+            await base.Select_over_10_nested_ternary_condition(isAsync);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [c].[CustomerID] = N'1' THEN N'01'
+    WHEN [c].[CustomerID] = N'2' THEN N'02'
+    WHEN [c].[CustomerID] = N'3' THEN N'03'
+    WHEN [c].[CustomerID] = N'4' THEN N'04'
+    WHEN [c].[CustomerID] = N'5' THEN N'05'
+    WHEN [c].[CustomerID] = N'6' THEN N'06'
+    WHEN [c].[CustomerID] = N'7' THEN N'07'
+    WHEN [c].[CustomerID] = N'8' THEN N'08'
+    WHEN [c].[CustomerID] = N'9' THEN N'09'
+    WHEN [c].[CustomerID] = N'10' THEN N'10'
+    WHEN [c].[CustomerID] = N'11' THEN N'11'
+    ELSE NULL
+END
+FROM [Customers] AS [c]");
+        }
     }
 }


### PR DESCRIPTION
**Description**
- Added CaseWhenFlatteningExpressionVisitor postprocessor
- Recursively collapse relevant CaseExpression

**Customer Impact**
Invalid sql generated for query with multi level conditional expression. Some scenarios can work around the problem by rewriting the queries, but when the case statements are generated (e.g. in some OData scenarios) we don't have a good workaround.

**How found**
Reported by multiple customers.

**Test coverage**
We have added test to cover this scenario.

**Regression?**
No.

**Risk**
Low. Fix is very isolated and the logic the fix employs is straightforward. Quirk added to further mitigate the risk.

