### PR TITLE
Query: Remove AnonymousObject

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/AnonymousObject.cs
+++ b/src/EFCore.InMemory/Query/Internal/AnonymousObject.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.Query.Internal
+namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -457,6 +456,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     : (CreateAnonymousObject(leftExpressions), CreateAnonymousObject(rightExpressions))
                 : (null, null);
 
+            // InMemory joins need to use AnonymousObject to perform correct key comparison for server side joins
             static Expression CreateAnonymousObject(List<Expression> expressions)
                 => Expression.New(
                     AnonymousObject.AnonymousObjectCtor,

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -544,8 +544,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var outerKey = RemapLambdaBody(outer, outerKeySelector);
             var innerKey = RemapLambdaBody(inner, innerKeySelector);
 
-            if (outerKey is NewExpression outerNew
-                && outerNew.Type != typeof(AnonymousObject))
+            if (outerKey is NewExpression outerNew)
             {
                 var innerNew = (NewExpression)innerKey;
 

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -293,13 +293,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             bool makeNullable = false)
             => properties.Count == 1
                 ? target.CreateEFPropertyExpression(properties[0], makeNullable)
-                : Expression.New(
-                    AnonymousObject.AnonymousObjectCtor,
-                    Expression.NewArrayInit(
-                        typeof(object),
-                        properties
-                            .Select(p => Expression.Convert(target.CreateEFPropertyExpression(p, makeNullable), typeof(object)))
-                            .Cast<Expression>()));
+                : Expression.NewArrayInit(
+                    typeof(object),
+                    properties
+                        .Select(p => Expression.Convert(target.CreateEFPropertyExpression(p, makeNullable), typeof(object)))
+                        .Cast<Expression>());
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -215,8 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     // This is intentionally deferred to be applied to innerSource.Source
                     // Since outerKey's reference could change if a reference navigation is expanded afterwards
                     var predicateBody = Expression.AndAlso(
-                        outerKey is NewExpression newExpression
-                        && newExpression.Arguments[0] is NewArrayExpression newArrayExpression
+                        outerKey is NewArrayExpression newArrayExpression
                             ? newArrayExpression.Expressions
                                 .Select(e =>
                                 {


### PR DESCRIPTION
- Make it implementation detail of InMemory provider which still needs it to match outer/inner keys of a join executed on server side

Resolves #20565
