### PR TITLE
Add option for specifying stored/virtual on computed columns

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -186,6 +186,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .AppendLine(",")
                         .Append("computedColumnSql: ")
                         .Append(Code.Literal(operation.ComputedColumnSql));
+
+                    if (operation.ComputedColumnIsStored != null)
+                    {
+                        builder
+                            .AppendLine(",")
+                            .Append("computedColumnIsStored: ")
+                            .Append(Code.Literal(operation.ComputedColumnIsStored));
+                    }
                 }
                 else if (operation.DefaultValue != null)
                 {
@@ -552,6 +560,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .AppendLine(",")
                         .Append("computedColumnSql: ")
                         .Append(Code.Literal(operation.ComputedColumnSql));
+
+                    if (operation.ComputedColumnIsStored != null)
+                    {
+                        builder
+                            .AppendLine(",")
+                            .Append("computedColumnIsStored: ")
+                            .Append(Code.Literal(operation.ComputedColumnIsStored));
+                    }
                 }
                 else if (operation.DefaultValue != null)
                 {
@@ -653,6 +669,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .AppendLine(",")
                         .Append("oldComputedColumnSql: ")
                         .Append(Code.Literal(operation.OldColumn.ComputedColumnSql));
+
+                    if (operation.ComputedColumnIsStored != null)
+                    {
+                        builder
+                            .AppendLine(",")
+                            .Append("oldComputedColumnIsStored: ")
+                            .Append(Code.Literal(operation.OldColumn.ComputedColumnIsStored));
+                    }
                 }
                 else if (operation.OldColumn.DefaultValue != null)
                 {
@@ -1152,6 +1176,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             builder
                                 .Append(", computedColumnSql: ")
                                 .Append(Code.Literal(column.ComputedColumnSql));
+
+                            if (column.ComputedColumnIsStored != null)
+                            {
+                                builder
+                                    .Append(", computedColumnIsStored: ")
+                                    .Append(Code.Literal(column.ComputedColumnIsStored));
+                            }
                         }
                         else if (column.DefaultValue != null)
                         {

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -552,11 +552,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
                 stringBuilder);
 
-            GenerateFluentApiForAnnotation(
-                ref annotations,
-                RelationalAnnotationNames.ComputedColumnSql,
-                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
-                stringBuilder);
+            GenerateFluentApiForComputedColumn(ref annotations, stringBuilder);
 
             GenerateFluentApiForAnnotation(
                 ref annotations,
@@ -582,9 +578,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 nameof(PropertyBuilder.HasMaxLength),
                 stringBuilder);
 
-            GenerateFluentApiForPrecisionAndScale(
-                ref annotations,
-                stringBuilder);
+            GenerateFluentApiForPrecisionAndScale(ref annotations, stringBuilder);
 
             GenerateFluentApiForAnnotation(
                 ref annotations,
@@ -1352,6 +1346,47 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                 annotations.Remove(precisionAnnotation);
             }
+        }
+
+        /// <summary>
+        ///     Generates a Fluent API call for the computed column annotations.
+        /// </summary>
+        /// <param name="annotations"> The list of annotations. </param>
+        /// <param name="stringBuilder"> The builder code is added to. </param>
+        protected virtual void GenerateFluentApiForComputedColumn(
+            [NotNull] ref List<IAnnotation> annotations,
+            [NotNull] IndentedStringBuilder stringBuilder)
+        {
+            var sql = annotations
+                .FirstOrDefault(a => a.Name == RelationalAnnotationNames.ComputedColumnSql);
+
+            if (sql is null)
+            {
+                return;
+            }
+
+            stringBuilder
+                .AppendLine()
+                .Append(".")
+                .Append(nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql))
+                .Append("(")
+                .Append(Code.UnknownLiteral(sql.Value));
+
+            var isStored = annotations
+                .FirstOrDefault(a => a.Name == RelationalAnnotationNames.ComputedColumnIsStored);
+
+            if (isStored != null)
+            {
+                stringBuilder
+                    .Append(", ")
+                    .Append(Code.UnknownLiteral(isStored.Value));
+
+                annotations.Remove(isStored);
+            }
+
+            stringBuilder.Append(")");
+
+            annotations.Remove(sql);
         }
 
         /// <summary>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -643,6 +643,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.Comment);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.Collation);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.ComputedColumnSql);
