### PR TITLE
I need a crystal ball

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -451,7 +451,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 case MaterializeCollectionNavigationExpression materializeCollectionNavigationExpression:
-                    return materializeCollectionNavigationExpression.Navigation.IsEmbedded()
+                    return materializeCollectionNavigationExpression.Navigation is INavigation embeddableNavigation
+                        && embeddableNavigation.IsEmbedded()
                         ? base.Visit(materializeCollectionNavigationExpression.Subquery)
                         : base.VisitExtension(materializeCollectionNavigationExpression);
 
@@ -461,12 +462,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         return null;
                     }
 
-                    if (!includeExpression.Navigation.IsEmbedded())
+                    if (!(includeExpression.Navigation is INavigation includableNavigation
+                        && includableNavigation.IsEmbedded()))
                     {
                         throw new InvalidOperationException(CosmosStrings.NonEmbeddedIncludeNotSupported(includeExpression.Print()));
                     }
 
-                    _includedNavigations.Push(includeExpression.Navigation);
+                    _includedNavigations.Push(includableNavigation);
 
                     var newIncludeExpression = base.VisitExtension(includeExpression);
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 : Expression.Convert(expression, convertTo);
 
         private CollectionShaperExpression AddCollectionProjection(
-            ShapedQueryExpression subquery, INavigation navigation, Type elementType)
+            ShapedQueryExpression subquery, INavigationBase navigation, Type elementType)
             => new CollectionShaperExpression(
                 new ProjectionBindingExpression(
                     _queryExpression,

--- a/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             [CanBeNull] IReadOnlyList<ValueComparer> outerIdentifierValueComparers,
             [CanBeNull] IReadOnlyList<ValueComparer> selfIdentifierValueComparers,
             [NotNull] Expression innerShaper,
-            [CanBeNull] INavigation navigation,
+            [CanBeNull] INavigationBase navigation,
             [NotNull] Type elementType)
         {
             Check.NotNull(parentIdentifier, nameof(parentIdentifier));
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///    The navigation if associated with the collection.
         /// </summary>
-        public virtual INavigation Navigation { get; }
+        public virtual INavigationBase Navigation { get; }
         /// <summary>
         ///     The clr type of elements of the collection.
         /// </summary>

--- a/src/EFCore.Relational/Query/RelationalSplitCollectionShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalSplitCollectionShaperExpression.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IReadOnlyList<ValueComparer> identifierValueComparers,
             [NotNull] SelectExpression selectExpression,
             [NotNull] Expression innerShaper,
-            [CanBeNull] INavigation navigation,
+            [CanBeNull] INavigationBase navigation,
             [NotNull] Type elementType)
         {
             Check.NotNull(parentIdentifier, nameof(parentIdentifier));
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///    The navigation if associated with the collection.
         /// </summary>
-        public virtual INavigation Navigation { get; }
+        public virtual INavigationBase Navigation { get; }
         /// <summary>
         ///     The clr type of elements of the collection.
         /// </summary>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// <returns> A <see cref="CollectionShaperExpression"/> which represents shaping of this collection. </returns>
         public CollectionShaperExpression AddCollectionProjection(
             [NotNull] ShapedQueryExpression shapedQueryExpression,
-            [CanBeNull] INavigation navigation,
+            [CanBeNull] INavigationBase navigation,
             [CanBeNull] Type elementType)
         {
             Check.NotNull(shapedQueryExpression, nameof(shapedQueryExpression));
@@ -1110,7 +1110,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             int collectionIndex,
             int collectionId,
             [NotNull] Expression innerShaper,
-            [CanBeNull] INavigation navigation,
+            [CanBeNull] INavigationBase navigation,
             [NotNull] Type elementType,
             bool splitQuery = false)
         {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1659,7 +1659,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void SetIsLoaded([NotNull] INavigation navigation, bool loaded = true)
+        public virtual void SetIsLoaded([NotNull] INavigationBase navigation, bool loaded = true)
         {
             if (!loaded
                 && !navigation.IsCollection

--- a/src/EFCore/Extensions/NavigationExtensions.cs
+++ b/src/EFCore/Extensions/NavigationExtensions.cs
@@ -80,33 +80,6 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Calls <see cref="ILazyLoader.SetLoaded"/> for a <see cref="INavigation"/> to mark it as loaded
-        ///         when a no-tracking query has eagerly loaded this relationship.
-        ///     </para>
-        ///     <para>
-        ///         This method is not exposed as a normal extension method since it is typically used by database providers.
-        ///         It is generally not used in application code.
-        ///     </para>
-        /// </summary>
-        /// <param name="navigation"> The navigation loaded. </param>
-        /// <param name="entity"> The entity for which the navigation has been loaded. </param>
-        public static void SetIsLoadedWhenNoTracking([NotNull] INavigation navigation, [NotNull] object entity)
-        {
-            var serviceProperties = navigation
-                .DeclaringEntityType
-                .GetDerivedTypesInclusive()
-                .Where(t => t.ClrType.IsInstanceOfType(entity))
-                .SelectMany(e => e.GetServiceProperties())
-                .Where(p => p.ClrType == typeof(ILazyLoader));
-
-            foreach (var serviceProperty in serviceProperties)
-            {
-                ((ILazyLoader)serviceProperty.GetGetter().GetClrValue(entity))?.SetLoaded(entity, navigation.Name);
-            }
-        }
-
-        /// <summary>
-        ///     <para>
         ///         Creates a human-readable representation of the given metadata.
         ///     </para>
         ///     <para>

--- a/src/EFCore/Infrastructure/NavigationBaseExtensions.cs
+++ b/src/EFCore/Infrastructure/NavigationBaseExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     <para>
+    ///         Extension methods for <see cref="INavigationBase" />.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public static class NavigationBaseExtensions
+    {
+        /// <summary>
+        ///     Calls <see cref="ILazyLoader.SetLoaded"/> for a <see cref="INavigationBase"/> to mark it as loaded
+        ///     when a no-tracking query has eagerly loaded this relationship.
+        /// </summary>
+        /// <param name="navigation"> The navigation loaded. </param>
+        /// <param name="entity"> The entity for which the navigation has been loaded. </param>
+        public static void SetIsLoadedWhenNoTracking([NotNull] this INavigationBase navigation, [NotNull] object entity)
+        {
+            Check.NotNull(navigation, nameof(navigation));
+            Check.NotNull(entity, nameof(entity));
+
+            var serviceProperties = navigation
+                .DeclaringEntityType
+                .GetDerivedTypesInclusive()
+                .Where(t => t.ClrType.IsInstanceOfType(entity))
+                .SelectMany(e => e.GetServiceProperties())
+                .Where(p => p.ClrType == typeof(ILazyLoader));
+
+            foreach (var serviceProperty in serviceProperties)
+            {
+                ((ILazyLoader)serviceProperty.GetGetter().GetClrValue(entity))?.SetLoaded(entity, navigation.Name);
+            }
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -373,6 +373,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static IEnumerable<SkipNavigation> GetDerivedSkipNavigations([NotNull] this IEntityType entityType)
+            => entityType.AsEntityType().GetDerivedSkipNavigations();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations(
             [NotNull] this IEntityType entityType)
             => entityType.GetProperties().Concat<IPropertyBase>(entityType.GetNavigations());

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2477,12 +2477,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("InvalidTypeConversationWithInclude");
 
         /// <summary>
-        ///     Invalid expression type stored in NavigationMap.
-        /// </summary>
-        public static string InvalidExpressionTypeStoredInNavigationMap
-            => GetString("InvalidExpressionTypeStoredInNavigationMap");
-
-        /// <summary>
         ///     The Include path '{navigationName}-&gt;{inverseNavigationName}' results in a cycle. Cycles are not allowed in no-tracking queries. Either use a tracking query or remove the cycle.
         /// </summary>
         public static string IncludeWithCycle([CanBeNull] object navigationName, [CanBeNull] object inverseNavigationName)
@@ -2523,7 +2517,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("OwnedEntitiesCannotBeTrackedWithoutTheirOwner");
 
         /// <summary>
-        ///     Calling {visitMethodName} is not allowed. Visit expression manually for relevant part.
+        ///     Calling '{visitMethodName}' is not allowed. Visit expression manually for relevant part.
         /// </summary>
         public static string VisitIsNotAllowed([CanBeNull] object visitMethodName)
             => string.Format(
@@ -2705,6 +2699,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("UnnamedIndexDefinedOnNonExistentProperty", nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
                 entityType, indexPropertyList, propertyName);
+
+        /// <summary>
+        ///     Unhandled 'INavigationBase' of type '{type}'.
+        /// </summary>
+        public static string UnhandledNavigationBase([CanBeNull] object type)
+            => string.Format(
+                GetString("UnhandledNavigationBase", nameof(type)),
+                type);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1317,9 +1317,6 @@
   <data name="InvalidTypeConversationWithInclude" xml:space="preserve">
     <value>Invalid type conversion when specifying include.</value>
   </data>
-  <data name="InvalidExpressionTypeStoredInNavigationMap" xml:space="preserve">
-    <value>Invalid expression type stored in NavigationMap.</value>
-  </data>
   <data name="IncludeWithCycle" xml:space="preserve">
     <value>The Include path '{navigationName}-&gt;{inverseNavigationName}' results in a cycle. Cycles are not allowed in no-tracking queries. Either use a tracking query or remove the cycle.</value>
   </data>
@@ -1339,7 +1336,7 @@
     <value>A tracking query projects owned entity without corresponding owner in result. Owned entities cannot be tracked without their owner. Either include the owner entity in the result or make query non-tracking using AsNoTracking().</value>
   </data>
   <data name="VisitIsNotAllowed" xml:space="preserve">
-    <value>Calling {visitMethodName} is not allowed. Visit expression manually for relevant part.</value>
+    <value>Calling '{visitMethodName}' is not allowed. Visit expression manually for relevant part.</value>
   </data>
   <data name="EntityProjectionExpressionCalledWithIncorrectInterface" xml:space="preserve">
     <value>Called EntityProjectionExpression.{methodName}() with incorrect {interfaceType}. EntityType:{entityType}, {entityValue}</value>
@@ -1420,5 +1417,8 @@
   </data>
   <data name="UnnamedIndexDefinedOnNonExistentProperty" xml:space="preserve">
     <value>An unnamed index on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.</value>
+  </data>
+  <data name="UnhandledNavigationBase" xml:space="preserve">
+    <value>Unhandled 'INavigationBase' of type '{type}'.</value>
   </data>
 </root>

--- a/src/EFCore/Query/CollectionShaperExpression.cs
+++ b/src/EFCore/Query/CollectionShaperExpression.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public CollectionShaperExpression(
             [NotNull] Expression projection,
             [NotNull] Expression innerShaper,
-            [CanBeNull] INavigation navigation,
+            [CanBeNull] INavigationBase navigation,
             [CanBeNull] Type elementType)
         {
             Check.NotNull(projection, nameof(projection));
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///    The navigation if associated with the collection.
         /// </summary>
-        public virtual INavigation Navigation { get; }
+        public virtual INavigationBase Navigation { get; }
         /// <summary>
         ///     The clr type of elements of the collection.
         /// </summary>

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IncludeExpression(
             [NotNull] Expression entityExpression,
             [NotNull] Expression navigationExpression,
-            [NotNull] INavigation navigation)
+            [NotNull] INavigationBase navigation)
         {
             Check.NotNull(entityExpression, nameof(entityExpression));
             Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     The navigation associated with this include operation.
         /// </summary>
-        public virtual INavigation Navigation { get; }
+        public virtual INavigationBase Navigation { get; }
 
         /// <inheritdoc />
         public sealed override ExpressionType NodeType => ExpressionType.Extension;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public IEntityType EntityType { get; }
-            public IDictionary<INavigation, Expression> NavigationMap { get; } = new Dictionary<INavigation, Expression>();
+            public IDictionary<(IForeignKey, bool), Expression> ForeignKeyExpansionMap { get; } = new Dictionary<(IForeignKey, bool), Expression>();
 
             public bool IsOptional { get; private set; }
             public IncludeTreeNode IncludePaths { get; private set; }
@@ -38,16 +38,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return this;
             }
 
-            public void SetIncludePaths(IncludeTreeNode includePaths)
-            {
-                IncludePaths = includePaths;
-                includePaths.SetEntityReference(this);
-            }
-
-            public EntityReference Clone()
+            public EntityReference Snapshot()
             {
                 var result = new EntityReference(EntityType) { IsOptional = IsOptional };
-                result.IncludePaths = IncludePaths.Clone(result);
+                result.IncludePaths = IncludePaths.Snapshot(result);
 
                 return result;
             }
@@ -80,11 +74,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// <summary>
         ///     A tree structure of includes for a given entity type in <see cref="EntityReference"/>.
         /// </summary>
-        private sealed class IncludeTreeNode : Dictionary<INavigation, IncludeTreeNode>
+        private sealed class IncludeTreeNode : Dictionary<INavigationBase, IncludeTreeNode>
         {
             private EntityReference _entityReference;
 
-            public LambdaExpression FilterExpression { get; set; }
+            public IncludeTreeNode(IEntityType entityType)
+            {
+                EntityType = entityType;
+            }
 
             public IncludeTreeNode(IEntityType entityType, EntityReference entityReference)
             {
@@ -92,51 +89,72 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _entityReference = entityReference;
             }
 
-            public IEntityType EntityType { get; private set; }
+            public IEntityType EntityType { get; }
+            public LambdaExpression FilterExpression { get; private set; }
 
-            public IncludeTreeNode AddNavigation(INavigation navigation)
+            public IncludeTreeNode AddNavigation(INavigationBase navigation)
             {
                 if (TryGetValue(navigation, out var existingValue))
                 {
                     return existingValue;
                 }
 
-                if (_entityReference != null
-                    && _entityReference.NavigationMap.TryGetValue(navigation, out var expandedNavigation))
+                IncludeTreeNode nodeToAdd = null;
+                if (_entityReference != null)
                 {
-                    var entityReference = expandedNavigation switch
+                    if (navigation is INavigation concreteNavigation
+                        && _entityReference.ForeignKeyExpansionMap.TryGetValue(
+                            (concreteNavigation.ForeignKey, concreteNavigation.IsOnDependent), out var expansion))
                     {
-                        NavigationTreeExpression navigationTree => (EntityReference)navigationTree.Value,
-                        OwnedNavigationReference ownedNavigationReference => ownedNavigationReference.EntityReference,
-                        _ => throw new InvalidOperationException(CoreStrings.InvalidExpressionTypeStoredInNavigationMap),
-                    };
+                        nodeToAdd = UnwrapEntityReference(expansion).IncludePaths;
+                    }
+                    else if (navigation is ISkipNavigation skipNavigation
+                        && _entityReference.ForeignKeyExpansionMap.TryGetValue(
+                            (skipNavigation.ForeignKey, skipNavigation.IsOnDependent), out var firstExpansion)
+                        && UnwrapEntityReference(firstExpansion).ForeignKeyExpansionMap.TryGetValue(
+                            (skipNavigation.Inverse.ForeignKey, !skipNavigation.Inverse.IsOnDependent), out var secondExpansion))
+                    {
+                        nodeToAdd = UnwrapEntityReference(secondExpansion).IncludePaths;
+                    }
+                }
 
-                    this[navigation] = entityReference.IncludePaths;
-                }
-                else
+                if (nodeToAdd == null)
                 {
-                    this[navigation] = new IncludeTreeNode(navigation.TargetEntityType, null);
+                    nodeToAdd = new IncludeTreeNode(navigation.TargetEntityType, null);
                 }
+
+                this[navigation] = nodeToAdd;
 
                 return this[navigation];
             }
 
-            public void SetEntityReference(EntityReference entityReference)
+            public IncludeTreeNode Snapshot(EntityReference entityReference)
             {
-                _entityReference = entityReference;
-                EntityType = entityReference.EntityType;
-            }
+                var result = new IncludeTreeNode(EntityType, entityReference)
+                {
+                    FilterExpression = FilterExpression
+                };
 
-            public IncludeTreeNode Clone(EntityReference entityReference)
-            {
-                var result = new IncludeTreeNode(EntityType, entityReference);
                 foreach (var kvp in this)
                 {
-                    result[kvp.Key] = kvp.Value.Clone(kvp.Value._entityReference);
+                    result[kvp.Key] = kvp.Value.Snapshot(null);
                 }
 
                 return result;
             }
+
+            public void Merge(IncludeTreeNode includeTreeNode)
+            {
+                // EntityReference is intentionally ignored
+                FilterExpression = includeTreeNode.FilterExpression;
+                foreach (var item in includeTreeNode)
+                {
+                    AddNavigation(item.Key).Merge(item.Value);
+                }
+            }
+
+            public void AssignEntityReference(EntityReference entityReference) => _entityReference = entityReference;
+            public void ApplyFilter(LambdaExpression filterExpression) => FilterExpression = filterExpression;
 
             public override bool Equals(object obj)
                 => obj != null

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -666,7 +666,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     newEntityReference.MarkAsOptional();
                 }
 
-                newEntityReference.SetIncludePaths(entityReference.IncludePaths);
+                newEntityReference.IncludePaths.Merge(entityReference.IncludePaths);
 
                 // Prune includes for sibling types
                 var siblingNavigations = newEntityReference.IncludePaths.Keys
@@ -858,7 +858,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     FormatFilter(lastIncludeTree.FilterExpression.Body).Print()));
                         }
 
-                        lastIncludeTree.FilterExpression = filterExpression;
+                        lastIncludeTree.ApplyFilter(filterExpression);
                     }
 
                     entityReference.SetLastInclude(lastIncludeTree);
@@ -1597,7 +1597,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private LambdaExpression ProcessLambdaExpression(NavigationExpansionExpression source, LambdaExpression lambdaExpression)
             => GenerateLambda(ExpandNavigationsForSource(source, RemapLambdaExpression(source, lambdaExpression)), source.CurrentParameter);
 
-        private static IEnumerable<INavigation> FindNavigations(IEntityType entityType, string navigationName)
+        private static IEnumerable<INavigationBase> FindNavigations(IEntityType entityType, string navigationName)
         {
             var navigation = entityType.FindNavigation(navigationName);
             if (navigation != null)
@@ -1610,6 +1610,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     .Select(et => et.FindDeclaredNavigation(navigationName)).Where(n => n != null))
                 {
                     yield return derivedNavigation;
+                }
+            }
+
+            var skipNavigation = entityType.FindSkipNavigation(navigationName);
+            if (skipNavigation != null)
+            {
+                yield return skipNavigation;
+            }
+            else
+            {
+                foreach (var derivedSkipNavigation in entityType.GetDerivedTypes()
+                    .Select(et => et.FindDeclaredSkipNavigation(navigationName)).Where(n => n != null))
+                {
+                    yield return derivedSkipNavigation;
                 }
             }
         }
