### PR TITLE
Cosmos: Populate __jObject on SaveChanges

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseWrapper.cs
@@ -209,7 +209,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             switch (state)
             {
                 case EntityState.Added:
-                    var newDocument = documentSource.CreateDocument(entry);
+                    var newDocument = documentSource.GetCurrentDocument(entry);
+                    if (newDocument != null)
+                    {
+                        documentSource.UpdateDocument(newDocument, entry);
+                    }
+                    else
+                    {
+                        newDocument = documentSource.CreateDocument(entry);
+                    }
+
                     return _cosmosClient.CreateItem(collectionId, newDocument, entry);
 
                 case EntityState.Modified:
@@ -267,7 +276,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             switch (state)
             {
                 case EntityState.Added:
-                    var newDocument = documentSource.CreateDocument(entry);
+                    var newDocument = documentSource.GetCurrentDocument(entry);
+                    if (newDocument != null)
+                    {
+                        documentSource.UpdateDocument(newDocument, entry);
+                    }
+                    else
+                    {
+                        newDocument = documentSource.CreateDocument(entry);
+                    }
+
                     return _cosmosClient.CreateItemAsync(
                         collectionId, newDocument, entry, cancellationToken);
 

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -182,6 +182,142 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             }
         }
 
+        [ConditionalFact]
+        public void Can_add_update_untracked_properties()
+        {
+            var options = Fixture.CreateOptions();
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new CustomerContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                var entry = context.Add(customer);
+
+                entry.Property<JObject>("__jObject").CurrentValue = new JObject
+                {
+                    ["key1"] = "value1"
+                };
+
+                context.SaveChanges();
+
+                var providersJson = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(providersJson);
+
+                providersJson["key2"] = "value2";
+                entry.State = EntityState.Modified;
+                context.SaveChanges();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
+
+                var entry = context.Entry(customerFromStore);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.Equal("value1", document["key1"]);
+                Assert.Equal("value2", document["key2"]);
+
+                document["key1"] = "value1.1";
+                customerFromStore.Name = "Theon Greyjoy";
+
+                context.SaveChanges();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = context.Set<Customer>().Single();
+
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+
+                var entry = context.Entry(customerFromStore);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.Equal("value1.1", document["key1"]);
+                Assert.Equal("value2", document["key2"]);
+
+                context.Remove(customerFromStore);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
+            }
+        }
+
+        [ConditionalFact]
+        public async Task Can_add_update_untracked_properties_async()
+        {
+            var options = Fixture.CreateOptions();
+
+            var customer = new Customer { Id = 42, Name = "Theon" };
+
+            using (var context = new CustomerContext(options))
+            {
+                context.Database.EnsureCreated();
+
+                var entry = context.Add(customer);
+
+                entry.Property<JObject>("__jObject").CurrentValue = new JObject
+                {
+                    ["key1"] = "value1"
+                };
+
+                await context.SaveChangesAsync();
+
+                var providersJson = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(providersJson);
+
+                providersJson["key2"] = "value2";
+                entry.State = EntityState.Modified;
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>().SingleAsync();
+
+                Assert.Equal(42, customerFromStore.Id);
+                Assert.Equal("Theon", customerFromStore.Name);
+
+                var entry = context.Entry(customerFromStore);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.Equal("value1", document["key1"]);
+                Assert.Equal("value2", document["key2"]);
+
+                document["key1"] = "value1.1";
+                customerFromStore.Name = "Theon Greyjoy";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                var customerFromStore = await context.Set<Customer>().SingleAsync();
+
+                Assert.Equal("Theon Greyjoy", customerFromStore.Name);
+
+                var entry = context.Entry(customerFromStore);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.Equal("value1.1", document["key1"]);
+                Assert.Equal("value2", document["key2"]);
+
+                context.Remove(customerFromStore);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
+            }
+        }
+
         private class Customer
         {
             public int Id { get; set; }

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -195,6 +195,23 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
                 var entry = context.Add(customer);
 
+                context.SaveChanges();
+
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(document);
+                Assert.Equal("Theon", document["Name"]);
+
+                context.Remove(customer);
+
+                context.SaveChanges();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(context.Set<Customer>().ToList());
+
+                var entry = context.Add(customer);
+
                 entry.Property<JObject>("__jObject").CurrentValue = new JObject
                 {
                     ["key1"] = "value1"
@@ -202,10 +219,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
                 context.SaveChanges();
 
-                var providersJson = entry.Property<JObject>("__jObject").CurrentValue;
-                Assert.NotNull(providersJson);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(document);
+                Assert.Equal("Theon", document["Name"]);
+                Assert.Equal("value1", document["key1"]);
 
-                providersJson["key2"] = "value2";
+                document["key2"] = "value2";
                 entry.State = EntityState.Modified;
                 context.SaveChanges();
             }
@@ -259,7 +278,24 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             using (var context = new CustomerContext(options))
             {
-                context.Database.EnsureCreated();
+                await context.Database.EnsureCreatedAsync();
+
+                var entry = context.Add(customer);
+
+                await context.SaveChangesAsync();
+
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(document);
+                Assert.Equal("Theon", document["Name"]);
+
+                context.Remove(customer);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CustomerContext(options))
+            {
+                Assert.Empty(await context.Set<Customer>().ToListAsync());
 
                 var entry = context.Add(customer);
 
@@ -270,10 +306,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
                 await context.SaveChangesAsync();
 
-                var providersJson = entry.Property<JObject>("__jObject").CurrentValue;
-                Assert.NotNull(providersJson);
+                var document = entry.Property<JObject>("__jObject").CurrentValue;
+                Assert.NotNull(document);
+                Assert.Equal("Theon", document["Name"]);
+                Assert.Equal("value1", document["key1"]);
 
-                providersJson["key2"] = "value2";
+                document["key2"] = "value2";
                 entry.State = EntityState.Modified;
                 await context.SaveChangesAsync();
             }
@@ -314,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             using (var context = new CustomerContext(options))
             {
-                Assert.Empty(context.Set<Customer>().ToList());
+                Assert.Empty(await context.Set<Customer>().ToListAsync());
             }
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -284,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.TestUtilities
             public IIndex FindIndex(IReadOnlyList<IProperty> properties) => throw new NotImplementedException();
             public IKey FindKey(IReadOnlyList<IProperty> properties) => throw new NotImplementedException();
             public IKey FindPrimaryKey() => throw new NotImplementedException();
-            public IProperty FindProperty(string name) => throw new NotImplementedException();
+            public IProperty FindProperty(string name) => null;
             public IServiceProperty FindServiceProperty(string name) => throw new NotImplementedException();
             public ISkipNavigation FindSkipNavigation(string name) => throw new NotImplementedException();
             public IEnumerable<IAnnotation> GetAnnotations() => throw new NotImplementedException();


### PR DESCRIPTION
- Store the document that Cosmos returns after Create and Replace operations onto the __jObject shadow property, ensuring it always exists after a database operation (previously it would only exist after queries)
- Use instead of ignore the value of the __jObject shadow property on entity adds, allowing untracked properties to be populated on new entities before they're added.

 Resolves #17778