+            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ComputedColumnIsStored);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.IsFixedLength);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.TableColumnMappings);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewColumnMappings);
@@ -742,7 +743,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 lines.Add(
                     $".{nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql)}" +
-                    $"({_code.Literal(property.GetComputedColumnSql())})");
+                    $"({_code.Literal(property.GetComputedColumnSql())}" +
+                    (property.GetComputedColumnIsStored() is bool computedColumnIsStored
+                        ? $", stored: {_code.Literal(computedColumnIsStored)})"
+                        : ")"));
             }
 
             if (property.GetComment() != null)

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -480,7 +480,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (column.ComputedColumnSql != null)
             {
-                property.HasComputedColumnSql(column.ComputedColumnSql);
+                property.HasComputedColumnSql(column.ComputedColumnSql, column.ComputedColumnIsStored);
             }
 
             if (column.Comment != null)

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -443,6 +443,67 @@ namespace Microsoft.EntityFrameworkCore
             => property.FindAnnotation(RelationalAnnotationNames.ComputedColumnSql)?.GetConfigurationSource();
 
         /// <summary>
+        ///     Gets whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns>
+        ///     Whether the value of the computed column this property is mapped to is stored in the database,
+        ///     or calculated when it is read.
+        /// </returns>
+        public static bool? GetComputedColumnIsStored([NotNull] this IProperty property)
+        {
+            var computedColumnIsStored = (bool?)property[RelationalAnnotationNames.ComputedColumnIsStored];
+            if (computedColumnIsStored != null)
+            {
+                return computedColumnIsStored;
+            }
+
+            var sharedTablePrincipalPrimaryKeyProperty = property.FindSharedRootPrimaryKeyProperty();
+            if (sharedTablePrincipalPrimaryKeyProperty != null)
+            {
+                return GetComputedColumnIsStored(sharedTablePrincipalPrimaryKeyProperty);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     Sets whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <param name="value"> The value to set. </param>
+        public static void SetComputedColumnIsStored([NotNull] this IMutableProperty property, bool? value)
+            => property.SetOrRemoveAnnotation(
+                RelationalAnnotationNames.ComputedColumnIsStored,
+                value);
+
+        /// <summary>
+        ///     Sets whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <param name="value"> The value to set. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The configured value. </returns>
+        public static bool? SetComputedColumnIsStored(
+            [NotNull] this IConventionProperty property, bool? value, bool fromDataAnnotation = false)
+        {
+            property.SetOrRemoveAnnotation(RelationalAnnotationNames.ComputedColumnIsStored, value, fromDataAnnotation);
+
+            return value;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="ConfigurationSource" /> for the computed value SQL expression.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The <see cref="ConfigurationSource" /> for the computed value SQL expression. </returns>
+        public static ConfigurationSource? GetComputedColumnIsStoredConfigurationSource([NotNull] this IConventionProperty property)
+            => property.FindAnnotation(RelationalAnnotationNames.ComputedColumnIsStored)?.GetConfigurationSource();
+
+        /// <summary>
         ///     Returns the object that is used as the default value for the column this property is mapped to.
         /// </summary>
         /// <param name="property"> The property. </param>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -489,6 +489,22 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         currentComputedColumnSql));
             }
 
+            var currentComputedColumnIsStored = property.GetComputedColumnIsStored();
+            var previousComputedColumnIsStored = duplicateProperty.GetComputedColumnIsStored();
+            if (currentComputedColumnIsStored != previousComputedColumnIsStored)
+            {
+                throw new InvalidOperationException(
+                    RelationalStrings.DuplicateColumnNameComputedIsStoredMismatch(
+                        duplicateProperty.DeclaringEntityType.DisplayName(),
+                        duplicateProperty.Name,
+                        property.DeclaringEntityType.DisplayName(),
+                        property.Name,
+                        columnName,
+                        tableName,
+                        previousComputedColumnIsStored,
+                        currentComputedColumnIsStored));
+            }
+
             var currentDefaultValue = property.GetDefaultValue();
             var previousDefaultValue = duplicateProperty.GetDefaultValue();
             if (!Equals(currentDefaultValue, previousDefaultValue))

--- a/src/EFCore.Relational/Metadata/IColumn.cs
+++ b/src/EFCore.Relational/Metadata/IColumn.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
@@ -82,6 +83,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Returns the SQL expression that is used as the computed value for this column.
         /// </summary>
         public virtual string ComputedColumnSql => PropertyMappings.First().Property.GetComputedColumnSql();
+
+        /// <summary>
+        ///     Returns whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        public virtual bool? ComputedColumnIsStored => PropertyMappings.First().Property.GetComputedColumnIsStored();
 
         /// <summary>
         ///     Comment for this column

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -42,6 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string ComputedColumnSql = Prefix + "ComputedColumnSql";
 
         /// <summary>
+        ///     The name for computed column type annotations.
+        /// </summary>
+        public const string ComputedColumnIsStored = Prefix + "ComputedColumnIsStored";
+
+        /// <summary>
         ///     The name for default value annotations.
         /// </summary>
         public const string DefaultValue = Prefix + "DefaultValue";

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -899,6 +899,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 && source.IsFixedLength() == target.IsFixedLength()
                 && source.GetConfiguredColumnType() == target.GetConfiguredColumnType()
                 && source.GetComputedColumnSql() == target.GetComputedColumnSql()
+                && source.GetComputedColumnIsStored() == target.GetComputedColumnIsStored()
                 && Equals(GetDefaultValue(source), GetDefaultValue(target))
                 && source.GetDefaultValueSql() == target.GetDefaultValueSql();
 
@@ -995,6 +996,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 || columnTypeChanged
                 || source.DefaultValueSql != target.DefaultValueSql
                 || source.ComputedColumnSql != target.ComputedColumnSql
+                || source.ComputedColumnIsStored != target.ComputedColumnIsStored
                 || !Equals(GetDefaultValue(sourceProperty, GetValueConverter(sourceProperty, sourceTypeMapping)),
                     GetDefaultValue(targetProperty, GetValueConverter(sourceProperty, targetTypeMapping)))
                 || source.Comment != target.Comment
@@ -1107,6 +1109,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             columnOperation.DefaultValueSql = column.DefaultValueSql;
             columnOperation.ComputedColumnSql = column.ComputedColumnSql;
+            columnOperation.ComputedColumnIsStored = column.ComputedColumnIsStored;
             columnOperation.Comment = column.Comment;
             columnOperation.Collation = column.Collation;
             columnOperation.AddAnnotations(migrationsAnnotations);

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -59,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="defaultValue"> The default value for the column. </param>
         /// <param name="defaultValueSql"> The SQL expression to use for the column's default constraint. </param>
         /// <param name="computedColumnSql"> The SQL expression to use to compute the column value. </param>
+        /// <param name="computedColumnIsStored"> Whether the value of the computed column is stored in the database or not. </param>
         /// <param name="fixedLength"> Indicates whether or not the column is constrained to fixed-length data. </param>
         /// <param name="comment"> A comment to associate with the column. </param>
         /// <param name="collation"> A collation to apply to the column. </param>
@@ -81,6 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] object defaultValue = null,
             [CanBeNull] string defaultValueSql = null,
             [CanBeNull] string computedColumnSql = null,
+            bool? computedColumnIsStored = null,
             bool? fixedLength = null,
             [CanBeNull] string comment = null,
             [CanBeNull] string collation = null,
@@ -104,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
                 ComputedColumnSql = computedColumnSql,
+                ComputedColumnIsStored = computedColumnIsStored,
                 IsFixedLength = fixedLength,
                 Comment = comment,
                 Collation = collation,
@@ -325,6 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="defaultValue"> The default value for the column. </param>
         /// <param name="defaultValueSql"> The SQL expression to use for the column's default constraint. </param>
         /// <param name="computedColumnSql"> The SQL expression to use to compute the column value. </param>
+        /// <param name="computedColumnIsStored"> Whether the value of the computed column is stored in the database or not. </param>
         /// <param name="oldClrType">
         ///     The CLR type that the column was previously mapped to. Can be <c>null</c>, in which case previous value is considered unknown.
         /// </param>
@@ -355,6 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="oldComputedColumnSql">
         ///     The previous SQL expression used to compute the column value. Can be <c>null</c>, in which case previous value is considered unknown.
         /// </param>
+        /// <param name="oldComputedColumnIsStored"> Whether the value of the previous computed column was stored in the database or not. </param>
         /// <param name="fixedLength"> Indicates whether or not the column is constrained to fixed-length data. </param>
         /// <param name="oldFixedLength"> Indicates whether or not the column was previously constrained to fixed-length data. </param>
         /// <param name="comment"> A comment to associate with the column. </param>
@@ -386,6 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] object defaultValue = null,
             [CanBeNull] string defaultValueSql = null,
             [CanBeNull] string computedColumnSql = null,
