### PR TITLE
Query: Avoid potential null to bool cast

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -252,7 +252,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         public virtual void ApplyPredicate([NotNull] SqlExpression expression)
         {
             if (expression is SqlConstantExpression sqlConstant
-                && (bool)sqlConstant.Value)
+                && sqlConstant.Value is bool boolValue
+                && boolValue)
             {
                 return;
             }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -230,7 +230,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(expression, nameof(expression));
 
             if (expression is SqlConstantExpression sqlConstant
-                && (bool)sqlConstant.Value)
+                && sqlConstant.Value is bool boolValue
+                && boolValue)
             {
                 return;
             }


### PR DESCRIPTION
Resolves #20498

Manually tested in debugger. Cannot write a test since LINQ Where requires bool and does not accept bool?
