### PR TITLE
Query: Check if parameter.Name is not null before comparing it with q…

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -435,7 +435,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
-            => new SqlParameterExpression(Check.NotNull(parameterExpression, nameof(parameterExpression)), null);
+            => parameterExpression.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true
+                ? new SqlParameterExpression(Check.NotNull(parameterExpression, nameof(parameterExpression)), null)
+                : null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -601,7 +601,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         {
             Check.NotNull(parameterExpression, nameof(parameterExpression));
 
-            if (parameterExpression.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal))
+            if (parameterExpression.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true)
             {
                 return Expression.Call(
                     _getParameterValueMethodInfo.MakeGenericMethod(parameterExpression.Type),

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -93,10 +93,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             return expression;
 
                         case ParameterExpression parameterExpression:
-                            return Expression.Call(
-                                _getParameterValueMethodInfo.MakeGenericMethod(parameterExpression.Type),
-                                QueryCompilationContext.QueryContextParameter,
-                                Expression.Constant(parameterExpression.Name));
+                            if (parameterExpression.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true)
+                            {
+                                return Expression.Call(
+                                    _getParameterValueMethodInfo.MakeGenericMethod(parameterExpression.Type),
+                                    QueryCompilationContext.QueryContextParameter,
+                                    Expression.Constant(parameterExpression.Name));
+                            }
+
+                            throw new InvalidOperationException(CoreStrings.TranslationFailed(parameterExpression.Print()));
 
                         case MaterializeCollectionNavigationExpression materializeCollectionNavigationExpression:
                             return _selectExpression.AddCollectionProjection(

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -564,7 +564,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected override Expression VisitNewArray(NewArrayExpression newArrayExpression) => null;
 
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
-            => new SqlParameterExpression(Check.NotNull(parameterExpression, nameof(parameterExpression)), null);
+            => parameterExpression.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true
+                ? new SqlParameterExpression(Check.NotNull(parameterExpression, nameof(parameterExpression)), null)
+                : null;
 
         protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression)
         {

--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 || expression is MemberInitExpression
                 || expression is NewExpression
                 || expression is ParameterExpression parameter
-                    && parameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal);
+                    && parameter.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true;
 
         private static bool CanConvertEnumerableToQueryable(Type enumerableType, Type queryableType)
         {


### PR DESCRIPTION
…uery parameter

Resolves #20485
- Parameters which are used inside lambda should get replaced with appropriate shaper/selector.
- All other parameters should be query parameters otherwise it is an error.

Resolves #18502
- Non query parameters should not get translated. Query parameters which are translated will always have value in QueryContext.
