### PR TITLE
Fix for 20508 - Throw if only 1 navigation on many-to-many

### DIFF
--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -198,6 +198,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public virtual CollectionCollectionBuilder WithMany([NotNull] string navigationName)
         {
+            if (Builder != null
+                && Builder.Metadata.PrincipalToDependent == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.MissingInverseNavigation(
+                        Builder.Metadata.PrincipalEntityType.DisplayName(),
+                        Builder.Metadata.DeclaringEntityType.DisplayName()));
+            }
+
             var leftName = Builder?.Metadata.PrincipalToDependent.Name;
             return new CollectionCollectionBuilder(
                            RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && Builder.Metadata.PrincipalToDependent == null)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.MissingInverseNavigation(
+                    CoreStrings.MissingInverseManyToManyNavigation(
                         Builder.Metadata.PrincipalEntityType.DisplayName(),
                         Builder.Metadata.DeclaringEntityType.DisplayName()));
             }

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 && Builder.Metadata.PrincipalToDependent == null)
             {
                 throw new InvalidOperationException(
-                    CoreStrings.MissingInverseNavigation(
+                    CoreStrings.MissingInverseManyToManyNavigation(
                         Builder.Metadata.PrincipalEntityType.DisplayName(),
                         Builder.Metadata.DeclaringEntityType.DisplayName()));
             }

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -115,6 +116,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual CollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
             [NotNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
         {
+            if (Builder != null
+                && Builder.Metadata.PrincipalToDependent == null)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.MissingInverseNavigation(
+                        Builder.Metadata.PrincipalEntityType.DisplayName(),
+                        Builder.Metadata.DeclaringEntityType.DisplayName()));
+            }
+
             var leftName = Builder?.Metadata.PrincipalToDependent.Name;
             return new CollectionCollectionBuilder<TRelatedEntity, TEntity>(
                            RelatedEntityType,

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2597,12 +2597,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{navigationName}' on the entity type '{entityType}' because the navigation property has the opposite multiplicity.'
+        ///     Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{navigationName}' on the entity type '{entityType}' because the navigation property has the opposite multiplicity.
         /// </summary>
         public static string UnableToSetIsUnique([CanBeNull] object isUnique, [CanBeNull] object navigationName, [CanBeNull] object entityType)
             => string.Format(
                 GetString("UnableToSetIsUnique", nameof(isUnique), nameof(navigationName), nameof(entityType)),
                 isUnique, navigationName, entityType);
+
+        /// <summary>
+        ///     Unable to set up a many-to-many relationship between the entities '{principalEntityType}' and '{declaringEntityType}' because no inverse navigation was specified. Please provide a navigation property in both the HasMany() and WithMany() calls.
+        /// </summary>
+        public static string MissingInverseNavigation([CanBeNull] object principalEntityType, [CanBeNull] object declaringEntityType)
+            => string.Format(
+                GetString("MissingInverseNavigation", nameof(principalEntityType), nameof(declaringEntityType)),
+                principalEntityType, declaringEntityType);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2605,11 +2605,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 isUnique, navigationName, entityType);
 
         /// <summary>
-        ///     Unable to set up a many-to-many relationship between the entities '{principalEntityType}' and '{declaringEntityType}' because no inverse navigation was specified. Please provide a navigation property in both the HasMany() and WithMany() calls.
+        ///     Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation property in the HasMany() call.
         /// </summary>
-        public static string MissingInverseNavigation([CanBeNull] object principalEntityType, [CanBeNull] object declaringEntityType)
+        public static string MissingInverseManyToManyNavigation([CanBeNull] object principalEntityType, [CanBeNull] object declaringEntityType)
             => string.Format(
-                GetString("MissingInverseNavigation", nameof(principalEntityType), nameof(declaringEntityType)),
+                GetString("MissingInverseManyToManyNavigation", nameof(principalEntityType), nameof(declaringEntityType)),
                 principalEntityType, declaringEntityType);
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1372,7 +1372,7 @@
   <data name="UnableToSetIsUnique" xml:space="preserve">
     <value>Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{navigationName}' on the entity type '{entityType}' because the navigation property has the opposite multiplicity.</value>
   </data>
-  <data name="MissingInverseNavigation" xml:space="preserve">
-    <value>Unable to set up a many-to-many relationship between the entities '{principalEntityType}' and '{declaringEntityType}' because no inverse navigation was specified. Please provide a navigation property in both the HasMany() and WithMany() calls.</value>
+  <data name="MissingInverseManyToManyNavigation" xml:space="preserve">
+    <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation property in the HasMany() call.</value>
   </data>
 </root>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1370,6 +1370,9 @@
     <value>Materialization condition passed for entity shaper of entity type '{entityType}' is not of correct shape. Materialization condition must be LambdaExpression of 'Func&lt;ValueBuffer, IEntityType&gt;'</value>
   </data>
   <data name="UnableToSetIsUnique" xml:space="preserve">
-    <value>Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{navigationName}' on the entity type '{entityType}' because the navigation property has the opposite multiplicity.'</value>
+    <value>Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{navigationName}' on the entity type '{entityType}' because the navigation property has the opposite multiplicity.</value>
+  </data>
+  <data name="MissingInverseNavigation" xml:space="preserve">
+    <value>Unable to set up a many-to-many relationship between the entities '{principalEntityType}' and '{declaringEntityType}' because no inverse navigation was specified. Please provide a navigation property in both the HasMany() and WithMany() calls.</value>
   </data>
 </root>

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -161,6 +161,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Throws_for_many_to_many_with_only_one_navigation_configured()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                Assert.Equal(
+                    CoreStrings.MissingInverseNavigation(
+                        nameof(ManyToManyNavPrincipal),
+                        nameof(NavDependent)),
+                    Assert.Throws<InvalidOperationException>(
+                        () => modelBuilder.Entity<ManyToManyNavPrincipal>()
+                                .HasMany<NavDependent>(/* leaving empty causes the exception */)
+                                .WithMany(d => d.ManyToManyPrincipals)).Message);
+            }
+
+            [ConditionalFact]
             public virtual void Navigation_properties_can_set_access_mode_using_expressions()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
 
                 Assert.Equal(
-                    CoreStrings.MissingInverseNavigation(
+                    CoreStrings.MissingInverseManyToManyNavigation(
                         nameof(ManyToManyNavPrincipal),
                         nameof(NavDependent)),
                     Assert.Throws<InvalidOperationException>(


### PR DESCRIPTION
Throw a better exception if only 1 navigation is specified on a many-to-many relationship.

Fixes #20508