+            bool? computedColumnIsStored = null,
             [CanBeNull] Type oldClrType = null,
             [CanBeNull] string oldType = null,
             bool? oldUnicode = null,
@@ -395,6 +401,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] object oldDefaultValue = null,
             [CanBeNull] string oldDefaultValueSql = null,
             [CanBeNull] string oldComputedColumnSql = null,
+            bool? oldComputedColumnIsStored = null,
             bool? fixedLength = null,
             bool? oldFixedLength = null,
             [CanBeNull] string comment = null,
@@ -423,6 +430,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
                 ComputedColumnSql = computedColumnSql,
+                ComputedColumnIsStored = computedColumnIsStored,
                 IsFixedLength = fixedLength,
                 Comment = comment,
                 Collation = collation,
@@ -439,6 +447,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     DefaultValue = oldDefaultValue,
                     DefaultValueSql = oldDefaultValueSql,
                     ComputedColumnSql = oldComputedColumnSql,
+                    ComputedColumnIsStored = oldComputedColumnIsStored,
                     IsFixedLength = oldFixedLength,
                     Comment = oldComment,
                     Collation = oldCollation,

--- a/src/EFCore.Relational/Migrations/Operations/Builders/ColumnsBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/ColumnsBuilder.cs
@@ -43,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <param name="defaultValue"> The default value for the column. </param>
         /// <param name="defaultValueSql"> The SQL expression to use for the column's default constraint. </param>
         /// <param name="computedColumnSql"> The SQL expression to use to compute the column value. </param>
