### PR TITLE
Query: Improve detection of non-composed FromSql

### DIFF
--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.RelationalProjectionBindingRemovingExpressionVisitor.cs
@@ -7,6 +7,8 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -22,10 +24,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             private static readonly MethodInfo _isDbNullMethod =
                 typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.IsDBNull), new[] { typeof(int) });
+            private static readonly MethodInfo _getFieldValueMethod =
+                typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetFieldValue), new[] { typeof(int) });
+            private static readonly MethodInfo _throwReadValueExceptionMethod =
+                typeof(RelationalProjectionBindingRemovingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ThrowReadValueException));
 
             private readonly SelectExpression _selectExpression;
             private readonly ParameterExpression _dbDataReaderParameter;
             private readonly ParameterExpression _indexMapParameter;
+            private readonly bool _detailedErrorsEnabled;
 
             private readonly IDictionary<ParameterExpression, IDictionary<IProperty, int>> _materializationContextBindings
                 = new Dictionary<ParameterExpression, IDictionary<IProperty, int>>();
@@ -34,11 +41,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SelectExpression selectExpression,
                 ParameterExpression dbDataReaderParameter,
                 ParameterExpression indexMapParameter,
+                bool detailedErrorsEnabled,
                 bool buffer)
             {
                 _selectExpression = selectExpression;
                 _dbDataReaderParameter = dbDataReaderParameter;
                 _indexMapParameter = indexMapParameter;
+                _detailedErrorsEnabled = detailedErrorsEnabled;
                 if (buffer)
                 {
                     ProjectionColumns = new ReaderColumn[selectExpression.Projection.Count];
@@ -108,7 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         projectionIndex,
                         IsNullableProjection(projection),
                         property.GetRelationalTypeMapping(),
-                        methodCallExpression.Type);
+                        methodCallExpression.Type,
+                        property);
                 }
 
                 return base.VisitMethodCall(methodCallExpression);
@@ -149,7 +159,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 int index,
                 bool nullable,
                 RelationalTypeMapping typeMapping,
-                Type clrType)
+                Type clrType,
+                IPropertyBase property = null)
             {
                 var getMethod = typeMapping.GetDataReaderMethod();
 
@@ -221,34 +232,27 @@ namespace Microsoft.EntityFrameworkCore.Query
                     valueExpression = Expression.Convert(valueExpression, clrType);
                 }
 
-                //var exceptionParameter
-                //    = Expression.Parameter(typeof(Exception), name: "e");
+                var exceptionParameter
+                    = Expression.Parameter(typeof(Exception), name: "e");
 
-                //var property = materializationInfo.Property;
+                if (_detailedErrorsEnabled)
+                {
+                    var catchBlock
+                        = Expression
+                            .Catch(
+                                exceptionParameter,
+                                Expression.Call(
+                                    _throwReadValueExceptionMethod
+                                        .MakeGenericMethod(valueExpression.Type),
+                                    exceptionParameter,
+                                    Expression.Call(
+                                        dbDataReader,
+                                        _getFieldValueMethod.MakeGenericMethod(typeof(object)),
+                                        indexExpression),
+                                    Expression.Constant(property, typeof(IPropertyBase))));
 
-                //if (detailedErrorsEnabled)
-                //{
-                //    var catchBlock
-                //        = Expression
-                //            .Catch(
-                //                exceptionParameter,
-                //                Expression.Call(
-                //                    _throwReadValueExceptionMethod
-                //                        .MakeGenericMethod(valueExpression.Type),
-                //                    exceptionParameter,
-                //                    Expression.Call(
-                //                        dataReaderExpression,
-                //                        _getFieldValueMethod.MakeGenericMethod(typeof(object)),
-                //                        indexExpression),
-                //                    Expression.Constant(property, typeof(IPropertyBase))));
-
-                //    valueExpression = Expression.TryCatch(valueExpression, catchBlock);
-                //}
-
-                //if (box && valueExpression.Type.GetTypeInfo().IsValueType)
-                //{
-                //    valueExpression = Expression.Convert(valueExpression, typeof(object));
-                //}
+                    valueExpression = Expression.TryCatch(valueExpression, catchBlock);
+                }
 
                 if (nullable)
                 {
@@ -260,6 +264,44 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
 
                 return valueExpression;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static TValue ThrowReadValueException<TValue>(
+                Exception exception, object value, IPropertyBase property = null)
+            {
+                var expectedType = typeof(TValue);
+                var actualType = value?.GetType();
+
+                string message;
+
+                if (property != null)
+                {
+                    var entityType = property.DeclaringType.DisplayName();
+                    var propertyName = property.Name;
+                    if (expectedType == typeof(object))
+                    {
+                        expectedType = property.ClrType;
+                    }
+
+                    message = exception is NullReferenceException
+                        || Equals(value, DBNull.Value)
+                        ? CoreStrings.ErrorMaterializingPropertyNullReference(entityType, propertyName, expectedType)
+                        : exception is InvalidCastException
+                            ? CoreStrings.ErrorMaterializingPropertyInvalidCast(entityType, propertyName, expectedType, actualType)
+                            : CoreStrings.ErrorMaterializingProperty(entityType, propertyName);
+                }
+                else
+                {
+                    message = exception is NullReferenceException
+                        || Equals(value, DBNull.Value)
+                        ? CoreStrings.ErrorMaterializingValueNullReference(expectedType)
+                        : exception is InvalidCastException
+                            ? CoreStrings.ErrorMaterializingValueInvalidCast(expectedType, actualType)
+                            : CoreStrings.ErrorMaterializingValue;
+                }
+
+                throw new InvalidOperationException(message, exception);
             }
         }
     }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private readonly ISet<string> _tags;
