### PR TITLE
Cleanup and add documentation for IndentedStringBuilder

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/SqlUnaryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlUnaryExpression.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 
-            expressionPrinter.Append(OperatorType);
+            expressionPrinter.Append(OperatorType.ToString());
             expressionPrinter.Append("(");
             expressionPrinter.Visit(Operand);
             expressionPrinter.Append(")");

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -580,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             if (valuesList.Count == 0)
             {
                 builder
-                    .Append(' ')
+                    .Append(" ")
                     .Append(Reference(type))
                     .Append("[0]");
             }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             if (entityType.FindPrimaryKey() == null)
             {
-                _sb.AppendLine(new AttributeWriter(nameof(KeylessAttribute)));
+                _sb.AppendLine(new AttributeWriter(nameof(KeylessAttribute)).ToString());
             }
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     tableAttribute.AddParameter($"{nameof(TableAttribute.Schema)} = {_code.Literal(schema)}");
                 }
 
-                _sb.AppendLine(tableAttribute);
+                _sb.AppendLine(tableAttribute.ToString());
             }
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var key = property.FindContainingPrimaryKey();
             if (key != null)
             {
-                _sb.AppendLine(new AttributeWriter(nameof(KeyAttribute)));
+                _sb.AppendLine(new AttributeWriter(nameof(KeyAttribute)).ToString());
             }
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     columnAttribute.AddParameter($"{nameof(ColumnAttribute.TypeName)} = {delimitedColumnType}");
                 }
 
-                _sb.AppendLine(columnAttribute);
+                _sb.AppendLine(columnAttribute.ToString());
             }
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                 lengthAttribute.AddParameter(_code.Literal(maxLength.Value));
 
-                _sb.AppendLine(lengthAttribute);
+                _sb.AppendLine(lengthAttribute.ToString());
             }
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 && property.ClrType.IsNullableType()
                 && !property.IsPrimaryKey())
             {
-                _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)));
+                _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)).ToString());
             }
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
                     }
 
-                    _sb.AppendLine(foreignKeyAttribute);
+                    _sb.AppendLine(foreignKeyAttribute.ToString());
                 }
             }
         }
@@ -382,7 +382,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
                             : _code.Literal(inverseNavigation.Name));
 
-                    _sb.AppendLine(inversePropertyAttribute);
+                    _sb.AppendLine(inversePropertyAttribute.ToString());
                 }
             }
         }

--- a/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationCommandListBuilder.cs
@@ -65,11 +65,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
-        ///     Appends the given object (as a string) to the command being built.
+        ///     Appends the given string to the command being built.
         /// </summary>
-        /// <param name="o"> The object to append. </param>
+        /// <param name="o"> The string to append. </param>
         /// <returns> This builder so that additional calls can be chained. </returns>