+        /// <param name="computedColumnIsStored"> Whether the value of the computed column is stored in the database or not. </param>
         /// <param name="fixedLength"> Indicates whether or not the column is constrained to fixed-length data. </param>
         /// <param name="comment"> A comment to be applied to the column. </param>
         /// <param name="collation"> A collation to be applied to the column. </param>
@@ -59,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
             [CanBeNull] object defaultValue = null,
             [CanBeNull] string defaultValueSql = null,
             [CanBeNull] string computedColumnSql = null,
+            bool? computedColumnIsStored = null,
             bool? fixedLength = null,
             [CanBeNull] string comment = null,
             [CanBeNull] string collation = null,
@@ -79,6 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
                 ComputedColumnSql = computedColumnSql,
+                ComputedColumnIsStored = computedColumnIsStored,
                 IsFixedLength = fixedLength,
                 Comment = comment,
                 Collation = collation,

--- a/src/EFCore.Relational/Migrations/Operations/ColumnOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/ColumnOperation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Operations
 {
@@ -81,7 +82,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string ComputedColumnSql { get; [param: CanBeNull] set; }
 
         /// <summary>
-        ///     Comment for this column.
+        ///     Whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        public virtual bool? ComputedColumnIsStored { get; set; }
+
+        /// <summary>
+        ///     Comment for this column
         /// </summary>
         public virtual string Comment { get; [param: CanBeNull] set; }
 

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -285,6 +285,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType1, property1, entityType2, property2, columnName, table, value1, value2);
 
         /// <summary>
+        ///     '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different stored computed column settings ('{value1}' and '{value2}').
+        /// </summary>
+        public static string DuplicateColumnNameComputedIsStoredMismatch([CanBeNull] object entityType1, [CanBeNull] object property1, [CanBeNull] object entityType2, [CanBeNull] object property2, [CanBeNull] object columnName, [CanBeNull] object table, [CanBeNull] object value1, [CanBeNull] object value2)
+            => string.Format(
+                GetString("DuplicateColumnNameComputedIsStoredMismatch", nameof(entityType1), nameof(property1), nameof(entityType2), nameof(property2), nameof(columnName), nameof(table), nameof(value1), nameof(value2)),
+                entityType1, property1, entityType2, property2, columnName, table, value1, value2);
+
+        /// <summary>
         ///     '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different default values ('{value1}' and '{value2}').
         /// </summary>
         public static string DuplicateColumnNameDefaultSqlMismatch([CanBeNull] object entityType1, [CanBeNull] object property1, [CanBeNull] object entityType2, [CanBeNull] object property2, [CanBeNull] object columnName, [CanBeNull] object table, [CanBeNull] object value1, [CanBeNull] object value2)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -353,6 +353,9 @@
   <data name="DuplicateColumnNameComputedSqlMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different computed values ('{value1}' and '{value2}').</value>
   </data>
+  <data name="DuplicateColumnNameComputedIsStoredMismatch" xml:space="preserve">
+    <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different stored computed column settings ('{value1}' and '{value2}').</value>
+  </data>
   <data name="DuplicateColumnNameDefaultSqlMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different default values ('{value1}' and '{value2}').</value>
   </data>

--- a/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
+++ b/src/EFCore.Relational/Scaffolding/Metadata/DatabaseColumn.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 #nullable enable
 
@@ -47,9 +48,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Metadata
         public virtual string? DefaultValueSql { get; [param: CanBeNull] set; }
 
         /// <summary>
-        ///     The SQL expression that computes the value of the column, or <c>null</c> if this is not a computed column.
+        ///     Whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
         /// </summary>
         public virtual string? ComputedColumnSql { get; [param: CanBeNull] set; }
+
+        /// <summary>
+        ///     Whether the value of the computed column this property is mapped to is stored in the database, or calculated when
+        ///     it is read.
+        /// </summary>
+        public virtual bool? ComputedColumnIsStored { get; set; }
 
         /// <summary>
         ///     The column comment, or <c>null</c> if none is set.

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -152,7 +152,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             bool nullable,
             bool identity,
             [CanBeNull] string defaultValue,
