### PR TITLE
Fix for 20406. Do not output unnecessary decimal warning

### DIFF
--- a/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
@@ -74,15 +74,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                     p => p.ClrType.UnwrapNullableType() == typeof(decimal)
                         && !p.IsForeignKey()))
             {
+                var valueConverterConfigurationSource = (property as IConventionProperty)?.GetValueConverterConfigurationSource();
+                var valueConverterProviderType = property.GetValueConverter()?.ProviderClrType;
+                if (!ConfigurationSource.Convention.Overrides(valueConverterConfigurationSource)
+                    && typeof(decimal) != valueConverterProviderType)
+                {
+                    continue;
+                }
+
                 var columnTypeConfigurationSource = (property as IConventionProperty)?.GetColumnTypeConfigurationSource();
                 var typeMappingConfigurationSource = (property as IConventionProperty)?.GetTypeMappingConfigurationSource();
-                var valueConverterConfigurationSource = (property as IConventionProperty)?.GetValueConverterConfigurationSource();
                 if ((columnTypeConfigurationSource == null
-                        && ConfigurationSource.Convention.Overrides(typeMappingConfigurationSource)
-                        && ConfigurationSource.Convention.Overrides(valueConverterConfigurationSource))
+                        && ConfigurationSource.Convention.Overrides(typeMappingConfigurationSource))
                     || (columnTypeConfigurationSource != null
-                        && ConfigurationSource.Convention.Overrides(columnTypeConfigurationSource)
-                        && ConfigurationSource.Convention.Overrides(valueConverterConfigurationSource)))
+                        && ConfigurationSource.Convention.Overrides(columnTypeConfigurationSource)))
                 {
                     logger.DecimalTypeDefaultWarning(property);
                 }

--- a/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerModelValidator.cs
@@ -74,12 +74,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                     p => p.ClrType.UnwrapNullableType() == typeof(decimal)
                         && !p.IsForeignKey()))
             {
-                var typeConfigurationSource = (property as IConventionProperty)?.GetColumnTypeConfigurationSource();
+                var columnTypeConfigurationSource = (property as IConventionProperty)?.GetColumnTypeConfigurationSource();
                 var typeMappingConfigurationSource = (property as IConventionProperty)?.GetTypeMappingConfigurationSource();
-                if ((typeConfigurationSource == null
-                        && ConfigurationSource.Convention.Overrides(typeMappingConfigurationSource))
-                    || (typeConfigurationSource != null
-                        && ConfigurationSource.Convention.Overrides(typeConfigurationSource)))
+                var valueConverterConfigurationSource = (property as IConventionProperty)?.GetValueConverterConfigurationSource();
+                if ((columnTypeConfigurationSource == null
+                        && ConfigurationSource.Convention.Overrides(typeMappingConfigurationSource)
+                        && ConfigurationSource.Convention.Overrides(valueConverterConfigurationSource))
+                    || (columnTypeConfigurationSource != null
+                        && ConfigurationSource.Convention.Overrides(columnTypeConfigurationSource)
+                        && ConfigurationSource.Convention.Overrides(valueConverterConfigurationSource)))
                 {
                     logger.DecimalTypeDefaultWarning(property);
                 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.SqlServer.Properties.SqlServerStrings", typeof(SqlServerResources).Assembly);
 
         /// <summary>
-        ///     No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
+        ///     No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()' or specify a ValueConverter.
         /// </summary>
         public static EventDefinition<string, string> LogDefaultDecimalTypeColumn([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -142,7 +142,7 @@
     <value>An exception has been raised that is likely due to a transient failure. Consider enabling transient error resiliency by adding 'EnableRetryOnFailure()' to the 'UseSqlServer' call.</value>
   </data>
   <data name="LogDefaultDecimalTypeColumn" xml:space="preserve">
-    <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.</value>
+    <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()' or specify a ValueConverter.</value>
     <comment>Warning SqlServerEventId.DecimalTypeDefaultWarning string string</comment>
   </data>
   <data name="LogByteIdentityColumn" xml:space="preserve">

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -1160,6 +1160,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             }
         }
 
+        public class TestDecimalToDecimalConverter : ValueConverter<decimal, decimal>
+        {
+            private static readonly Expression<Func<decimal, decimal>> convertToProviderExpression = d => d * 100m;
+            private static readonly Expression<Func<decimal, decimal>> convertFromProviderExpression = l => l / 100m;
+
+            public TestDecimalToDecimalConverter()
+                : base(convertToProviderExpression, convertFromProviderExpression)
+            {
+            }
+        }
+
         protected override TestHelpers TestHelpers => RelationalTestHelpers.Instance;
     }
 }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
