### PR TITLE
Fix to #20612 - Throw helpful translation exception for String.Equals(String, StringComparison)

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -27,6 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
     {
         private readonly IModel _model;
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
+        private readonly IMemberTranslatorProvider _memberTranslatorProvider;
+        private readonly IMethodCallTranslatorProvider _methodCallTranslatorProvider;
         private readonly CosmosSqlTranslatingExpressionVisitor _sqlTranslator;
         private readonly CosmosProjectionBindingExpressionVisitor _projectionBindingExpressionVisitor;
 
@@ -46,11 +48,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             _model = queryCompilationContext.Model;
             _sqlExpressionFactory = sqlExpressionFactory;
+            _memberTranslatorProvider = memberTranslatorProvider;
+            _methodCallTranslatorProvider = methodCallTranslatorProvider;
             _sqlTranslator = new CosmosSqlTranslatingExpressionVisitor(
                 queryCompilationContext,
-                sqlExpressionFactory,
-                memberTranslatorProvider,
-                methodCallTranslatorProvider);
+                _sqlExpressionFactory,
+                _memberTranslatorProvider,
+                _methodCallTranslatorProvider);
             _projectionBindingExpressionVisitor = new CosmosProjectionBindingExpressionVisitor(_model, _sqlTranslator);
         }
 
@@ -66,7 +70,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             _model = parentVisitor._model;
             _sqlExpressionFactory = parentVisitor._sqlExpressionFactory;
-            _sqlTranslator = parentVisitor._sqlTranslator;
+            _sqlTranslator = new CosmosSqlTranslatingExpressionVisitor(
+                QueryCompilationContext,
+                _sqlExpressionFactory,
+                _memberTranslatorProvider,
+                _methodCallTranslatorProvider);
             _projectionBindingExpressionVisitor = new CosmosProjectionBindingExpressionVisitor(_model, _sqlTranslator);
         }
 
@@ -1091,7 +1099,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         }
 
         private SqlExpression TranslateExpression(Expression expression)
