### PR TITLE
BackingFieldAttribute also works for Navigations.

### DIFF
--- a/src/EFCore.Abstractions/BackingFieldAttribute.cs
+++ b/src/EFCore.Abstractions/BackingFieldAttribute.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     Names the backing field associated with this property.
+    ///     Names the backing field associated with this property or navigation property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class BackingFieldAttribute : Attribute

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -185,6 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizedConventions.Add(new ValidatingConvention(Dependencies));
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
+            conventionSet.NavigationAddedConventions.Add(new NavigationBackingFieldAttributeConvention(Dependencies));
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(Dependencies));
             conventionSet.NavigationAddedConventions.Add(nonNullableNavigationConvention);
             conventionSet.NavigationAddedConventions.Add(inversePropertyAttributeConvention);

--- a/src/EFCore/Metadata/Conventions/NavigationBackingFieldAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/NavigationBackingFieldAttributeConvention.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures a navigation property as having a backing field
+    ///     based on the <see cref="BackingFieldAttribute"/> attribute.
+    /// </summary>
+    public class NavigationBackingFieldAttributeConvention : NavigationAttributeConventionBase<BackingFieldAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="NavigationBackingFieldAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public NavigationBackingFieldAttributeConvention([NotNull] ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after a navigation property that has an attribute is added to an entity type.
+        /// </summary>
+        /// <param name="navigationBuilder"> The builder for the navigation. </param>
+        /// <param name="attribute"> The attribute. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public override void ProcessNavigationAdded(
+            IConventionNavigationBuilder navigationBuilder,
+            BackingFieldAttribute attribute,
+            IConventionContext<IConventionNavigationBuilder> context)
+        {
+            navigationBuilder.HasField(attribute.Name, fromDataAnnotation: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #20471 

Update so the `BackingFieldAttribute` also works for navigation properties.