@@ -11,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -1145,6 +1147,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         protected class Employee : Person
         {
+        }
+
+        public class TestDecimalToLongConverter : ValueConverter<decimal, long>
+        {
+            private static readonly Expression<Func<decimal, long>> convertToProviderExpression = d => (long)(d*100);
+            private static readonly Expression<Func<long, decimal>> convertFromProviderExpression = l => l / 100m;
+
+            public TestDecimalToLongConverter()
+                : base(convertToProviderExpression, convertFromProviderExpression)
+            {
+            }
         }
 
         protected override TestHelpers TestHelpers => RelationalTestHelpers.Instance;

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -370,6 +370,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
+        public virtual void Does_not_warn_if_default_decimal_mapping_has_value_converter()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Animal>()
+                .Property<decimal>("Price")
+                .HasConversion(new TestDecimalToLongConverter());
+
+            VerifyLogDoesNotContain(
+                SqlServerResources.LogDefaultDecimalTypeColumn(new TestLogger<SqlServerLoggingDefinitions>())
+                    .GenerateMessage("Price", nameof(Animal)), modelBuilder.Model);
+        }
+
+        [ConditionalFact]
         public void Detects_byte_identity_column()
         {
             var modelBuilder = CreateConventionalModelBuilder();

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -370,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
-        public virtual void Does_not_warn_if_default_decimal_mapping_has_value_converter()
+        public virtual void Does_not_warn_if_default_decimal_mapping_has_non_decimal_to_decimal_value_converter()
         {
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Animal>()
@@ -378,6 +378,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .HasConversion(new TestDecimalToLongConverter());
 
             VerifyLogDoesNotContain(
+                SqlServerResources.LogDefaultDecimalTypeColumn(new TestLogger<SqlServerLoggingDefinitions>())
+                    .GenerateMessage("Price", nameof(Animal)), modelBuilder.Model);
+        }
+
+        [ConditionalFact]
+        public virtual void Warn_if_default_decimal_mapping_has_decimal_to_decimal_value_converter()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Animal>()
+                .Property<decimal>("Price")
+                .HasConversion(new TestDecimalToDecimalConverter());
+
+            VerifyWarning(
                 SqlServerResources.LogDefaultDecimalTypeColumn(new TestLogger<SqlServerLoggingDefinitions>())
                     .GenerateMessage("Price", nameof(Animal)), modelBuilder.Model);
         }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -275,6 +275,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             Assert.Equal(expectedMessage, message);
         }
 
+        protected virtual void VerifyLogDoesNotContain(string expectedMessage, IMutableModel model)
+        {
+            Validate(model);
+
+            var logEntries = LoggerFactory.Log.Where(l => l.Message.Contains(expectedMessage));
+
+            Assert.Empty(logEntries);
+        }
+
         protected virtual IModel Validate(IMutableModel model) => model.FinalizeModel();
 
         protected DiagnosticsLogger<DbLoggerCategory.Model.Validation> CreateValidationLogger(bool sensitiveDataLoggingEnabled = false)


### PR DESCRIPTION
Do not output the SQL Server decimal warning if the user has specified a value converter.

Fixes #20406 