### PR TITLE
Calling ModelBuilder.Entity() followed by .Owned() could cause NRE

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -3127,12 +3127,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            foreach (var foreignKey in incompatibleRelationships)
+            var firstForeignKey = incompatibleRelationships.FirstOrDefault();
+            if (firstForeignKey == null)
             {
-                foreignKey.DeclaringEntityType.Builder.HasNoRelationship(foreignKey, configurationSource);
+                return true;
             }
 
-            return true;
+            firstForeignKey.DeclaringEntityType
+                .Builder.HasNoRelationship(firstForeignKey, configurationSource);
+
+            // have to recalculate the list of incompatible relationships
+            // because the HasNoRelationship() call above may have changed them
+            return RemoveNonOwnershipRelationships(ownership, configurationSource);
         }
 
         private bool Contains(IForeignKey inheritedFk, IForeignKey derivedFk)

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -429,6 +429,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Null(model.FindEntityType(typeof(SpecialOrder)));
             }
 
+            [ConditionalFact]
+            public virtual void Can_call_Owner_fluent_api_after_calling_Entity()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<OwnerOfOwnees>();
+                modelBuilder.Owned<Ownee1>();
+                modelBuilder.Owned<Ownee2>();
+                modelBuilder.Owned<Ownee3>();
+            }
+
             [Flags]
             public enum HasDataOverload
             {

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -919,10 +919,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public class OwnerOfOwnees
         {
             public string Id { get; private set; }
+
             public Ownee2 AnOwnee2 { get; private set; }
-
             public Ownee1 Ownee1 { get; private set; }
-
         }
 
         public class Ownee1

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -915,5 +915,29 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public OneToManyNavPrincipalOwner OneToManyOwner { get; set; }
         }
+
+        public class OwnerOfOwnees
+        {
+            public string Id { get; private set; }
+            public Ownee2 AnOwnee2 { get; private set; }
+
+            public Ownee1 Ownee1 { get; private set; }
+
+        }
+
+        public class Ownee1
+        {
+            public Ownee3 NewOwnee3 { get; private set; }
+        }
+
+        public class Ownee2
+        {
+            public Ownee3 Ownee3 { get; private set; }
+        }
+
+        public class Ownee3
+        {
+            public string Name { get; private set; }
+        }
     }
 }


### PR DESCRIPTION
Calling ModelBuilder.Entity() followed by .Owned() could cause NRE.

Fixes #20446  
