### PR TITLE
[Internal] Suppress internal warning in TableNameFromDbSetConvention

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableNameFromDbSetConvention.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] ProviderConventionSetBuilderDependencies dependencies,
             [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
             _sets = dependencies.SetFinder.CreateClrTypeDbSetMapping(dependencies.ContextType);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
             Dependencies = dependencies;
         }
@@ -61,7 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 && entityType.ClrType != null
                 && _sets.ContainsKey(entityType.ClrType))
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 entityTypeBuilder.ToTable(_sets[entityType.ClrType].Name);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }
 
@@ -79,7 +83,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 && entityType.ClrType != null
                 && _sets.ContainsKey(entityType.ClrType))
             {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 entityTypeBuilder.ToTable(_sets[entityType.ClrType].Name);
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }
 


### PR DESCRIPTION
Part of #15393

This could be made public, may be.
Offending types
- DbSetProperty
- DbSetFinderExtensions