### PR TITLE
Remove testing for ToString behavior on TimeSpan

### DIFF
--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -2014,10 +2014,7 @@ namespace Microsoft.EntityFrameworkCore
                     Float = b.TestSingle.ToString(),
                     Double = b.TestDouble.ToString(),
                     Decimal = b.TestDecimal.ToString(),
-                    Char = b.TestCharacter.ToString(),
-                    DateTime = b.TestDateTime.ToString(),
-                    DateTimeOffset = b.TestDateTimeOffset.ToString(),
-                    TimeSpan = b.TestTimeSpan.ToString(),
+                    Char = b.TestCharacter.ToString()
                 })
                 .First();
 
@@ -2036,10 +2033,7 @@ namespace Microsoft.EntityFrameworkCore
                     Float = b.TestSingle.ToString(),
                     Double = b.TestDouble.ToString(),
                     Decimal = b.TestDecimal.ToString(),
-                    Char = b.TestCharacter.ToString(),
-                    DateTime = b.TestDateTime.ToString(),
-                    DateTimeOffset = b.TestDateTimeOffset.ToString(),
-                    TimeSpan = b.TestTimeSpan.ToString(),
+                    Char = b.TestCharacter.ToString()
                 })
                 .ToList();
 
@@ -2054,7 +2048,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(expected.Ulong, actual.Ulong);
             Assert.Equal(expected.Decimal, actual.Decimal);
             Assert.Equal(expected.Char, actual.Char);
-            Assert.Equal(expected.TimeSpan, actual.TimeSpan);
         }
 
         public abstract class BuiltInDataTypesFixtureBase : SharedStoreFixtureBase<PoolableDbContext>

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -2014,7 +2014,10 @@ namespace Microsoft.EntityFrameworkCore
                     Float = b.TestSingle.ToString(),
                     Double = b.TestDouble.ToString(),
                     Decimal = b.TestDecimal.ToString(),
-                    Char = b.TestCharacter.ToString()
+                    Char = b.TestCharacter.ToString(),
+                    DateTime = b.TestDateTime.ToString(),
+                    DateTimeOffset = b.TestDateTimeOffset.ToString(),
+                    TimeSpan = b.TestTimeSpan.ToString()
                 })
                 .First();
 
@@ -2033,7 +2036,10 @@ namespace Microsoft.EntityFrameworkCore
                     Float = b.TestSingle.ToString(),
                     Double = b.TestDouble.ToString(),
                     Decimal = b.TestDecimal.ToString(),
-                    Char = b.TestCharacter.ToString()
+                    Char = b.TestCharacter.ToString(),
+                    DateTime = b.TestDateTime.ToString(),
+                    DateTimeOffset = b.TestDateTimeOffset.ToString(),
+                    TimeSpan = b.TestTimeSpan.ToString()
                 })
                 .ToList();
 

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -2011,13 +2011,8 @@ namespace Microsoft.EntityFrameworkCore
                     Uint = b.TestUnsignedInt32.ToString(),
                     Long = b.TestInt64.ToString(),
                     Ulong = b.TestUnsignedInt64.ToString(),
-                    Float = b.TestSingle.ToString(),
-                    Double = b.TestDouble.ToString(),
                     Decimal = b.TestDecimal.ToString(),
-                    Char = b.TestCharacter.ToString(),
-                    DateTime = b.TestDateTime.ToString(),
-                    DateTimeOffset = b.TestDateTimeOffset.ToString(),
-                    TimeSpan = b.TestTimeSpan.ToString()
+                    Char = b.TestCharacter.ToString()
                 })
                 .First();
 

--- a/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
@@ -11,6 +11,8 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override void Object_to_string_conversion() {}
+
         public abstract class ConvertToProviderTypesFixtureBase : BuiltInDataTypesFixtureBase
         {
             protected override string StoreName { get; } = "ConvertToProviderTypes";

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -617,6 +617,8 @@ namespace Microsoft.EntityFrameworkCore
             Seller
         }
 
+        public override void Object_to_string_conversion() {}
+
         public abstract class CustomConvertersFixtureBase : BuiltInDataTypesFixtureBase
         {
             protected override string StoreName { get; } = "CustomConverters";


### PR DESCRIPTION
Testing introduced in #20470

When syncing, EFCore.PG fails the new Object_to_string_conversion because PostgreSQL strips trailing zeros from the TimeSpan representation, so we get back `10:09:08.007` instead of `10:09:08.0070000` which is what .NET does.

As recently discussed, we shouldn't expect parameterless ToString to yield precisely the same representation in the database as in .NET. The other types tested in this test seem fine, except maybe for decimal which could also suffer from a similar issue (but doesn't for PG).