### PR TITLE
Detect SqlServer features automagically rather than using env vars

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -30,7 +30,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         [InlineData(59, 6)]
         [InlineData(50, 5)]
         [InlineData(20, 2)]
@@ -82,10 +81,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsSequences)) ?? true)
-                {
-                    modelBuilder.UseHiLo();
-                }
+                modelBuilder.UseHiLo();
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -37,7 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         #region Sequences
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Create_sequences_with_facets()
         {
             Test(
@@ -82,7 +81,6 @@ DROP SEQUENCE db2.CustomFacetsSequence");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Sequence_min_max_start_values_are_null_if_default()
         {
             Test(
@@ -118,7 +116,6 @@ DROP SEQUENCE [BigIntSequence];");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Sequence_min_max_start_values_are_not_null_if_decimal()
         {
             Test(
@@ -146,7 +143,6 @@ DROP SEQUENCE [NumericSequence];");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Sequence_using_type_alias()
         {
             Fixture.TestStore.ExecuteNonQuery(
@@ -177,7 +173,6 @@ DROP TYPE [dbo].[TestTypeAlias];");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Sequence_using_type_with_facets()
         {
             Test(
@@ -200,7 +195,6 @@ DROP SEQUENCE [TypeFacetSequence];");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Filter_sequences_based_on_schema()
         {
             Test(

--- a/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -13,7 +13,6 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    [SqlServerCondition(SqlServerCondition.SupportsSequences)]
     public class SequenceEndToEndTest : IDisposable
     {
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -51,7 +51,6 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         [ConditionalFact]
         public void Insert_with_sequence_HiLo()
         {
@@ -99,7 +98,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Insert_with_default_value_from_sequence()
         {
             using var testStore = SqlServerTestStore.CreateInitialized(DatabaseName);
@@ -177,7 +175,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Insert_with_default_string_value_from_sequence()
         {
             using var testStore = SqlServerTestStore.CreateInitialized(DatabaseName);
@@ -231,7 +228,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Insert_with_key_default_value_from_sequence()
         {
             using var testStore = SqlServerTestStore.CreateInitialized(DatabaseName);
@@ -872,7 +868,6 @@ END");
         }
 
         [ConditionalFact]
-        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public void Insert_explicit_value_throws_when_readonly_sequence_before_save()
         {
             using var testStore = SqlServerTestStore.CreateInitialized(DatabaseName);

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerCondition.cs
@@ -8,14 +8,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
     [Flags]
     public enum SqlServerCondition
     {
-        SupportsSequences = 1 << 0,
-        IsSqlAzure = 1 << 1,
-        IsNotSqlAzure = 1 << 2,
-        SupportsMemoryOptimized = 1 << 3,
-        SupportsAttach = 1 << 4,
-        SupportsHiddenColumns = 1 << 5,
-        IsNotCI = 1 << 6,
-        SupportsFullTextSearch = 1 << 7,
-        SupportsOnlineIndexes = 1 << 8
+        IsSqlAzure = 1 << 0,
+        IsNotSqlAzure = 1 << 1,
+        SupportsMemoryOptimized = 1 << 2,
+        SupportsAttach = 1 << 3,
+        SupportsHiddenColumns = 1 << 4,
+        IsNotCI = 1 << 5,
+        SupportsFullTextSearch = 1 << 6,
+        SupportsOnlineIndexes = 1 << 7,
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerConditionAttribute.cs
@@ -22,19 +22,15 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public ValueTask<bool> IsMetAsync()
         {
             var isMet = true;
-            if (Conditions.HasFlag(SqlServerCondition.SupportsSequences))
-            {
-                isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsSequences)) ?? true;
-            }
 
             if (Conditions.HasFlag(SqlServerCondition.SupportsHiddenColumns))
             {
-                isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsHiddenColumns)) ?? false;
+                isMet &= TestEnvironment.IsHiddenColumnsSupported;
             }
 
             if (Conditions.HasFlag(SqlServerCondition.SupportsMemoryOptimized))
             {
-                isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsMemoryOptimized)) ?? false;
+                isMet &= TestEnvironment.IsMemoryOptimizedTablesSupported;
             }
 
             if (Conditions.HasFlag(SqlServerCondition.IsSqlAzure))
@@ -50,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             if (Conditions.HasFlag(SqlServerCondition.SupportsAttach))
             {
                 var defaultConnection = new SqlConnectionStringBuilder(TestEnvironment.DefaultConnection);
-                isMet &= defaultConnection.DataSource.Contains("(localdb)")
+                isMet &= defaultConnection.DataSource.Contains("(localdb)", StringComparison.OrdinalIgnoreCase)
                     || defaultConnection.UserInstance;
             }
 
@@ -62,6 +58,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             if (Conditions.HasFlag(SqlServerCondition.SupportsFullTextSearch))
             {
                 isMet &= TestEnvironment.IsFullTextSearchSupported;
+            }
+
+            if (Conditions.HasFlag(SqlServerCondition.SupportsOnlineIndexes))
+            {
+                isMet &= TestEnvironment.IsOnlineIndexingSupported;
             }
 
             return new ValueTask<bool>(isMet);

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -25,13 +25,52 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public static bool IsConfigured { get; } = !string.IsNullOrEmpty(_dataSource);
 
-        public static bool IsLocalDb { get; } = _dataSource.StartsWith("(localdb)", StringComparison.OrdinalIgnoreCase);
-
-        public static bool IsSqlAzure { get; } = _dataSource.Contains("database.windows.net");
-
         public static bool IsCI { get; } = Environment.GetEnvironmentVariable("PIPELINE_WORKSPACE") != null;
 
+        private static bool? _isAzureSqlDb;
+
         private static bool? _fullTextInstalled;
+
+        private static bool? _supportsHiddenColumns;
+
+        private static bool? _supportsOnlineIndexing;
+
+        private static bool? _supportsMemoryOptimizedTables;
+
+        private static byte? _productMajorVersion;
+
+        private static int? _engineEdition;
+
+        public static bool IsSqlAzure
+        {
+            get
+            {
+                if (!IsConfigured)
+                {
+                    return false;
+                }
+
+                if (_isAzureSqlDb.HasValue)
+                {
+                    return _isAzureSqlDb.Value;
+                }
+
+                try
+                {
+                    _engineEdition = GetEngineEdition();
+
+                    _isAzureSqlDb = (_engineEdition == 5 || _engineEdition == 8);
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    _isAzureSqlDb = false;
+                }
+                
+                return _isAzureSqlDb.Value;
+            }
+        }
+
+        public static bool IsLocalDb { get; } = _dataSource.StartsWith("(localdb)", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsFullTextSearchSupported
         {
@@ -49,23 +88,119 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 try
                 {
-                    using (var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master")))
-                    {
-                        sqlConnection.Open();
+                    using var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master"));
+                    sqlConnection.Open();
 
-                        using var command = new SqlCommand(
-                            "SELECT FULLTEXTSERVICEPROPERTY('IsFullTextInstalled')", sqlConnection);
-                        var result = (int)command.ExecuteScalar();
+                    using var command = new SqlCommand(
+                        "SELECT FULLTEXTSERVICEPROPERTY('IsFullTextInstalled')", sqlConnection);
+                    var result = (int)command.ExecuteScalar();
 
-                        _fullTextInstalled = result == 1;
-                    }
+                    _fullTextInstalled = result == 1;
                 }
                 catch (PlatformNotSupportedException)
                 {
+                    _fullTextInstalled = false;
                 }
 
-                _fullTextInstalled = false;
-                return false;
+                return _fullTextInstalled.Value;
+            }
+        }
+
+        public static bool IsHiddenColumnsSupported 
+        {
+            get
+            {
+                if (!IsConfigured)
+                {
+                    return false;
+                }
+
+                if (_supportsHiddenColumns.HasValue)
+                {
+                    return _supportsHiddenColumns.Value;
+                }
+
+                try
+                {
+                    _engineEdition = GetEngineEdition();
+                    _productMajorVersion = GetProductMajorVersion();
+
+                    _supportsHiddenColumns = (_productMajorVersion >= 13 && _engineEdition != 6) || IsSqlAzure;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    _supportsHiddenColumns = false;
+                }
+                
+                return _supportsHiddenColumns.Value;
+            }
+        }
+
+        public static bool IsOnlineIndexingSupported
+        {
+            get
+            {
+                if (!IsConfigured)
+                {
+                    return false;
+                }
+
+                if (_supportsOnlineIndexing.HasValue)
+                {
+                    return _supportsOnlineIndexing.Value;
+                }
+
+                try
+                {
+                    _engineEdition = GetEngineEdition();
+
+                    _supportsOnlineIndexing = _engineEdition == 3 || IsSqlAzure;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    _supportsOnlineIndexing = false;
+                }
+
+                return _supportsOnlineIndexing.Value;
+            }
+        }
+
+        public static bool IsMemoryOptimizedTablesSupported
+        {
+            get
+            {
+                if (!IsConfigured)
+                {
+                    return false;
+                }
+
+                var supported = GetFlag(nameof(SqlServerCondition.SupportsMemoryOptimized));
+                if (supported.HasValue)
+                {
+                    _supportsMemoryOptimizedTables = supported.Value;
+                }
+
+                if (_supportsMemoryOptimizedTables.HasValue)
+                {
+                    return _supportsMemoryOptimizedTables.Value;
+                }
+
+                try
+                {
+                    using var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master"));
+                    sqlConnection.Open();
+
+                    using var command = new SqlCommand(
+                        "SELECT SERVERPROPERTY('IsXTPSupported');", sqlConnection);
+                    var result = command.ExecuteScalar();
+                    _supportsMemoryOptimizedTables = (result != null ? Convert.ToInt32(result) : 0) == 1 && !IsSqlAzure && !IsLocalDb;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    _supportsMemoryOptimizedTables = false;
+                }
+
+                return _supportsMemoryOptimizedTables.Value;
             }
         }
 
@@ -76,5 +211,39 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public static int? GetInt(string key)
             => int.TryParse(Config[key], out var value) ? value : (int?)null;
+
+        private static int GetEngineEdition()
+        {
+            if (_engineEdition.HasValue)
+            {
+                return _engineEdition.Value;
+            }
+
+            using var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master"));
+            sqlConnection.Open();
+
+            using var command = new SqlCommand(
+                "SELECT SERVERPROPERTY('EngineEdition');", sqlConnection);
+            _engineEdition = (int)command.ExecuteScalar();
+
+            return _engineEdition.Value;
+        }
+
+        private static byte GetProductMajorVersion()
+        {
+            if (_productMajorVersion.HasValue)
+            {
+                return _productMajorVersion.Value;
+            }
+
+            using var sqlConnection = new SqlConnection(SqlServerTestStore.CreateConnectionString("master"));
+            sqlConnection.Open();
+
+            using var command = new SqlCommand(
+                "SELECT SERVERPROPERTY('ProductVersion');", sqlConnection);
+            _productMajorVersion = (byte)Version.Parse((string)command.ExecuteScalar()).Major;
+
+            return _productMajorVersion.Value;
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/config.json
+++ b/test/EFCore.SqlServer.FunctionalTests/config.json
@@ -3,10 +3,7 @@
       "SqlServer": {
         "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Database=master;Integrated Security=True;Connect Timeout=60;ConnectRetryCount=0",
         "ElasticPoolName": "",
-        "SupportsSequences": true,
-        "SupportsMemoryOptimized": false,
-        "SupportsHiddenColumns": true,
-        "SupportsOnlineIndexes": false
+        "SupportsMemoryOptimized": null
       }
     }
 }


### PR DESCRIPTION
fixes #20318

I have attempted to cater for current implicit assumptions - but it is opaque to me what SQL Server edtions tests are actually run against.

Tested with SQL 2016 Developer Edition and LocalDb version 14

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