-            [CanBeNull] string computedValue)
+            [CanBeNull] string computedValue,
+            bool? computedValueIsStored)
         {
             var definition = SqlServerResources.LogFoundColumn(diagnostics);
 
@@ -174,7 +175,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                         nullable,
                         identity,
                         defaultValue,
-                        computedValue));
+                        computedValue,
+                        computedValueIsStored));
             }
 
             // No DiagnosticsSource events because these are purely design-time messages

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
@@ -243,6 +244,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     DefaultValue = operation.DefaultValue,
                     DefaultValueSql = operation.DefaultValueSql,
                     ComputedColumnSql = operation.ComputedColumnSql,
+                    ComputedColumnIsStored = operation.ComputedColumnIsStored,
                     IsFixedLength = operation.IsFixedLength
                 };
                 addColumnOperation.AddAnnotations(operation.GetAnnotations());
@@ -1411,6 +1413,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder
                 .Append(" AS ")
                 .Append(operation.ComputedColumnSql);
+
+            if (operation.ComputedColumnIsStored == true)
+            {
+                builder.Append(" PERSISTED");
+            }
 
             if (operation.Collation != null)
             {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -167,8 +167,8 @@
     <comment>Debug SqlServerEventId.TypeAliasFound string string</comment>
   </data>
   <data name="LogFoundColumn" xml:space="preserve">
-    <value>Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}</value>
-    <comment>Debug SqlServerEventId.ColumnFound string string int string int int int bool bool string string</comment>
+    <value>Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}, computed value is stored: {computedValueIsStored}</value>
+    <comment>Debug SqlServerEventId.ColumnFound string string int string int int int bool bool string string bool?</comment>
   </data>
   <data name="LogFoundForeignKey" xml:space="preserve">
     <value>Found foreign key on table: {tableName}, name: {foreignKeyName}, principal table: {principalTableName}, delete action: {deleteAction}.</value>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -13,6 +13,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -613,6 +614,7 @@ SELECT
     [c].[is_identity],
     [dc].[definition] AS [default_sql],
     [cc].[definition] AS [computed_sql],
+    [cc].[is_persisted] AS [computed_is_persisted],
     CAST([e].[value] AS nvarchar(MAX)) AS [comment],
     [c].[collation_name]
 FROM
@@ -673,6 +675,7 @@ ORDER BY [table_schema], [table_name], [c].[column_id]";
                     var isIdentity = dataRecord.GetValueOrDefault<bool>("is_identity");
                     var defaultValue = dataRecord.GetValueOrDefault<string>("default_sql");
                     var computedValue = dataRecord.GetValueOrDefault<string>("computed_sql");
+                    var computedIsPersisted = dataRecord.GetValueOrDefault<bool>("computed_is_persisted");
                     var comment = dataRecord.GetValueOrDefault<string>("comment");
                     var collation = dataRecord.GetValueOrDefault<string>("collation_name");
 
@@ -687,7 +690,8 @@ ORDER BY [table_schema], [table_name], [c].[column_id]";
                         nullable,
                         isIdentity,
                         defaultValue,
-                        computedValue);
+                        computedValue,
+                        computedIsPersisted);
 
                     string storeType;
                     string systemTypeName;
@@ -711,6 +715,7 @@ ORDER BY [table_schema], [table_name], [c].[column_id]";
                         IsNullable = nullable,
                         DefaultValueSql = defaultValue,
                         ComputedColumnSql = computedValue,
+                        ComputedColumnIsStored = computedIsPersisted,
                         Comment = comment,
                         Collation = collation == databaseCollation ? null : collation,
                         ValueGenerated = isIdentity

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -167,7 +167,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Name = "Id",
                     Table = "Post",
                     ClrType = typeof(int),
-                    ComputedColumnSql = "1"
+                    ComputedColumnSql = "1",
+                    ComputedColumnIsStored = true
                 },
                 "mb.AddColumn<int>("
                 + _eol
@@ -177,13 +178,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + _eol
                 + "    nullable: false,"
                 + _eol
-                + "    computedColumnSql: \"1\");",
+                + "    computedColumnSql: \"1\","
+                + _eol
+                + "    computedColumnIsStored: true);",
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
                     Assert.Equal(typeof(int), o.ClrType);
                     Assert.Equal("1", o.ComputedColumnSql);
+                    Assert.True(o.ComputedColumnIsStored);
                 });
         }
 
@@ -734,7 +738,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Name = "Id",
                     Table = "Post",
                     ClrType = typeof(int),
-                    ComputedColumnSql = "1"
+                    ComputedColumnSql = "1",
+                    ComputedColumnIsStored = true
                 },
                 "mb.AlterColumn<int>("
                 + _eol