-        public virtual MigrationCommandListBuilder Append([NotNull] object o)
+        public virtual MigrationCommandListBuilder Append([NotNull] string o)
         {
             Check.NotNull(o, nameof(o));
 
@@ -90,31 +90,31 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         /// <summary>
-        ///     Appends the given object (as a string) to the command being built, and then starts a new line.
+        ///     Appends the given string to the command being built, and then starts a new line.
         /// </summary>
-        /// <param name="o"> The object to append. </param>
+        /// <param name="value"> The string to append. </param>
         /// <returns> This builder so that additional calls can be chained. </returns>
-        public virtual MigrationCommandListBuilder AppendLine([NotNull] object o)
+        public virtual MigrationCommandListBuilder AppendLine([NotNull] string value)
         {
-            Check.NotNull(o, nameof(o));
+            Check.NotNull(value, nameof(value));
 
-            _commandBuilder.AppendLine(o);
+            _commandBuilder.AppendLine(value);
 
             return this;
         }
 
         /// <summary>
         ///     Appends the given object to the command being built as multiple lines of text. That is,
-        ///     each line in the passed object (as a string) is added as a line to the command being built.
+        ///     each line in the passed string is added as a line to the command being built.
         ///     This results in the lines having the correct indentation.
         /// </summary>
-        /// <param name="o"> The object to append. </param>
+        /// <param name="value"> The string to append. </param>
         /// <returns> This builder so that additional calls can be chained. </returns>
-        public virtual MigrationCommandListBuilder AppendLines([NotNull] object o)
+        public virtual MigrationCommandListBuilder AppendLines([NotNull] string value)
         {
-            Check.NotNull(o, nameof(o));
+            Check.NotNull(value, nameof(value));
 
-            _commandBuilder.AppendLines(o);
+            _commandBuilder.AppendLines(value);
 
             return this;
         }

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             }
             else
             {
-                expressionPrinter.Append(OperatorType);
+                expressionPrinter.Append(OperatorType.ToString());
                 expressionPrinter.Append("(");
                 expressionPrinter.Visit(Operand);
                 expressionPrinter.Append(")");

--- a/src/EFCore.Relational/Storage/IRelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommandBuilder.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="value"> The object to be written. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        IRelationalCommandBuilder Append([NotNull] object value);
+        IRelationalCommandBuilder Append([NotNull] string value);
 
         /// <summary>
         ///     Appends a blank line to the command text.

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilder.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="value"> The object to be written. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public virtual IRelationalCommandBuilder Append(object value)
+        public virtual IRelationalCommandBuilder Append(string value)
         {
             Check.NotNull(value, nameof(value));
 

--- a/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static IRelationalCommandBuilder AppendLine(
             [NotNull] this IRelationalCommandBuilder commandBuilder,
-            [NotNull] object value)
+            [NotNull] string value)
         {
             Check.NotNull(commandBuilder, nameof(commandBuilder));
             Check.NotNull(value, nameof(value));
@@ -45,13 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static IRelationalCommandBuilder AppendLines(
             [NotNull] this IRelationalCommandBuilder commandBuilder,
-            [NotNull] object value,
+            [NotNull] string value,
             bool skipFinalNewline = false)
         {
             Check.NotNull(commandBuilder, nameof(commandBuilder));
             Check.NotNull(value, nameof(value));
 
-            using (var reader = new StringReader(value.ToString()))
+            using (var reader = new StringReader(value))
             {
                 var first = true;
                 string line;

--- a/src/EFCore/Infrastructure/IndentedStringBuilder.cs
+++ b/src/EFCore/Infrastructure/IndentedStringBuilder.cs
@@ -8,6 +8,15 @@ using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
+    /// <summary>
+    ///     <para>
+    ///         A thin wrapper over <see cref="StringBuilder" /> that adds indentation to each line built.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
     public class IndentedStringBuilder
     {
         private const byte IndentSize = 4;
@@ -16,21 +25,29 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         private readonly StringBuilder _stringBuilder = new StringBuilder();
 
-        public IndentedStringBuilder()
-        {
-        }
-
+        /// <summary>
+        ///     The current length of the built string.
+        /// </summary>
         public virtual int Length => _stringBuilder.Length;
 
-        public virtual IndentedStringBuilder Append([NotNull] object o)
+        /// <summary>
+        ///     Appends an indent and then the given string to the string being built.
+        /// </summary>
+        /// <param name="value"> The string to append. </param>
+        /// <returns> This builder so that additional calls can be chained. </returns>
+        public virtual IndentedStringBuilder Append([NotNull] string value)
         {
             DoIndent();
 
-            _stringBuilder.Append(o);
+            _stringBuilder.Append(value);
 
             return this;
         }
 
+        /// <summary>
+        ///     Appends a new line to the string being built.
+        /// </summary>
+        /// <returns> This builder so that additional calls can be chained. </returns>
         public virtual IndentedStringBuilder AppendLine()
         {
             AppendLine(string.Empty);
@@ -38,10 +55,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             return this;
         }
 
-        public virtual IndentedStringBuilder AppendLine([NotNull] object o)
+        /// <summary>
+        ///     Appends an indent, the given string, and a new line to the string being built.
+        /// </summary>
+        /// <param name="value"> The string to append. </param>
+        /// <returns> This builder so that additional calls can be chained. </returns>
+        public virtual IndentedStringBuilder AppendLine([NotNull] string value)
         {
-            var value = o.ToString();
-
             if (value.Length != 0)
             {
                 DoIndent();
@@ -54,9 +74,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             return this;
         }
 
-        public virtual IndentedStringBuilder AppendLines([NotNull] object o, bool skipFinalNewline = false)
+        /// <summary>
+        ///     Appends all the lines in the given string, prefixed by the current indent.
+        /// </summary>
+        /// <param name="value"> The string to append. </param>
+        /// <param name="skipFinalNewline"> If true, then a terminating new line is not added. </param>
+        /// <returns> This builder so that additional calls can be chained. </returns>
+        public virtual IndentedStringBuilder AppendLines([NotNull] string value, bool skipFinalNewline = false)
         {
-            using (var reader = new StringReader(o.ToString()))
+            using (var reader = new StringReader(value))
             {
                 var first = true;
                 string line;
@@ -86,13 +112,22 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             return this;
         }
 
+        /// <summary>
+        ///     Resets this builder ready to build a new string.
+        /// </summary>
+        /// <returns> This builder so that additional calls can be chained. </returns>
         public virtual IndentedStringBuilder Clear()
         {
             _stringBuilder.Clear();
+            _indent = 0;
 
             return this;
         }
 
+        /// <summary>
+        ///     Increments the indent.
+        /// </summary>
+        /// <returns> This builder so that additional calls can be chained. </returns>
         public virtual IndentedStringBuilder IncrementIndent()
         {
             _indent++;
@@ -100,6 +135,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             return this;
         }
 
+        /// <summary>
+        ///     Decrements the indent.
+        /// </summary>
+        /// <returns> This builder so that additional calls can be chained. </returns>
         public virtual IndentedStringBuilder DecrementIndent()
         {
             if (_indent > 0)
@@ -110,8 +149,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             return this;
         }
 
+        /// <summary>
+        ///     Creates a scoped indenter that will increment the index, then decrement it when disposed.
+        /// </summary>
+        /// <returns> An indenter. </returns>
         public virtual IDisposable Indent() => new Indenter(this);
 
+        /// <summary>
+        ///     Returns the built string.
+        /// </summary>
+        /// <returns> The built string. </returns>
         public override string ToString() => _stringBuilder.ToString();
 
         private void DoIndent()

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -163,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             expressionPrinter.AppendLine(nameof(EntityShaperExpression) + ": ");
             using (expressionPrinter.Indent())
             {
-                expressionPrinter.AppendLine(EntityType);
+                expressionPrinter.AppendLine(EntityType.ToString());
                 expressionPrinter.AppendLine(nameof(ValueBufferExpression) + ": ");
                 using (expressionPrinter.Indent())
                 {
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
 
                 expressionPrinter.Append(nameof(IsNullable) + ": ");
-                expressionPrinter.AppendLine(IsNullable);
+                expressionPrinter.AppendLine(IsNullable.ToString());
             }
         }
     }

--- a/src/EFCore/Query/ExpressionPrinter.cs
+++ b/src/EFCore/Query/ExpressionPrinter.cs
@@ -81,37 +81,30 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        public virtual ExpressionPrinter Append([NotNull] object o)
-        {
-            _stringBuilder.Append(o);
-            return this;
-        }
-
         public virtual ExpressionPrinter AppendLine()
         {
             _stringBuilder.AppendLine();
             return this;
         }
 
-        public virtual ExpressionVisitor AppendLine([NotNull] object o)
+        public virtual ExpressionVisitor AppendLine([NotNull] string value)
         {
-            _stringBuilder.AppendLine(o);
+            _stringBuilder.AppendLine(value);
             return this;
         }
 
-        public virtual ExpressionPrinter AppendLines([NotNull] object o, bool skipFinalNewline = false)
+        public virtual ExpressionPrinter AppendLines([NotNull] string value, bool skipFinalNewline = false)
         {
-            _stringBuilder.AppendLines(o, skipFinalNewline);
+            _stringBuilder.AppendLines(value, skipFinalNewline);
             return this;
         }
 
         public virtual IDisposable Indent() => _stringBuilder.Indent();
 
-        private void Append(string message) => _stringBuilder.Append(message);
-
-        private void AppendLine(string message)
+        public virtual ExpressionPrinter Append([NotNull] string message)
         {
-            _stringBuilder.AppendLine(message);
+            _stringBuilder.Append(message);
+            return this;
         }
 
         public virtual string Print(
@@ -527,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             _stringBuilder.Append("new " + memberInitExpression.Type.ShortDisplayName());
 
-            var appendAction = memberInitExpression.Bindings.Count > 1 ? (Action<string>)AppendLine : Append;
+            var appendAction = memberInitExpression.Bindings.Count > 1 ? (Func<string, ExpressionVisitor>)AppendLine : Append;
             appendAction("{ ");
             using (_stringBuilder.Indent())
             {
@@ -615,7 +608,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 || methodArguments.Count < 2
                 || method.IsEFPropertyMethod();
 
-            var appendAction = isSimpleMethodOrProperty ? (Action<string>)Append : AppendLine;
+            var appendAction = isSimpleMethodOrProperty ? (Func<string, ExpressionVisitor>)Append : AppendLine;
 
             if (methodArguments.Count > 0)
             {
@@ -696,7 +689,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             _stringBuilder.Append("new ");
 
             var isComplex = newExpression.Arguments.Count > 1;
-            var appendAction = isComplex ? (Action<string>)AppendLine : Append;
+            var appendAction = isComplex ? (Func<string, ExpressionVisitor>)AppendLine : Append;
 
             var isAnonymousType = newExpression.Type.IsAnonymousType();
             if (!isAnonymousType)
@@ -748,7 +741,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(newArrayExpression, nameof(newArrayExpression));
 
             var isComplex = newArrayExpression.Expressions.Count > 1;
-            var appendAction = isComplex ? (Action<string>)AppendLine : Append;
+            var appendAction = isComplex ? (Func<string, ExpressionVisitor>)AppendLine : Append;
 
             appendAction("new " + newArrayExpression.Type.GetElementType().ShortDisplayName() + "[]");
             appendAction("{ ");
@@ -786,7 +779,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }
 
                     Append("namelessParameter{");
-                    Append(_namelessParameters.IndexOf(parameterExpression));
+                    Append(_namelessParameters.IndexOf(parameterExpression).ToString());
                     Append("}");
                 }
                 else if (parameterName.Contains("."))
@@ -915,7 +908,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Visit(indexExpression.Object);
             _stringBuilder.Append("[");
-            VisitArguments(indexExpression.Arguments, s => _stringBuilder.Append(s));
+            VisitArguments(indexExpression.Arguments, s =>
+            {
+                _stringBuilder.Append(s);
+                return null;
+            });
             _stringBuilder.Append("]");
 
             return indexExpression;
@@ -992,7 +989,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private void VisitArguments(
             IReadOnlyList<Expression> arguments,
-            Action<string> appendAction,
+            Func<string, ExpressionVisitor> appendAction,
             string lastSeparator = "",
             bool areConnected = false)
         {

--- a/src/EFCore/Query/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/ProjectionBindingExpression.cs
@@ -73,11 +73,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             expressionPrinter.Append(nameof(ProjectionBindingExpression) + ": ");
             if (ProjectionMember != null)
             {
-                expressionPrinter.Append(ProjectionMember);
+                expressionPrinter.Append(ProjectionMember.ToString());
             }
             else if (Index != null)
             {
-                expressionPrinter.Append(Index);
+                expressionPrinter.Append(Index.ToString());
             }
             else
             {

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     Instance.ToString(),
                     Parameters);
 
-            public IRelationalCommandBuilder Append(object value)
+            public IRelationalCommandBuilder Append(string value)
             {
                 Instance.Append(value);
 

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -221,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public IRelationalCommand Build() => new FakeRelationalCommand();
 
-            public IRelationalCommandBuilder Append(object value)
+            public IRelationalCommandBuilder Append(string value)
             {
                 Instance.Append(value);
 


### PR DESCRIPTION
Fixes #20383

Looked at making it pubternal or internal again, but it seems to be fundamental to the C# code generators in the design assembly. Considered moving it to design, but that would result in duplicate internal code other places. So just documented and cleaned up the surface--in particular, it only handles strings so that any possible locale-specific string conversions are forced to happen outside.