-            => _sqlTranslator.Translate(expression);
+        {
+            var translation = _sqlTranslator.Translate(expression);
+            if (translation == null && _sqlTranslator.TranslationErrorDetails != null)
+            {
+                ProvideTranslationErrorDetails(_sqlTranslator.TranslationErrorDetails);
+            }
+
+            return translation;
+        }
 
         private SqlExpression TranslateLambdaExpression(
             ShapedQueryExpression shapedQueryExpression, LambdaExpression lambdaExpression)

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -85,7 +85,44 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual string TranslationErrorDetails { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected virtual void ProvideTranslationErrorDetails([NotNull] string details)
+        {
+            Check.NotNull(details, nameof(details));
+
+            if (TranslationErrorDetails == null)
+            {
+                TranslationErrorDetails = details;
+            }
+            else
+            {
+                TranslationErrorDetails += Environment.NewLine + details;
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual Expression Translate([NotNull] Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            TranslationErrorDetails = null;
+
+            return TranslateInternal(expression);
+        }
+
+        private Expression TranslateInternal(Expression expression)
         {
             var result = Visit(expression);
 
@@ -366,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     case nameof(Enumerable.Min):
                     case nameof(Enumerable.Sum):
                     {
-                        var translation = Translate(GetSelectorOnGrouping(methodCallExpression, groupByShaperExpression));
+                        var translation = TranslateInternal(GetSelectorOnGrouping(methodCallExpression, groupByShaperExpression));
                         if (translation == null)
                         {
                             return null;
@@ -409,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                                 groupByShaperExpression.GroupingParameter);
                         }
 
-                        var translation = Translate(predicate);
+                        var translation = TranslateInternal(predicate);
                         if (translation == null)
                         {
                             return null;
@@ -829,7 +866,18 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 ? entityType.FindProperty(member.MemberInfo)
                 : entityType.FindProperty(member.Name);
 
-            return property != null ? BindProperty(entityReferenceExpression, property, type) : null;
+            if (property != null)
+            {
+                return BindProperty(entityReferenceExpression, property, type);
+
+            }
+
+            ProvideTranslationErrorDetails(
+                CoreStrings.QueryUnableToTranslateMember(
+                    member.Name,
+                    entityReferenceExpression.EntityType.DisplayName()));
+
+            return null;
         }
 
         private Expression BindProperty(EntityReferenceExpression entityReferenceExpression, IProperty property, Type type)

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -56,8 +56,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             [NotNull] InMemoryQueryableMethodTranslatingExpressionVisitor parentVisitor)
             : base(parentVisitor.Dependencies, parentVisitor.QueryCompilationContext, subquery: true)
         {
-            _expressionTranslator = parentVisitor._expressionTranslator;
-            _weakEntityExpandingExpressionVisitor = parentVisitor._weakEntityExpandingExpressionVisitor;
+            _expressionTranslator = new InMemoryExpressionTranslatingExpressionVisitor(QueryCompilationContext, parentVisitor);
+            _weakEntityExpandingExpressionVisitor = new WeakEntityExpandingExpressionVisitor(_expressionTranslator);
             _projectionBindingExpressionVisitor = new InMemoryProjectionBindingExpressionVisitor(this, _expressionTranslator);
             _model = parentVisitor._model;
         }
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     return memberInitExpression.Update(updatedNewExpression, newBindings);
 
                 default:
-                    var translation = _expressionTranslator.Translate(expression);
+                    var translation = TranslateExpression(expression);
                     if (translation == null)
                     {
                         return null;
@@ -1204,19 +1204,23 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
         private Expression TranslateExpression(Expression expression, bool preserveType = false)
         {
-            var result = _expressionTranslator.Translate(expression);
-
-            if (expression != null
-                && result != null
-                && preserveType
-                && expression.Type != result.Type)
+            var translation = _expressionTranslator.Translate(expression);
+            if (translation == null && _expressionTranslator.TranslationErrorDetails != null)
             {
-                result = expression.Type == typeof(bool)
-                    ? Expression.Equal(result, Expression.Constant(true, result.Type))
-                    : (Expression)Expression.Convert(result, expression.Type);
+                ProvideTranslationErrorDetails(_expressionTranslator.TranslationErrorDetails);
             }
 
-            return result;
+            if (expression != null
+                && translation != null
+                && preserveType
+                && expression.Type != translation.Type)
+            {
+                translation = expression.Type == typeof(bool)
+                    ? Expression.Equal(translation, Expression.Constant(true, translation.Type))
+                    : (Expression)Expression.Convert(translation, expression.Type);
+            }
+
+            return translation;
         }
 
         private LambdaExpression TranslateLambdaExpression(
@@ -1253,6 +1257,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             {
                 _expressionTranslator = expressionTranslator;
             }
+
+            public string TranslationErrorDetails => _expressionTranslator.TranslationErrorDetails;
 
             public Expression Expand(InMemoryQueryExpression queryExpression, Expression lambdaBody)
             {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -41,6 +41,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 expression);
 
         /// <summary>
+        ///     The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
+        /// </summary>
+        public static string TranslationFailedWithDetails([CanBeNull] object expression, [CanBeNull] object details)
+            => string.Format(
+                GetString("TranslationFailedWithDetails", nameof(expression), nameof(details)),
+                expression, details);
+
+        /// <summary>
         ///     Processing of the LINQ expression '{expression}' by '{visitor}' failed. This may indicate either a bug or a limitation in EF Core. See https://go.microsoft.com/fwlink/?linkid=2101433 for more detailed information.
         /// </summary>
         public static string QueryFailed([CanBeNull] object expression, [CanBeNull] object visitor)
@@ -2559,6 +2567,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("QueryUnableToTranslateEFProperty", nameof(expression)),
                 expression);
+
+        /// <summary>
+        ///     Translation of member '{member}' on entity type '{entityType}' failed. Possibly the specified member is not mapped.
+        /// </summary>
+        public static string QueryUnableToTranslateMember([CanBeNull] object member, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("QueryUnableToTranslateMember", nameof(member), nameof(entityType)),
+                member, entityType);
+
+        /// <summary>
+        ///     Translation of 'string.Equals' method which takes 'StringComparison' argument is not supported. See https://go.microsoft.com/fwlink/?linkid=2129535 for more information.
+        /// </summary>
+        public static string QueryUnableToTranslateStringEqualsWithStringComparison
+            => GetString("QueryUnableToTranslateStringEqualsWithStringComparison");
 
         /// <summary>
         ///     Invalid {state} encountered.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -123,6 +123,9 @@
   <data name="TranslationFailed" xml:space="preserve">
     <value>The LINQ expression '{expression}' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
   </data>
+  <data name="TranslationFailedWithDetails" xml:space="preserve">
+    <value>The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
+  </data>
   <data name="QueryFailed" xml:space="preserve">
     <value>Processing of the LINQ expression '{expression}' by '{visitor}' failed. This may indicate either a bug or a limitation in EF Core. See https://go.microsoft.com/fwlink/?linkid=2101433 for more detailed information.</value>
   </data>
@@ -1355,6 +1358,12 @@
   </data>
   <data name="QueryUnableToTranslateEFProperty" xml:space="preserve">
     <value>Translation of '{expression}' failed. Either source is not an entity type or the specified property does not exist on the entity type.</value>
+  </data>
+  <data name="QueryUnableToTranslateMember" xml:space="preserve">
+    <value>Translation of member '{member}' on entity type '{entityType}' failed. Possibly the specified member is not mapped.</value>
+  </data>
+  <data name="QueryUnableToTranslateStringEqualsWithStringComparison" xml:space="preserve">
+    <value>Translation of 'string.Equals' method which takes 'StringComparison' argument is not supported. See https://go.microsoft.com/fwlink/?linkid=2129535 for more information.</value>
   </data>
   <data name="InvalidStateEncountered" xml:space="preserve">
     <value>Invalid {state} encountered.</value>

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -55,6 +55,29 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual QueryableMethodTranslatingExpressionVisitorDependencies Dependencies { get; }
 
         /// <summary>
+        ///     Additional information about errors encountered during translation.
+        /// </summary>
+        public virtual string TranslationErrorDetails { get; private set; }
+
+        /// <summary>
+        ///     Provides additional information about errors encountered during translation.
+        /// </summary>
+        /// <param name="details">Error encountered during translation</param>
+        protected virtual void ProvideTranslationErrorDetails([NotNull] string details)
+        {
+            Check.NotNull(details, nameof(details));
+
+            if (TranslationErrorDetails == null)
+            {
+                TranslationErrorDetails = details;
+            }
+            else
+            {
+                TranslationErrorDetails += Environment.NewLine + details;
+            }
+        }
+
+        /// <summary>
         ///     The query compilation context object for current compilation.
         /// </summary>
         protected virtual QueryCompilationContext QueryCompilationContext { get; }
@@ -79,7 +102,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             ShapedQueryExpression CheckTranslated(ShapedQueryExpression translated)
             {
-                return translated ?? throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
+                return translated ?? throw new InvalidOperationException(
+                    TranslationErrorDetails == null
+                        ? CoreStrings.TranslationFailed(methodCallExpression.Print())
+                        : CoreStrings.TranslationFailedWithDetails(
+                            methodCallExpression.Print(),
+                            TranslationErrorDetails));
             }
 
             var method = methodCallExpression.Method;
@@ -596,7 +624,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(expression, nameof(expression));
 
-            return (ShapedQueryExpression)CreateSubqueryVisitor().Visit(expression);
+            var subqueryVisitor = CreateSubqueryVisitor();
+            var translation = (ShapedQueryExpression)subqueryVisitor.Visit(expression);
+            if (translation == null && subqueryVisitor.TranslationErrorDetails != null)
+            {
+                ProvideTranslationErrorDetails(subqueryVisitor.TranslationErrorDetails);
+            }
+
+            return translation;
         }
 
         /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1600,6 +1600,12 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             return base.Min_after_default_if_empty_does_not_throw(isAsync);
         }
 
+        [ConditionalTheory(Skip = "Issue#20677")]
+        public override Task Average_with_unmapped_property_access_throws_meaningful_exception(bool async)
+        {
+            return base.Average_with_unmapped_property_access_throws_meaningful_exception(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4125,6 +4125,14 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
             return base.Perform_identity_resolution_reuses_same_instances_across_joins(async);
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task All_client_and_server_top_level(bool async)
+            => base.All_client_and_server_top_level(async);
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task All_client_or_server_top_level(bool async)
+            => base.All_client_or_server_top_level(async);
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -17,82 +17,58 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
-        {
-            return base.Correlated_collection_order_by_constant_null_of_non_mapped_type(async);
-        }
+            => base.Correlated_collection_order_by_constant_null_of_non_mapped_type(async);
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Client_side_equality_with_parameter_works_with_optional_navigations(bool async)
-        {
-            return base.Client_side_equality_with_parameter_works_with_optional_navigations(async);
-        }
+            => base.Client_side_equality_with_parameter_works_with_optional_navigations(async);
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Where_coalesce_with_anonymous_types(bool async)
-        {
-            return base.Where_coalesce_with_anonymous_types(async);
-        }
+            => base.Where_coalesce_with_anonymous_types(async);
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Where_conditional_with_anonymous_type(bool async)
-        {
-            return base.Where_conditional_with_anonymous_type(async);
-        }
+            => base.Where_conditional_with_anonymous_type(async);
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task GetValueOrDefault_on_DateTimeOffset(bool async)
-        {
-            return base.GetValueOrDefault_on_DateTimeOffset(async);
-        }
+            => base.GetValueOrDefault_on_DateTimeOffset(async);
 
         [ConditionalFact(Skip = "issue #17537")]
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
-        {
-            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1();
-        }
+            => base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1();
 
         [ConditionalFact(Skip = "issue #17537")]
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
-        {
-            base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2();
-        }
+            => base.Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2();
 
         [ConditionalTheory(Skip = "issue #17540")]
-        public override Task
-            Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool async)
-        {
-            return base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(
-                async);
-        }
+        public override Task Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool async)
+            => base.Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(async);
 
         [ConditionalTheory(Skip = "issue #18284")]
         public override Task GroupBy_with_boolean_groupin_key_thru_navigation_access(bool async)
-        {
-            return GroupBy_with_boolean_groupin_key_thru_navigation_access(async);
-        }
+            => GroupBy_with_boolean_groupin_key_thru_navigation_access(async);
 
         [ConditionalTheory(Skip = "issue #17620")]
         public override Task Select_subquery_projecting_single_constant_inside_anonymous(bool async)
-        {
-            return base.Select_subquery_projecting_single_constant_inside_anonymous(async);
-        }
+            => base.Select_subquery_projecting_single_constant_inside_anonymous(async);
 
         [ConditionalTheory(Skip = "issue #19683")]
         public override Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
-        {
-            return base.Group_by_on_StartsWith_with_null_parameter_as_argument(async);
-        }
+            => base.Group_by_on_StartsWith_with_null_parameter_as_argument(async);
 
         [ConditionalTheory(Skip = "issue #18284")]
         public override Task Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(bool async)
-        {
-            return base.Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
-        }
+            => base.Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
+            => base.Client_member_and_unsupported_string_Equals_in_the_same_query(async);
 
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
-        {
-            return base.Client_eval_followed_by_set_operation_throws_meaningful_exception(async);
-        }
+            => base.Client_eval_followed_by_set_operation_throws_meaningful_exception(async);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
@@ -22,106 +22,84 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         public override Task Where_query_composition_entity_equality_one_element_Single(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_one_element_Single(async));
-        }
 
         public override Task Where_query_composition_entity_equality_one_element_First(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_one_element_First(async));
-        }
 
         public override Task Where_query_composition_entity_equality_no_elements_Single(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_no_elements_Single(async));
