### PR TITLE
Fix for 19670. ForeignKeyAttributeConvention run when new Navigation is added.

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -79,9 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
         }
 
-        private IConventionForeignKeyBuilder UpdateRelationshipBuilder<TBuilder>(
-            IConventionForeignKeyBuilder relationshipBuilder, IConventionContext<TBuilder> context)
-            where TBuilder : IConventionAnnotatableBuilder
+        private IConventionForeignKeyBuilder UpdateRelationshipBuilder(
+            IConventionForeignKeyBuilder relationshipBuilder, IConventionContext context)
         {
             var foreignKey = relationshipBuilder.Metadata;
 

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -190,6 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.NavigationAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);
+            conventionSet.NavigationAddedConventions.Add(foreignKeyAttributeConvention);
 
             conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
 

--- a/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
@@ -47,12 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            RunConvention(principalEntityTypeBuilder);
+            RunEntityTypeConventions(principalEntityTypeBuilder);
 
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.DoesNotContain(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            RunConvention(dependentEntityTypeBuilder);
+            RunEntityTypeConventions(dependentEntityTypeBuilder);
 
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            RunConvention(principalEntityTypeBuilder);
+            RunEntityTypeConventions(principalEntityTypeBuilder);
 
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
-            RunConvention(relationshipBuilder, navigation);
+            RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
             Assert.True(relationshipBuilder.Metadata.IsRequired);
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.Posts));
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
-            RunConvention(relationshipBuilder, navigation);
+            RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.Posts));
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
-            RunConvention(relationshipBuilder, navigation);
+            RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
-            RunConvention(relationshipBuilder, navigation);
+            RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
             Assert.False(relationshipBuilder.Metadata.IsRequired);
 
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent));
 
-            RunConvention(relationshipBuilder, navigation);
+            RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
             var newForeignKey = principalEntityTypeBuilder.Metadata.GetForeignKeys().Single();
             Assert.Equal(nameof(Principal.Dependent), newForeignKey.DependentToPrincipal.Name);
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependent));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Dependent.Principal));
 
-            RunConvention(dependentEntityTypeBuilder);
+            RunEntityTypeConventions(dependentEntityTypeBuilder);
 
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependents));
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependent));
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependent));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Dependent.Principal));
 
-            RunConvention(dependentEntityTypeBuilder);
+            RunEntityTypeConventions(dependentEntityTypeBuilder);
 
             Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependents));
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependent));
@@ -454,7 +454,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 CoreStrings.SelfReferencingNavigationWithInverseProperty(
                     "AnotherEntity", nameof(SelfReferencingEntity), "AnotherEntity", nameof(SelfReferencingEntity)),
                 Assert.Throws<InvalidOperationException>(
-                    () => RunConvention(entityTypeBuilder)).Message);
+                    () => RunEntityTypeConventions(entityTypeBuilder)).Message);
         }
 
         [ConditionalFact]
@@ -466,7 +466,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 CoreStrings.InvalidNavigationWithInverseProperty(
                     "Principal", nameof(NonExistentNavigation), "WrongNavigation", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(
-                    () => RunConvention(entityTypeBuilder)).Message);
+                    () => RunEntityTypeConventions(entityTypeBuilder)).Message);
         }
 
         [ConditionalFact]
@@ -477,7 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal(
                 CoreStrings.InvalidNavigationWithInverseProperty("Principal", nameof(WrongNavigationType), "Dependent", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(
-                    () => RunConvention(entityTypeBuilder)).Message);
+                    () => RunEntityTypeConventions(entityTypeBuilder)).Message);
         }
 
         [ConditionalFact]