+        private readonly bool _detailedErrorsEnabled;
         private readonly bool _useRelationalNulls;
 
         public RelationalShapedQueryCompilingExpressionVisitor(
@@ -36,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             _contextType = queryCompilationContext.ContextType;
             _logger = queryCompilationContext.Logger;
             _tags = queryCompilationContext.Tags;
+            _detailedErrorsEnabled = relationalDependencies.CoreSingletonOptions.AreDetailedErrorsEnabled;
             _useRelationalNulls = RelationalOptionsExtension.Extract(queryCompilationContext.ContextOptions).UseRelationalNulls;
         }
 
@@ -66,6 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     selectExpression,
                     dataReaderParameter,
                     isNonComposedFromSql ? indexMapParameter : null,
+                    _detailedErrorsEnabled,
                     IsBuffering)
                 .Visit(shaper, out var projectionColumns);
 

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitorDependencies.cs
@@ -58,7 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IQuerySqlGeneratorFactory querySqlGeneratorFactory,
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
             [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
-            [NotNull] IRelationalParameterBasedQueryTranslationPostprocessorFactory relationalParameterBasedQueryTranslationPostprocessorFactory)
+            [NotNull] IRelationalParameterBasedQueryTranslationPostprocessorFactory relationalParameterBasedQueryTranslationPostprocessorFactory,
+            [NotNull] ICoreSingletonOptions coreSingletonOptions)
         {
             Check.NotNull(querySqlGeneratorFactory, nameof(querySqlGeneratorFactory));
             Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
@@ -69,6 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             SqlExpressionFactory = sqlExpressionFactory;
             ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
             RelationalParameterBasedQueryTranslationPostprocessorFactory = relationalParameterBasedQueryTranslationPostprocessorFactory;
+            CoreSingletonOptions = coreSingletonOptions;
         }
 
         /// <summary>
@@ -92,6 +94,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IRelationalParameterBasedQueryTranslationPostprocessorFactory RelationalParameterBasedQueryTranslationPostprocessorFactory { get; }
 
         /// <summary>
+        ///     Core singleton options.
+        /// </summary>
+        public ICoreSingletonOptions CoreSingletonOptions { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="querySqlGeneratorFactory"> A replacement for the current dependency of this type. </param>
@@ -102,7 +109,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 querySqlGeneratorFactory,
                 SqlExpressionFactory,
                 ParameterNameGeneratorFactory,
-                RelationalParameterBasedQueryTranslationPostprocessorFactory);
+                RelationalParameterBasedQueryTranslationPostprocessorFactory,
+                CoreSingletonOptions);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -114,7 +122,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QuerySqlGeneratorFactory,
                 sqlExpressionFactory,
                 ParameterNameGeneratorFactory,