@@ -744,12 +749,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + _eol
                 + "    nullable: false,"
                 + _eol
-                + "    computedColumnSql: \"1\");",
+                + "    computedColumnSql: \"1\","
+                + _eol
+                + "    computedColumnIsStored: true);",
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
                     Assert.Equal("1", o.ComputedColumnSql);
+                    Assert.True(o.ComputedColumnIsStored);
                     Assert.Equal(typeof(int), o.ClrType);
                     Assert.Null(o.ColumnType);
                     Assert.Null(o.IsUnicode);
@@ -771,6 +779,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Assert.Null(o.OldColumn.DefaultValue);
                     Assert.Null(o.OldColumn.DefaultValueSql);
                     Assert.Null(o.OldColumn.ComputedColumnSql);
+                    Assert.Null(o.OldColumn.ComputedColumnIsStored);
                 });
         }
 
@@ -1303,7 +1312,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             Name = "Id",
                             Table = "Post",
                             ClrType = typeof(int),
-                            ComputedColumnSql = "1"
+                            ComputedColumnSql = "1",
+                            ComputedColumnIsStored = true
                         }
                     }
                 },
@@ -1315,7 +1325,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + _eol
                 + "    {"
                 + _eol
-                + "        Id = table.Column<int>(nullable: false, computedColumnSql: \"1\")"
+                + "        Id = table.Column<int>(nullable: false, computedColumnSql: \"1\", computedColumnIsStored: true)"
                 + _eol
                 + "    },"
                 + _eol
@@ -1332,6 +1342,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Assert.Equal("Post", o.Columns[0].Table);
                     Assert.Equal(typeof(int), o.Columns[0].ClrType);
                     Assert.Equal("1", o.Columns[0].ComputedColumnSql);
+                    Assert.True(o.Columns[0].ComputedColumnIsStored);
                 });
         }
 

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -345,8 +345,11 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Contains("2", sumColumn.DefaultValueSql);
                 });
 
-        [ConditionalFact]
-        public virtual Task Add_column_with_computedSql()
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(null)]
+        public virtual Task Add_column_with_computedSql(bool? computedColumnStored)
             => Test(
                 builder => builder.Entity(
                     "People", e =>
@@ -356,13 +359,16 @@ namespace Microsoft.EntityFrameworkCore
                         e.Property<int>("Y");
                     }),
                 builder => { },
-                builder => builder.Entity("People").Property<string>("Sum").HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}"),
+                builder => builder.Entity("People").Property<string>("Sum")
+                    .HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}", computedColumnStored),
                 model =>
                 {
                     var table = Assert.Single(model.Tables);
                     var sumColumn = Assert.Single(table.Columns, c => c.Name == "Sum");
                     Assert.Contains("X", sumColumn.ComputedColumnSql);
                     Assert.Contains("Y", sumColumn.ComputedColumnSql);
+                    if (computedColumnStored != null)
+                        Assert.Equal(computedColumnStored, sumColumn.ComputedColumnIsStored);
                 });
 
         // TODO: Check this out
@@ -600,8 +606,11 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Contains(table.Columns.Single(c => c.Name == "LastName"), index.Columns);
                 });
 
-        [ConditionalFact]
-        public virtual Task Alter_column_make_computed()
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(null)]
+        public virtual Task Alter_column_make_computed(bool? computedColumnStored)
             => Test(
                 builder => builder.Entity(
                     "People", e =>
@@ -611,7 +620,8 @@ namespace Microsoft.EntityFrameworkCore
                         e.Property<int>("Y");
                     }),
                 builder => builder.Entity("People").Property<int>("Sum"),
-                builder => builder.Entity("People").Property<int>("Sum").HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}"),
+                builder => builder.Entity("People").Property<int>("Sum")
+                    .HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}", computedColumnStored),
                 model =>
                 {
                     var table = Assert.Single(model.Tables);
@@ -619,6 +629,8 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Contains("X", sumColumn.ComputedColumnSql);
                     Assert.Contains("Y", sumColumn.ComputedColumnSql);
                     Assert.Contains("+", sumColumn.ComputedColumnSql);
+                    if (computedColumnStored != null)
+                        Assert.Equal(computedColumnStored, sumColumn.ComputedColumnIsStored);
                 });
 
         [ConditionalFact]
@@ -642,6 +654,28 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Contains("Y", sumColumn.ComputedColumnSql);
                     Assert.Contains("-", sumColumn.ComputedColumnSql);
                 });
