### PR TITLE
Added the ability to specify Target Migration while calling DatabaseFacade.Migrate method

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -27,9 +27,9 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalDatabaseFacadeExtensions
     {
         /// <summary>
-        ///     <para>
-        ///         Applies any pending migrations for the context to the database. Will create the database
-        ///         if it does not already exist.
+        ///     <para>Migrates the database to either a specified target migration or up to the latest pending
+        ///         Migrates the database to either a specified target migration or up to the latest pending migration.
+        ///         Will create the database if it does not already exist.
         ///     </para>
         ///     <para>
         ///         Note that this API is mutually exclusive with DbContext.Database.EnsureCreated(). EnsureCreated does not use migrations
@@ -37,8 +37,11 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
-        public static void Migrate([NotNull] this DatabaseFacade databaseFacade)
-            => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>().Migrate();
+        /// <param name="targetMigration">
+        ///     The target migration to migrate the database to, or <c>null</c> to migrate to the latest.
+        /// </param>
+        public static void Migrate([NotNull] this DatabaseFacade databaseFacade, [CanBeNull] string targetMigration = null)
+            => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>().Migrate(targetMigration);
 
         /// <summary>
         ///     Gets all the migrations that are defined in the configured migrations assembly.

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -27,8 +27,8 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalDatabaseFacadeExtensions
     {
         /// <summary>
-        ///     <para>Migrates the database to either a specified target migration or up to the latest pending
-        ///         Migrates the database to either a specified target migration or up to the latest pending migration.
+        ///     <para>
+        ///         Migrates the database to either a specific target migration or up to the latest pending.
         ///         Will create the database if it does not already exist.
         ///     </para>
         ///     <para>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -40,7 +40,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="targetMigration">
         ///     The target migration to migrate the database to, or <c>null</c> to migrate to the latest.
         /// </param>
-        public static void Migrate([NotNull] this DatabaseFacade databaseFacade, [CanBeNull] string targetMigration = null)
+        public static void Migrate(
+            [NotNull] this DatabaseFacade databaseFacade,
+            [CanBeNull] string targetMigration = null)
             => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>().Migrate(targetMigration);
 
         /// <summary>


### PR DESCRIPTION
Added the ability to specify Target Migration while calling DatabaseFacade.Migrate method.

The actual functionality existed previously. Here we just pass the version so we can do reverts using the same technique.
This is important functionality since the current lack of reverts blocks the usage of Migrate in the real world projects since if you revert the actual application there is still no way to revert the DB.