-                RelationalParameterBasedQueryTranslationPostprocessorFactory);
+                RelationalParameterBasedQueryTranslationPostprocessorFactory,
+                CoreSingletonOptions);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -127,7 +136,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QuerySqlGeneratorFactory,
                 SqlExpressionFactory,
                 parameterNameGeneratorFactory,
-                RelationalParameterBasedQueryTranslationPostprocessorFactory);
+                RelationalParameterBasedQueryTranslationPostprocessorFactory,
+                CoreSingletonOptions);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -140,6 +150,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QuerySqlGeneratorFactory,
                 SqlExpressionFactory,
                 ParameterNameGeneratorFactory,
-                relationalParameterBasedQueryTranslationPostprocessorFactory);
+                relationalParameterBasedQueryTranslationPostprocessorFactory,
+                CoreSingletonOptions);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="coreSingletonOptions"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalShapedQueryCompilingExpressionVisitorDependencies With(
+            [NotNull] ICoreSingletonOptions coreSingletonOptions)
+            => new RelationalShapedQueryCompilingExpressionVisitorDependencies(
+                QuerySqlGeneratorFactory,
+                SqlExpressionFactory,
+                ParameterNameGeneratorFactory,
+                RelationalParameterBasedQueryTranslationPostprocessorFactory,
+                coreSingletonOptions);
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -108,7 +108,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 && Tables[0] is FromSqlExpression fromSql
                 && Projection.All(
                     pe => pe.Expression is ColumnExpression column
-                        && string.Equals(fromSql.Alias, column.Table.Alias, StringComparison.OrdinalIgnoreCase));
+                        && string.Equals(fromSql.Alias, column.Table.Alias, StringComparison.OrdinalIgnoreCase))
+                && _projectionMapping.TryGetValue(new ProjectionMember(), out var mapping)
+                && mapping.Type == typeof(Dictionary<IProperty, int>);
 
         public void ApplyProjection()
         {

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected TFixture Fixture { get; }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_invalid_cast_key()
         {
             using var context = CreateContext();
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_invalid_cast()
         {
             using var context = CreateContext();
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_invalid_cast_projection()
         {
             using var context = CreateContext();
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_invalid_cast_no_tracking()
         {
             using var context = CreateContext();
@@ -94,15 +94,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_null()
         {
             using var context = CreateContext();
-            context.Set<Product>().FromSqlRaw(
-                    NormalizeDelimitersInRawString(
-                        @"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
-                               FROM [Products]"))
-                .ToList();
             Assert.Equal(
                 CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
                 Assert.Throws<InvalidOperationException>(
@@ -114,12 +109,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_null_projection()
         {
             using var context = CreateContext();
             Assert.Equal(
-                CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
+                CoreStrings.ErrorMaterializingValueNullReference(typeof(bool)),
                 Assert.Throws<InvalidOperationException>(
                     () =>
                         context.Set<Product>().FromSqlRaw(
@@ -130,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .ToList()).Message);
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void Bad_data_error_handling_null_no_tracking()
         {
             using var context = CreateContext();
@@ -184,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(91, context.ChangeTracker.Entries().Count());
         }
 
-        [ConditionalFact(Skip = "#15751")]
+        [ConditionalFact]
         public virtual void FromSqlRaw_queryable_simple_columns_out_of_order_and_not_enough_columns_throws()
         {
             using var context = CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -75,12 +75,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .FromSqlRaw(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters())
                 .Select(mep => mep.TenMostExpensiveProducts);
 
-            var actual = async
-                ? await query.ToArrayAsync()
-                : query.ToArray();
-
-            Assert.Equal(10, actual.Length);
-            Assert.Contains(actual, r => r == "Côte de Blaye");
+            Assert.Equal(
+                RelationalStrings.FromSqlNonComposable,
+                (async
+                    ? await Assert.ThrowsAsync<InvalidOperationException>(() => query.ToArrayAsync())
+                    : Assert.Throws<InvalidOperationException>(() => query.ToArray())).Message);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -396,15 +396,14 @@ SELECT * FROM ""Customers"" WHERE ""City"" = @p0 AND ""ContactTitle"" = @p1");
         {
             base.FromSqlRaw_queryable_simple_projection_composed();
 
-            // issue #16079
-            //            AssertSql(
-            //                @"SELECT [p].[ProductName]
-            //FROM (
-            //    SELECT *
-            //    FROM ""Products""
-            //    WHERE ""Discontinued"" <> CAST(1 AS bit)
-            //    AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")
-            //) AS [p]");
+            AssertSql(
+                @"SELECT [p].[ProductName]
+FROM (
+    SELECT *
+    FROM ""Products""
+    WHERE ""Discontinued"" <> CAST(1 AS bit)
+    AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")
+) AS [p]");
         }
 
         public override void FromSqlRaw_queryable_simple_include()
@@ -717,7 +716,10 @@ WHERE EXISTS (
             AssertSql(
                 @"p0='10300'
 
-SELECT * FROM ""Orders"" WHERE ""OrderID"" >= @p0",
+SELECT [o].[OrderID]
+FROM (
+    SELECT * FROM ""Orders"" WHERE ""OrderID"" >= @p0
+) AS [o]",
                 //
                 @"@__max_0='10400'
 p0='10300'

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -785,6 +785,54 @@ FROM (
 ) AS [c0]");
         }
 
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_invalid_cast()
+        {
+            base.Bad_data_error_handling_invalid_cast();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_invalid_cast_key()
+        {
+            base.Bad_data_error_handling_invalid_cast_key();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_invalid_cast_no_tracking()
+        {
+            base.Bad_data_error_handling_invalid_cast_no_tracking();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_invalid_cast_projection()
+        {
+            base.Bad_data_error_handling_invalid_cast_projection();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_null()
+        {
+            base.Bad_data_error_handling_null();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_null_no_tracking()
+        {
+            base.Bad_data_error_handling_null_no_tracking();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void Bad_data_error_handling_null_projection()
+        {
+            base.Bad_data_error_handling_null_projection();
+        }
+
+        [ConditionalFact(Skip = "Issue#20364")]
+        public override void FromSqlRaw_queryable_simple_columns_out_of_order_and_not_enough_columns_throws()
+        {
+            base.FromSqlRaw_queryable_simple_columns_out_of_order_and_not_enough_columns_throws();
+        }
+
         protected override DbParameter CreateDbParameter(string name, object value)
             => new SqlParameter { ParameterName = name, Value = value };
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlSprocQuerySqlServerTest.cs
@@ -31,13 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 [dbo].[Ten Most Expensive Products]");
         }
 
-        public override async Task From_sql_queryable_stored_procedure_projection(bool async)
-        {
-            await base.From_sql_queryable_stored_procedure_projection(async);
-
-            AssertSql("[dbo].[Ten Most Expensive Products]");
-        }
-
         public override async Task From_sql_queryable_stored_procedure_with_parameter(bool async)
         {
             await base.From_sql_queryable_stored_procedure_with_parameter(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -442,7 +442,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
 
         #endregion
 
-        [ConditionalFact(Skip = "Issue#15751")]
+        [ConditionalFact(Skip = "Issue#20364")]
         public void Query_when_null_key_in_database_should_throw()
         {
             using var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest");

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -20,10 +20,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    // Issue #15751
-#pragma warning disable xUnit1000 // Test classes must be public
-    internal class BadDataSqliteTest : IClassFixture<BadDataSqliteTest.BadDataSqliteFixture>
-#pragma warning restore xUnit1000 // Test classes must be public
+    public class BadDataSqliteTest : IClassFixture<BadDataSqliteTest.BadDataSqliteFixture>
     {
         public BadDataSqliteTest(BadDataSqliteFixture fixture) => Fixture = fixture;
 
@@ -67,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext(1);
             Assert.Equal(
-                CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "ProductName", typeof(string), typeof(int)),
+                CoreStrings.ErrorMaterializingValueInvalidCast(typeof(string), typeof(int)),
                 Assert.Throws<InvalidOperationException>(
                     () =>
                         context.Set<Product>().Where(p => p.ProductID != 4)
@@ -105,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext(new object[] { null });
             Assert.Equal(
-                CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
+                CoreStrings.ErrorMaterializingValueNullReference(typeof(bool)),
                 Assert.Throws<InvalidOperationException>(
                     () =>
                         context.Set<Product>()


### PR DESCRIPTION
Resolves #16079