+
+        [ConditionalFact]
+        public virtual Task Alter_column_change_computed_type()
+            => Test(
+                builder => builder.Entity(
+                    "People", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("X");
+                            e.Property<int>("Y");
+                            e.Property<int>("Sum");
+                        }),
+                builder => builder.Entity("People").Property<int>("Sum")
+                    .HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}", stored: false),
+                builder => builder.Entity("People").Property<int>("Sum")
+                    .HasComputedColumnSql($"{DelimitIdentifier("X")} + {DelimitIdentifier("Y")}", stored: true),
+                model =>
+                    {
+                        var table = Assert.Single(model.Tables);
+                        var sumColumn = Assert.Single(table.Columns, c => c.Name == "Sum");
+                        Assert.True(sumColumn.ComputedColumnIsStored);
+                    });
 
         [ConditionalFact]
         public virtual Task Alter_column_add_comment()

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -328,12 +328,14 @@ EXEC(N'ALTER SCHEMA [' + @defaultSchema + N'] TRANSFER [TestTableSchema].[TestTa
                 @"ALTER TABLE [People] ADD [Sum] int NOT NULL DEFAULT (1 + 2);");
         }
 
-        public override async Task Add_column_with_computedSql()
+        public override async Task Add_column_with_computedSql(bool? computedColumnStored)
         {
-            await base.Add_column_with_computedSql();
+            await base.Add_column_with_computedSql(computedColumnStored);
+
+            var computedColumnTypeSql = computedColumnStored == true ? " PERSISTED" : "";
 
             AssertSql(
-                @"ALTER TABLE [People] ADD [Sum] AS [X] + [Y];");
+                @$"ALTER TABLE [People] ADD [Sum] AS [X] + [Y]{computedColumnTypeSql};");
         }
 
         public override async Task Add_column_with_required()
@@ -513,20 +515,21 @@ ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NOT NULL;
 CREATE INDEX [IX_People_FirstName_LastName] ON [People] ([FirstName], [LastName]);");
         }
 
-        [ConditionalFact]
-        public override async Task Alter_column_make_computed()
+        public override async Task Alter_column_make_computed(bool? computedColumnStored)
         {
-            await base.Alter_column_make_computed();
+            await base.Alter_column_make_computed(computedColumnStored);
+
+            var computedColumnTypeSql = computedColumnStored == true ? " PERSISTED" : "";
 
             AssertSql(
-                @"DECLARE @var0 sysname;
+                $@"DECLARE @var0 sysname;
 SELECT @var0 = [d].[name]
 FROM [sys].[default_constraints] [d]
 INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
 WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Sum');
 IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
 ALTER TABLE [People] DROP COLUMN [Sum];
-ALTER TABLE [People] ADD [Sum] AS [X] + [Y];");
+ALTER TABLE [People] ADD [Sum] AS [X] + [Y]{computedColumnTypeSql};");
         }
 
         public override async Task Alter_column_change_computed()
@@ -542,6 +545,21 @@ WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Sum');
 IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
 ALTER TABLE [People] DROP COLUMN [Sum];
 ALTER TABLE [People] ADD [Sum] AS [X] - [Y];");
+        }
+
+        public override async Task Alter_column_change_computed_type()
+        {
+            await base.Alter_column_change_computed_type();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Sum');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] DROP COLUMN [Sum];
+ALTER TABLE [People] ADD [Sum] AS [X] + [Y] PERSISTED;");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -1334,7 +1334,8 @@ CREATE TABLE DefaultComputedValues (
     ComputedValue AS GETDATE(),
     A int NOT NULL,
     B int NOT NULL,
-    SumOfAAndB AS A + B PERSISTED,
+    SumOfAAndB AS A + B,
+    SumOfAAndBPersisted AS A + B PERSISTED,
 );",
                 Enumerable.Empty<string>(),
                 Enumerable.Empty<string>(),