-        }
 
         public override Task Where_query_composition_entity_equality_no_elements_First(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_no_elements_First(async));
-        }
 
         public override Task Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_multiple_elements_SingleOrDefault(async));
-        }
 
         public override Task Where_query_composition_entity_equality_multiple_elements_Single(bool async)
-        {
-            return Assert.ThrowsAsync<InvalidOperationException>(
+            => Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Where_query_composition_entity_equality_multiple_elements_Single(async));
-        }
 
         // Sending client code to server
         [ConditionalFact(Skip = "Issue#17050")]
         public override void Client_code_using_instance_in_anonymous_type()
-        {
-            base.Client_code_using_instance_in_anonymous_type();
-        }
+            => base.Client_code_using_instance_in_anonymous_type();
 
         [ConditionalFact(Skip = "Issue#17050")]
         public override void Client_code_using_instance_in_static_method()
-        {
-            base.Client_code_using_instance_in_static_method();
-        }
+            => base.Client_code_using_instance_in_static_method();
 
         [ConditionalFact(Skip = "Issue#17050")]
         public override void Client_code_using_instance_method_throws()
-        {
-            base.Client_code_using_instance_method_throws();
-        }
+            => base.Client_code_using_instance_method_throws();
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task OrderBy_multiple_queries(bool async)
-        {
-            return base.OrderBy_multiple_queries(async);
-        }
+            => base.OrderBy_multiple_queries(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_1(bool async)
-        {
-            return base.Random_next_is_not_funcletized_1(async);
-        }
+            => base.Random_next_is_not_funcletized_1(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_2(bool async)
-        {
-            return base.Random_next_is_not_funcletized_2(async);
-        }
+            => base.Random_next_is_not_funcletized_2(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_3(bool async)
-        {
-            return base.Random_next_is_not_funcletized_3(async);
-        }
+            => base.Random_next_is_not_funcletized_3(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_4(bool async)
-        {
-            return base.Random_next_is_not_funcletized_4(async);
-        }
+            => base.Random_next_is_not_funcletized_4(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_5(bool async)
-        {
-            return base.Random_next_is_not_funcletized_5(async);
-        }
+            => base.Random_next_is_not_funcletized_5(async);
 
         [ConditionalTheory(Skip = "Issue#17386")]
         public override Task Random_next_is_not_funcletized_6(bool async)
-        {
-            return base.Random_next_is_not_funcletized_6(async);
-        }
+            => base.Random_next_is_not_funcletized_6(async);
 
-        [ConditionalTheory]
-        public override Task DefaultIfEmpty_in_subquery_nested(bool async)
-        {
-            return base.DefaultIfEmpty_in_subquery_nested(async);
-        }
+        [ConditionalTheory(Skip = "issue#17386")]
+        public override Task Where_query_composition5(bool async)
+            => base.Where_query_composition5(async);
+
+        [ConditionalTheory(Skip = "issue#17386")]
+        public override Task Where_query_composition6(bool async)
+            => base.Where_query_composition6(async);
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+            => base.Using_string_Equals_with_StringComparison_throws_informative_error(async);
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+            => base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async);
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -23,25 +23,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Throws_when_where()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.Where(c => c.IsLondon).ToList());
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.Where(c => c.IsLondon).ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_orderby()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.OrderBy(c => c.IsLondon).ToList());
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.OrderBy(c => c.IsLondon).ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_orderby_multiple()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(
+            AssertTranslationFailedWithDetails(
                 () => context.Customers
                     .OrderBy(c => c.IsLondon)
                     .ThenBy(c => ClientMethod(c))
-                    .ToList());
+                    .ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         private static object ClientMethod(object o) => o.GetHashCode();
@@ -50,28 +55,32 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Throws_when_where_subquery_correlated()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(
+            AssertTranslationFailedWithDetails(
                 () => context.Customers
                     .Where(c1 => context.Customers.Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon))
-                    .ToList());
+                    .ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_all()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.All(c => c.IsLondon));
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.All(c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_from_sql_composed()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(
+            AssertTranslationFailedWithDetails(
                 () => context.Customers
                     .FromSqlRaw(NormalizeDelimitersInRawString("select * from [Customers]"))
                     .Where(c => c.IsLondon)
-                    .ToList());
+                    .ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
@@ -90,13 +99,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Throws_when_subquery_main_from_clause()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(
+            AssertTranslationFailedWithDetails(
                 () => (from c1 in context.Customers
                            .Where(c => c.IsLondon)
                            .OrderBy(c => c.CustomerID)
                            .Take(5)
                        select c1)
-                    .ToList());
+                    .ToList(),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
@@ -151,28 +161,36 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Throws_when_first()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.First(c => c.IsLondon));
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.First(c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_single()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.Single(c => c.IsLondon));
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.Single(c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_first_or_default()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.FirstOrDefault(c => c.IsLondon));
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.FirstOrDefault(c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalFact]
         public virtual void Throws_when_single_or_default()
         {
             using var context = CreateContext();
-            AssertTranslationFailed(() => context.Customers.SingleOrDefault(c => c.IsLondon));
+            AssertTranslationFailedWithDetails(
+                () => context.Customers.SingleOrDefault(c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         private string NormalizeDelimitersInRawString(string sql)
@@ -181,6 +199,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         private void AssertTranslationFailed(Action testCode)
             => Assert.Contains(
                 CoreStrings.TranslationFailed("").Substring(21),
+                Assert.Throws<InvalidOperationException>(testCode).Message);
+
+        private void AssertTranslationFailedWithDetails(Action testCode, string details)
+            => Assert.Contains(
+                CoreStrings.TranslationFailedWithDetails("", details).Substring(21),
                 Assert.Throws<InvalidOperationException>(testCode).Message);
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 
@@ -581,7 +582,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             Assert.Equal(
-                @"The LINQ expression 'DbSet<CollectionScalar>()    .Where(c => c.Tags.Count == 2)' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                CoreStrings.TranslationFailed(
+                    @"DbSet<CollectionScalar>()    .Where(c => c.Tags.Count == 2)"),
                 Assert.Throws<InvalidOperationException>(
                     () => context.Set<CollectionScalar>().Where(e => e.Tags.Count == 2).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1563,12 +1563,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Where_Navigation_Client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from t in ss.Set<CogTag>()
                           where t.Gear != null && t.Gear.IsMarcus
-                          select t));
+                          select t),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
         }
 
         [ConditionalTheory]
@@ -7504,6 +7505,85 @@ namespace Microsoft.EntityFrameworkCore.Query
                 () => AssertMax(
                     async,
                     ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_unmapped_property_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Gear>().Where(g => g.IsMarcus)),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_unmapped_property_in_projection(bool async)
+        {
+            return AssertQueryScalar(
+                async,
+                ss => ss.Set<Gear>().Select(g => g.IsMarcus));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_unmapped_property_inside_aggregate(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<City>().Where(c => c.BornGears.Count(g => g.IsMarcus) > 0)),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_unmapped_property_inside_subquery(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<City>().Where(c => ss.Set<Gear>().Where(g => g.IsMarcus).Select(g => g.Nickname).FirstOrDefault() == "Marcus")),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_unmapped_property_inside_join_key_selector(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                async,
+                ss => from w in ss.Set<Weapon>()
+                      join g in ss.Set<Gear>() on w.IsAutomatic equals g.IsMarcus into grouping
+                      from g in grouping.DefaultIfEmpty()
+                      select new { w, g }),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Client_projection_with_nested_unmapped_property_bubbles_up_translation_failure_info(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Gear>().Select(g => new { nested = ss.Set<Gear>().Where(gg => gg.IsMarcus).ToList() })),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Gear>().Where(g => g.FullName.Equals(g.Nickname, StringComparison.InvariantCulture) || g.IsMarcus)),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison
+                + Environment.NewLine + CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
         }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -1887,6 +1888,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertCount(
                 async,
                 ss => ss.Set<Order>().Select(o => new { Id = CodeFormat(o.OrderID) }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_with_unmapped_property_access_throws_meaningful_exception(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertAverage(
+                async,
+                ss => ss.Set<Order>(),
+                selector: c => c.ShipVia),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Order.ShipVia), nameof(Order)));
         }
 
         private static string CodeFormat(int str) => str.ToString();

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeAsyncQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeAsyncQueryTestBase.cs
@@ -567,7 +567,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
             Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(21),
+                CoreStrings.TranslationFailedWithDetails(
+                    "",
+                    CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer))).Substring(21),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => context.Set<Customer>()
                         .Include(c => c.Orders)

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -1812,7 +1812,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using var context = CreateContext();
             Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(21),