@@ -1662,7 +1676,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var entityType = includeTreeNode.EntityType;
             var outboundNavigations
                 = entityType.GetNavigations()
+                    .Cast<INavigationBase>()
+                    .Concat(entityType.GetSkipNavigations())
                     .Concat(entityType.GetDerivedNavigations())
+                    .Concat(entityType.GetDerivedSkipNavigations())
                     .Where(n => n.IsEagerLoaded);
 
             foreach (var navigation in outboundNavigations)
@@ -1704,6 +1721,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         return addedNode;
                     }
 
+                    var skipNavigation = entityType.FindSkipNavigation(memberExpression.Member);
+                    if (skipNavigation != null)
+                    {
+                        var addedNode = innerIncludeTreeNode.AddNavigation(skipNavigation);
+
+                        // This is to add eager Loaded navigations when owner type is included.
+                        PopulateEagerLoadedNavigations(addedNode);
+
+                        return addedNode;
+                    }
+
                     break;
             }
 
@@ -1717,7 +1745,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             switch (selector)
             {
                 case EntityReference entityReference:
-                    return entityReference.Clone();
+                    return entityReference.Snapshot();
 
                 case NavigationTreeExpression navigationTreeExpression:
                     return SnapshotExpression(navigationTreeExpression.Value);
@@ -1738,7 +1766,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
 
                 case OwnedNavigationReference ownedNavigationReference:
-                    return ownedNavigationReference.EntityReference.Clone();
+                    return ownedNavigationReference.EntityReference.Snapshot();
 
                 default:
                     return Expression.Default(selector.Type);

--- a/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="subquery"> An expression reprensenting how to get value from query to create the collection. </param>
         /// <param name="navigation"> A navigation associated with this collection. </param>
-        public MaterializeCollectionNavigationExpression([NotNull] Expression subquery, [NotNull] INavigation navigation)
+        public MaterializeCollectionNavigationExpression([NotNull] Expression subquery, [NotNull] INavigationBase navigation)
         {
             Check.NotNull(subquery, nameof(subquery));
             Check.NotNull(navigation, nameof(navigation));
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     The navigation associated with this collection.
         /// </summary>
-        public virtual INavigation Navigation { get; }
+        public virtual INavigationBase Navigation { get; }
 
         /// <inheritdoc />
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             expressionPrinter.AppendLine("MaterializeCollectionNavigation(");
             using (expressionPrinter.Indent())
             {
-                expressionPrinter.AppendLine($"navigation: Navigation: {Navigation.DeclaringEntityType.DisplayName()}.{Navigation.Name},");
+                expressionPrinter.AppendLine($"Navigation: {Navigation.DeclaringEntityType.DisplayName()}.{Navigation.Name},");
                 expressionPrinter.Append("subquery: ");
                 expressionPrinter.Visit(Subquery);
             }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="entity"> The entity instance. </param>
         /// <param name="navigation"> The navigation property. </param>
-        public virtual void SetNavigationIsLoaded([NotNull] object entity, [NotNull] INavigation navigation)
+        public virtual void SetNavigationIsLoaded([NotNull] object entity, [NotNull] INavigationBase navigation)
         {
             Check.NotNull(entity, nameof(entity));
             Check.NotNull(navigation, nameof(navigation));

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyQueryRelationalTestBase.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -14,6 +19,263 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         protected virtual bool CanExecuteQueryString => false;
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.RootSkipShared).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<EntityCompositeKey>(et => et.RootSkipShared)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_reference_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip).ThenInclude(e => e.Reference).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityTwo>(et => et.OneSkip),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkip")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_include_skip_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.LeafSkipFull).ThenInclude(e => e.OneSkip).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityCompositeKey>(et => et.LeafSkipFull),
+                    new ExpectedInclude<EntityLeaf>(et => et.OneSkip, "LeafSkipFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_include_reference_and_skip_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.Reference)
+                    .Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.SelfSkipPayloadRight).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityThree>(et => et.OneSkipPayloadFull),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkipPayloadFull"),
+                    new ExpectedInclude<EntityOne>(et => et.SelfSkipPayloadRight, "OneSkipPayloadFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_and_reference_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkipShared).Include(e => e.Reference).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityTwo>(et => et.OneSkipShared),
+                    new ExpectedInclude<EntityTwo>(et => et.Reference)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFullShared.Where(i => i.Id < 10)).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(
+                        et => et.OneSkipPayloadFullShared, includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.TwoSkipFull.OrderBy(i => i.Id)).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityTwo>(
+                        et => et.TwoSkipFull, includeFilter: x => x.OrderBy(i => i.Id))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.SelfSkipSharedRight.OrderBy(i => i.Id).Skip(2)).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityTwo>(
+                        et => et.SelfSkipSharedRight, includeFilter: x => x.OrderBy(i => i.Id).Skip(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_take_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.TwoSkipShared.OrderBy(i => i.Id).Take(2)).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityTwo>(
+                        et => et.TwoSkipShared, includeFilter: x => x.OrderBy(i => i.Id).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2)).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityThree>(
+                        et => et.ThreeSkipFull, includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_then_include_skip_navigation_where_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityRoot>().Include(e => e.ThreeSkipShared)
+                    .ThenInclude(e => e.OneSkipPayloadFullShared.Where(i => i.Id < 10))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityRoot>(et => et.ThreeSkipShared),
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(
+                        et => et.OneSkipPayloadFullShared, "ThreeSkipShared", includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityRoot>().Include(e => e.CompositeKeySkipShared)
+                    .ThenInclude(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityRoot>(et => et.CompositeKeySkipShared),
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityThree>(
+                        et => et.ThreeSkipFull, "CompositeKeySkipShared", includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityLeaf>().Include(e => e.CompositeKeySkipFull.Where(i => i.Key1 < 5))
+                    .ThenInclude(e => e.TwoSkipShared).AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityLeaf, EntityCompositeKey>(
+                        et => et.CompositeKeySkipFull, includeFilter: x => x.Where(i => i.Key1 < 5)),
+                    new ExpectedInclude<EntityCompositeKey>(et => et.TwoSkipShared, "CompositeKeySkipFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.TwoSkip.OrderBy(i => i.Id).Skip(1).Take(2))
+                    .ThenInclude(e => e.ThreeSkipFull.Where(i => i.Id < 10))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(
+                        et => et.TwoSkip, includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(
+                        et => et.ThreeSkipFull, "TwoSkip", includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.TwoSkip.Where(i => i.Id < 10))
+                    .ThenInclude(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(
+                        et => et.TwoSkip, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(
+                        et => et.ThreeSkipFull, "TwoSkip", includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filter_include_on_skip_navigation_combined_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip.Where(i => i.Id < 10)).ThenInclude(e => e.Reference)
+                    .Include(e => e.OneSkip).ThenInclude(e => e.Collection)
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityOne>(et => et.OneSkip, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkip"),
+                    new ExpectedInclude<EntityOne>(et => et.Collection, "OneSkip")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>()
+                    .Include(e => e.OneSkipPayloadFull.Where(i => i.Id < 10))
+                        .ThenInclude(e => e.TwoSkip.OrderBy(e => e.Id).Skip(1).Take(2))
+                    .Include(e => e.OneSkipPayloadFull)
+                        .ThenInclude(e => e.BranchSkip.Where(e => e.Id < 20))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(et => et.OneSkipPayloadFull, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.TwoSkip, "OneSkipPayloadFull", includeFilter: x => x.OrderBy(e => e.Id).Skip(1).Take(2)),
+                    new ExpectedFilteredInclude<EntityOne, EntityBranch>(et => et.BranchSkip, "OneSkipPayloadFull", includeFilter: x => x.Where(e => e.Id < 20))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip.Where(i => i.Id > 15))
+                    .ThenInclude(e => e.Collection.Where(i => i.Id < 5))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityOne>(et => et.OneSkip, includeFilter: x => x.Where(i => i.Id > 15)),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.Collection, "OneSkip", includeFilter: x => x.Where(i => i.Id < 5))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation_split(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.Collection.Where(i => i.Id > 15))
+                    .ThenInclude(e => e.ThreeSkipFull.Where(i => i.Id < 5))
+                    .AsSplitQuery(),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.Collection, includeFilter: x => x.Where(i => i.Id > 15)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(et => et.ThreeSkipFull, "Collection", includeFilter: x => x.Where(i => i.Id < 5))));
+        }
 
         protected override QueryAsserter CreateQueryAsserter(TFixture fixture)
             => new RelationalQueryAsserter(fixture, RewriteExpectedQueryExpression, RewriteServerQueryExpression, canExecuteQueryString: CanExecuteQueryString);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1503,13 +1503,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 CoreStrings.TranslationFailed(
                     @"MaterializeCollectionNavigation(
-    navigation: Navigation: Gear.Weapons,
+    Navigation: Gear.Weapons,
     subquery: DbSet<Weapon>()
         .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
         .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))
     .AsQueryable()
     .Concat(MaterializeCollectionNavigation(
-        navigation: Navigation: Gear.Weapons,
+        Navigation: Gear.Weapons,
         subquery: DbSet<Weapon>()
             .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
             .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))"),
@@ -1528,13 +1528,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 CoreStrings.TranslationFailed(
                     @"MaterializeCollectionNavigation(
-    navigation: Navigation: Gear.Weapons,
+    Navigation: Gear.Weapons,
     subquery: DbSet<Weapon>()
         .Where(w => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w, ""OwnerFullName""))
         .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName""))
     .AsQueryable()
     .Union(MaterializeCollectionNavigation(
-        navigation: Navigation: Gear.Weapons,
+        Navigation: Gear.Weapons,
         subquery: DbSet<Weapon>()
             .Where(w0 => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(w0, ""OwnerFullName""))
             .Where(i => EF.Property<string>(g, ""FullName"") != null && EF.Property<string>(g, ""FullName"") == EF.Property<string>(i, ""OwnerFullName"")))"),

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -18,12 +21,725 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Can_use_skip_navigation_in_predicate(bool async)
+        public virtual Task Skip_navigation_all(bool async)
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<EntityOne>().Where(e => e.JoinThreePayloadFull.Select(e => e.Three).Count() > 1));
+                ss => ss.Set<EntityOne>().Where(e => e.TwoSkip.All(e => e.Name.Contains("B"))));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_any_without_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Where(e => e.ThreeSkipPayloadFull.Where(e => e.Name.Contains("B")).Any()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_any_with_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Where(e => e.TwoSkipShared.Any(e => e.Name.Contains("B"))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_contains(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Where(e => e.ThreeSkipPayloadFullShared.Contains(new EntityThree { Id = 1 })),
+                ss => ss.Set<EntityOne>().Where(e => e.ThreeSkipPayloadFullShared.Select(i => i.Id).Contains(1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_count_without_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Where(e => e.SelfSkipPayloadLeft.Count > 0));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_count_with_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().OrderBy(e => e.BranchSkip.Count(e => e.Name.StartsWith("L")))
+                    .ThenBy(e => e.Id),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_long_count_without_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Where(e => e.ThreeSkipFull.LongCount() > 0));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_long_count_with_predicate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().OrderByDescending(e => e.SelfSkipSharedLeft.LongCount(e => e.Name.StartsWith("L"))),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_many_average(bool async)
+        {
+            return AssertAverage(
+                async,
+                ss => ss.Set<EntityTwo>().SelectMany(e => e.CompositeKeySkipShared.Select(e => e.Key1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_many_max(bool async)
+        {
+            return AssertMax(
+                async,
+                ss => ss.Set<EntityThree>().SelectMany(e => e.CompositeKeySkipFull.Select(e => e.Key1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_many_min(bool async)
+        {
+            return AssertMin(
+                async,
+                ss => ss.Set<EntityThree>().SelectMany(e => e.RootSkipShared.Select(e => e.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_many_sum(bool async)
+        {
+            return AssertSum(
+                async,
+                ss => ss.Set<EntityRoot>().SelectMany(e => e.CompositeKeySkipShared.Select(e => e.Key1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_subquery_average(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<EntityLeaf>().Select(e => e.CompositeKeySkipFull.Average(e => e.Key1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_subquery_max(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<EntityTwo>().Select(e => e.OneSkip.Max(e => e.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_subquery_min(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<EntityThree>().Select(e => e.OneSkipPayloadFull.Min(e => e.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_select_subquery_sum(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<EntityTwo>().Select(e => e.OneSkipShared.Sum(e => e.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_order_by_first_or_default(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Select(e => e.OneSkipPayloadFullShared.OrderBy(i => i.Id).FirstOrDefault()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_order_by_single_or_default(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Select(e => e.SelfSkipPayloadRight.OrderBy(i => i.Id).Take(1).SingleOrDefault()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_order_by_last_or_default(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityBranch>().Select(e => e.OneSkip.OrderBy(i => i.Id).LastOrDefault()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_order_by_reverse_first_or_default(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Select(e => e.TwoSkipFull.OrderBy(i => i.Id).Reverse().FirstOrDefault()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_cast(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().OrderBy(e => e.Key1).Select(e => e.LeafSkipFull.Cast<EntityRoot>()),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_navigation_of_type(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().OrderBy(e => e.Key1).Select(e => e.RootSkipShared.OfType<EntityLeaf>()),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Join_with_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from t in ss.Set<EntityTwo>()
+                      join s in ss.Set<EntityTwo>()
+                        on t.Id equals s.SelfSkipSharedRight.FirstOrDefault().Id
+                      select new { t, s },
+                elementSorter: e => (e.t.Id, e.s.Id),
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.t, a.t);
+                    AssertEqual(e.s, a.s);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Left_join_with_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from t in ss.Set<EntityCompositeKey>()
+                      join s in ss.Set<EntityCompositeKey>()
+                        on t.TwoSkipShared.FirstOrDefault().Id equals s.ThreeSkipFull.FirstOrDefault().Id into grouping
+                      from s in grouping.DefaultIfEmpty()
+                      orderby t.Key1, s.Key1
+                      select new { t, s },
+                ss => from t in ss.Set<EntityCompositeKey>()
+                      join s in ss.Set<EntityCompositeKey>()
+                        on t.TwoSkipShared.FirstOrDefault().MaybeScalar(e => e.Id) equals s.ThreeSkipFull.FirstOrDefault().MaybeScalar(e => e.Id) into grouping
+                      from s in grouping.DefaultIfEmpty()
+                      orderby t.MaybeScalar(e => e.Key1), s.MaybeScalar(e => e.Key1)
+                      select new { t, s },
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.t, a.t);
+                    AssertEqual(e.s, a.s);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityRoot>()
+                      from t in r.ThreeSkipShared
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_where(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.TwoSkip.DefaultIfEmpty()
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_order_by_skip(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.ThreeSkipPayloadFull.OrderBy(e => e.Id).Skip(2)
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_order_by_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.TwoSkipShared.OrderBy(e => e.Id).Take(2)
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_order_by_skip_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.ThreeSkipPayloadFullShared.OrderBy(e => e.Id).Skip(2).Take(3)
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_of_type(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityThree>()
+                      from t in r.RootSkipShared.OfType<EntityBranch>()
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_cast(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.BranchSkip.Cast<EntityRoot>()
+                      select t);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      orderby r.Id
+                      select r.SelfSkipPayloadLeft,
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_skip_navigation_multiple(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityTwo>()
+                      orderby r.Id
+                      select new
+                      {
+                          r.ThreeSkipFull,
+                          r.SelfSkipSharedLeft,
+                          r.CompositeKeySkipShared
+                      },
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e.ThreeSkipFull, a.ThreeSkipFull);
+                    AssertCollection(e.SelfSkipSharedLeft, a.SelfSkipSharedLeft);
+                    AssertCollection(e.CompositeKeySkipShared, a.CompositeKeySkipShared);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_skip_navigation_first_or_default(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityThree>()
+                      orderby r.Id
+                      select r.CompositeKeySkipFull.FirstOrDefault(),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.RootSkipShared),
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<EntityCompositeKey>(et => et.RootSkipShared)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_reference(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip).ThenInclude(e => e.Reference),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityTwo>(et => et.OneSkip),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkip")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_include_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.LeafSkipFull).ThenInclude(e => e.OneSkip),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityCompositeKey>(et => et.LeafSkipFull),
+                    new ExpectedInclude<EntityLeaf>(et => et.OneSkip, "LeafSkipFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.Reference)
+                    .Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.SelfSkipPayloadRight),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityThree>(et => et.OneSkipPayloadFull),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkipPayloadFull"),
+                    new ExpectedInclude<EntityOne>(et => et.SelfSkipPayloadRight, "OneSkipPayloadFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_skip_navigation_and_reference(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkipShared).Include(e => e.Reference),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityTwo>(et => et.OneSkipShared),
+                    new ExpectedInclude<EntityTwo>(et => et.Reference)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
+        {
+            Assert.Equal(
+                CoreStrings.IncludeWithCycle(nameof(EntityThree.OneSkipPayloadFullShared), nameof(EntityOne.ThreeSkipPayloadFullShared)),
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        async,
+                        ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFullShared).ThenInclude(e => e.ThreeSkipPayloadFullShared),
+                        elementAsserter: (e, a) => AssertInclude(e, a,
+                            new ExpectedInclude<EntityThree>(et => et.OneSkipPayloadFullShared),
+                            new ExpectedInclude<EntityOne>(et => et.ThreeSkipPayloadFullShared, "OneSkipPayloadFullShared"))))).Message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFullShared.Where(i => i.Id < 10)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(
+                        et => et.OneSkipPayloadFullShared, includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.TwoSkipFull.OrderBy(i => i.Id)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityTwo>(
+                        et => et.TwoSkipFull, includeFilter: x => x.OrderBy(i => i.Id))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.SelfSkipSharedRight.OrderBy(i => i.Id).Skip(2)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityTwo>(
+                        et => et.SelfSkipSharedRight, includeFilter: x => x.OrderBy(i => i.Id).Skip(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.TwoSkipShared.OrderBy(i => i.Id).Take(2)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityTwo>(
+                        et => et.TwoSkipShared, includeFilter: x => x.OrderBy(i => i.Id).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityCompositeKey>().Include(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityThree>(
+                        et => et.ThreeSkipFull, includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_then_include_skip_navigation_where(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityRoot>().Include(e => e.ThreeSkipShared).ThenInclude(e => e.OneSkipPayloadFullShared.Where(i => i.Id < 10)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityRoot>(et => et.ThreeSkipShared),
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(
+                        et => et.OneSkipPayloadFullShared, "ThreeSkipShared", includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityRoot>().Include(e => e.CompositeKeySkipShared).ThenInclude(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityRoot>(et => et.CompositeKeySkipShared),
+                    new ExpectedFilteredInclude<EntityCompositeKey, EntityThree>(
+                        et => et.ThreeSkipFull, "CompositeKeySkipShared", includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityLeaf>().Include(e => e.CompositeKeySkipFull.Where(i => i.Key1 < 5)).ThenInclude(e => e.TwoSkipShared),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityLeaf, EntityCompositeKey>(
+                        et => et.CompositeKeySkipFull, includeFilter: x => x.Where(i => i.Key1 < 5)),
+                    new ExpectedInclude<EntityCompositeKey>(et => et.TwoSkipShared, "CompositeKeySkipFull")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.TwoSkip.OrderBy(i => i.Id).Skip(1).Take(2))
+                    .ThenInclude(e => e.ThreeSkipFull.Where(i => i.Id < 10)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(
+                        et => et.TwoSkip, includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(
+                        et => et.ThreeSkipFull, "TwoSkip", includeFilter: x => x.Where(i => i.Id < 10))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.TwoSkip.Where(i => i.Id < 10))
+                    .ThenInclude(e => e.ThreeSkipFull.OrderBy(i => i.Id).Skip(1).Take(2)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(
+                        et => et.TwoSkip, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(
+                        et => et.ThreeSkipFull, "TwoSkip", includeFilter: x => x.OrderBy(i => i.Id).Skip(1).Take(2))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filter_include_on_skip_navigation_combined(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip.Where(i => i.Id < 10)).ThenInclude(e => e.Reference)
+                    .Include(e => e.OneSkip).ThenInclude(e => e.Collection),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityOne>(et => et.OneSkip, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedInclude<EntityOne>(et => et.Reference, "OneSkip"),
+                    new ExpectedInclude<EntityOne>(et => et.Collection, "OneSkip")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFull.Where(i => i.Id < 10)).ThenInclude(e => e.TwoSkip.OrderBy(e => e.Id).Skip(1).Take(2))
+                    .Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.BranchSkip.Where(e => e.Id < 20)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityThree, EntityOne>(et => et.OneSkipPayloadFull, includeFilter: x => x.Where(i => i.Id < 10)),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.TwoSkip, "OneSkipPayloadFull", includeFilter: x => x.OrderBy(e => e.Id).Skip(1).Take(2)),
+                    new ExpectedFilteredInclude<EntityOne, EntityBranch>(et => et.BranchSkip, "OneSkipPayloadFull", includeFilter: x => x.Where(e => e.Id < 20))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Throws_when_different_filtered_include(bool async)
+        {
+            Assert.Equal(
+                CoreStrings.MultipleFilteredIncludesOnSameNavigation("navigation    .Where(i => i.Id < 20)", "navigation    .Where(i => i.Id < 10)")
+                    .Replace("\r", "").Replace("\n", ""),
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        async,
+                        ss => ss.Set<EntityTwo>().Include(e => e.OneSkip.Where(i => i.Id < 10)).ThenInclude(e => e.BranchSkip)
+                            .Include(e => e.OneSkip.Where(i => i.Id < 20)).ThenInclude(e => e.ThreeSkipPayloadFull)))).Message
+                    .Replace("\r", "").Replace("\n", ""));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Throws_when_different_filtered_then_include(bool async)
+        {
+            Assert.Equal(
+                CoreStrings.MultipleFilteredIncludesOnSameNavigation("navigation    .Where(i => i.Id < 20)", "navigation    .Where(i => i.Id < 10)")
+                    .Replace("\r", "").Replace("\n", ""),
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        async,
+                        ss => ss.Set<EntityCompositeKey>()
+                            .Include(e => e.TwoSkipShared)
+                                .ThenInclude(e => e.OneSkip.Where(i => i.Id < 10)).ThenInclude(e => e.BranchSkip)
+                            .Include(e => e.TwoSkipShared)
+                                .ThenInclude(e => e.OneSkip.Where(i => i.Id < 20)).ThenInclude(e => e.ThreeSkipPayloadFull)))).Message
+                    .Replace("\r", "").Replace("\n", ""));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityTwo>().Include(e => e.OneSkip.Where(i => i.Id > 15)).ThenInclude(e => e.Collection.Where(i => i.Id < 5)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityTwo, EntityOne>(et => et.OneSkip, includeFilter: x => x.Where(i => i.Id > 15)),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.Collection, "OneSkip", includeFilter: x => x.Where(i => i.Id < 5))));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.Collection.Where(i => i.Id > 15)).ThenInclude(e => e.ThreeSkipFull.Where(i => i.Id < 5)),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(et => et.Collection, includeFilter: x => x.Where(i => i.Id > 15)),
+                    new ExpectedFilteredInclude<EntityTwo, EntityThree>(et => et.ThreeSkipFull, "Collection", includeFilter: x => x.Where(i => i.Id < 5))));
+        }
+
+        [ConditionalTheory(Skip = "Issue#21332")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Includes_accessed_via_different_path_are_merged(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityOne>().Include(e => e.ThreeSkipPayloadFull).ThenInclude(e => e.CollectionInverse)
+                    .Include(e => e.JoinThreePayloadFull).ThenInclude(e => e.Three).ThenInclude(e => e.ReferenceInverse),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityOne>(e => e.ThreeSkipPayloadFull),
+                    new ExpectedInclude<EntityThree>(e => e.CollectionInverse, "ThreeSkipPayloadFull"),
+                    new ExpectedInclude<EntityOne>(e => e.JoinThreePayloadFull),
+                    new ExpectedInclude<JoinOneToThreePayloadFull>(e => e.Three, "JoinThreePayloadFull"),
+                    new ExpectedInclude<EntityThree>(e => e.ReferenceInverse, "JoinThreePayloadFull.Three"),
+                    new ExpectedInclude<EntityThree>(e => e.ReferenceInverse, "ThreeSkipPayloadFull"),
+                    new ExpectedInclude<EntityThree>(e => e.CollectionInverse, "JoinThreePayloadFull.Three")));
+        }
+
+        [ConditionalTheory(Skip = "Issue#21332")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Filered_includes_accessed_via_different_path_are_merged(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFull).ThenInclude(e => e.Collection.Where(i => i.Id < 5))
+                    .Include(e => e.JoinOnePayloadFull).ThenInclude(e => e.One).ThenInclude(e => e.Collection).ThenInclude(e => e.Reference),
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityThree>(e => e.OneSkipPayloadFull),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(e => e.Collection, "OneSkipPayloadFull", includeFilter: x => x.Where(i => i.Id < 5)),
+                    new ExpectedInclude<EntityThree>(e => e.JoinOnePayloadFull),
+                    new ExpectedInclude<JoinOneToThreePayloadFull>(e => e.One, "JoinOnePayloadFull"),
+                    new ExpectedFilteredInclude<EntityOne, EntityTwo>(e => e.Collection, "JoinOnePayloadFull.One", includeFilter: x => x.Where(i => i.Id < 5)),
+                    new ExpectedInclude<EntityTwo>(e => e.Reference, "OneSkipPayloadFull.Collection"),
+                    new ExpectedInclude<EntityTwo>(e => e.Reference, "JoinOnePayloadFull.One.Collection")));
+        }
+
+        [ConditionalTheory(Skip = "Issue#21332")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Throws_when_different_filtered_then_include_via_different_paths(bool async)
+        {
+            Assert.Equal(
+                CoreStrings.MultipleFilteredIncludesOnSameNavigation("navigation    .Where(i => i.Id < 20)", "navigation    .Where(i => i.Id < 10)")
+                    .Replace("\r", "").Replace("\n", ""),
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => AssertQuery(
+                        async,
+                        ss => ss.Set<EntityThree>()
+                            .Include(e => e.OneSkipPayloadFull)
+                                .ThenInclude(e => e.Collection.Where(i => i.Id < 20))
+                            .Include(e => e.JoinOnePayloadFull)
+                                .ThenInclude(e => e.One)
+                                    .ThenInclude(e => e.Collection.Where(i => i.Id < 10))))).Message
+                    .Replace("\r", "").Replace("\n", ""));
+        }
+
+        // When adding include test here always add a tracking version and a split version in relational layer.
+        // Keep this line at the bottom for next dev writing tests to see.
 
         protected ManyToManyContext CreateContext() => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -126,14 +126,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Include_property_expression_invalid(bool async)
+        public virtual Task Include_property_expression_invalid(bool async)
         {
-            Assert.Equal(
-                CoreStrings.InvalidIncludeExpression("new <>f__AnonymousType358`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => AssertQuery(
-                        async,
-                        ss => ss.Set<Order>().Include(o => new { o.Customer, o.OrderDetails })))).Message);
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Order>().Include(o => new { o.Customer, o.OrderDetails })));
         }
 
         [ConditionalTheory]
@@ -155,16 +153,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Then_include_property_expression_invalid(bool async)
+        public virtual Task Then_include_property_expression_invalid(bool async)
         {
-            Assert.Equal(
-                CoreStrings.InvalidIncludeExpression("new <>f__AnonymousType358`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => AssertQuery(
-                        async,
-                        ss => ss.Set<Customer>()
-                            .Include(o => o.Orders)
-                            .ThenInclude(o => new { o.Customer, o.OrderDetails })))).Message);
+            return Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>()
+                        .Include(o => o.Orders)
+                        .ThenInclude(o => new { o.Customer, o.OrderDetails })));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -17,17 +17,1553 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override bool CanExecuteQueryString => true;
 
-        public override async Task Can_use_skip_navigation_in_predicate(bool async)
+        public override async Task Skip_navigation_all(bool async)
         {
-            await base.Can_use_skip_navigation_in_predicate(async);
+            await base.Skip_navigation_all(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    WHERE ([e].[Id] = [j].[OneId]) AND NOT ([e0].[Name] LIKE N'%B%'))");
+        }
+
+        public override async Task Skip_navigation_any_without_predicate(bool async)
+        {
+            await base.Skip_navigation_any_without_predicate(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+WHERE EXISTS (
+    SELECT 1
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    WHERE ([e].[Id] = [j].[OneId]) AND ([e0].[Name] LIKE N'%B%'))");
+        }
+
+        public override async Task Skip_navigation_any_with_predicate(bool async)
+        {
+            await base.Skip_navigation_any_with_predicate(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+WHERE EXISTS (
+    SELECT 1
+    FROM [JoinOneToTwoShared] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    WHERE ([e].[Id] = [j].[OneId]) AND ([e0].[Name] LIKE N'%B%'))");
+        }
+
+        public override async Task Skip_navigation_contains(bool async)
+        {
+            await base.Skip_navigation_contains(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+WHERE EXISTS (
+    SELECT 1
+    FROM [JoinOneToThreePayloadFullShared] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    WHERE ([e].[Id] = [j].[OneId]) AND ([e0].[Id] = 1))");
+        }
+
+        public override async Task Skip_navigation_count_without_predicate(bool async)
+        {
+            await base.Skip_navigation_count_without_predicate(async);
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Name]
 FROM [EntityOnes] AS [e]
 WHERE (
     SELECT COUNT(*)
+    FROM [JoinOneSelfPayload] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
+    WHERE [e].[Id] = [j].[RightId]) > 0");
+        }
+
+        public override async Task Skip_navigation_count_with_predicate(bool async)
+        {
+            await base.Skip_navigation_count_with_predicate(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+ORDER BY (
+    SELECT COUNT(*)
+    FROM [JoinOneToBranch] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+    ) AS [t] ON [j].[BranchId] = [t].[Id]
+    WHERE ([e].[Id] = [j].[OneId]) AND ([t].[Name] IS NOT NULL AND ([t].[Name] LIKE N'L%'))), [e].[Id]");
+        }
+
+        public override async Task Skip_navigation_long_count_without_predicate(bool async)
+        {
+            await base.Skip_navigation_long_count_without_predicate(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+WHERE (
+    SELECT COUNT_BIG(*)
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    WHERE [e].[Id] = [j].[TwoId]) > CAST(0 AS bigint)");
+        }
+
+        public override async Task Skip_navigation_long_count_with_predicate(bool async)
+        {
+            await base.Skip_navigation_long_count_with_predicate(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+ORDER BY (
+    SELECT COUNT_BIG(*)
+    FROM [JoinTwoSelfShared] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[LeftId] = [e0].[Id]
+    WHERE ([e].[Id] = [j].[RightId]) AND ([e0].[Name] IS NOT NULL AND ([e0].[Name] LIKE N'L%'))) DESC");
+        }
+
+        public override async Task Skip_navigation_select_many_average(bool async)
+        {
+            await base.Skip_navigation_select_many_average(async);
+
+            AssertSql(
+                @"SELECT AVG(CAST([t].[Key1] AS float))
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [e0].[Key1], [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Key2], [e0].[Key3]
+    FROM [JoinTwoToCompositeKeyShared] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+) AS [t] ON [e].[Id] = [t].[TwoId]");
+        }
+
+        public override async Task Skip_navigation_select_many_max(bool async)
+        {
+            await base.Skip_navigation_select_many_max(async);
+
+            AssertSql(
+                @"SELECT MAX([t].[Key1])
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [e0].[Key1], [j].[ThreeId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Key2], [e0].[Key3]
+    FROM [JoinThreeToCompositeKeyFull] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+) AS [t] ON [e].[Id] = [t].[ThreeId]");
+        }
+
+        public override async Task Skip_navigation_select_many_min(bool async)
+        {
+            await base.Skip_navigation_select_many_min(async);
+
+            AssertSql(
+                @"SELECT MIN([t].[Id])
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [j].[ThreeId], [j].[RootId]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[ThreeId]");
+        }
+
+        public override async Task Skip_navigation_select_many_sum(bool async)
+        {
+            await base.Skip_navigation_select_many_sum(async);
+
+            AssertSql(
+                @"SELECT COALESCE(SUM([t].[Key1]), 0)
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [e0].[Key1], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key2], [e0].[Key3]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootId]");
+        }
+
+        public override async Task Skip_navigation_select_subquery_average(bool async)
+        {
+            await base.Skip_navigation_select_subquery_average(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT AVG(CAST([e].[Key1] AS float))
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e] ON (([j].[CompositeId1] = [e].[Key1]) AND ([j].[CompositeId2] = [e].[Key2])) AND ([j].[CompositeId3] = [e].[Key3])
+    WHERE [e0].[Id] = [j].[LeafId])
+FROM [EntityRoots] AS [e0]
+WHERE [e0].[Discriminator] = N'EntityLeaf'");
+        }
+
+        public override async Task Skip_navigation_select_subquery_max(bool async)
+        {
+            await base.Skip_navigation_select_subquery_max(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT MAX([e].[Id])
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e] ON [j].[OneId] = [e].[Id]
+    WHERE [e0].[Id] = [j].[TwoId])
+FROM [EntityTwos] AS [e0]");
+        }
+
+        public override async Task Skip_navigation_select_subquery_min(bool async)
+        {
+            await base.Skip_navigation_select_subquery_min(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT MIN([e].[Id])
     FROM [JoinOneToThreePayloadFull] AS [j]
-    WHERE [e].[Id] = [j].[OneId]) > 1");
+    INNER JOIN [EntityOnes] AS [e] ON [j].[OneId] = [e].[Id]
+    WHERE [e0].[Id] = [j].[ThreeId])
+FROM [EntityThrees] AS [e0]");
+        }
+
+        public override async Task Skip_navigation_select_subquery_sum(bool async)
+        {
+            await base.Skip_navigation_select_subquery_sum(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COALESCE(SUM([e].[Id]), 0)
+    FROM [JoinOneToTwoShared] AS [j]
+    INNER JOIN [EntityOnes] AS [e] ON [j].[OneId] = [e].[Id]
+    WHERE [e0].[Id] = [j].[TwoId])
+FROM [EntityTwos] AS [e0]");
+        }
+
+        public override async Task Skip_navigation_order_by_first_or_default(bool async)
+        {
+            await base.Skip_navigation_order_by_first_or_default(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[Name]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Name], [t].[OneId], [t].[ThreeId]
+    FROM (
+        SELECT [e0].[Id], [e0].[Name], [j].[OneId], [j].[ThreeId], ROW_NUMBER() OVER(PARTITION BY [j].[ThreeId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToThreePayloadFullShared] AS [j]
+        INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [e].[Id] = [t0].[ThreeId]");
+        }
+
+        public override async Task Skip_navigation_order_by_single_or_default(bool async)
+        {
+            await base.Skip_navigation_order_by_single_or_default(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[Name]
+FROM [EntityOnes] AS [e]
+OUTER APPLY (
+    SELECT TOP(1) [t].[Id], [t].[Name], [t].[LeftId], [t].[RightId]
+    FROM (
+        SELECT TOP(1) [e0].[Id], [e0].[Name], [j].[LeftId], [j].[RightId]
+        FROM [JoinOneSelfPayload] AS [j]
+        INNER JOIN [EntityOnes] AS [e0] ON [j].[RightId] = [e0].[Id]
+        WHERE [e].[Id] = [j].[LeftId]
+        ORDER BY [e0].[Id]
+    ) AS [t]
+    ORDER BY [t].[Id]
+) AS [t0]");
+        }
+
+        public override async Task Skip_navigation_order_by_last_or_default(bool async)
+        {
+            await base.Skip_navigation_order_by_last_or_default(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[Name]
+FROM [EntityRoots] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Name], [t].[BranchId], [t].[OneId]
+    FROM (
+        SELECT [e0].[Id], [e0].[Name], [j].[BranchId], [j].[OneId], ROW_NUMBER() OVER(PARTITION BY [j].[BranchId] ORDER BY [e0].[Id] DESC) AS [row]
+        FROM [JoinOneToBranch] AS [j]
+        INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [e].[Id] = [t0].[BranchId]
+WHERE [e].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')");
+        }
+
+        public override async Task Skip_navigation_order_by_reverse_first_or_default(bool async)
+        {
+            await base.Skip_navigation_order_by_reverse_first_or_default(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[ThreeId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[ThreeId], ROW_NUMBER() OVER(PARTITION BY [j].[ThreeId] ORDER BY [e0].[Id] DESC) AS [row]
+        FROM [JoinTwoToThree] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [e].[Id] = [t0].[ThreeId]");
+        }
+
+        public override async Task Skip_navigation_cast(bool async)
+        {
+            await base.Skip_navigation_cast(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[Number], [t0].[IsGreen], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] = N'EntityLeaf'
+    ) AS [t] ON [j].[LeafId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+        }
+
+        public override async Task Skip_navigation_of_type(bool async)
+        {
+            await base.Skip_navigation_of_type(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
+    WHERE [e0].[Discriminator] = N'EntityLeaf'
+) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+        }
+
+        public override async Task Join_with_skip_navigation(bool async)
+        {
+            await base.Join_with_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+INNER JOIN [EntityTwos] AS [e0] ON [e].[Id] = (
+    SELECT TOP(1) [e1].[Id]
+    FROM [JoinTwoSelfShared] AS [j]
+    INNER JOIN [EntityTwos] AS [e1] ON [j].[RightId] = [e1].[Id]
+    WHERE [e0].[Id] = [j].[LeftId])");
+        }
+
+        public override async Task Left_join_with_skip_navigation(bool async)
+        {
+            await base.Left_join_with_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN [EntityCompositeKeys] AS [e0] ON (
+    SELECT TOP(1) [e1].[Id]
+    FROM [JoinTwoToCompositeKeyShared] AS [j]
+    INNER JOIN [EntityTwos] AS [e1] ON [j].[TwoId] = [e1].[Id]
+    WHERE (([e].[Key1] = [j].[CompositeId1]) AND ([e].[Key2] = [j].[CompositeId2])) AND ([e].[Key3] = [j].[CompositeId3])) = (
+    SELECT TOP(1) [e2].[Id]
+    FROM [JoinThreeToCompositeKeyFull] AS [j0]
+    INNER JOIN [EntityThrees] AS [e2] ON [j0].[ThreeId] = [e2].[Id]
+    WHERE (([e0].[Key1] = [j0].[CompositeId1]) AND ([e0].[Key2] = [j0].[CompositeId2])) AND ([e0].[Key3] = [j0].[CompositeId3]))
+ORDER BY [e].[Key1], [e0].[Key1]");
+        }
+
+        public override async Task Select_many_over_skip_navigation(bool async)
+        {
+            await base.Select_many_over_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[RootId]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[RootId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_where(bool async)
+        {
+            await base.Select_many_over_skip_navigation_where(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[OneId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_order_by_skip(bool async)
+        {
+            await base.Select_many_over_skip_navigation_order_by_skip(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[OneId], [t].[ThreeId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[ThreeId], ROW_NUMBER() OVER(PARTITION BY [j].[OneId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToThreePayloadFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    ) AS [t]
+    WHERE 2 < [t].[row]
+) AS [t0] ON [e].[Id] = [t0].[OneId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_order_by_take(bool async)
+        {
+            await base.Select_many_over_skip_navigation_order_by_take(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[OneId], [t].[TwoId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId], ROW_NUMBER() OVER(PARTITION BY [j].[OneId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToTwoShared] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 2
+) AS [t0] ON [e].[Id] = [t0].[OneId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_order_by_skip_take(bool async)
+        {
+            await base.Select_many_over_skip_navigation_order_by_skip_take(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[OneId], [t].[ThreeId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[ThreeId], ROW_NUMBER() OVER(PARTITION BY [j].[OneId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToThreePayloadFullShared] AS [j]
+        INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    ) AS [t]
+    WHERE (2 < [t].[row]) AND ([t].[row] <= 5)
+) AS [t0] ON [e].[Id] = [t0].[OneId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_of_type(bool async)
+        {
+            await base.Select_many_over_skip_navigation_of_type(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[ThreeId], [j].[RootId]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
+    WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+) AS [t] ON [e].[Id] = [t].[ThreeId]");
+        }
+
+        public override async Task Select_many_over_skip_navigation_cast(bool async)
+        {
+            await base.Select_many_over_skip_navigation_cast(async);
+
+            AssertSql(
+                @"SELECT [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[Number], [t0].[IsGreen]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [j].[BranchId], [j].[OneId]
+    FROM [JoinOneToBranch] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+    ) AS [t] ON [j].[BranchId] = [t].[Id]
+) AS [t0] ON [e].[Id] = [t0].[OneId]");
+        }
+
+        public override async Task Select_skip_navigation(bool async)
+        {
+            await base.Select_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [t].[Id], [t].[Name], [t].[LeftId], [t].[RightId]
+FROM [EntityOnes] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [j].[LeftId], [j].[RightId]
+    FROM [JoinOneSelfPayload] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[RightId]
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+        }
+
+        public override async Task Select_skip_navigation_multiple(bool async)
+        {
+            await base.Select_skip_navigation_multiple(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[ThreeId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3]
+FROM [EntityTwos] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[ThreeId]
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[TwoId]
+LEFT JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[LeftId], [j0].[RightId]
+    FROM [JoinTwoSelfShared] AS [j0]
+    INNER JOIN [EntityTwos] AS [e1] ON [j0].[LeftId] = [e1].[Id]
+) AS [t0] ON [e].[Id] = [t0].[RightId]
+LEFT JOIN (
+    SELECT [e2].[Key1], [e2].[Key2], [e2].[Key3], [e2].[Name], [j1].[TwoId], [j1].[CompositeId1], [j1].[CompositeId2], [j1].[CompositeId3]
+    FROM [JoinTwoToCompositeKeyShared] AS [j1]
+    INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
+) AS [t1] ON [e].[Id] = [t1].[TwoId]
+ORDER BY [e].[Id], [t].[TwoId], [t].[ThreeId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+        }
+
+        public override async Task Select_skip_navigation_first_or_default(bool async)
+        {
+            await base.Select_skip_navigation_first_or_default(async);
+
+            AssertSql(
+                @"SELECT [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [t].[ThreeId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    FROM (
+        SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[ThreeId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[ThreeId] ORDER BY [j].[ThreeId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Key1], [e0].[Key2], [e0].[Key3]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [e].[Id] = [t0].[ThreeId]
+ORDER BY [e].[Id]");
+        }
+
+        public override async Task Include_skip_navigation(bool async)
+        {
+            await base.Include_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+        }
+
+        public override async Task Include_skip_navigation_then_reference(bool async)
+        {
+            await base.Include_skip_navigation_then_reference(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t].[Id], [t].[Name], [t].[Id0], [t].[CollectionInverseId], [t].[Name0], [t].[ReferenceInverseId], [t].[OneId], [t].[TwoId]
+FROM [EntityTwos] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId], [j].[OneId], [j].[TwoId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+        }
+
+        public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
+        {
+            await base.Include_skip_navigation_then_include_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t1].[Id], [t1].[Discriminator], [t1].[Name], [t1].[Number], [t1].[IsGreen], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id0], [t1].[Name0], [t1].[BranchId], [t1].[OneId]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t0].[Id] AS [Id0], [t0].[Name] AS [Name0], [t0].[BranchId], [t0].[OneId]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] = N'EntityLeaf'
+    ) AS [t] ON [j].[LeafId] = [t].[Id]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[Name], [j0].[BranchId], [j0].[OneId]
+        FROM [JoinOneToBranch] AS [j0]
+        INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
+    ) AS [t0] ON [t].[Id] = [t0].[BranchId]
+) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[BranchId], [t1].[OneId], [t1].[Id0]");
+        }
+
+        public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
+        {
+            await base.Include_skip_navigation_then_include_reference_and_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[Name], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[OneId], [t0].[ThreeId], [t0].[Id1], [t0].[Name1], [t0].[LeftId], [t0].[RightId]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId], [j].[OneId], [j].[ThreeId], [t].[Id] AS [Id1], [t].[Name] AS [Name1], [t].[LeftId], [t].[RightId]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+    LEFT JOIN (
+        SELECT [e2].[Id], [e2].[Name], [j0].[LeftId], [j0].[RightId]
+        FROM [JoinOneSelfPayload] AS [j0]
+        INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
+    ) AS [t] ON [e0].[Id] = [t].[LeftId]
+) AS [t0] ON [e].[Id] = [t0].[ThreeId]
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+        }
+
+        public override async Task Include_skip_navigation_and_reference(bool async)
+        {
+            await base.Include_skip_navigation_and_reference(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t].[Id], [t].[Name], [t].[OneId], [t].[TwoId]
+FROM [EntityTwos] AS [e]
+LEFT JOIN [EntityThrees] AS [e0] ON [e].[Id] = [e0].[ReferenceInverseId]
+LEFT JOIN (
+    SELECT [e1].[Id], [e1].[Name], [j].[OneId], [j].[TwoId]
+    FROM [JoinOneToTwoShared] AS [j]
+    INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [e0].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t].[Id], [t].[Name], [t].[OneId], [t].[ThreeId]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [j].[OneId], [j].[ThreeId]
+    FROM [JoinOneToThreePayloadFullShared] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[ThreeId]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[ThreeId]
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+ORDER BY [e].[Id], [t].[Id], [t].[TwoId], [t].[ThreeId]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[LeftId], [t0].[RightId]
+FROM [EntityTwos] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[LeftId], [t].[RightId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[LeftId], [j].[RightId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinTwoSelfShared] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+    ) AS [t]
+    WHERE 2 < [t].[row]
+) AS [t0] ON [e].[Id] = [t0].[LeftId]
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_take(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinTwoToCompositeKeyShared] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 2
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[TwoId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip_take(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[ThreeId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3]
+FROM [EntityCompositeKeys] AS [e]
+LEFT JOIN (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    ) AS [t]
+    WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[ThreeId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+        }
+
+        public override async Task Filtered_then_include_skip_navigation_where(bool async)
+        {
+            await base.Filtered_then_include_skip_navigation_where(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[ThreeId], [t0].[RootId], [t0].[Id0], [t0].[Name0], [t0].[OneId], [t0].[ThreeId0]
+FROM [EntityRoots] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[ThreeId], [j].[RootId], [t].[Id] AS [Id0], [t].[Name] AS [Name0], [t].[OneId], [t].[ThreeId] AS [ThreeId0]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[Name], [j0].[OneId], [j0].[ThreeId]
+        FROM [JoinOneToThreePayloadFullShared] AS [j0]
+        INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
+        WHERE [e1].[Id] < 10
+    ) AS [t] ON [e0].[Id] = [t].[ThreeId]
+) AS [t0] ON [e].[Id] = [t0].[RootId]
+ORDER BY [e].[Id], [t0].[ThreeId], [t0].[RootId], [t0].[Id], [t0].[OneId], [t0].[ThreeId0], [t0].[Id0]");
+        }
+
+        public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            await base.Filtered_then_include_skip_navigation_order_by_skip_take(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[Name], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [t1].[ThreeId], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30]
+FROM [EntityRoots] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[ThreeId], [t0].[CompositeId1] AS [CompositeId10], [t0].[CompositeId2] AS [CompositeId20], [t0].[CompositeId3] AS [CompositeId30]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    LEFT JOIN (
+        SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[ThreeId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3]
+        FROM (
+            SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[ThreeId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+            FROM [JoinThreeToCompositeKeyFull] AS [j0]
+            INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+        ) AS [t]
+        WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+    ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
+) AS [t1] ON [e].[Id] = [t1].[RootId]
+ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[ThreeId], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where_then_include_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[Name], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name0], [t0].[ReferenceInverseId], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]
+FROM [EntityRoots] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[CollectionInverseId], [t].[Name] AS [Name0], [t].[ReferenceInverseId], [t].[TwoId], [t].[CompositeId1] AS [CompositeId10], [t].[CompositeId2] AS [CompositeId20], [t].[CompositeId3] AS [CompositeId30]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3]
+        FROM [JoinTwoToCompositeKeyShared] AS [j0]
+        INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
+    ) AS [t] ON (([e0].[Key1] = [t].[CompositeId1]) AND ([e0].[Key2] = [t].[CompositeId2])) AND ([e0].[Key3] = [t].[CompositeId3])
+    WHERE [e0].[Key1] < 5
+) AS [t0] ON [e].[Id] = [t0].[LeafId]
+WHERE [e].[Discriminator] = N'EntityLeaf'
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [t1].[OneId], [t1].[TwoId], [t1].[Id0], [t1].[CollectionInverseId0], [t1].[Name0], [t1].[ReferenceInverseId0], [t1].[TwoId0], [t1].[ThreeId]
+FROM [EntityOnes] AS [e]
+OUTER APPLY (
+    SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[OneId], [t].[TwoId], [t0].[Id] AS [Id0], [t0].[CollectionInverseId] AS [CollectionInverseId0], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId] AS [ReferenceInverseId0], [t0].[TwoId] AS [TwoId0], [t0].[ThreeId]
+    FROM (
+        SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId]
+        FROM [JoinOneToTwo] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+        WHERE [e].[Id] = [j].[OneId]
+        ORDER BY [e0].[Id]
+        OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY
+    ) AS [t]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[TwoId], [j0].[ThreeId]
+        FROM [JoinTwoToThree] AS [j0]
+        INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+        WHERE [e1].[Id] < 10
+    ) AS [t0] ON [t].[Id] = [t0].[TwoId]
+) AS [t1]
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[TwoId0], [t1].[ThreeId], [t1].[Id0]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [t1].[OneId], [t1].[TwoId], [t1].[Id0], [t1].[CollectionInverseId0], [t1].[Name0], [t1].[ReferenceInverseId0], [t1].[TwoId0], [t1].[ThreeId]
+FROM [EntityOnes] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId], [t0].[Id] AS [Id0], [t0].[CollectionInverseId] AS [CollectionInverseId0], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId] AS [ReferenceInverseId0], [t0].[TwoId] AS [TwoId0], [t0].[ThreeId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    LEFT JOIN (
+        SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[TwoId], [t].[ThreeId]
+        FROM (
+            SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[TwoId], [j0].[ThreeId], ROW_NUMBER() OVER(PARTITION BY [j0].[TwoId] ORDER BY [e1].[Id]) AS [row]
+            FROM [JoinTwoToThree] AS [j0]
+            INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+        ) AS [t]
+        WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+    ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
+    WHERE [e0].[Id] < 10
+) AS [t1] ON [e].[Id] = [t1].[OneId]
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[ThreeId], [t1].[Id0]");
+        }
+
+        public override async Task Filter_include_on_skip_navigation_combined(bool async)
+        {
+            await base.Filter_include_on_skip_navigation_combined(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t].[Id], [t].[Name], [t].[Id0], [t].[CollectionInverseId], [t].[Name0], [t].[ReferenceInverseId], [t].[OneId], [t].[TwoId], [t].[Id1], [t].[CollectionInverseId0], [t].[Name1], [t].[ReferenceInverseId0]
+FROM [EntityTwos] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId], [j].[OneId], [j].[TwoId], [e2].[Id] AS [Id1], [e2].[CollectionInverseId] AS [CollectionInverseId0], [e2].[Name] AS [Name1], [e2].[ReferenceInverseId] AS [ReferenceInverseId0]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+    LEFT JOIN [EntityTwos] AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+        }
+
+        public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
+        {
+            await base.Filter_include_on_skip_navigation_combined_with_filtered_then_includes(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t3].[Id], [t3].[Name], [t3].[OneId], [t3].[ThreeId], [t3].[Id0], [t3].[CollectionInverseId], [t3].[Name0], [t3].[ReferenceInverseId], [t3].[OneId0], [t3].[TwoId], [t3].[Id1], [t3].[Discriminator], [t3].[Name1], [t3].[Number], [t3].[IsGreen], [t3].[BranchId], [t3].[OneId1]
+FROM [EntityThrees] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [j].[OneId], [j].[ThreeId], [t0].[Id] AS [Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[OneId] AS [OneId0], [t0].[TwoId], [t2].[Id] AS [Id1], [t2].[Discriminator], [t2].[Name] AS [Name1], [t2].[Number], [t2].[IsGreen], [t2].[BranchId], [t2].[OneId] AS [OneId1]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN (
+        SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t].[OneId], [t].[TwoId]
+        FROM (
+            SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j0].[OneId], [j0].[TwoId], ROW_NUMBER() OVER(PARTITION BY [j0].[OneId] ORDER BY [e1].[Id]) AS [row]
+            FROM [JoinOneToTwo] AS [j0]
+            INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
+        ) AS [t]
+        WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+    ) AS [t0] ON [e0].[Id] = [t0].[OneId]
+    LEFT JOIN (
+        SELECT [t1].[Id], [t1].[Discriminator], [t1].[Name], [t1].[Number], [t1].[IsGreen], [j1].[BranchId], [j1].[OneId]
+        FROM [JoinOneToBranch] AS [j1]
+        INNER JOIN (
+            SELECT [e2].[Id], [e2].[Discriminator], [e2].[Name], [e2].[Number], [e2].[IsGreen]
+            FROM [EntityRoots] AS [e2]
+            WHERE [e2].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+        ) AS [t1] ON [j1].[BranchId] = [t1].[Id]
+        WHERE [t1].[Id] < 20
+    ) AS [t2] ON [e0].[Id] = [t2].[OneId]
+    WHERE [e0].[Id] < 10
+) AS [t3] ON [e].[Id] = [t3].[ThreeId]
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[TwoId], [t3].[Id0], [t3].[BranchId], [t3].[OneId1], [t3].[Id1]");
+        }
+
+        public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
+        {
+            await base.Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [t0].[Id], [t0].[Name], [t0].[OneId], [t0].[TwoId], [t0].[Id0], [t0].[CollectionInverseId], [t0].[Name0], [t0].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[Name], [j].[OneId], [j].[TwoId], [t].[Id] AS [Id0], [t].[CollectionInverseId], [t].[Name] AS [Name0], [t].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+        FROM [EntityTwos] AS [e1]
+        WHERE [e1].[Id] < 5
+    ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
+    WHERE [e0].[Id] > 15
+) AS [t0] ON [e].[Id] = [t0].[TwoId]
+ORDER BY [e].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id], [t0].[Id0]");
+        }
+
+        public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
+        {
+            await base.Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [t0].[Id0], [t0].[CollectionInverseId0], [t0].[Name0], [t0].[ReferenceInverseId0], [t0].[TwoId], [t0].[ThreeId]
+FROM [EntityOnes] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [t].[Id] AS [Id0], [t].[CollectionInverseId] AS [CollectionInverseId0], [t].[Name] AS [Name0], [t].[ReferenceInverseId] AS [ReferenceInverseId0], [t].[TwoId], [t].[ThreeId]
+    FROM [EntityTwos] AS [e0]
+    LEFT JOIN (
+        SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [j].[TwoId], [j].[ThreeId]
+        FROM [JoinTwoToThree] AS [j]
+        INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
+        WHERE [e1].[Id] < 5
+    ) AS [t] ON [e0].[Id] = [t].[TwoId]
+    WHERE [e0].[Id] > 15
+) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
+ORDER BY [e].[Id], [t0].[Id], [t0].[TwoId], [t0].[ThreeId], [t0].[Id0]");
+        }
+
+        public override async Task Includes_accessed_via_different_path_are_merged(bool async)
+        {
+            await base.Includes_accessed_via_different_path_are_merged(async);
+
+            AssertSql(" ");
+        }
+
+        public override async Task Filered_includes_accessed_via_different_path_are_merged(bool async)
+        {
+            await base.Filered_includes_accessed_via_different_path_are_merged(async);
+
+            AssertSql(" ");
+        }
+
+        public override async Task Include_skip_navigation_split(bool async)
+        {
+            await base.Include_skip_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name]
+FROM [EntityCompositeKeys] AS [e]
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
+                //
+                @"SELECT [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3]
+FROM [EntityCompositeKeys] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
+) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]");
+        }
+
+        public override async Task Include_skip_navigation_then_reference_split(bool async)
+        {
+            await base.Include_skip_navigation_then_reference_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [t].[Id0], [t].[CollectionInverseId], [t].[Name0], [t].[ReferenceInverseId], [e].[Id]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id]");
+        }
+
+        public override async Task Include_skip_navigation_then_include_skip_navigation_split(bool async)
+        {
+            await base.Include_skip_navigation_then_include_skip_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name]
+FROM [EntityCompositeKeys] AS [e]
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
+                //
+                @"SELECT [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[Number], [t0].[IsGreen], [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]
+FROM [EntityCompositeKeys] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] = N'EntityLeaf'
+    ) AS [t] ON [j].[LeafId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]",
+                //
+                @"SELECT [t1].[Id], [t1].[Name], [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]
+FROM [EntityCompositeKeys] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [t].[Id], [t].[Discriminator], [t].[Name], [t].[Number], [t].[IsGreen]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN (
+        SELECT [e0].[Id], [e0].[Discriminator], [e0].[Name], [e0].[Number], [e0].[IsGreen]
+        FROM [EntityRoots] AS [e0]
+        WHERE [e0].[Discriminator] = N'EntityLeaf'
+    ) AS [t] ON [j].[LeafId] = [t].[Id]
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+INNER JOIN (
+    SELECT [j0].[BranchId], [j0].[OneId], [e1].[Id], [e1].[Name]
+    FROM [JoinOneToBranch] AS [j0]
+    INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
+) AS [t1] ON [t0].[Id] = [t1].[BranchId]
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+        }
+
+        public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation_split(bool async)
+        {
+            await base.Include_skip_navigation_then_include_reference_and_skip_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityThrees] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [t].[Id0], [t].[CollectionInverseId], [t].[Name0], [t].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[ThreeId]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id], [t].[Id0]",
+                //
+                @"SELECT [t0].[Id], [t0].[Name], [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id], [t].[Id0]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+INNER JOIN (
+    SELECT [j0].[LeftId], [j0].[RightId], [j0].[Payload], [e2].[Id], [e2].[Name]
+    FROM [JoinOneSelfPayload] AS [j0]
+    INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
+) AS [t0] ON [t].[Id] = [t0].[LeftId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id], [t].[Id0]");
+        }
+
+        public override async Task Include_skip_navigation_and_reference_split(bool async)
+        {
+            await base.Include_skip_navigation_and_reference_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+LEFT JOIN [EntityThrees] AS [e0] ON [e].[Id] = [e0].[ReferenceInverseId]
+ORDER BY [e].[Id], [e0].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [e].[Id], [e0].[Id]
+FROM [EntityTwos] AS [e]
+LEFT JOIN [EntityThrees] AS [e0] ON [e].[Id] = [e0].[ReferenceInverseId]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e1].[Id], [e1].[Name]
+    FROM [JoinOneToTwoShared] AS [j]
+    INNER JOIN [EntityOnes] AS [e1] ON [j].[OneId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [e0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityThrees] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [e].[Id]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToThreePayloadFullShared] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+ORDER BY [e].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityThrees] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [t].[TwoId], [t].[ThreeId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[TwoId], [j].[ThreeId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[ThreeId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinTwoToThree] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE 0 < [t].[row]
+) AS [t0] ON [e].[Id] = [t0].[ThreeId]
+ORDER BY [e].[Id], [t0].[ThreeId], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [t].[LeftId], [t].[RightId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[LeftId], [j].[RightId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[LeftId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinTwoSelfShared] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[RightId] = [e0].[Id]
+    ) AS [t]
+    WHERE 2 < [t].[row]
+) AS [t0] ON [e].[Id] = [t0].[LeftId]
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_take_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_take_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name]
+FROM [EntityCompositeKeys] AS [e]
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
+FROM [EntityCompositeKeys] AS [e]
+INNER JOIN (
+    SELECT [t].[TwoId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[TwoId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinTwoToCompositeKeyShared] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE [t].[row] <= 2
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip_take_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Key1], [e].[Key2], [e].[Key3], [e].[Name]
+FROM [EntityCompositeKeys] AS [e]
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Key1], [e].[Key2], [e].[Key3]
+FROM [EntityCompositeKeys] AS [e]
+INNER JOIN (
+    SELECT [t].[ThreeId], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[ThreeId], [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j]
+        INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+    ) AS [t]
+    WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
+        }
+
+        public override async Task Filtered_then_include_skip_navigation_where_split(bool async)
+        {
+            await base.Filtered_then_include_skip_navigation_where_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+FROM [EntityRoots] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[ThreeId], [t].[RootId]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[ThreeId], [j].[RootId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[RootId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[RootId], [t].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[Name], [e].[Id], [t].[ThreeId], [t].[RootId], [t].[Id]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[ThreeId], [j].[RootId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [JoinThreeToRootShared] AS [j]
+    INNER JOIN [EntityThrees] AS [e0] ON [j].[ThreeId] = [e0].[Id]
+) AS [t] ON [e].[Id] = [t].[RootId]
+INNER JOIN (
+    SELECT [j0].[OneId], [j0].[ThreeId], [j0].[Payload], [e1].[Id], [e1].[Name]
+    FROM [JoinOneToThreePayloadFullShared] AS [j0]
+    INNER JOIN [EntityOnes] AS [e1] ON [j0].[OneId] = [e1].[Id]
+    WHERE [e1].[Id] < 10
+) AS [t0] ON [t].[Id] = [t0].[ThreeId]
+ORDER BY [e].[Id], [t].[ThreeId], [t].[RootId], [t].[Id]");
+        }
+
+        public override async Task Filtered_then_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            await base.Filtered_then_include_skip_navigation_order_by_skip_take_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+FROM [EntityRoots] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootId]
+ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]",
+                //
+                @"SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[RootId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+    FROM [JoinCompositeKeyToRootShared] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+) AS [t] ON [e].[Id] = [t].[RootId]
+INNER JOIN (
+    SELECT [t0].[ThreeId], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+    FROM (
+        SELECT [j0].[ThreeId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3] ORDER BY [e1].[Id]) AS [row]
+        FROM [JoinThreeToCompositeKeyFull] AS [j0]
+        INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+    ) AS [t0]
+    WHERE (1 < [t0].[row]) AND ([t0].[row] <= 3)
+) AS [t1] ON (([t].[Key1] = [t1].[CompositeId1]) AND ([t].[Key2] = [t1].[CompositeId2])) AND ([t].[Key3] = [t1].[CompositeId3])
+ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Key1], [t].[Key2], [t].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where_then_include_skip_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[Number], [e].[IsGreen]
+FROM [EntityRoots] AS [e]
+WHERE [e].[Discriminator] = N'EntityLeaf'
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Key1], [t].[Key2], [t].[Key3], [t].[Name], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    WHERE [e0].[Key1] < 5
+) AS [t] ON [e].[Id] = [t].[LeafId]
+WHERE [e].[Discriminator] = N'EntityLeaf'
+ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]
+FROM [EntityRoots] AS [e]
+INNER JOIN (
+    SELECT [j].[CompositeId1], [j].[CompositeId2], [j].[CompositeId3], [j].[LeafId], [e0].[Key1], [e0].[Key2], [e0].[Key3], [e0].[Name]
+    FROM [JoinCompositeKeyToLeaf] AS [j]
+    INNER JOIN [EntityCompositeKeys] AS [e0] ON (([j].[CompositeId1] = [e0].[Key1]) AND ([j].[CompositeId2] = [e0].[Key2])) AND ([j].[CompositeId3] = [e0].[Key3])
+    WHERE [e0].[Key1] < 5
+) AS [t] ON [e].[Id] = [t].[LeafId]
+INNER JOIN (
+    SELECT [j0].[TwoId], [j0].[CompositeId1], [j0].[CompositeId2], [j0].[CompositeId3], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+    FROM [JoinTwoToCompositeKeyShared] AS [j0]
+    INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
+) AS [t0] ON (([t].[Key1] = [t0].[CompositeId1]) AND ([t].[Key2] = [t0].[CompositeId2])) AND ([t].[Key3] = [t0].[CompositeId3])
+WHERE [e].[Discriminator] = N'EntityLeaf'
+ORDER BY [e].[Id], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[LeafId], [t].[Key1], [t].[Key2], [t].[Key3]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t0].[OneId], [t0].[TwoId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[OneId], [t].[TwoId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[OneId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToTwo] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+) AS [t0] ON [e].[Id] = [t0].[OneId]
+ORDER BY [e].[Id], [t0].[OneId], [t0].[Id], [t0].[TwoId]",
+                //
+                @"SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [e].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [t].[OneId], [t].[TwoId], [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+    FROM (
+        SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j].[OneId] ORDER BY [e0].[Id]) AS [row]
+        FROM [JoinOneToTwo] AS [j]
+        INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    ) AS [t]
+    WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
+) AS [t0] ON [e].[Id] = [t0].[OneId]
+INNER JOIN (
+    SELECT [j0].[TwoId], [j0].[ThreeId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+    FROM [JoinTwoToThree] AS [j0]
+    INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+    WHERE [e1].[Id] < 10
+) AS [t1] ON [t0].[Id] = [t1].[TwoId]
+ORDER BY [e].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id]");
+        }
+
+        public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take_split(bool async)
+        {
+            await base.Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[OneId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]",
+                //
+                @"SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[OneId]
+INNER JOIN (
+    SELECT [t0].[TwoId], [t0].[ThreeId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+    FROM (
+        SELECT [j0].[TwoId], [j0].[ThreeId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[TwoId] ORDER BY [e1].[Id]) AS [row]
+        FROM [JoinTwoToThree] AS [j0]
+        INNER JOIN [EntityThrees] AS [e1] ON [j0].[ThreeId] = [e1].[Id]
+    ) AS [t0]
+    WHERE (1 < [t0].[row]) AND ([t0].[row] <= 3)
+) AS [t1] ON [t].[Id] = [t1].[TwoId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t1].[TwoId], [t1].[Id]");
+        }
+
+        public override async Task Filter_include_on_skip_navigation_combined_split(bool async)
+        {
+            await base.Filter_include_on_skip_navigation_combined_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [t].[Id0], [t].[CollectionInverseId], [t].[Name0], [t].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]",
+                //
+                @"SELECT [e2].[Id], [e2].[CollectionInverseId], [e2].[Name], [e2].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[Name], [e1].[Id] AS [Id0], [e1].[CollectionInverseId], [e1].[Name] AS [Name0], [e1].[ReferenceInverseId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[TwoId]
+INNER JOIN [EntityTwos] AS [e2] ON [t].[Id] = [e2].[CollectionInverseId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+        }
+
+        public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes_split(bool async)
+        {
+            await base.Filter_include_on_skip_navigation_combined_with_filtered_then_includes_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityThrees] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [e].[Id], [t].[OneId], [t].[ThreeId]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]",
+                //
+                @"SELECT [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+INNER JOIN (
+    SELECT [t0].[OneId], [t0].[TwoId], [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId]
+    FROM (
+        SELECT [j0].[OneId], [j0].[TwoId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], ROW_NUMBER() OVER(PARTITION BY [j0].[OneId] ORDER BY [e1].[Id]) AS [row]
+        FROM [JoinOneToTwo] AS [j0]
+        INNER JOIN [EntityTwos] AS [e1] ON [j0].[TwoId] = [e1].[Id]
+    ) AS [t0]
+    WHERE (1 < [t0].[row]) AND ([t0].[row] <= 3)
+) AS [t1] ON [t].[Id] = [t1].[OneId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id], [t1].[OneId], [t1].[Id]",
+                //
+                @"SELECT [t1].[Id], [t1].[Discriminator], [t1].[Name], [t1].[Number], [t1].[IsGreen], [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]
+FROM [EntityThrees] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[ThreeId], [j].[Payload], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToThreePayloadFull] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] < 10
+) AS [t] ON [e].[Id] = [t].[ThreeId]
+INNER JOIN (
+    SELECT [j0].[BranchId], [j0].[OneId], [t0].[Id], [t0].[Discriminator], [t0].[Name], [t0].[Number], [t0].[IsGreen]
+    FROM [JoinOneToBranch] AS [j0]
+    INNER JOIN (
+        SELECT [e1].[Id], [e1].[Discriminator], [e1].[Name], [e1].[Number], [e1].[IsGreen]
+        FROM [EntityRoots] AS [e1]
+        WHERE [e1].[Discriminator] IN (N'EntityBranch', N'EntityLeaf')
+    ) AS [t0] ON [j0].[BranchId] = [t0].[Id]
+    WHERE [t0].[Id] < 20
+) AS [t1] ON [t].[Id] = [t1].[OneId]
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+        }
+
+        public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation_split(bool async)
+        {
+            await base.Filtered_include_on_skip_navigation_then_filtered_include_on_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[CollectionInverseId], [e].[Name], [e].[ReferenceInverseId]
+FROM [EntityTwos] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[Name], [e].[Id], [t].[OneId], [t].[TwoId]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] > 15
+) AS [t] ON [e].[Id] = [t].[TwoId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]
+FROM [EntityTwos] AS [e]
+INNER JOIN (
+    SELECT [j].[OneId], [j].[TwoId], [e0].[Id], [e0].[Name]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
+    WHERE [e0].[Id] > 15
+) AS [t] ON [e].[Id] = [t].[TwoId]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+    FROM [EntityTwos] AS [e1]
+    WHERE [e1].[Id] < 5
+) AS [t0] ON [t].[Id] = [t0].[CollectionInverseId]
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
+        }
+
+        public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation_split(bool async)
+        {
+            await base.Filtered_include_on_navigation_then_filtered_include_on_skip_navigation_split(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Name]
+FROM [EntityOnes] AS [e]
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [EntityTwos] AS [e0]
+    WHERE [e0].[Id] > 15
+) AS [t] ON [e].[Id] = [t].[CollectionInverseId]
+ORDER BY [e].[Id], [t].[Id]",
+                //
+                @"SELECT [t0].[Id], [t0].[CollectionInverseId], [t0].[Name], [t0].[ReferenceInverseId], [e].[Id], [t].[Id]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId]
+    FROM [EntityTwos] AS [e0]
+    WHERE [e0].[Id] > 15
+) AS [t] ON [e].[Id] = [t].[CollectionInverseId]
+INNER JOIN (
+    SELECT [j].[TwoId], [j].[ThreeId], [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId]
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
+    WHERE [e1].[Id] < 5
+) AS [t0] ON [t].[Id] = [t0].[TwoId]
+ORDER BY [e].[Id], [t].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Xunit;
+
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class ManyToManyQuerySqliteTest : ManyToManyQueryRelationalTestBase<ManyToManyQuerySqliteFixture>
@@ -9,5 +12,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        // Sqlite does not support Apply operations
+
+        public override Task Skip_navigation_order_by_single_or_default(bool async) => Task.CompletedTask;
+
+        public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async) => Task.CompletedTask;
+
+        [ConditionalTheory(Skip = "SQLite bug")]
+        public override Task Left_join_with_skip_navigation(bool async) => base.Left_join_with_skip_navigation(async);
     }
 }


