### PR TITLE
Fix Linux build breaks

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -172,6 +172,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                 return $"{unicodePrefix}'{value}'";
             }
 
+            if (value.Length == 1)
+            {
+                return value[0] == '\n' ? "CHAR(10)" : "CHAR(13)";
+            }
+
             return ($"CONCAT({unicodePrefix}'" + value
                     .Replace("\r", $"', CHAR(13), {unicodePrefix}'")
                     .Replace("\n", $"', CHAR(10), {unicodePrefix}'") + "')")

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -177,14 +177,8 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public virtual Task Create_table_with_multiline_comments()
         {
-            var tableComment = @"This is a multi-line
-table comment.
-More information can
-be found in the docs.";
-            var columnComment = @"This is a multi-line
-column comment.
-More information can
-be found in the docs.";
+            var tableComment = "This is a multi-line\r\ntable comment.\r\nMore information can\r\nbe found in the docs.";
+            var columnComment = "This is a multi-line\ncolumn comment.\nMore information can\nbe found in the docs.";
 
             return Test(
                 builder => { },

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -108,7 +108,7 @@ SET @defaultSchema = SCHEMA_NAME();
 DECLARE @description AS sql_variant;
 SET @description = CONCAT(N'This is a multi-line', CHAR(13), CHAR(10), N'table comment.', CHAR(13), CHAR(10), N'More information can', CHAR(13), CHAR(10), N'be found in the docs.');
 EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSchema, 'TABLE', N'People';
-SET @description = CONCAT(N'This is a multi-line', CHAR(13), CHAR(10), N'column comment.', CHAR(13), CHAR(10), N'More information can', CHAR(13), CHAR(10), N'be found in the docs.');
+SET @description = CONCAT(N'This is a multi-line', CHAR(10), N'column comment.', CHAR(10), N'More information can', CHAR(10), N'be found in the docs.');
 EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSchema, 'TABLE', N'People', 'COLUMN', N'Name';");
         }
 


### PR DESCRIPTION
Fix two issues building and testing on Linux introduced by #20304 (bad generated SQL for DefaultValue with line breaks /cc @lajones)
* Test literals were using machine line endings
* Replacement mechanism for new lines in literals did not handle a single `\n`

Fixes #20439
Fixes #20438
