### PR TITLE
[release/3.1] Cosmos: Avoid using "value" as an alias

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -204,7 +204,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             var currentAlias = baseAlias;
             var counter = 0;
-            while (_projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
+            while (string.Equals("value", currentAlias, StringComparison.OrdinalIgnoreCase)
+                || _projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
             {
                 currentAlias = $"{baseAlias}{counter++}";
             }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Select.cs
@@ -10,6 +10,21 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class SimpleQueryCosmosTest
     {
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Projection_with_Value_Property(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Order>().Select(o => new { Value = o.OrderID }),
+                e => (e.Value));
+
+            AssertSql(
+                @"SELECT c[""OrderID""] AS Value0
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
         public override async Task Projection_when_arithmetic_expression_precedence(bool isAsync)
         {
             await base.Projection_when_arithmetic_expression_precedence(isAsync);


### PR DESCRIPTION
Fixes #20557

### Description

EF generates aliases in the SQL query based on the projection properties. However "value" is a keyword in CosmosDB, so projections with a "Value" property result in invalid SQL.

### Customer Impact
This is especially impactful when used with OData, as it generates this type of queries frequently and there's no workaround for the user.

### How found
Reported by customer.

### Test coverage
Added a test using this pattern.

### Regression?
No.

### Risk
Low. Fix only affects the alias used in the SQL.
