### PR TITLE
Add a convention to discover the entity type returned by a queryable function.

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -265,37 +265,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Configures the entity as a result of a queryable function.  Prevents a table from being created for this entity.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder ToQueryableFunctionResultType(
-            [NotNull] this EntityTypeBuilder entityTypeBuilder)
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-
-            entityTypeBuilder.Metadata.SetAnnotation(RelationalAnnotationNames.QueryableFunctionResultType, null);
-
-            return entityTypeBuilder;
-        }
-
-        /// <summary>
-        ///     Configures the entity as a result of a queryable function.  Prevents a table from being created for this entity.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
-        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> ToQueryableFunctionResultType<TEntity>(
-            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder)
-             where TEntity : class
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-
-            entityTypeBuilder.Metadata.SetAnnotation(RelationalAnnotationNames.QueryableFunctionResultType, null);
-
-            return entityTypeBuilder;
-        }
-
-        /// <summary>
         ///     Configures the view that the entity type maps to when targeting a relational database.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -531,11 +531,6 @@ namespace Microsoft.EntityFrameworkCore
                 return false;
             }
 
-            if (entityType.FindAnnotation(RelationalAnnotationNames.QueryableFunctionResultType) != null)
-            {
-                return true;
-            }
-
             var viewDefinition = entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinition);
             if (viewDefinition?.Value != null)
             {

--- a/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore
             => (IConventionDbFunction)((IModel)model).FindDbFunction(method);
 
         /// <summary>
-        ///     Finds a <see cref="IDbFunction" /> that is mapped to the method represented by the given name.
+        ///     Finds an <see cref="IDbFunction" /> that is mapped to the method represented by the given name.
         /// </summary>
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
@@ -274,7 +274,7 @@ namespace Microsoft.EntityFrameworkCore
                 Check.NotNull(name, nameof(name)));
 
         /// <summary>
-        ///     Finds a <see cref="IMutableDbFunction" /> that is mapped to the method represented by the given name.
+        ///     Finds an <see cref="IMutableDbFunction" /> that is mapped to the method represented by the given name.
         /// </summary>
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore
             => (IMutableDbFunction)((IModel)model).FindDbFunction(name);
 
         /// <summary>
-        ///     Finds a <see cref="IConventionDbFunction" /> that is mapped to the method represented by the given name.
+        ///     Finds an <see cref="IConventionDbFunction" /> that is mapped to the method represented by the given name.
         /// </summary>
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
@@ -292,24 +292,22 @@ namespace Microsoft.EntityFrameworkCore
             => (IConventionDbFunction)((IModel)model).FindDbFunction(name);
 
         /// <summary>
-        ///     Either returns the existing <see cref="DbFunction" /> mapped to the given method
-        ///     or creates a new function mapped to the method.
+        ///     Creates an <see cref="IMutableDbFunction" /> mapped to the given method.
         /// </summary>
         /// <param name="model"> The model to add the function to. </param>
         /// <param name="methodInfo"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
-        /// <returns> The <see cref="DbFunction" />. </returns>
+        /// <returns> The new <see cref="IMutableDbFunction" />. </returns>
         public static IMutableDbFunction AddDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo methodInfo)
             => DbFunction.AddDbFunction(
                  model, Check.NotNull(methodInfo, nameof(methodInfo)), ConfigurationSource.Explicit);
 
         /// <summary>
-        ///     Either returns the existing <see cref="DbFunction" /> mapped to the given method
-        ///     or creates a new function mapped to the method.
+        ///     Creates an <see cref="IConventionDbFunction" /> mapped to the given method.
         /// </summary>
         /// <param name="model"> The model to add the function to. </param>
         /// <param name="methodInfo"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns> The <see cref="DbFunction" />. </returns>
+        /// <returns> The new <see cref="IConventionDbFunction" />. </returns>
         public static IConventionDbFunction AddDbFunction(
             [NotNull] this IConventionModel model, [NotNull] MethodInfo methodInfo, bool fromDataAnnotation = false)
             => DbFunction.AddDbFunction(
@@ -317,28 +315,36 @@ namespace Microsoft.EntityFrameworkCore
                  fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
-        ///     Either returns the existing <see cref="DbFunction" /> mapped to the given method
-        ///     or creates a new function mapped to the method.
+        ///     Creates an <see cref="IMutableDbFunction" />.
         /// </summary>
         /// <param name="model"> The model to add the function to. </param>
         /// <param name="name"> The model name of the function. </param>
-        /// <returns> The <see cref="DbFunction" />. </returns>
-        public static IMutableDbFunction AddDbFunction([NotNull] this IMutableModel model, [NotNull] string name)
+        /// <param name="returnType"> The function return type. </param>
+        /// <returns> The new <see cref="IMutableDbFunction" />. </returns>
+        public static IMutableDbFunction AddDbFunction(
+            [NotNull] this IMutableModel model,
+            [NotNull] string name,
+            [NotNull] Type returnType)
             => DbFunction.AddDbFunction(
-                 model, Check.NotNull(name, nameof(name)), ConfigurationSource.Explicit);
+                 model, Check.NotNull(name, nameof(name)), returnType, ConfigurationSource.Explicit);
 
         /// <summary>
-        ///     Either returns the existing <see cref="DbFunction" /> mapped to the given method
-        ///     or creates a new function mapped to the method.
+        ///     Creates an <see cref="IConventionDbFunction" />.
         /// </summary>
         /// <param name="model"> The model to add the function to. </param>
         /// <param name="name"> The model name of the function. </param>
