### PR TITLE
[3.1] Fix to #19128 - Query: Error for queries with enum parameters whose value is of underlying type but the value expected by type mapping is the actual enum type

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -76,5 +76,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Select_subquery_projecting_single_constant_inside_anonymous(isAsync);
         }
+
+        [ConditionalTheory(Skip = "issue #18284")]
+        public override Task Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
+        {
+            return base.Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7595,6 +7595,54 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Mission>().Where(m => m.Timeline.Date >= dateTimeOffset.Date));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
+        {
+            var prm = (int)AmmunitionType.Cartridge;
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Weapon>().Where(w => prm == (int)w.AmmunitionType),
+                ss => ss.Set<Weapon>().Where(w => w.AmmunitionType != null && prm == (int)w.AmmunitionType));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Enum_flags_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
+        {
+            var prm = (int)MilitaryRank.Private + (int)MilitaryRank.Sergeant + (int)MilitaryRank.General;
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Where(g => (prm & (int)g.Rank) == (int)g.Rank));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Enum_flags_closure_typed_as_different_type_generates_correct_parameter_type(bool async)
+        {
+            var prm = (byte)MilitaryRank.Private + (byte)MilitaryRank.Sergeant;
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Where(g => (prm & (short)g.Rank) == (short)g.Rank));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Constant_enum_with_same_underlying_value_as_previously_parameterized_int(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Gear>()
+                    .OrderBy(g => g.Nickname)
+                    .Take(1)
+                    .Select(g => g.Rank & MilitaryRank.Corporal));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
@@ -151,7 +151,7 @@ WHERE FREETEXT([e].[Title], N'Representative President', LANGUAGE 1033)");
                 AssertSql(
                     @"SELECT TOP(1) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]
-WHERE FREETEXT([e].[City], N'London')) AND (FREETEXT([e].[Title], N'Manager', LANGUAGE 1033)");
+WHERE FREETEXT([e].[City], N'London') AND FREETEXT([e].[Title], N'Manager', LANGUAGE 1033)");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7562,6 +7562,55 @@ FROM [Missions] AS [m]
 WHERE CONVERT(date, [m].[Timeline]) >= @__dateTimeOffset_Date_0");
         }
 
+        public override async Task Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
+        {
+            await base.Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
+
+            AssertSql(
+                @"@__prm_0='1'
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE @__prm_0 = [w].[AmmunitionType]");
+        }
+
+        public override async Task Enum_flags_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
+        {
+            await base.Enum_flags_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
+
+            AssertSql(
+                @"@__prm_0='66'
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ((@__prm_0 & [g].[Rank]) = [g].[Rank])");
+        }
+
+        public override async Task Enum_flags_closure_typed_as_different_type_generates_correct_parameter_type(bool async)
+        {
+            await base.Enum_flags_closure_typed_as_different_type_generates_correct_parameter_type(async);
+
+            AssertSql(
+                @"@__prm_0='2'
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer') AND ((@__prm_0 & CAST([g].[Rank] AS int)) = CAST([g].[Rank] AS int))");
+        }
+
+        public override async Task Constant_enum_with_same_underlying_value_as_previously_parameterized_int(bool async)
+        {
+            await base.Constant_enum_with_same_underlying_value_as_previously_parameterized_int(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT TOP(@__p_0) [g].[Rank] & @__p_0
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Gear', N'Officer')
+ORDER BY [g].[Nickname]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
**Description**
Problem was that we were not correctly compensating for type differences between parameter value and the DbParameter type (determined from type mapping). This can happen when the parameter is explicitly typed as the underlying type, but in the query the type is inferred from other side of binary expression etc.

Fix is to detect the case when expected parameter value is Enum, but the actual type is the underlying type and convert the value back to the enum type, just like we do for constants.

**Customer Impact**
Error for some queries using enum parameters. There are several workarounds, depending on which "flavor" of the issue customer experiences, but it is hard to understand which workaround works for which case.

**How found**
Reported by multiple customers.

**Test coverage**
We have added test to cover this scenario.

**Regression?**
No.

**Risk**
Low. Fix only affects queries with enums, also the logic in the fix has already been used for case with constants. Fix applies the same logic to parameters.