@@ -489,15 +489,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 CoreStrings.InversePropertyMismatch(
                     "Principal", nameof(MismatchedInverseProperty), "MismatchedInverseProperty", nameof(Principal)),
                 Assert.Throws<InvalidOperationException>(
-                    () => RunConvention(entityTypeBuilder)).Message);
+                    () => RunEntityTypeConventions(entityTypeBuilder)).Message);
         }
 
         #endregion
 
         #region ForeignKeyAttribute
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_overrides_configuration_from_convention_source()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_overrides_configuration_from_convention_source(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -515,13 +517,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalFk", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_does_not_override_configuration_from_explicit_source()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_does_not_override_configuration_from_explicit_source(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -539,13 +551,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_dependent_to_principal_navigation()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_dependent_to_principal_navigation(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -563,13 +585,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalFk", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_principal_to_dependent_navigation()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_principal_to_dependent_navigation(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -587,13 +619,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.PrincipalToDependent;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalAnotherFk", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_property_on_dependent_side()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_property_on_dependent_side(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -611,13 +653,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalAnotherFk", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_on_field_sets_foreign_key_properties_when_applied_on_property_on_dependent_side()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_on_field_sets_foreign_key_properties_when_applied_on_property_on_dependent_side(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<DependentField>();
             var principalEntityTypeBuilder =
@@ -635,13 +687,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalFieldId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("_principalFieldAnotherFk", relationshipBuilder.Metadata.Properties.First().Name);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_sets_foreign_key_properties_after_inverting_when_applied_on_property_on_principal_side()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_sets_foreign_key_properties_after_inverting_when_applied_on_property_on_principal_side(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Principal>();
             var principalEntityTypeBuilder =
@@ -661,15 +723,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal(typeof(Principal), relationshipBuilder.Metadata.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(Dependent), relationshipBuilder.Metadata.PrincipalEntityType.ClrType);
 
-            relationshipBuilder = RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.PrincipalToDependent;
+                relationshipBuilder = RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                relationshipBuilder = RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal("PrincipalAnotherFk", relationshipBuilder.Metadata.Properties.First().Name);
             Assert.Equal(typeof(Dependent), relationshipBuilder.Metadata.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(Principal), relationshipBuilder.Metadata.PrincipalEntityType.ClrType);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_sets_composite_foreign_key_properties_when_applied_on_navigation()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_sets_composite_foreign_key_properties_when_applied_on_navigation(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder =
@@ -687,7 +759,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
-            relationshipBuilder = RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.PrincipalToDependent;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal(2, relationshipBuilder.Metadata.Properties.Count);
             Assert.Collection(
@@ -696,8 +776,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 p => Assert.Equal("PrincipalFk", p.Name));
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_throws_when_values_on_property_and_navigation_in_entity_type_do_not_match()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_throws_when_values_on_property_and_navigation_in_entity_type_do_not_match(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<FkPropertyNavigationMismatch>();
             var principalEntityTypeBuilder =
@@ -709,13 +791,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
+            var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
             Assert.Equal(
                 CoreStrings.FkAttributeOnPropertyNavigationMismatch("PrincipalId", "Principal", nameof(FkPropertyNavigationMismatch)),
-                Assert.Throws<InvalidOperationException>(() => RunConvention(relationshipBuilder)).Message);
+                Assert.Throws<InvalidOperationException>(
+                    () => useNavigation
+                        ? RunForeignKeyAttributeConvention(relationshipBuilder, navigation)
+                        : RunForeignKeyAttributeConvention(relationshipBuilder)
+                    ).Message);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_throws_when_defining_composite_foreign_key_using_attribute_on_properties()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_throws_when_defining_composite_foreign_key_using_attribute_on_properties(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<CompositeFkOnProperty>();
             var principalEntityTypeBuilder =
@@ -727,13 +816,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
+            var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
             Assert.Equal(
                 CoreStrings.CompositeFkOnProperty("Principal", nameof(CompositeFkOnProperty)),
-                Assert.Throws<InvalidOperationException>(() => RunConvention(relationshipBuilder)).Message);
+                Assert.Throws<InvalidOperationException>(
+                    () => useNavigation
+                        ? RunForeignKeyAttributeConvention(relationshipBuilder, navigation)
+                        : RunForeignKeyAttributeConvention(relationshipBuilder)
+                    ).Message);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_throws_when_property_list_on_navigation_is_in_incorrect_format()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_throws_when_property_list_on_navigation_is_in_incorrect_format(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<InvalidPropertyListOnNavigation>();
             var principalEntityTypeBuilder =
@@ -745,13 +841,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
+            var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
             Assert.Equal(
                 CoreStrings.InvalidPropertyListOnNavigation("Principal", nameof(InvalidPropertyListOnNavigation)),
-                Assert.Throws<InvalidOperationException>(() => RunConvention(relationshipBuilder)).Message);
+                Assert.Throws<InvalidOperationException>(
+                    () => useNavigation
+                        ? RunForeignKeyAttributeConvention(relationshipBuilder, navigation)
+                        : RunForeignKeyAttributeConvention(relationshipBuilder)
+                    ).Message);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_throws_when_same_set_of_properties_are_pointed_by_multiple_navigations()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_throws_when_same_set_of_properties_are_pointed_by_multiple_navigations(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<MultipleNavigationsSameFk>();
             var principalEntityTypeBuilder =
@@ -763,13 +866,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
+            var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
             Assert.Equal(
                 CoreStrings.MultipleNavigationsSameFk(typeof(MultipleNavigationsSameFk).Name, "CommonFkProperty"),
-                Assert.Throws<InvalidOperationException>(() => RunConvention(relationshipBuilder)).Message);
+                Assert.Throws<InvalidOperationException>(
+                    () => useNavigation
+                        ? RunForeignKeyAttributeConvention(relationshipBuilder, navigation)
+                        : RunForeignKeyAttributeConvention(relationshipBuilder)
+                    ).Message);
         }
 
-        [ConditionalFact]
-        public void ForeignKeyAttribute_throws_when_specified_on_principal_property_with_collection()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ForeignKeyAttribute_throws_when_specified_on_principal_property_with_collection(bool useNavigation)
         {
             var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
             var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(
@@ -781,7 +891,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 nameof(InvertedPrincipal.Dependents),
                 ConfigurationSource.Convention);
 
-            RunConvention(relationshipBuilder);
+            if (useNavigation)
+            {
+                var navigation = relationshipBuilder.Metadata.PrincipalToDependent;
+                RunForeignKeyAttributeConvention(relationshipBuilder, navigation);
+            }
+            else
+            {
+                RunForeignKeyAttributeConvention(relationshipBuilder);
+            }
 
             Assert.Equal(
                 CoreStrings.FkAttributeOnNonUniquePrincipal(
@@ -791,7 +909,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 Assert.Throws<InvalidOperationException>(() => Validate(dependentEntityTypeBuilder)).Message);
         }
 
-        private void RunConvention(InternalEntityTypeBuilder entityTypeBuilder)
+        private void RunEntityTypeConventions(InternalEntityTypeBuilder entityTypeBuilder)
         {
             var dependencies = CreateDependencies(CreateLogger());
             var context = new ConventionContext<IConventionEntityTypeBuilder>(
@@ -807,7 +925,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .ProcessEntityTypeAdded(entityTypeBuilder, context);
         }
 
-        private InternalForeignKeyBuilder RunConvention(InternalForeignKeyBuilder relationshipBuilder)
+        private InternalForeignKeyBuilder RunForeignKeyAttributeConvention(InternalForeignKeyBuilder relationshipBuilder)
         {
             var dependencies = CreateDependencies(CreateLogger());
             var context = new ConventionContext<IConventionForeignKeyBuilder>(
@@ -819,7 +937,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             return context.ShouldStopProcessing() ? (InternalForeignKeyBuilder)context.Result : relationshipBuilder;
         }
 
-        private void RunConvention(InternalForeignKeyBuilder relationshipBuilder, Navigation navigation)
+        private InternalForeignKeyBuilder RunForeignKeyAttributeConvention(
+            InternalForeignKeyBuilder relationshipBuilder, Navigation navigation)
+        {
+            var dependencies = CreateDependencies(CreateLogger());
+            var context = new ConventionContext<IConventionNavigationBuilder>(
+                relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
+
+            new ForeignKeyAttributeConvention(dependencies)
+                .ProcessNavigationAdded(navigation.Builder, context);
+
+            return context.ShouldStopProcessing()
+                ? (InternalForeignKeyBuilder)context.Result?.Metadata.ForeignKey.Builder
+                : relationshipBuilder;
+        }
+
+        private void RunRequiredNavigationAttributeConvention(InternalForeignKeyBuilder relationshipBuilder, Navigation navigation)
         {
             var dependencies = CreateDependencies(CreateLogger());
             var context = new ConventionContext<IConventionNavigationBuilder>(


### PR DESCRIPTION
Fixes #19670 

Update `ForeignKeyAttributeConvention` to also run when a new navigation is added.
