### PR TITLE
[3.1] Updating Microsoft.Data.SqlClient to 1.1.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <SQLitePCLRawCorePackageVersion>2.0.2</SQLitePCLRawCorePackageVersion>
     <StyleCopAnalyzersPackageVersion>1.1.118</StyleCopAnalyzersPackageVersion>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
-    <MicrosoftDataSqlClientPackageVersion>1.0.19269.1</MicrosoftDataSqlClientPackageVersion>
+    <MicrosoftDataSqlClientPackageVersion>1.1.3</MicrosoftDataSqlClientPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from aspnet/Extensions">
     <MicrosoftExtensionsCachingMemoryPackageVersion>3.1.6</MicrosoftExtensionsCachingMemoryPackageVersion>


### PR DESCRIPTION
Issue #20316

We brought this issue originally in March, at which time we decided to hold off on updating the dependency to gather more data that this is a safe update to make. The 1.1.3 patch has now been out a couple of months and is proving stable. We talked to the SqlClient folks again and they agreed that it is now time to make this change.

### Description

SqlClient fixed a deadlock issue in their 3.1.1 patch. EF Core customers are hitting this, so we want to update our dependency to that version version.

### Customer Impact

Several customers have hit the deadlock issue. They can fix the issue themselves by updating their SqlClient package, but this can be hard to discover as is often the case with deadlock issues.

### How found

Reported by multiple customers.

### Test coverage

SqlClient have tested and released the patch. We have run all EF Core tests with the updated package.

### Regression?

Not in EF Core, but the underlying issue was a regression.

### Risk

Low. The only risk to EF customers is if SqlClient broke something in their patch, which has already been out for some time.