### PR TITLE
HiLo value generation fix for owned entity key

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -235,10 +235,7 @@ namespace Microsoft.EntityFrameworkCore
             var sharedTablePrincipalPrimaryKeyProperty = property.FindSharedRootPrimaryKeyProperty();
             if (sharedTablePrincipalPrimaryKeyProperty != null)
             {
-                return sharedTablePrincipalPrimaryKeyProperty.GetValueGenerationStrategy()
-                    == SqlServerValueGenerationStrategy.IdentityColumn
-                        ? SqlServerValueGenerationStrategy.IdentityColumn
-                        : SqlServerValueGenerationStrategy.None;
+                return sharedTablePrincipalPrimaryKeyProperty.GetValueGenerationStrategy();
             }
 
             if (property.ValueGenerated != ValueGenerated.OnAdd


### PR DESCRIPTION
While working on https://github.com/npgsql/efcore.pg/issues/1324, I stumbled upon the fact that we "propagate" only the identity value generation strategy to primary keys of owned tables in a shared table. If it's SequenceHiLo we'd return None. This isn't an issue because SequenceHiLo isn't even passed to migrations, but it seems incorrect anyway.