+        /// <param name="returnType"> The function return type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns> The <see cref="DbFunction" />. </returns>
+        /// <returns> The new <see cref="IConventionDbFunction" />. </returns>
         public static IConventionDbFunction AddDbFunction(
-            [NotNull] this IConventionModel model, [NotNull] string name, bool fromDataAnnotation = false)
+            [NotNull] this IConventionModel model,
+            [NotNull] string name,
+            [NotNull] Type returnType,
+            bool fromDataAnnotation = false)
             => DbFunction.AddDbFunction(
-                 (IMutableModel)model, Check.NotNull(name, nameof(name)),
+                 (IMutableModel)model,
+                 Check.NotNull(name, nameof(name)),
+                 returnType,
                  fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -74,14 +74,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             {
                 var methodInfo = dbFunction.MethodInfo;
 
-                if (string.IsNullOrEmpty(dbFunction.Name))
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DbFunctionNameEmpty(methodInfo.DisplayName()));
-                }
-
-                if (dbFunction.TypeMapping == null &&
-                    !(dbFunction.IsQueryable && model.FindEntityType(dbFunction.MethodInfo.ReturnType.GetGenericArguments()[0]) != null))
+                if (dbFunction.TypeMapping == null
+                    && dbFunction.QueryableEntityType == null)
                 {
                     throw new InvalidOperationException(
                         RelationalStrings.DbFunctionInvalidReturnType(

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
@@ -4,14 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
+using System.Diagnostics;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
@@ -19,10 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     /// <summary>
     ///     Provides a simple API for configuring a <see cref="IMutableDbFunction" />.
     /// </summary>
-    public class DbFunctionBuilder : IConventionDbFunctionBuilder
+    public class DbFunctionBuilder : IInfrastructure<IConventionDbFunctionBuilder>
     {
-        private readonly DbFunction _function;
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -34,13 +29,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             Check.NotNull(function, nameof(function));
 
-            _function = (DbFunction)function;
+            Builder = ((DbFunction)function).Builder;
+        }
+
+        private InternalDbFunctionBuilder Builder { [DebuggerStepThrough] get; }
+
+        /// <inheritdoc />
+        IConventionDbFunctionBuilder IInfrastructure<IConventionDbFunctionBuilder>.Instance
+        {
+            [DebuggerStepThrough] get => Builder;
         }
 
         /// <summary>
         ///     The function being configured.
         /// </summary>
-        public virtual IMutableDbFunction Metadata => _function;
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        public virtual IMutableDbFunction Metadata => Builder.Metadata;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Sets the name of the database function.
@@ -49,29 +54,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual DbFunctionBuilder HasName([NotNull] string name)
         {
-            Check.NotEmpty(name, nameof(name));
-
-            _function.Name = name;
+            Builder.HasName(name, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasName(string name, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionBuilder)this).CanSetName(name, fromDataAnnotation))
-            {
-                ((IConventionDbFunction)_function).SetName(name, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionBuilder.CanSetName(string name, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _function.GetNameConfigurationSource())
-                || _function.Name == name;
 
         /// <summary>
         ///     Sets the schema of the database function.
@@ -80,27 +66,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual DbFunctionBuilder HasSchema([CanBeNull] string schema)
         {
-            _function.Schema = schema;
+            Builder.HasSchema(schema, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasSchema(string schema, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionBuilder)this).CanSetSchema(schema, fromDataAnnotation))
-            {
-                ((IConventionDbFunction)_function).SetSchema(schema, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionBuilder.CanSetSchema(string schema, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _function.GetSchemaConfigurationSource())
-                || _function.Schema == schema;
 
         /// <summary>
         ///     Sets the store type of the database function.
@@ -109,45 +78,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual DbFunctionBuilder HasStoreType([CanBeNull] string storeType)
         {
-            _function.StoreType = storeType;
+            Builder.HasStoreType(storeType, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionBuilder)this).CanSetStoreType(storeType, fromDataAnnotation))
-            {
-                ((IConventionDbFunction)_function).SetStoreType(storeType, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionBuilder.CanSetStoreType(string storeType, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _function.GetStoreTypeConfigurationSource())
-                || _function.StoreType == storeType;
-
-        /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTypeMapping(
-            RelationalTypeMapping returnTypeMapping, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionBuilder)this).CanSetTypeMapping(returnTypeMapping, fromDataAnnotation))
-            {
-                ((IConventionDbFunction)_function).SetTypeMapping(returnTypeMapping, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionBuilder.CanSetTypeMapping(RelationalTypeMapping returnTypeMapping, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _function.GetTypeMappingConfigurationSource())
-                || _function.TypeMapping == returnTypeMapping;
 
         /// <summary>
         ///     <para>
@@ -164,62 +98,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual DbFunctionBuilder HasTranslation([NotNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation)
         {
-            Check.NotNull(translation, nameof(translation));
-
-            _function.Translation = translation;
+            Builder.HasTranslation(translation, ConfigurationSource.Explicit);
 
             return this;
         }
 
-        /// <inheritdoc />
-        IConventionDbFunction IConventionDbFunctionBuilder.Metadata => _function;
-
-        /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTranslation(
-            Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionBuilder)this).CanSetTranslation(translation, fromDataAnnotation))
-            {
-                ((IConventionDbFunction)_function).SetTranslation(translation, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
         /// <summary>
-        ///     Creates a <see cref="DbFunctionParameterBuilder" /> for a parameter with the given name.
+        ///     Returns an object that can be used to configure a parameter with the given name.
+        ///     If no parameter with the given name exists, then a new parameter will be added.
         /// </summary>
         /// <param name="name"> The parameter name. </param>
         /// <returns> The builder to use for further parameter configuration. </returns>
         public virtual DbFunctionParameterBuilder HasParameter([NotNull] string name)
-        {
-            return new DbFunctionParameterBuilder((DbFunctionParameter)FindParameter(name));
-        }
-
-        private IDbFunctionParameter FindParameter(string name)
-        {
-            var parameter = Metadata.Parameters.SingleOrDefault(
-                funcParam => string.Compare(funcParam.Name, name, StringComparison.OrdinalIgnoreCase) == 0);
-
-            if (parameter == null)
-            {
-                throw new ArgumentException(
-                    RelationalStrings.DbFunctionInvalidParameterName(name, Metadata.MethodInfo.DisplayName()));
-            }
-
-            return parameter;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionBuilder.CanSetTranslation(
-            Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _function.GetTranslationConfigurationSource())
-                || _function.Translation == translation;
-
-        private bool Overrides(bool fromDataAnnotation, ConfigurationSource? configurationSource)
-            => (fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention)
-                .Overrides(configurationSource);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            => new DbFunctionParameterBuilder(Builder.HasParameter(name, ConfigurationSource.Explicit).Metadata);
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         #region Hidden System.Object members
 

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionParameterBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -19,10 +20,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class DbFunctionParameterBuilder : IConventionDbFunctionParameterBuilder
+    public class DbFunctionParameterBuilder : IInfrastructure<IConventionDbFunctionParameterBuilder>
     {
-        private readonly DbFunctionParameter _parameter;
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -34,16 +33,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             Check.NotNull(parameter, nameof(parameter));
 
-            _parameter = (DbFunctionParameter)parameter;
+            Builder = ((DbFunctionParameter)parameter).Builder;
+        }
+
+        private InternalDbFunctionParameterBuilder Builder { [DebuggerStepThrough] get; }
+
+        /// <inheritdoc />
+        IConventionDbFunctionParameterBuilder IInfrastructure<IConventionDbFunctionParameterBuilder>.Instance
+        {
+            [DebuggerStepThrough]
+            get => Builder;
         }
 
         /// <summary>
         ///     The function parameter metadata that is being built.
         /// </summary>
-        public virtual IMutableDbFunctionParameter Metadata => _parameter;
-
-        /// <inheritdoc />
-        IConventionDbFunctionParameter IConventionDbFunctionParameterBuilder.Metadata => _parameter;
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        public virtual IMutableDbFunctionParameter Metadata => Builder.Metadata;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Sets the store type of the function parameter in the database.
@@ -52,49 +59,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder instance so that further configuration calls can be chained. </returns>
         public virtual DbFunctionParameterBuilder HasStoreType([CanBeNull] string storeType)
         {
-            _parameter.StoreType = storeType;
+            Builder.HasStoreType(storeType, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionParameterBuilder)this).CanSetStoreType(storeType, fromDataAnnotation))
-            {
-                ((IConventionDbFunctionParameter)_parameter).SetStoreType(storeType, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionParameterBuilder.CanSetStoreType(string storeType, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _parameter.GetStoreTypeConfigurationSource())
-                || _parameter.StoreType == storeType;
-
-        /// <inheritdoc />
-        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasTypeMapping(
-            RelationalTypeMapping typeMapping, bool fromDataAnnotation)
-        {
-            if (((IConventionDbFunctionParameterBuilder)this).CanSetTypeMapping(typeMapping, fromDataAnnotation))
-            {
-                ((IConventionDbFunctionParameter)_parameter).SetTypeMapping(typeMapping, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionDbFunctionParameterBuilder.CanSetTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _parameter.GetTypeMappingConfigurationSource())
-                || _parameter.TypeMapping == typeMapping;
-
-        private bool Overrides(bool fromDataAnnotation, ConfigurationSource? configurationSource)
-            => (fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention)
-                .Overrides(configurationSource);
 
         #region Hidden System.Object members
 

--- a/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
@@ -12,12 +12,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     /// <summary>
     ///     Provides a simple API for configuring a <see cref="IConventionDbFunction" />.
     /// </summary>
-    public interface IConventionDbFunctionBuilder
+    public interface IConventionDbFunctionBuilder : IConventionAnnotatableBuilder
     {
         /// <summary>
         ///     The function being configured.
         /// </summary>
-        IConventionDbFunction Metadata { get; }
+        new IConventionDbFunction Metadata { get; }
 
         /// <summary>
         ///     Sets the name of the database function.
@@ -123,5 +123,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> <c>true</c> if the given translation can be set for the database function. </returns>
         bool CanSetTranslation(
             [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns an object that can be used to configure a parameter with the given name.
+        /// </summary>
+        /// <param name="name"> The parameter name. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The builder to use for further parameter configuration. </returns>
+        IConventionDbFunctionParameterBuilder HasParameter([NotNull] string name, bool fromDataAnnotation = false);
     }
 }

--- a/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionParameterBuilder.cs
@@ -4,17 +4,17 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
-namespace Microsoft.EntityFrameworkCore.Metadata
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
     /// <summary>
     ///     Provides a simple API for configuring a <see cref="IConventionDbFunctionParameter" />.
     /// </summary>
-    public interface IConventionDbFunctionParameterBuilder
+    public interface IConventionDbFunctionParameterBuilder : IConventionAnnotatableBuilder
     {
         /// <summary>
         ///     The function parameter metadata that is being built.
         /// </summary>
-        IConventionDbFunctionParameter Metadata { get; }
+        new IConventionDbFunctionParameter Metadata { get; }
 
         /// <summary>
         ///     Sets the store type of the function parameter in the database.

--- a/src/EFCore.Relational/Metadata/Builders/IConventionSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionSequenceBuilder.cs
@@ -9,12 +9,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     /// <summary>
     ///     Provides a simple API for configuring a <see cref="IConventionSequence" />.
     /// </summary>
-    public interface IConventionSequenceBuilder
+    public interface IConventionSequenceBuilder : IConventionAnnotatableBuilder
     {
         /// <summary>
         ///     The sequence being configured.
         /// </summary>
-        IConventionSequence Metadata { get; }
+        new IConventionSequence Metadata { get; }
 
         /// <summary>
         ///     Sets the type of values returned by the sequence.

--- a/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/SequenceBuilder.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -13,10 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     /// <summary>
     ///     Provides a simple API for configuring a <see cref="ISequence" />.
     /// </summary>
-    public class SequenceBuilder : IConventionSequenceBuilder
+    public class SequenceBuilder : IInfrastructure<IConventionSequenceBuilder>
     {
-        private readonly Sequence _sequence;
-
         /// <summary>
         ///     Creates a new builder for the given <see cref="ISequence" />.
         /// </summary>
@@ -25,32 +25,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             Check.NotNull(sequence, nameof(sequence));
 
-            _sequence = (Sequence)sequence;
+            Builder = ((Sequence)sequence).Builder;
+        }
+
+        private InternalSequenceBuilder Builder { [DebuggerStepThrough] get; }
+
+        /// <inheritdoc />
+        IConventionSequenceBuilder IInfrastructure<IConventionSequenceBuilder>.Instance
+        {
+            [DebuggerStepThrough]
+            get => Builder;
         }
 
         /// <summary>
         ///     The sequence.
         /// </summary>
-        public virtual IMutableSequence Metadata => _sequence;
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasType(Type type, bool fromDataAnnotation)
-        {
-            if (Overrides(fromDataAnnotation, _sequence.GetClrTypeConfigurationSource())
-                || _sequence.ClrType == type)
-            {
-                ((IConventionSequence)_sequence).SetClrType(type, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetType(Type type, bool fromDataAnnotation)
-            => (type == null || Sequence.SupportedTypes.Contains(type))
-                && (Overrides(fromDataAnnotation, _sequence.GetClrTypeConfigurationSource())
-                    || _sequence.ClrType == type);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        public virtual IMutableSequence Metadata => Builder.Metadata;
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     Sets the <see cref="ISequence" /> to increment by the given amount when generating each next value.
@@ -59,27 +51,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual SequenceBuilder IncrementsBy(int increment)
         {
-            _sequence.IncrementBy = increment;
+            Builder.IncrementsBy(increment, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.IncrementsBy(int? increment, bool fromDataAnnotation)
-        {
-            if (((IConventionSequenceBuilder)this).CanSetIncrementsBy(increment, fromDataAnnotation))
-            {
-                ((IConventionSequence)_sequence).SetIncrementBy(increment, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetIncrementsBy(int? increment, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _sequence.GetIncrementByConfigurationSource())
-                || _sequence.IncrementBy == increment;
 
         /// <summary>
         ///     Sets the <see cref="ISequence" /> to start at the given value.
@@ -88,27 +63,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual SequenceBuilder StartsAt(long startValue)
         {
-            _sequence.StartValue = startValue;
+            Builder.StartsAt(startValue, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.StartsAt(long? startValue, bool fromDataAnnotation)
-        {
-            if (((IConventionSequenceBuilder)this).CanSetStartsAt(startValue, fromDataAnnotation))
-            {
-                ((IConventionSequence)_sequence).SetStartValue(startValue, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetStartsAt(long? startValue, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _sequence.GetStartValueConfigurationSource())
-                || _sequence.StartValue == startValue;
 
         /// <summary>
         ///     Sets the maximum value for the <see cref="ISequence" />.
@@ -117,27 +75,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual SequenceBuilder HasMax(long maximum)
         {
-            _sequence.MaxValue = maximum;
+            Builder.HasMax(maximum, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasMax(long? maximum, bool fromDataAnnotation)
-        {
-            if (((IConventionSequenceBuilder)this).CanSetMax(maximum, fromDataAnnotation))
-            {
-                ((IConventionSequence)_sequence).SetMaxValue(maximum, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetMax(long? maximum, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _sequence.GetMaxValueConfigurationSource())
-                || _sequence.MaxValue == maximum;
 
         /// <summary>
         ///     Sets the minimum value for the <see cref="ISequence" />.
@@ -146,27 +87,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual SequenceBuilder HasMin(long minimum)
         {
-            _sequence.MinValue = minimum;
+            Builder.HasMin(minimum, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasMin(long? minimum, bool fromDataAnnotation)
-        {
-            if (((IConventionSequenceBuilder)this).CanSetMin(minimum, fromDataAnnotation))
-            {
-                ((IConventionSequence)_sequence).SetMinValue(minimum, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetMin(long? minimum, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _sequence.GetMinValueConfigurationSource())
-                || _sequence.MinValue == minimum;
 
         /// <summary>
         ///     Sets whether or not the sequence will start again from the beginning once
@@ -176,33 +100,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The same builder so that multiple calls can be chained. </returns>
         public virtual SequenceBuilder IsCyclic(bool cyclic = true)
         {
-            _sequence.IsCyclic = cyclic;
+            Builder.IsCyclic(cyclic, ConfigurationSource.Explicit);
 
             return this;
         }
-
-        /// <inheritdoc />
-        IConventionSequenceBuilder IConventionSequenceBuilder.IsCyclic(bool? cyclic, bool fromDataAnnotation)
-        {
-            if (((IConventionSequenceBuilder)this).CanSetIsCyclic(cyclic, fromDataAnnotation))
-            {
-                ((IConventionSequence)_sequence).SetIsCyclic(cyclic, fromDataAnnotation);
-                return this;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
-        bool IConventionSequenceBuilder.CanSetIsCyclic(bool? cyclic, bool fromDataAnnotation)
-            => Overrides(fromDataAnnotation, _sequence.GetIsCyclicConfigurationSource())
-                || _sequence.IsCyclic == cyclic;
-
-        private bool Overrides(bool fromDataAnnotation, ConfigurationSource? configurationSource)
-            => (fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention)
-                .Overrides(configurationSource);
-
-        IConventionSequence IConventionSequenceBuilder.Metadata => (IConventionSequence)Metadata;
 
         #region Hidden System.Object members
 

--- a/src/EFCore.Relational/Metadata/Conventions/DbFunctionTypeMappingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/DbFunctionTypeMappingConvention.cs
@@ -41,20 +41,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             foreach (var dbFunction in modelBuilder.Metadata.GetDbFunctions())
             {
-                var typeMapping = !string.IsNullOrEmpty(dbFunction.StoreType)
-                    ? _relationalTypeMappingSource.FindMapping(dbFunction.StoreType)
-                    : _relationalTypeMappingSource.FindMapping(dbFunction.MethodInfo.ReturnType);
-
-                dbFunction.Builder.HasTypeMapping(typeMapping);
-
                 foreach (var parameter in dbFunction.Parameters)
                 {
-                    typeMapping = !string.IsNullOrEmpty(parameter.StoreType)
+                    parameter.Builder.HasTypeMapping(!string.IsNullOrEmpty(parameter.StoreType)
                         ? _relationalTypeMappingSource.FindMapping(parameter.StoreType)
-                        : _relationalTypeMappingSource.FindMapping(parameter.ClrType);
-
-                    parameter.Builder.HasTypeMapping(typeMapping);
+                        : _relationalTypeMappingSource.FindMapping(parameter.ClrType));
                 }
+
+                if (dbFunction.IsQueryable)
+                {
+                    continue;
+                }
+
+                dbFunction.Builder.HasTypeMapping(!string.IsNullOrEmpty(dbFunction.StoreType)
+                    ? _relationalTypeMappingSource.FindMapping(dbFunction.StoreType)
+                    : _relationalTypeMappingSource.FindMapping(dbFunction.ReturnType));
             }
         }
     }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -88,6 +88,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var dbFunctionAttributeConvention = new RelationalDbFunctionAttributeConvention(Dependencies, RelationalDependencies);
             conventionSet.ModelInitializedConventions.Add(dbFunctionAttributeConvention);
 
+            // ModelCleanupConvention would remove the entity types added by QueryableDbFunctionConvention #15898
+            ConventionSet.AddAfter(
+                conventionSet.ModelFinalizingConventions,
+                new QueryableDbFunctionConvention(Dependencies, RelationalDependencies),
+                typeof(ModelCleanupConvention));
             conventionSet.ModelFinalizingConventions.Add(dbFunctionAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(tableNameFromDbSetConvention);
             conventionSet.ModelFinalizingConventions.Add(storeGenerationConvention);

--- a/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
@@ -27,9 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IConventionDbFunctionBuilder Builder { get; }
 
         /// <summary>
-        ///     Gets the configuration source for this <see cref="IConventionDbFunction" />.
+        ///     Gets the configuration source for this function.
         /// </summary>
-        /// <returns> The configuration source for <see cref="IConventionDbFunction" />. </returns>
+        /// <returns> The configuration source for this function. </returns>
         ConfigurationSource GetConfigurationSource();
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/IConventionDbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunctionParameter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -20,6 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The <see cref="IConventionDbFunctionParameterBuilder" /> for building a by-convention function parameter.
         /// </summary>
         new IConventionDbFunctionParameterBuilder Builder { get; }
+
+        /// <summary>
+        ///     Returns the configuration source for the parameter.
+        /// </summary>
+        /// <returns> The configuration source for the parameter. </returns>
+        ConfigurationSource GetConfigurationSource();
 
         /// <summary>
         ///     Sets the store type of the parameter in the database.

--- a/src/EFCore.Relational/Metadata/IDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunction.cs
@@ -46,9 +46,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         bool IsQueryable { get; }
 
         /// <summary>
+        ///     Gets the entity type returned by this queryable function
+        /// </summary>
+        IEntityType QueryableEntityType => IsQueryable
+            ? Model.FindEntityType(ReturnType.GetGenericArguments()[0])
+            : null;
+
+        /// <summary>
         ///     Gets the configured store type string
         /// </summary>
         string StoreType { get; }
+
+        /// <summary>
+        ///     Gets the returned CLR type.
+        /// </summary>
+        Type ReturnType { get; }
 
         /// <summary>
         ///     Gets the type mapping for the function's return type

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -159,6 +159,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         IConventionEntityType IConventionCheckConstraint.EntityType => (IConventionEntityType)EntityType;
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraintExtensions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static class CheckConstraintExtensions
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static string ToDebugString(
+            [NotNull] this ICheckConstraint constraint,
+            MetadataDebugStringOptions options,
+            [NotNull] string indent = "")
+        {
+            var builder = new StringBuilder();
+
+            builder
+                .Append(indent)
+                .Append("Check: ");
+
+            builder.Append(constraint.Name)
+                .Append(" \"")
+                .Append(constraint.Sql)
+                .Append("\"");
+
+            if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+            {
+                if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+                {
+                    builder.Append(constraint.AnnotationsToDebugString(indent: indent + "  "));
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -12,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -23,7 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConventionDbFunction
     {
-        private readonly IMutableModel _model;
         private readonly List<DbFunctionParameter> _parameters;
         private string _schema;
         private string _name;
@@ -37,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ConfigurationSource? _storeTypeConfigurationSource;
         private ConfigurationSource? _typeMappingConfigurationSource;
         private ConfigurationSource? _translationConfigurationSource;
+        private IEntityType _queryableEntityType;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,6 +50,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] MethodInfo methodInfo,
             [NotNull] IMutableModel model,
             ConfigurationSource configurationSource)
+            : this(methodInfo.DisplayName(),
+                  methodInfo.ReturnType,
+                  methodInfo.GetParameters().Select(pi => (pi.Name, pi.ParameterType)),
+                  model,
+                  configurationSource)
         {
             if (methodInfo.IsGenericMethod)
             {
@@ -63,40 +70,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         methodInfo.DisplayName(), methodInfo.DeclaringType.ShortDisplayName()));
             }
 
-            if (methodInfo.ReturnType == null
-                || methodInfo.ReturnType == typeof(void))
-            {
-                throw new ArgumentException(
-                    RelationalStrings.DbFunctionInvalidReturnType(
-                        methodInfo.DisplayName(), methodInfo.ReturnType.ShortDisplayName()));
-            }
-
-            if (methodInfo.ReturnType.IsGenericType
-                && methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(IQueryable<>))
-            {
-                IsQueryable = true;
-
-                //todo - if the generic argument is not usuable as an entitytype should we throw here?  IE IQueryable<int>
-                //the built in entitytype will throw is the type is not a class
-                if (model.FindEntityType(methodInfo.ReturnType.GetGenericArguments()[0]) == null)
-                {
-                    model.AddEntityType(methodInfo.ReturnType.GetGenericArguments()[0]).SetAnnotation(RelationalAnnotationNames.QueryableFunctionResultType, null);
-                }
-            }
-
             MethodInfo = methodInfo;
 
-            var parameters = methodInfo.GetParameters();
-
-            _parameters = parameters
-                .Select((pi, i) => new DbFunctionParameter(this, pi.Name, pi.ParameterType))
-                .ToList();
-
-            ModelName = GetFunctionName(methodInfo, parameters);
-
-            _model = model;
-            _configurationSource = configurationSource;
-            Builder = new DbFunctionBuilder(this);
+            ModelName = GetFunctionName(methodInfo, methodInfo.GetParameters());
         }
 
         /// <summary>
@@ -107,24 +83,53 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public DbFunction(
             [NotNull] string name,
+            [NotNull] Type returnType,
+            [CanBeNull] IEnumerable<(string Name, Type Type)> parameters,
             [NotNull] IMutableModel model,
             ConfigurationSource configurationSource)
         {
+            if (returnType == null
+                || returnType == typeof(void))
+            {
+                throw new ArgumentException(
+                    RelationalStrings.DbFunctionInvalidReturnType(
+                        name, returnType.ShortDisplayName()));
+            }
+
+            if (returnType.IsGenericType
+                && returnType.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                IsQueryable = true;
+            }
+
             ModelName = name;
-            _parameters = new List<DbFunctionParameter>();
-            _model = model;
+            ReturnType = returnType;
+            Model = model;
             _configurationSource = configurationSource;
-            Builder = new DbFunctionBuilder(this);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            Builder = new InternalDbFunctionBuilder(this, ((Model)model).Builder.ModelBuilder);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+            _parameters = parameters == null
+                ? new List<DbFunctionParameter>()
+                : parameters
+                    .Select(p => new DbFunctionParameter(this, p.Name, p.Type))
+                    .ToList();
         }
 
         private static string GetFunctionName(MethodInfo methodInfo, ParameterInfo[] parameters)
             => methodInfo.DeclaringType.FullName + "." + methodInfo.Name
                 + "(" + string.Join(",", parameters.Select(p => p.ParameterType.FullName)) + ")";
 
+        /// <inheritdoc />
+        public virtual IMutableModel Model { get; }
+
         /// <summary>
-        ///     The builder that can be used to configure this function.
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual DbFunctionBuilder Builder { get; private set; }
+        public virtual InternalDbFunctionBuilder Builder { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -184,9 +189,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static DbFunction AddDbFunction(
             [NotNull] IMutableModel model,
             [NotNull] string name,
+            [NotNull] Type returnType,
             ConfigurationSource configurationSource)
         {
-            var function = new DbFunction(name, model, configurationSource);
+            var function = new DbFunction(name, returnType, null, model, configurationSource);
 
             GetOrCreateFunctions(model).Add(name, function);
             return function;
@@ -241,21 +247,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return null;
         }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
         public virtual string ModelName { get; private set; }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
         public virtual MethodInfo MethodInfo { get; }
+
+        /// <inheritdoc />
+        public virtual Type ReturnType { get; }
+
+        /// <inheritdoc />
+        public virtual bool IsQueryable { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -263,6 +265,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        IEntityType QueryableEntityType
+        {
+            get
+            {
+                if (!IsQueryable)
+                {
+                    return null;
+                }
+
+                if (_queryableEntityType == null)
+                {
+                    _queryableEntityType = Model.FindEntityType(ReturnType.GetGenericArguments()[0]);
+                }
+
+                return _queryableEntityType;
+            }
+
+            [param: CanBeNull]
+            set => _queryableEntityType = value;
+        }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         public virtual ConfigurationSource GetConfigurationSource()
             => _configurationSource;
 
@@ -272,6 +297,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
             => _configurationSource = configurationSource.Max(_configurationSource);
 
@@ -283,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual string Schema
         {
-            get => _schema ?? _model.GetDefaultSchema();
+            get => _schema ?? Model.GetDefaultSchema();
             set => SetSchema(value, ConfigurationSource.Explicit);
         }
 
@@ -332,6 +358,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual string SetName([CanBeNull] string name, ConfigurationSource configurationSource)
         {
+            Check.NullButNotEmpty(name, nameof(name));
+
             _name = name;
 
             _nameConfigurationSource = name == null
@@ -449,12 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (translation != null
                 && IsQueryable)
             {
-                if (configurationSource == ConfigurationSource.Explicit)
-                {
-                    throw new InvalidOperationException(RelationalStrings.DbFunctionQueryableCustomTranslation(MethodInfo.DisplayName()));
-                }
-
-                return null;
+                throw new InvalidOperationException(RelationalStrings.DbFunctionQueryableCustomTranslation(MethodInfo.DisplayName()));
             }
 
             _translation = translation;
@@ -480,7 +503,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool IsQueryable { get; }
+        public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+        /// <inheritdoc />
+        IConventionDbFunctionBuilder IConventionDbFunction.Builder
+        {
+            [DebuggerStepThrough]
+            get => Builder;
+        }
+
+        /// <inheritdoc />
+        IModel IDbFunction.Model
+        {
+            [DebuggerStepThrough]
+            get => Model;
+        }
+
+        /// <inheritdoc />
+        IConventionModel IConventionDbFunction.Model
+        {
+            [DebuggerStepThrough]
+            get => (IConventionModel)Model;
+        }
+
+        /// <inheritdoc />
+        IEntityType IDbFunction.QueryableEntityType => QueryableEntityType;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -488,7 +535,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionDbFunctionBuilder IConventionDbFunction.Builder => Builder;
+        public virtual IReadOnlyList<DbFunctionParameter> Parameters
+        {
+            [DebuggerStepThrough]
+            get => _parameters;
+        }
+
+        /// <inheritdoc />
+        IReadOnlyList<IDbFunctionParameter> IDbFunction.Parameters
+        {
+            [DebuggerStepThrough]
+            get => _parameters;
+        }
+
+        /// <inheritdoc />
+        IReadOnlyList<IConventionDbFunctionParameter> IConventionDbFunction.Parameters
+        {
+            [DebuggerStepThrough]
+            get => _parameters;
+        }
+
+        /// <inheritdoc />
+        IReadOnlyList<IMutableDbFunctionParameter> IMutableDbFunction.Parameters
+        {
+            [DebuggerStepThrough]
+            get => _parameters;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -496,92 +568,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IModel IDbFunction.Model => _model;
+        public virtual DbFunctionParameter FindParameter([NotNull] string name) => Parameters.SingleOrDefault(p => p.Name == name);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        IMutableModel IMutableDbFunction.Model => _model;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        IConventionModel IConventionDbFunction.Model => (IConventionModel)_model;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         string IConventionDbFunction.SetName(string name, bool fromDataAnnotation)
             => SetName(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         string IConventionDbFunction.SetSchema(string schema, bool fromDataAnnotation)
             => SetSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         string IConventionDbFunction.SetStoreType(string storeType, bool fromDataAnnotation)
             => SetStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         RelationalTypeMapping IConventionDbFunction.SetTypeMapping(RelationalTypeMapping returnTypeMapping, bool fromDataAnnotation)
             => SetTypeMapping(returnTypeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
+        /// <inheritdoc />
+        [DebuggerStepThrough]
         Func<IReadOnlyCollection<SqlExpression>, SqlExpression> IConventionDbFunction.SetTranslation(
             Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation)
             => SetTranslation(translation, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual IReadOnlyList<IDbFunctionParameter> Parameters => _parameters;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        IReadOnlyList<IConventionDbFunctionParameter> IConventionDbFunction.Parameters => _parameters;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        IReadOnlyList<IMutableDbFunctionParameter> IMutableDbFunction.Parameters => _parameters;
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static class TableExtensions
+    public static class DbFunctionExtensions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static string ToDebugString(
-            [NotNull] this ITable table,
+            [NotNull] this IDbFunction function,
             MetadataDebugStringOptions options,
             [NotNull] string indent = "")
         {
@@ -31,57 +31,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder
                 .Append(indent)
-                .Append("Table: ");
+                .Append("DbFunction: ");
 
-            if (table.Schema != null)
+            builder.Append(function.ReturnType.ShortDisplayName())
+                .Append(" ");
+
+            if (function.Schema != null)
             {
                 builder
-                    .Append(table.Schema)
+                    .Append(function.Schema)
                     .Append(".");
             }
 
-            builder.Append(table.Name);
-
-            if (!table.IsMigratable)
-            {
-                builder.Append(" NonMigratable");
-            }
+            builder.Append(function.Name);
 
             if ((options & MetadataDebugStringOptions.SingleLine) == 0)
             {
-                var mappings = table.EntityTypeMappings.ToList();
-                if (mappings.Count != 0)
+                var parameters = function.Parameters.ToList();
+                if (parameters.Count != 0)
                 {
-                    builder.AppendLine().Append(indent).Append("  EntityTypeMappings: ");
-                    foreach (var mapping in mappings)
+                    builder.AppendLine().Append(indent).Append("  Parameters: ");
+                    foreach (var parameter in parameters)
                     {
-                        builder.AppendLine().Append(mapping.ToDebugString(options, indent + "    "));
-                    }
-                }
-
-                var columns = table.Columns.ToList();
-                if (columns.Count != 0)
-                {
-                    builder.AppendLine().Append(indent).Append("  Columns: ");
-                    foreach (var column in columns)
-                    {
-                        builder.AppendLine().Append(column.ToDebugString(options, indent + "    "));
-                    }
-                }
-
-                var checkConstraints = table.CheckConstraints.ToList();
-                if (checkConstraints.Count != 0)
-                {
-                    builder.AppendLine().Append(indent).Append("  Check constraints: ");
-                    foreach (var checkConstraint in checkConstraints)
-                    {
-                        builder.AppendLine().Append(checkConstraint.ToDebugString(options, indent + "    "));
+                        builder.AppendLine().Append(parameter.ToDebugString(options, indent + "    "));
                     }
                 }
 
                 if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
                 {
-                    builder.Append(table.AnnotationsToDebugString(indent + "  "));
+                    builder.Append(function.AnnotationsToDebugString(indent: indent + "  "));
                 }
             }
 

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionParameterExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionParameterExtensions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static class DbFunctionParameterExtensions
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static string ToDebugString(
+            [NotNull] this IDbFunctionParameter parameter,
+            MetadataDebugStringOptions options,
+            [NotNull] string indent = "")
+        {
+            var builder = new StringBuilder();
+
+            builder
+                .Append(indent)
+                .Append("DbFunctionParameter: ");
+
+            builder.Append(parameter.Name)
+                .Append(" ")
+                .Append(parameter.StoreType);
+
+            if ((options & MetadataDebugStringOptions.SingleLine) == 0)
+            {
+                if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
+                {
+                    builder.Append(parameter.AnnotationsToDebugString(indent: indent + "  "));
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
@@ -1,0 +1,258 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
+    public class InternalDbFunctionBuilder : InternalModelItemBuilder<DbFunction>, IConventionDbFunctionBuilder
+#pragma warning restore EF1001 // Internal EF Core API usage.
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public InternalDbFunctionBuilder([NotNull] DbFunction function, [NotNull] InternalModelBuilder modelBuilder)
+            : base(function, modelBuilder)
+        {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionBuilder HasName([CanBeNull] string name, ConfigurationSource configurationSource)
+        {
+            if (CanSetName(name, configurationSource))
+            {
+                Metadata.SetName(name, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetName([CanBeNull] string name, ConfigurationSource configurationSource)
+            => (name != "" || configurationSource == ConfigurationSource.Explicit)
+                && (configurationSource.Overrides(Metadata.GetNameConfigurationSource())
+                    || Metadata.Name == name);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionBuilder HasSchema([CanBeNull] string schema, ConfigurationSource configurationSource)
+        {
+            if (CanSetSchema(schema, configurationSource))
+            {
+                Metadata.SetSchema(schema, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetSchema([CanBeNull] string schema, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetSchemaConfigurationSource())
+                || Metadata.Schema == schema;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionBuilder HasStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        {
+            if (CanSetStoreType(storeType, configurationSource))
+            {
+                Metadata.SetStoreType(storeType, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetStoreTypeConfigurationSource())
+                || Metadata.StoreType == storeType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionBuilder HasTypeMapping(
+            [CanBeNull] RelationalTypeMapping returnTypeMapping, ConfigurationSource configurationSource)
+        {
+            if (CanSetTypeMapping(returnTypeMapping, configurationSource))
+            {
+                Metadata.SetTypeMapping(returnTypeMapping, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping returnTypeMapping, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetTypeMappingConfigurationSource())
+                || Metadata.TypeMapping == returnTypeMapping;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionBuilder HasTranslation(
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, ConfigurationSource configurationSource)
+        {
+            if (CanSetTranslation(translation, configurationSource))
+            {
+                Metadata.SetTranslation(translation, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetTranslation(
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, ConfigurationSource configurationSource)
+            => (!Metadata.IsQueryable || configurationSource == ConfigurationSource.Explicit)
+                && (configurationSource.Overrides(Metadata.GetTranslationConfigurationSource())
+                    || Metadata.Translation == translation);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual InternalDbFunctionParameterBuilder HasParameter([NotNull] string name, ConfigurationSource configurationSource)
+        {
+            var parameter = Metadata.FindParameter(name);
+            if (parameter == null)
+            {
+                throw new ArgumentException(
+                    RelationalStrings.DbFunctionInvalidParameterName(name, Metadata.MethodInfo.DisplayName()));
+            }
+
+            return parameter.Builder;
+        }
+
+        IConventionDbFunction IConventionDbFunctionBuilder.Metadata
+        {
+            [DebuggerStepThrough] get => Metadata;
+        }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasName(string name, bool fromDataAnnotation)
+            => HasName(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetName(string name, bool fromDataAnnotation)
+            => CanSetName(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasSchema(string schema, bool fromDataAnnotation)
+            => HasSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetSchema(string schema, bool fromDataAnnotation)
+            => CanSetSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
+            => HasStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetStoreType(string storeType, bool fromDataAnnotation)
+            => CanSetStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+            => HasTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+            => CanSetTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTranslation(
+            Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation)
+            => HasTranslation(translation, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetTranslation(
+            Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation, bool fromDataAnnotation)
+            => CanSetTranslation(translation, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionParameterBuilder IConventionDbFunctionBuilder.HasParameter(string name, bool fromDataAnnotation)
+            => HasParameter(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a <see cref="DbFunctionParameter" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
+    public class InternalDbFunctionParameterBuilder : InternalModelItemBuilder<DbFunctionParameter>, IConventionDbFunctionParameterBuilder
+#pragma warning restore EF1001 // Internal EF Core API usage.
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public InternalDbFunctionParameterBuilder([NotNull] DbFunctionParameter parameter, [NotNull] InternalModelBuilder modelBuilder)
+            : base(parameter, modelBuilder)
+        {
+        }
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionParameterBuilder HasStoreType(
+            [CanBeNull] string storeType, ConfigurationSource configurationSource)
+        {
+            if (CanSetStoreType(storeType, configurationSource))
+            {
+                Metadata.SetStoreType(storeType, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetStoreTypeConfigurationSource())
+                || Metadata.StoreType == storeType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionParameterBuilder HasTypeMapping(
+            [CanBeNull] RelationalTypeMapping typeMapping, ConfigurationSource configurationSource)
+        {
+            if (CanSetTypeMapping(typeMapping, configurationSource))
+            {
+                Metadata.SetTypeMapping(typeMapping, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping typeMapping, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetTypeMappingConfigurationSource())
+                || Metadata.TypeMapping == typeMapping;
+
+        /// <inheritdoc />
+        IConventionDbFunctionParameter IConventionDbFunctionParameterBuilder.Metadata
+        {
+            [DebuggerStepThrough] get => Metadata;
+        }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
+            => HasStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionParameterBuilder.CanSetStoreType(string storeType, bool fromDataAnnotation)
+            => CanSetStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasTypeMapping(
+            RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+            => HasTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionParameterBuilder.CanSetTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+            => CanSetTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
@@ -1,0 +1,264 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
+    public class InternalSequenceBuilder : InternalModelItemBuilder<Sequence>, IConventionSequenceBuilder
+#pragma warning restore EF1001 // Internal EF Core API usage.
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public InternalSequenceBuilder([NotNull] Sequence sequence, [NotNull] InternalModelBuilder modelBuilder)
+            : base(sequence, modelBuilder)
+        {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder HasType([CanBeNull] Type type, ConfigurationSource configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetClrTypeConfigurationSource())
+                || Metadata.ClrType == type)
+            {
+                Metadata.SetClrType(type, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetType([CanBeNull] Type type, ConfigurationSource configurationSource)
+            => (type == null || Sequence.SupportedTypes.Contains(type))
+                && (configurationSource.Overrides(Metadata.GetClrTypeConfigurationSource())
+                    || Metadata.ClrType == type);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder IncrementsBy(
+            int? increment, ConfigurationSource configurationSource)
+        {
+            if (CanSetIncrementsBy(increment, configurationSource))
+            {
+                Metadata.SetIncrementBy(increment, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetIncrementsBy(int? increment, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetIncrementByConfigurationSource())
+                || Metadata.IncrementBy == increment;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder StartsAt(long? startValue, ConfigurationSource configurationSource)
+        {
+            if (CanSetStartsAt(startValue, configurationSource))
+            {
+                Metadata.SetStartValue(startValue, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetStartsAt(long? startValue, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetStartValueConfigurationSource())
+                || Metadata.StartValue == startValue;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder HasMax(long? maximum, ConfigurationSource configurationSource)
+        {
+            if (CanSetMax(maximum, configurationSource))
+            {
+                Metadata.SetMaxValue(maximum, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetMax(long? maximum, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetMaxValueConfigurationSource())
+                || Metadata.MaxValue == maximum;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder HasMin(long? minimum, ConfigurationSource configurationSource)
+        {
+            if (CanSetMin(minimum, configurationSource))
+            {
+                Metadata.SetMinValue(minimum, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetMin(long? minimum, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetMinValueConfigurationSource())
+                || Metadata.MinValue == minimum;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionSequenceBuilder IsCyclic(bool? cyclic, ConfigurationSource configurationSource)
+        {
+            if (CanSetIsCyclic(cyclic, configurationSource))
+            {
+                Metadata.SetIsCyclic(cyclic, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetIsCyclic(bool? cyclic, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetIsCyclicConfigurationSource())
+                || Metadata.IsCyclic == cyclic;
+
+        /// <inheritdoc />
+        IConventionSequence IConventionSequenceBuilder.Metadata
+        {
+            [DebuggerStepThrough] get => Metadata;
+        }
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.HasType(Type type, bool fromDataAnnotation)
+            => HasType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetType(Type type, bool fromDataAnnotation)
+            => CanSetType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.IncrementsBy(int? increment, bool fromDataAnnotation)
+            => IncrementsBy(increment, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetIncrementsBy(int? increment, bool fromDataAnnotation)
+            => CanSetIncrementsBy(increment, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.StartsAt(long? startValue, bool fromDataAnnotation)
+            => StartsAt(startValue, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetStartsAt(long? startValue, bool fromDataAnnotation)
+            => CanSetStartsAt(startValue, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.HasMax(long? maximum, bool fromDataAnnotation)
+            => HasMax(maximum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetMax(long? maximum, bool fromDataAnnotation)
+            => CanSetMax(maximum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.HasMin(long? minimum, bool fromDataAnnotation)
+            => HasMin(minimum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetMin(long? minimum, bool fromDataAnnotation)
+            => CanSetMin(minimum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionSequenceBuilder IConventionSequenceBuilder.IsCyclic(bool? cyclic, bool fromDataAnnotation)
+            => IsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionSequenceBuilder.CanSetIsCyclic(bool? cyclic, bool fromDataAnnotation)
+            => CanSetIsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -108,7 +108,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _name = name;
             _schema = schema;
             _configurationSource = configurationSource;
-            Builder = new SequenceBuilder(this);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            Builder = new InternalSequenceBuilder(this, ((Model)model).Builder.ModelBuilder);
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         /// <summary>
@@ -135,7 +137,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _maxValue = data.MaxValue;
             _clrType = data.ClrType;
             _isCyclic = data.IsCyclic;
-            Builder = new SequenceBuilder(this);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            Builder = new InternalSequenceBuilder(this, ((Model)model).Builder.ModelBuilder);
+#pragma warning restore EF1001 // Internal EF Core API usage.
         }
 
         /// <summary>
@@ -214,7 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SequenceBuilder Builder { get; private set; }
+        public virtual InternalSequenceBuilder Builder { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -239,6 +243,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string Schema => _schema ?? Model.GetDefaultSchema();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource GetConfigurationSource()
+            => _configurationSource;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+            => _configurationSource = _configurationSource.Max(configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -489,17 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ConfigurationSource GetConfigurationSource()
-            => _configurationSource;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
-            => _configurationSource = _configurationSource.Max(configurationSource);
+        public override string ToString() => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/SequenceExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SequenceExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -14,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public static class TableExtensions
+    public static class SequenceExtensions
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -23,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static string ToDebugString(
-            [NotNull] this ITable table,
+            [NotNull] this ISequence sequence,
             MetadataDebugStringOptions options,
             [NotNull] string indent = "")
         {
@@ -31,57 +30,51 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder
                 .Append(indent)
-                .Append("Table: ");
+                .Append("Sequence: ");
 
-            if (table.Schema != null)
+            if (sequence.Schema != null)
             {
                 builder
-                    .Append(table.Schema)
+                    .Append(sequence.Schema)
                     .Append(".");
             }
 
-            builder.Append(table.Name);
+            builder.Append(sequence.Name);
 
-            if (!table.IsMigratable)
+            if (!sequence.IsCyclic)
             {
-                builder.Append(" NonMigratable");
+                builder.Append(" Cyclic");
+            }
+
+            if (sequence.StartValue != 1)
+            {
+                builder.Append(" Start: ")
+                    .Append(sequence.StartValue);
+            }
+
+            if (sequence.IncrementBy != 1)
+            {
+                builder.Append(" IncrementBy: ")
+                    .Append(sequence.IncrementBy);
+            }
+
+            if (sequence.MinValue != null)
+            {
+                builder.Append(" Min: ")
+                    .Append(sequence.MinValue);
+            }
+
+            if (sequence.MaxValue != null)
+            {
+                builder.Append(" Max: ")
+                    .Append(sequence.MaxValue);
             }
 
             if ((options & MetadataDebugStringOptions.SingleLine) == 0)
             {
-                var mappings = table.EntityTypeMappings.ToList();
-                if (mappings.Count != 0)
-                {
-                    builder.AppendLine().Append(indent).Append("  EntityTypeMappings: ");
-                    foreach (var mapping in mappings)
-                    {
-                        builder.AppendLine().Append(mapping.ToDebugString(options, indent + "    "));
-                    }
-                }
-
-                var columns = table.Columns.ToList();
-                if (columns.Count != 0)
-                {
-                    builder.AppendLine().Append(indent).Append("  Columns: ");
-                    foreach (var column in columns)
-                    {
-                        builder.AppendLine().Append(column.ToDebugString(options, indent + "    "));
-                    }
-                }
-
-                var checkConstraints = table.CheckConstraints.ToList();
-                if (checkConstraints.Count != 0)
-                {
-                    builder.AppendLine().Append(indent).Append("  Check constraints: ");
-                    foreach (var checkConstraint in checkConstraints)
-                    {
-                        builder.AppendLine().Append(checkConstraint.ToDebugString(options, indent + "    "));
-                    }
-                }
-
                 if ((options & MetadataDebugStringOptions.IncludeAnnotations) != 0)
                 {
-                    builder.Append(table.AnnotationsToDebugString(indent + "  "));
+                    builder.Append(sequence.AnnotationsToDebugString(indent: indent + "  "));
                 }
             }
 

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -154,11 +154,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string ViewColumnMappings = Prefix + "ViewColumnMappings";
 
         /// <summary>
-        ///     The definition of a Queryable Function Result Type.
-        /// </summary>
-        public const string QueryableFunctionResultType = Prefix + "QueryableFunctionResultType";
-
-        /// <summary>
         ///     The name for foreign key mappings annotations.
         /// </summary>
         public const string ForeignKeyMappings = Prefix + "ForeignKeyMappings";

--- a/src/EFCore.Relational/Migrations/Migration.cs
+++ b/src/EFCore.Relational/Migrations/Migration.cs
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public virtual string ActiveProvider { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     Implemented to builds the <see cref="TargetModel" />.
+        ///     Implemented to build the <see cref="TargetModel" />.
         /// </summary>
         /// <param name="modelBuilder"> The <see cref="ModelBuilder" /> to use to build the model. </param>
         protected virtual void BuildTargetModel([NotNull] ModelBuilder modelBuilder)

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -413,14 +413,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 function, type);
 
         /// <summary>
-        ///     The DbFunction '{function}' has no name set. Name is a required property of a DbFunction.
-        /// </summary>
-        public static string DbFunctionNameEmpty([CanBeNull] object function)
-            => string.Format(
-                GetString("DbFunctionNameEmpty", nameof(function)),
-                function);
-
-        /// <summary>
         ///     The parameter '{parameter}' for the DbFunction '{function}' has an invalid type '{type}'. Ensure the parameter type can be mapped by the current provider.
         /// </summary>
         public static string DbFunctionInvalidParameterType([CanBeNull] object parameter, [CanBeNull] object function, [CanBeNull] object type)
@@ -631,6 +623,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("DbFunctionQueryableCustomTranslation", nameof(function)),
                 function);
+
+        /// <summary>
+        ///     The DbFunction '{function}' has an invalid return type '{type}'. Only functions that return IQueryable of entity type are supported.
+        /// </summary>
+        public static string DbFunctionInvalidIQueryableReturnType([CanBeNull] object function, [CanBeNull] object type)
+            => string.Format(
+                GetString("DbFunctionInvalidIQueryableReturnType", nameof(function), nameof(type)),
+                function, type);
+
+        /// <summary>
+        ///     The DbFunction '{function}' has an invalid return type '{type}'. Owned entity types cannot be used as the return type of a DbFunction.
+        /// </summary>
+        public static string DbFunctionInvalidIQueryableOwnedReturnType([CanBeNull] object function, [CanBeNull] object type)
+            => string.Format(
+                GetString("DbFunctionInvalidIQueryableOwnedReturnType", nameof(function), nameof(type)),
+                function, type);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -405,9 +405,6 @@
   <data name="DbFunctionInvalidReturnType" xml:space="preserve">
     <value>The DbFunction '{function}' has an invalid return type '{type}'. Ensure that the return type can be mapped by the current provider.</value>
   </data>
-  <data name="DbFunctionNameEmpty" xml:space="preserve">
-    <value>The DbFunction '{function}' has no name set. Name is a required property of a DbFunction.</value>
-  </data>
   <data name="DbFunctionInvalidParameterType" xml:space="preserve">
     <value>The parameter '{parameter}' for the DbFunction '{function}' has an invalid type '{type}'. Ensure the parameter type can be mapped by the current provider.</value>
   </data>
@@ -517,5 +514,11 @@
   </data>
   <data name="DbFunctionQueryableCustomTranslation" xml:space="preserve">
     <value>Cannot set custom translation on the DbFunction '{function}' since it returns IQueryable type.</value>
+  </data>
+  <data name="DbFunctionInvalidIQueryableReturnType" xml:space="preserve">
+    <value>The DbFunction '{function}' has an invalid return type '{type}'. Only functions that return IQueryable of entity type are supported.</value>
+  </data>
+  <data name="DbFunctionInvalidIQueryableOwnedReturnType" xml:space="preserve">
+    <value>The DbFunction '{function}' has an invalid return type '{type}'. Owned entity types cannot be used as the return type of a DbFunction.</value>
   </data>
 </root>

--- a/src/EFCore.Relational/Query/Internal/QueryableFunctionToQueryRootConvertingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryableFunctionToQueryRootConvertingExpressionVisitor.cs
@@ -31,10 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private Expression CreateQueryableFunctionQueryRootExpression(
             IDbFunction function, IReadOnlyCollection<Expression> arguments)
-        {
-            var entityType = _model.FindEntityType(function.MethodInfo.ReturnType.GetGenericArguments()[0]);
-
-            return new QueryableFunctionQueryRootExpression(entityType, function, arguments);
-        }
+            => new QueryableFunctionQueryRootExpression(function.QueryableEntityType, function, arguments);
     }
 }

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (entityType.FindPrimaryKey() != null)
             {
-                var linkingFks = entityType.GetViewOrTableMappings().Single().Table.GetInternalForeignKeys(entityType);
+                var linkingFks = entityType.GetViewOrTableMappings().SingleOrDefault()?.Table.GetInternalForeignKeys(entityType);
                 if (linkingFks != null
                     && linkingFks.Any())
                 {

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -762,7 +762,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             else
             {
                 var tableMappings = entityType.GetViewOrTableMappings();
-                if (tableMappings == null)
+                if (!tableMappings.Any())
                 {
                     return;
                 }

--- a/src/EFCore/Infrastructure/ConventionAnnotatable.cs
+++ b/src/EFCore/Infrastructure/ConventionAnnotatable.cs
@@ -24,7 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
     public abstract class ConventionAnnotatable : Annotatable, IConventionAnnotatable
     {
-
         /// <summary>
         ///     Gets all convention annotations on the current object.
         /// </summary>

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -11,7 +11,6 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var entityType = entityTypeBuilder.Metadata;
             if (entityType.BaseType != null
-                || entityType.IsKeyless
+                || (entityType.IsKeyless && entityType.GetIsKeylessConfigurationSource() != ConfigurationSource.Convention)
                 || !entityTypeBuilder.CanSetPrimaryKey(null))
             {
                 return;

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -152,7 +152,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return true;
             }
 
-            return configurationSource.Overrides(Metadata.GetPrimaryKeyConfigurationSource());
+            return configurationSource.Overrides(Metadata.GetPrimaryKeyConfigurationSource())
+                && (properties == null
+                    || !Metadata.IsKeyless
+                    || configurationSource.Overrides(Metadata.GetIsKeylessConfigurationSource()));
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -1057,22 +1057,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
-        public void Detects_function_with_empty_name()
-        {
-            var modelBuilder = CreateConventionalModelBuilder();
-
-            var methodInfo
-                = typeof(DbFunctionMetadataTests.TestMethods)
-                    .GetRuntimeMethod(nameof(DbFunctionMetadataTests.TestMethods.MethodD), Array.Empty<Type>());
-
-            ((IConventionDbFunctionBuilder)modelBuilder.HasDbFunction(methodInfo)).HasName("");
-
-            VerifyError(
-                RelationalStrings.DbFunctionNameEmpty(methodInfo.DisplayName()),
-                modelBuilder.Model);
-        }
-
-        [ConditionalFact]
         public void Detects_function_with_invalid_return_type()
         {
             var modelBuilder = CreateConventionalModelBuilder();

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/QueryableDbFunctionConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/QueryableDbFunctionConventionTest.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class QueryableDbFunctionConventionTest
+    {
+        [ConditionalFact]
+        public void Configures_return_entity_as_not_mapped_keyless()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.HasDbFunction(typeof(QueryableDbFunctionConventionTest).GetMethod(
+                        nameof(GetKeylessEntities),
+                        BindingFlags.NonPublic | BindingFlags.Static));
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(KeylessEntity));
+
+            Assert.Null(entityType.FindPrimaryKey());
+            Assert.Empty(entityType.GetViewOrTableMappings());
+        }
+
+        [ConditionalFact]
+        public void Finds_existing_entity_type()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<TestEntity>().ToTable("TestTable").HasKey(e => e.Name);
+            modelBuilder.HasDbFunction(typeof(QueryableDbFunctionConventionTest).GetMethod(
+                        nameof(GetEntities),
+                        BindingFlags.NonPublic | BindingFlags.Static));
+
+            var model = modelBuilder.FinalizeModel();
+
+            var entityType = model.FindEntityType(typeof(TestEntity));
+
+            Assert.Equal(nameof(TestEntity.Name), entityType.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal("TestTable", entityType.GetViewOrTableMappings().Single().Table.Name);
+        }
+
+        [ConditionalFact]
+        public void Throws_when_adding_a_function_returning_an_owned_type()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Owned<KeylessEntity>();
+            modelBuilder.HasDbFunction(typeof(QueryableDbFunctionConventionTest).GetMethod(
+                        nameof(GetKeylessEntities),
+                        BindingFlags.NonPublic | BindingFlags.Static));
+
+            Assert.Equal(
+                RelationalStrings.DbFunctionInvalidIQueryableOwnedReturnType(
+                    nameof(GetKeylessEntities), typeof(IQueryable<KeylessEntity>).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_when_adding_a_function_returning_an_existing_owned_type()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<TestEntity>().OwnsOne(e => e.KeylessEntity);
+            modelBuilder.HasDbFunction(typeof(QueryableDbFunctionConventionTest).GetMethod(
+                        nameof(GetKeylessEntities),
+                        BindingFlags.NonPublic | BindingFlags.Static));
+
+            Assert.Equal(
+                RelationalStrings.DbFunctionInvalidIQueryableOwnedReturnType(
+                    nameof(GetKeylessEntities), typeof(IQueryable<KeylessEntity>).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+        }
+
+        [ConditionalFact]
+        public void Throws_when_adding_a_function_returning_a_scalar()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.HasDbFunction(typeof(QueryableDbFunctionConventionTest).GetMethod(
+                        nameof(GetScalars),
+                        BindingFlags.NonPublic | BindingFlags.Static));
+
+            Assert.Equal(
+                RelationalStrings.DbFunctionInvalidIQueryableReturnType(
+                    nameof(GetScalars), typeof(IQueryable<int>).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
+        }
+
+        private static ModelBuilder CreateModelBuilder() => RelationalTestHelpers.Instance.CreateConventionBuilder();
+
+        private static IQueryable<TestEntity> GetEntities(int id)
+            => throw new NotImplementedException();
+
+        private static IQueryable<KeylessEntity> GetKeylessEntities(int id)
+            => throw new NotImplementedException();
+
+        private static IQueryable<int> GetScalars(int id)
+            => throw new NotImplementedException();
+
+        private class TestEntity
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+
+            [NotMapped]
+            public KeylessEntity KeylessEntity { get; set; }
+        }
+
+        private class KeylessEntity
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
@@ -82,6 +82,11 @@ namespace Microsoft.EntityFrameworkCore
                                 && m.DeclaringType == typeof(RelationalCompiledQueryCacheKeyGenerator))
                 };
 
+            public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } = new HashSet<MethodInfo>
+            {
+                typeof(IDbFunction).GetMethod("get_QueryableEntityType")
+            };
+
             public override HashSet<MethodInfo> AsyncMethodExceptions { get; } = new HashSet<MethodInfo>
             {
                 typeof(RelationalDatabaseFacadeExtensions).GetMethod(nameof(RelationalDatabaseFacadeExtensions.CloseConnectionAsync)),

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -202,8 +202,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public ModelBuilder CreateConventionBuilder(bool skipValidation = false)
         {
-            var conventionSet = CreateContextServices().GetRequiredService<IConventionSetBuilder>()
-                .CreateConventionSet();
+            var conventionSet = CreateConventionSetBuilder().CreateConventionSet();
 
             if (skipValidation)
             {
@@ -212,6 +211,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
             return new ModelBuilder(conventionSet);
         }
+
+        public virtual IConventionSetBuilder CreateConventionSetBuilder()
+            => CreateContextServices().GetRequiredService<IConventionSetBuilder>();
 
         public ModelBuilder CreateConventionBuilder(
             DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,

--- a/test/EFCore.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Tests/ApiConsistencyTestBase.cs
@@ -68,6 +68,9 @@ namespace Microsoft.EntityFrameworkCore
                 "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
         }
 
+        private static readonly string MetadataNamespace = typeof(IModel).Namespace;
+        private static readonly string MetadataBuilderNamespace = typeof(IConventionModelBuilder).Namespace;
+
         private string ValidateMetadata(KeyValuePair<Type, (Type, Type, Type)> types)
         {
             var readonlyType = types.Key;
@@ -83,11 +86,12 @@ namespace Microsoft.EntityFrameworkCore
                 return $"{mutableType.Name} should derive from {readonlyType.Name}";
             }
 
-            if (typeof(IAnnotation) != readonlyType)
+            if (typeof(IAnnotation) != readonlyType
+                && typeof(IAnnotatable) != readonlyType)
             {
                 if (!typeof(IAnnotatable).IsAssignableFrom(readonlyType))
                 {
-                    return $"{mutableType.Name} should derive from IAnnotatable";
+                    return $"{readonlyType.Name} should derive from IAnnotatable";
                 }
 
                 if (!typeof(IMutableAnnotatable).IsAssignableFrom(mutableType))
@@ -97,7 +101,34 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (!typeof(IConventionAnnotatable).IsAssignableFrom(conventionType))
                 {
-                    return $"{mutableType.Name} should derive from IConventionAnnotatable";
+                    return $"{conventionType.Name} should derive from IConventionAnnotatable";
+                }
+
+                if (conventionBuilderType != null
+                    && !typeof(IConventionAnnotatableBuilder).IsAssignableFrom(conventionBuilderType))
+                {
+                    return $"{conventionBuilderType.Name} should derive from IConventionAnnotatableBuilder";
+                }
+
+                if (readonlyType.Namespace != MetadataNamespace)
+                {
+                    return $"{readonlyType.Name} is expected to be in the {MetadataNamespace} namespace";
+                }
+
+                if (mutableType.Namespace != MetadataNamespace)
+                {
+                    return $"{mutableType.Name} is expected to be in the {MetadataNamespace} namespace";
+                }
+
+                if (conventionType.Namespace != MetadataNamespace)
+                {
+                    return $"{conventionType.Name} is expected to be in the {MetadataNamespace} namespace";
+                }
+
+                if (conventionBuilderType != null
+                    && conventionBuilderType.Namespace != MetadataBuilderNamespace)
+                {
+                    return $"{conventionBuilderType.Name} is expected to be in the {MetadataBuilderNamespace} namespace";
                 }
             }
 


### PR DESCRIPTION
Extract InternalDbFunctionBuilder and InternalDbFunctionParameterBuilder from DbFunctionBuilder and DbFunctionParameterBuilder.
Store mapped EntityType in the DbFunction.
Add more conditions to metadata API consistency test.

Part of #20051
Fixes #20160