### PR DESCRIPTION
Query: Expand/Include skip navigations in query
Part of #19003

- Expand skip navigations over
  - A 1<=>1 Join 1<=>1 B
  - A 1<=>* Join *<=>1 B
  - A 1<=>* Join 1<=>* B
  
- Change EntityReference to remember existing expansions based on FK & direction rather than INavigation since skipNavigation may not have intermediate navigations which should get de-dupe if navigation to join entity is expanded
- Include skip navigations
  - While searching for string based include
  - While adding eager loaded navigations

- Cosmos - SkipNavigations are not embedded so processing them is same as non-embedded navigations

- Change MaterializeCollectionNavigationExpression/IncludeTreeNode to accept INavigationBase to accomodate skip navigations
  - Downstream changes to flow INavigationBase to CollectionShaperExpression & family
  - Changes to IncludeReference/IncludeCollection & family to accept INavigationBase
  - Changes to ClrCollectionAccessorFactory to accept INavigationBase to create collection for skip navigations
  - Changes to EntityEntry APIs to accept INavigationBase to set IsLoaded via changetracker

- Tests
  - SkipNavigations used in different parts of query with different operators after them
  - Include/Filtered include over SkipNavigations mixing with navigation includes
  - AsSplitQuery tests for collection SkipNavigations in relational

Filed #21332 for merge issue over multiple include paths
Pending tests for tracking scenario which is blocked on changetracker changes