+                CoreStrings.TranslationFailedWithDetails(
+                    "",
+                    CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer))).Substring(21),
                 Assert.Throws<InvalidOperationException>(
                     () => useString
                         ? context.Set<Customer>()

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -559,11 +559,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Queryable_reprojection(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().Where(c => c.IsLondon)
-                        .Select(c => new Customer { CustomerID = "Foo", City = c.City })));
+                        .Select(c => new Customer { CustomerID = "Foo", City = c.City })),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -1140,33 +1141,36 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertAll(
                     async,
                     ss => ss.Set<Customer>(),
-                    predicate: c => c.IsLondon));
+                    predicate: c => c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client_and_server_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertAll(
                     async,
                     ss => ss.Set<Customer>(),
-                    predicate: c => c.CustomerID != "Foo" && c.IsLondon));
+                    predicate: c => c.CustomerID != "Foo" && c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task All_client_or_server_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertAll(
                     async,
                     ss => ss.Set<Customer>(),
-                    predicate: c => c.CustomerID != "Foo" || c.IsLondon));
+                    predicate: c => c.CustomerID != "Foo" || c.IsLondon),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -1207,12 +1211,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task First_client_predicate(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertFirst(
                     async,
                     ss => ss.Set<Customer>().OrderBy(c => c.CustomerID),
                     predicate: c => c.IsLondon,
-                    entryCount: 1));
+                    entryCount: 1),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -1935,20 +1940,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition3(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c1 in ss.Set<Customer>()
                           where c1.City == ss.Set<Customer>().OrderBy(c => c.CustomerID).First(c => c.IsLondon).City
                           select c1,
-                    entryCount: 6));
+                    entryCount: 6),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition4(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c1 in ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
@@ -1957,27 +1963,29 @@ namespace Microsoft.EntityFrameworkCore.Query
                                   from c3 in ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CustomerID)
                                   select new { c3 }).First().c3.City
                           select c1,
