### PR TITLE
Tweak slow-running test.

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -929,7 +929,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
                         .Maybe(x => x.OrderDetails)
-                        .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault()))); 
+                        .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault())));
         }
 
         [ConditionalTheory]
@@ -938,10 +938,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQueryScalar(
                 async,
-                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")).OrderBy(c => c.CustomerID).Select(
                     c => (int?)c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()
                         .ProductID),
-                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")).OrderBy(c => c.CustomerID).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
                         .Maybe(x => x.OrderDetails)
                         .MaybeScalar(x => x.OrderBy(od => od.ProductID).FirstOrDefault().ProductID)));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -629,6 +629,7 @@ ORDER BY [od].[ProductID]");
         ORDER BY [o1].[OrderID]) = [o].[OrderID])
     ORDER BY [o].[ProductID])
 FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A%'
 ORDER BY [c].[CustomerID]");
         }
 


### PR DESCRIPTION
This test was very slow against in-memory. Reduced the amount of data used without, hopefully, impacting the intent of the test. Results in 10 seconds faster total test run time on my machine.
