### PR TITLE
Query: Add ability for translation pipeline to translate property acc…

### DIFF
--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                 && unaryExpression.Operand.Type == typeof(byte[]))
             {
                 return base.Visit(unaryExpression.Operand) is SqlExpression sqlExpression
-                    ? SqlExpressionFactory.Function(
+                    ? Dependencies.SqlExpressionFactory.Function(
                         "length",
                         new[] { sqlExpression },
                         nullable: true,
@@ -127,9 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         {
             Check.NotNull(binaryExpression, nameof(binaryExpression));
 
-            var visitedExpression = (SqlExpression)base.VisitBinary(binaryExpression);
-
-            if (visitedExpression == null)
+            if (!(base.VisitBinary(binaryExpression) is SqlExpression visitedExpression))
             {
                 return null;
             }
@@ -140,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
                     && (_functionModuloTypes.Contains(GetProviderType(sqlBinary.Left))
                         || _functionModuloTypes.Contains(GetProviderType(sqlBinary.Right))))
                 {
-                    return SqlExpressionFactory.Function(
+                    return Dependencies.SqlExpressionFactory.Function(
                         "ef_mod",
                         new[] { sqlBinary.Left, sqlBinary.Right },
                         nullable: true,
@@ -242,20 +240,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
 
         private Expression DoDecimalCompare(SqlExpression visitedExpression, ExpressionType op, SqlExpression left, SqlExpression right)
         {
-            var actual = SqlExpressionFactory.Function(
+            var actual = Dependencies.SqlExpressionFactory.Function(
                 name: "ef_compare",
                 new[] { left, right },
                 nullable: true,
                 new[] { true, true },
                 typeof(int));
-            var oracle = SqlExpressionFactory.Constant(value: 0);
+            var oracle = Dependencies.SqlExpressionFactory.Constant(value: 0);
 
             return op switch
             {
-                ExpressionType.GreaterThan => SqlExpressionFactory.GreaterThan(left: actual, right: oracle),
-                ExpressionType.GreaterThanOrEqual => SqlExpressionFactory.GreaterThanOrEqual(left: actual, right: oracle),
-                ExpressionType.LessThan => SqlExpressionFactory.LessThan(left: actual, right: oracle),
-                ExpressionType.LessThanOrEqual => SqlExpressionFactory.LessThanOrEqual(left: actual, right: oracle),
+                ExpressionType.GreaterThan => Dependencies.SqlExpressionFactory.GreaterThan(left: actual, right: oracle),
+                ExpressionType.GreaterThanOrEqual => Dependencies.SqlExpressionFactory.GreaterThanOrEqual(left: actual, right: oracle),
+                ExpressionType.LessThan => Dependencies.SqlExpressionFactory.LessThan(left: actual, right: oracle),
+                ExpressionType.LessThanOrEqual => Dependencies.SqlExpressionFactory.LessThanOrEqual(left: actual, right: oracle),
                 _ => visitedExpression
             };
         }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2153,7 +2153,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, clrName);
 
         /// <summary>
-        ///     The indexed property '{property}' cannot be added to type '{entityType}' because the CLR class contains a member with the same name.
+        ///     The indexer property '{property}' cannot be added to type '{entityType}' because the CLR class contains a member with the same name.
         /// </summary>
         public static string PropertyClashingNonIndexer([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -2535,10 +2535,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("UnsupportedBinaryOperator");
 
         /// <summary>
-        ///     EF.Property called with wrong property name.
+        ///     Translation of '{expression}' failed. Either source is not an entity type or the specified property does not exist on the entity type.
         /// </summary>
-        public static string EFPropertyCalledWithWrongPropertyName
-            => GetString("EFPropertyCalledWithWrongPropertyName");
+        public static string QueryUnableToTranslateEFProperty([CanBeNull] object expression)
+            => string.Format(
+                GetString("QueryUnableToTranslateEFProperty", nameof(expression)),
+                expression);
 
         /// <summary>
         ///     Invalid {state} encountered.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1341,8 +1341,8 @@
   <data name="UnsupportedBinaryOperator" xml:space="preserve">
     <value>Unsupported Binary operator type specified.</value>
   </data>
-  <data name="EFPropertyCalledWithWrongPropertyName" xml:space="preserve">
-    <value>EF.Property called with wrong property name.</value>
+  <data name="QueryUnableToTranslateEFProperty" xml:space="preserve">
+    <value>Translation of '{expression}' failed. Either source is not an entity type or the specified property does not exist on the entity type.</value>
   </data>
   <data name="InvalidStateEncountered" xml:space="preserve">
     <value>Invalid {state} encountered.</value>

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -10,7 +10,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 


### PR DESCRIPTION
…ess over a subquery

This removes need to run subquery member pushdown after entity equality
Part of #20164
Part of #18923

This does not change anything on Cosmos as Cosmos does not have subquery scalar selection