-                    entryCount: 1));
+                    entryCount: 1),
+            CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition5(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c1 in ss.Set<Customer>()
                           where c1.IsLondon == ss.Set<Customer>().OrderBy(c => c.CustomerID).First().IsLondon
                           select c1,
-                    entryCount: 85));
+                    entryCount: 85),
+            CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_query_composition6(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c1 in ss.Set<Customer>()
@@ -1986,7 +1994,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                   .Select(c => new { Foo = c })
                                   .First().Foo.IsLondon
                           select c1,
-                    entryCount: 85));
+                    entryCount: 85),
+            CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -2614,12 +2623,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_client_mixed(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().OrderBy(c => c.IsLondon).ThenBy(c => c.CompanyName),
                     assertOrder: true,
-                    entryCount: 91));
+                    entryCount: 91),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -5918,6 +5928,28 @@ namespace Microsoft.EntityFrameworkCore.Query
             var firstArout = arouts[0];
             Assert.All(arouts, t => Assert.Same(firstArout, t));
             Assert.Empty(context.ChangeTracker.Entries());
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.InvariantCulture))),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.InvariantCulture))),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -146,13 +147,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Where_Navigation_Client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from o in ss.Set<Order>()
                           where o.Customer.IsLondon
                           select o,
-                    entryCount: 46));
+                    entryCount: 46),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -603,7 +605,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_select_nav_prop_all_client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c in ss.Set<Customer>()
@@ -612,7 +614,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ss => from c in ss.Set<Customer>()
                           orderby c.CustomerID
                           select new { All = (c.Orders ?? new List<Order>()).All(o => false) },