@@ -1342,14 +1343,23 @@ CREATE TABLE DefaultComputedValues (
                 {
                     var columns = dbModel.Tables.Single().Columns;
 
-                    Assert.Equal("('October 20, 2015 11am')", columns.Single(c => c.Name == "FixedDefaultValue").DefaultValueSql);
-                    Assert.Null(columns.Single(c => c.Name == "FixedDefaultValue").ComputedColumnSql);
+                    var fixedDefaultValue = columns.Single(c => c.Name == "FixedDefaultValue");
+                    Assert.Equal("('October 20, 2015 11am')", fixedDefaultValue.DefaultValueSql);
+                    Assert.Null(fixedDefaultValue.ComputedColumnSql);
 
-                    Assert.Null(columns.Single(c => c.Name == "ComputedValue").DefaultValueSql);
-                    Assert.Equal("(getdate())", columns.Single(c => c.Name == "ComputedValue").ComputedColumnSql);
+                    var computedValue = columns.Single(c => c.Name == "ComputedValue");
+                    Assert.Null(computedValue.DefaultValueSql);
+                    Assert.Equal("(getdate())", computedValue.ComputedColumnSql);
 
-                    Assert.Null(columns.Single(c => c.Name == "SumOfAAndB").DefaultValueSql);
-                    Assert.Equal("([A]+[B])", columns.Single(c => c.Name == "SumOfAAndB").ComputedColumnSql);
+                    var sumOfAAndB = columns.Single(c => c.Name == "SumOfAAndB");
+                    Assert.Null(sumOfAAndB.DefaultValueSql);
+                    Assert.Equal("([A]+[B])", sumOfAAndB.ComputedColumnSql);
+                    Assert.False(sumOfAAndB.ComputedColumnIsStored);
+
+                    var sumOfAAndBPersisted = columns.Single(c => c.Name == "SumOfAAndBPersisted");
+                    Assert.Null(sumOfAAndBPersisted.DefaultValueSql);
+                    Assert.Equal("([A]+[B])", sumOfAAndBPersisted.ComputedColumnSql);
+                    Assert.True(sumOfAAndBPersisted.ComputedColumnIsStored);
                 },
                 "DROP TABLE DefaultComputedValues;");
         }

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -212,8 +212,10 @@ be found in the docs.";
             Assert.Contains("Cannot add a column with non-constant default", ex.Message);
         }
 
-        public override Task Add_column_with_computedSql()
-            => AssertNotSupportedAsync(base.Add_column_with_computedSql, SqliteStrings.ComputedColumnsNotSupported);
+        public override Task Add_column_with_computedSql(bool? computedColumnStored)
+            => AssertNotSupportedAsync(
+                () => base.Add_column_with_computedSql(computedColumnStored),
+                SqliteStrings.ComputedColumnsNotSupported);
 
         public override async Task Add_column_with_max_length()
         {
@@ -272,10 +274,15 @@ be found in the docs.";
             => AssertNotSupportedAsync(
                 base.Alter_column_make_required_with_composite_index, SqliteStrings.InvalidMigrationOperation("AlterColumnOperation"));
 
-        public override Task Alter_column_make_computed()
-            => AssertNotSupportedAsync(base.Alter_column_make_computed, SqliteStrings.InvalidMigrationOperation("AlterColumnOperation"));
+        public override Task Alter_column_make_computed(bool? computedColumnStored)
+            => AssertNotSupportedAsync(
+                () => base.Alter_column_make_computed(computedColumnStored),
+                SqliteStrings.InvalidMigrationOperation("AlterColumnOperation"));
 
         public override Task Alter_column_change_computed()
+            => AssertNotSupportedAsync(base.Alter_column_change_computed, SqliteStrings.ComputedColumnsNotSupported);
+
+        public override Task Alter_column_change_computed_type()
             => AssertNotSupportedAsync(base.Alter_column_change_computed, SqliteStrings.ComputedColumnsNotSupported);
 
         public override Task Alter_column_add_comment()


### PR DESCRIPTION
Closes #6682

# Cross-database situation

| Database   | Stored name | Virtual name                  | Default                                  | Docs |
|------------|-------------|-------------------------------|------------------------------------------|------|
| SQL Server | PERSISTED   | &lt;empty&gt;                 | &lt;empty&gt; (virtual)                  | https://docs.microsoft.com/en-us/sql/relational-databases/tables/ |specify-computed-columns-in-a-table?view=sql-server-ver15
| Sqlite     | STORED      | VIRTUAL                       | VIRTUAL                                  | https://www.sqlite.org/gencol.html |
| PostgreSQL | STORED      | VIRTUAL (not yet implemented) | None, STORED must currently be specified | https://www.postgresql.org/docs/12/ddl-generated-columns.html |
| MySQL      | STORED      | VIRTUAL                       | VIRTUAL                                  | https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html |

# Notes

* tl;dr everyone calls it STORED except for SQL Server (surprise) which calls it PERSISTED. So I chose STORED as our naming.
* This currently introduces a new `ComputedColumnIsStored` annotation alongside `ComputedColumnSql`. @AndriySvyryd I know you prefer to merge annotations where possible for perf, but I'm hesitant to encode both SQL and other info in the same annotation string. We can change the annotation format to `<IsStored>,<SQL>` and identify old annotations not starting with true/false and a comma, but since SQL is arbitrary SQL it seems a bit dangerous.
* If we keep two annotations, what should be the behavior of HasComputedColumnSql accepting IConventionPropertyBuilder? Should we have two separate ones - one for the SQL annotation and another for the IsStored - or one which checks both and only updates if both are settable? Or each one if it's settable?
* Note that this introduces a binary break by adding a default argument to HasComputedColumnSql (but recompiling is OK). If we want to avoid this we can add an overload instead.
* Instead of a `stored` bool we could have a ComputedColumnType enum (Stored/Virtual), but this seems needless verbose/heavy.