-                    assertOrder: true));
+                    assertOrder: true),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Order.ShipCity), nameof(Order)));
         }
 
         [ConditionalTheory]
@@ -634,13 +637,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_where_nav_prop_all_client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => from c in ss.Set<Customer>()
                           orderby c.CustomerID
                           where c.Orders.All(o => o.ShipCity == "London")
-                          select c));
+                          select c),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Order.ShipCity), nameof(Order)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -591,11 +592,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().Where(c => c.IsLondon),
-                    entryCount: 6));
+                    entryCount: 6),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
@@ -612,59 +614,64 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_correlated_client_eval(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>()
                         .OrderBy(c1 => c1.CustomerID)
                         .Take(5)
                         .Where(c1 => ss.Set<Customer>().Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon)),
-                    entryCount: 1));
+                    entryCount: 1),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_and_server_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().Where(c => c.IsLondon && c.CustomerID != "AROUT"),
-                    entryCount: 5));
+                    entryCount: 5),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_or_server_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().Where(c => c.IsLondon || c.CustomerID == "ALFKI"),
-                    entryCount: 7));
+                    entryCount: 7),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_and_server_non_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>().Where(c => c.CustomerID != "ALFKI" == (c.IsLondon && c.CustomerID != "AROUT")),
-                    entryCount: 6));
+                    entryCount: 6),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_client_deep_inside_predicate_and_server_top_level(bool async)
         {
-            return AssertTranslationFailed(
+            return AssertTranslationFailedWithDetails(
                 () => AssertQuery(
                     async,
                     ss => ss.Set<Customer>()
                         .Where(c => c.CustomerID != "ALFKI" && (c.CustomerID == "MAUMAR" || (c.CustomerID != "AROUT" && c.IsLondon))),
-                    entryCount: 5));
+                    entryCount: 5),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -785,6 +785,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Trying_to_access_non_existent_indexer_property_throws_meaningful_exception(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<OwnedPerson>().Where(op => (bool)op["Foo"])),
+                CoreStrings.QueryUnableToTranslateMember("Foo", nameof(OwnedPerson)));
+        }
+
         protected virtual DbContext CreateContext() => Fixture.CreateContext();
 
         public abstract class OwnedQueryFixtureBase : SharedStoreFixtureBase<PoolableDbContext>, IQueryFixtureBase

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -1153,6 +1153,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (await Assert.ThrowsAsync<InvalidOperationException>(query))
                 .Message);
 
+        protected static async Task AssertTranslationFailedWithDetails(Func<Task> query, string details)
+            => Assert.Contains(
+                CoreStrings.TranslationFailedWithDetails("", details).Substring(21),
+                (await Assert.ThrowsAsync<InvalidOperationException>(query))
+                .Message);
+
         #endregion
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -6723,8 +6723,9 @@ FROM [MockEntities] AS [m]");
                 () => queryBase.Cast<IDummyEntity>().FirstOrDefault(x => x.Id == id)).Message;
 
             Assert.Equal(
-                CoreStrings.TranslationFailed(@"DbSet<MockEntity>()    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
-                message.Replace("\r", "").Replace("\n", ""));
+                CoreStrings.TranslationFailed(
+                    @"DbSet<MockEntity>()    .Cast<IDummyEntity>()    .Where(e => e.Id == __id_0)"),
+                    message.Replace("\r", "").Replace("\n", ""));
         }
 
         private SqlServerTestStore CreateDatabase18087()


### PR DESCRIPTION
Adding state to ExpressionTranslatingExpressionVisitor that stores the information about why translation failed. The information is bubbled up and added to the "translation failed" exception.
Currently only doing this for string.Equals and non-mapped member properties