### PR TITLE
API review changes

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder UseEtagConcurrency([NotNull] this EntityTypeBuilder entityTypeBuilder)
+        public static EntityTypeBuilder UseETagConcurrency([NotNull] this EntityTypeBuilder entityTypeBuilder)
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
@@ -276,11 +276,11 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> UseEtagConcurrency<TEntity>([NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder)
+        public static EntityTypeBuilder<TEntity> UseETagConcurrency<TEntity>([NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder)
             where TEntity : class
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-            UseEtagConcurrency((EntityTypeBuilder)entityTypeBuilder);
+            UseETagConcurrency((EntityTypeBuilder)entityTypeBuilder);
             return entityTypeBuilder;
         }
     }

--- a/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosPropertyBuilderExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static PropertyBuilder IsEtagConcurrency([NotNull] this PropertyBuilder propertyBuilder)
+        public static PropertyBuilder IsETagConcurrency([NotNull] this PropertyBuilder propertyBuilder)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             propertyBuilder
@@ -109,8 +109,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static PropertyBuilder<TProperty> IsEtagConcurrency<TProperty>(
+        public static PropertyBuilder<TProperty> IsETagConcurrency<TProperty>(
             [NotNull] this PropertyBuilder<TProperty> propertyBuilder)
-            => (PropertyBuilder<TProperty>)IsEtagConcurrency((PropertyBuilder)propertyBuilder);
+            => (PropertyBuilder<TProperty>)IsETagConcurrency((PropertyBuilder)propertyBuilder);
     }
 }

--- a/src/EFCore.Cosmos/Internal/CosmosModelValidator.cs
+++ b/src/EFCore.Cosmos/Internal/CosmosModelValidator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             base.Validate(model, logger);
 
             ValidateSharedContainerCompatibility(model, logger);
-            ValidateOnlyEtagConcurrencyToken(model, logger);
+            ValidateOnlyETagConcurrencyToken(model, logger);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void ValidateOnlyEtagConcurrencyToken(
+        protected virtual void ValidateOnlyETagConcurrencyToken(
             [NotNull] IModel model,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
         {
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                         if (storeName != "_etag")
                         {
                             throw new InvalidOperationException(
-                                CosmosStrings.NonEtagConcurrencyToken(entityType.DisplayName(), storeName));
+                                CosmosStrings.NonETagConcurrencyToken(entityType.DisplayName(), storeName));
                         }
 
                         var etagType = property.GetTypeMapping().Converter?.ProviderClrType ?? property.ClrType;

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
@@ -49,6 +49,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string ETagName = Prefix + "EtagName";
+        public const string ETagName = Prefix + "ETagName";
     }
 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -57,11 +57,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 entityType, container);
 
         /// <summary>
-        ///     The entity type '{entityType}' has property '{property}' as its concurrency token, but only '_etag' is supported. Consider using 'EntityTypeBuilder.UseEtagConcurrency'.
+        ///     The entity type '{entityType}' has property '{property}' as its concurrency token, but only '_etag' is supported. Consider using 'EntityTypeBuilder.UseETagConcurrency'.
         /// </summary>
-        public static string NonEtagConcurrencyToken([CanBeNull] object entityType, [CanBeNull] object property)
+        public static string NonETagConcurrencyToken([CanBeNull] object entityType, [CanBeNull] object property)
             => string.Format(
-                GetString("NonEtagConcurrencyToken", nameof(entityType), nameof(property)),
+                GetString("NonETagConcurrencyToken", nameof(entityType), nameof(property)),
                 entityType, property);
 
         /// <summary>

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -132,8 +132,8 @@
   <data name="NoDiscriminatorValue" xml:space="preserve">
     <value>The entity type '{entityType}' is sharing the container '{container}' with other types, but does not have a discriminator value configured.</value>
   </data>
-  <data name="NonEtagConcurrencyToken" xml:space="preserve">
-    <value>The entity type '{entityType}' has property '{property}' as its concurrency token, but only '_etag' is supported. Consider using 'EntityTypeBuilder.UseEtagConcurrency'.</value>
+  <data name="NonETagConcurrencyToken" xml:space="preserve">
+    <value>The entity type '{entityType}' has property '{property}' as its concurrency token, but only '_etag' is supported. Consider using 'EntityTypeBuilder.UseETagConcurrency'.</value>
   </data>
   <data name="NoPartitionKey" xml:space="preserve">
     <value>The entity type '{entityType}' does not have a partition key set, but it is mapped to the container '{container}' shared by entity types with partition keys.</value>

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1099,12 +1099,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         .Select(p => p.ClrType)
                         .Any(t => t.IsNullableType());
 
-                    var outerKey = entityShaperExpression.CreateKeyValueReadExpression(
+                    var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.Properties
                             : foreignKey.PrincipalKey.Properties,
                         makeNullable);
-                    var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValueReadExpression(
+                    var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.PrincipalKey.Properties
                             : foreignKey.Properties,
@@ -1147,12 +1147,12 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         .Select(p => p.ClrType)
                         .Any(t => t.IsNullableType());
 
-                    var outerKey = entityShaperExpression.CreateKeyValueReadExpression(
+                    var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.Properties
                             : foreignKey.PrincipalKey.Properties,
                         makeNullable);
-                    var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValueReadExpression(
+                    var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.PrincipalKey.Properties
                             : foreignKey.Properties,

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -296,16 +296,6 @@ namespace Microsoft.EntityFrameworkCore
                 ?? Enumerable.Empty<IColumnMapping>();
 
         /// <summary>
-        ///     Returns the view or table columns to which the property is mapped.
-        /// </summary>
-        /// <param name="property"> The property. </param>
-        /// <returns> The view or table columns to which the property is mapped. </returns>
-        public static IEnumerable<IColumnMappingBase> GetViewOrTableColumnMappings([NotNull] this IProperty property) =>
-            (IEnumerable<IColumnMappingBase>)(property[RelationalAnnotationNames.ViewColumnMappings]
-                ?? property[RelationalAnnotationNames.TableColumnMappings])
-                ?? Enumerable.Empty<IColumnMappingBase>();
-
-        /// <summary>
         ///     Returns the view columns to which the property is mapped.
         /// </summary>
         /// <param name="property"> The property. </param>

--- a/src/EFCore.Relational/Metadata/IColumnBase.cs
+++ b/src/EFCore.Relational/Metadata/IColumnBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the column type.
         /// </summary>
-        string Type { get; }
+        string StoreType { get; }
 
         /// <summary>
         ///     Gets the value indicating whether the column can contain NULL.

--- a/src/EFCore.Relational/Metadata/Internal/Column.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Column.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public Column([NotNull] string name, [CanBeNull] string type, [NotNull] Table table)
         {
             Name = name;
-            Type = type;
+            StoreType = type;
             Table = table;
         }
 
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual ITable Table { get; }
 
         /// <inheritdoc/>
-        public virtual string Type { get; }
+        public virtual string StoreType { get; }
 
         /// <inheritdoc/>
         public virtual bool IsNullable { get; set; }

--- a/src/EFCore.Relational/Metadata/Internal/ColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(column.Name).Append(" (");
 
-            builder.Append(column.Type).Append(")");
+            builder.Append(column.StoreType).Append(")");
 
             if (column.IsNullable)
             {

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public ViewColumn([NotNull] string name, [NotNull] string type, [NotNull] View view)
         {
             Name = name;
-            Type = type;
+            StoreType = type;
             View = view;
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IView View { get; }
 
         /// <inheritdoc/>
-        public virtual string Type { get; }
+        public virtual string StoreType { get; }
 
         /// <inheritdoc/>
         public virtual bool IsNullable { get; set; }

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumnExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             builder.Append(column.Name).Append(" (");
 
-            builder.Append(column.Type).Append(")");
+            builder.Append(column.StoreType).Append(")");
 
             if (column.IsNullable)
             {

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -982,8 +982,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var sourceTypeMapping = sourceMapping.TypeMapping;
             var targetTypeMapping = targetMapping.TypeMapping;
 
-            var sourceColumnType = source.Type ?? sourceTypeMapping.StoreType;
-            var targetColumnType = target.Type ?? targetTypeMapping.StoreType;
+            var sourceColumnType = source.StoreType ?? sourceTypeMapping.StoreType;
+            var targetColumnType = target.StoreType ?? targetTypeMapping.StoreType;
 
             var sourceMigrationsAnnotations = source.GetAnnotations();
             var targetMigrationsAnnotations = target.GetAnnotations();
@@ -1090,7 +1090,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 = (valueConverter?.ProviderClrType
                     ?? typeMapping.ClrType).UnwrapNullableType();
 
-            columnOperation.ColumnType = column.Type;
+            columnOperation.ColumnType = column.StoreType;
             columnOperation.MaxLength = column.MaxLength;
             columnOperation.Precision = column.Precision;
             columnOperation.Scale = column.Scale;

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -1433,7 +1433,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     && operation.IsFixedLength == column.IsFixedLength
                     && operation.IsRowVersion == column.IsRowVersion)
                 {
-                    return column.Type;
+                    return column.StoreType;
                 }
 
                 keyOrIndex = table.UniqueConstraints.Any(u => u.Columns.Contains(column))

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1184,12 +1184,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     var innerSequenceType = innerShapedQuery.Type.TryGetSequenceType();
                     var correlationPredicateParameter = Expression.Parameter(innerSequenceType);
 
-                    var outerKey = entityShaperExpression.CreateKeyValueReadExpression(
+                    var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.Properties
                             : foreignKey.PrincipalKey.Properties,
                         makeNullable);
-                    var innerKey = correlationPredicateParameter.CreateKeyValueReadExpression(
+                    var innerKey = correlationPredicateParameter.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.PrincipalKey.Properties
                             : foreignKey.Properties,
@@ -1245,12 +1245,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                             .Select(p => p.ClrType)
                             .Any(t => t.IsNullableType());
 
-                        var outerKey = entityShaperExpression.CreateKeyValueReadExpression(
+                        var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                             navigation.IsOnDependent
                                 ? foreignKey.Properties
                                 : foreignKey.PrincipalKey.Properties,
                             makeNullable);
-                        var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValueReadExpression(
+                        var innerKey = innerShapedQuery.ShaperExpression.CreateKeyValuesExpression(
                             navigation.IsOnDependent
                                 ? foreignKey.PrincipalKey.Properties
                                 : foreignKey.Properties,

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
         public override IEnumerable<IAnnotation> For(IRelationalModel model)
         {
             if (model.Tables.SelectMany(t => t.Columns).Any(
-                c => SqliteTypeMappingSource.IsSpatialiteType(c.Type)))
+                c => SqliteTypeMappingSource.IsSpatialiteType(c.StoreType)))
             {
                 yield return new Annotation(SqliteAnnotationNames.InitSpatialMetaData, true);
             }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        object IDbSetCache.GetOrAddSet(IDbSetSource source, string name, Type type)
+        object IDbSetCache.GetOrAddSet(IDbSetSource source, string entityTypeName, Type type)
         {
             CheckDisposed();
 
@@ -256,10 +256,10 @@ namespace Microsoft.EntityFrameworkCore
                 _sets = new Dictionary<(Type Type, string Name), object>();
             }
 
-            if (!_sets.TryGetValue((type, name), out var set))
+            if (!_sets.TryGetValue((type, entityTypeName), out var set))
             {
-                set = source.Create(this, name, type);
-                _sets[(type, name)] = set;
+                set = source.Create(this, entityTypeName, type);
+                _sets[(type, entityTypeName)] = set;
             }
 
             return set;

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="properties"> The list of properties to use to generate key values. </param>
         /// <param name="makeNullable"> A value indicating if the key values should be read nullable. </param>
         /// <returns> An expression to read the key values. </returns>
-        public static Expression CreateKeyValueReadExpression(
+        public static Expression CreateKeyValuesExpression(
             [NotNull] this Expression target,
             [NotNull] IReadOnlyList<IProperty> properties,
             bool makeNullable = false)

--- a/src/EFCore/Infrastructure/TypeExtensions.cs
+++ b/src/EFCore/Infrastructure/TypeExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -36,23 +35,5 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> The human-readable name. </returns>
         public static string ShortDisplayName([NotNull] this Type type)
             => type.DisplayName(fullName: false);
-
-        /// <summary>
-        ///     Gets a value indicating whether this type is same as or implements <see cref="IQueryable" />
-        /// </summary>
-        /// <param name="type"> The type to check. </param>
-        /// <returns>
-        ///     <c>True</c> if the type is same as or implements <see cref="IQueryable" />, otherwise <c>false</c>.
-        /// </returns>
-        public static bool IsQueryableType([NotNull] this Type type)
-        {
-            if (type.IsGenericType
-                && type.GetGenericTypeDefinition() == typeof(IQueryable<>))
-            {
-                return true;
-            }
-
-            return type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryable<>));
-        }
     }
 }

--- a/src/EFCore/Internal/IDbSetCache.cs
+++ b/src/EFCore/Internal/IDbSetCache.cs
@@ -28,6 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        object GetOrAddSet([NotNull] IDbSetSource source, [NotNull] string name, [NotNull] Type type);
+        object GetOrAddSet([NotNull] IDbSetSource source, [NotNull] string entityTypeName, [NotNull] Type type);
     }
 }

--- a/src/EFCore/Metadata/IConventionPropertyBase.cs
+++ b/src/EFCore/Metadata/IConventionPropertyBase.cs
@@ -66,9 +66,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fieldName"> The name of the field to use. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new <see cref="FieldInfo" />. </returns>
-        FieldInfo SetFieldInfo([CanBeNull] string fieldName, bool fromDataAnnotation = false)
+        FieldInfo SetField([CanBeNull] string fieldName, bool fromDataAnnotation = false)
             => this.AsPropertyBase()
-                .SetFieldInfo(fieldName, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+                .SetField(fieldName, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="IPropertyBase.FieldInfo" />.

--- a/src/EFCore/Metadata/IMutablePropertyBase.cs
+++ b/src/EFCore/Metadata/IMutablePropertyBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     </para>
         /// </summary>
         /// <param name="fieldName"> The name of the field to use. </param>
-        void SetFieldInfo([CanBeNull] string fieldName)
-            => this.AsPropertyBase().SetFieldInfo(fieldName, ConfigurationSource.Explicit);
+        void SetField([CanBeNull] string fieldName)
+            => this.AsPropertyBase().SetField(fieldName, ConfigurationSource.Explicit);
     }
 }

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -942,7 +942,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (navigation.FieldInfo?.GetSimpleMemberName() == fieldName
                 || configurationSource.Overrides(navigation.GetFieldInfoConfigurationSource()))
             {
-                navigation.SetFieldInfo(fieldName, configurationSource);
+                navigation.SetField(fieldName, configurationSource);
 
                 return this;
             }
@@ -2838,7 +2838,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 return null;
             }
-        
+
             // This workaround prevents the properties to be cleaned away before the new FK is created,
             // this should be replaced with reference counting
             // Issue #15898

--- a/src/EFCore/Metadata/Internal/InternalPropertyBaseBuilder`.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBaseBuilder`.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
                 || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
             {
-                Metadata.SetFieldInfo(fieldName, configurationSource);
+                Metadata.SetField(fieldName, configurationSource);
 
                 return this;
             }

--- a/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (Metadata.FieldInfo?.GetSimpleMemberName() == fieldName
                 || configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
             {
-                Metadata.SetFieldInfo(fieldName, configurationSource);
+                Metadata.SetField(fieldName, configurationSource);
 
                 return this;
             }

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -127,11 +127,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual FieldInfo SetFieldInfo([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+        public virtual FieldInfo SetField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
         {
             if (fieldName == null)
             {
-                return SetFieldInfo((FieldInfo)null, configurationSource);
+                return SetFieldInfo(null, configurationSource);
             }
 
             if (FieldInfo?.GetSimpleMemberName() == fieldName)

--- a/src/EFCore/Query/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/ExpressionEqualityComparer.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 // ReSharper disable LoopCanBeConvertedToQuery
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class ExpressionEqualityComparer : IEqualityComparer<Expression>
+    public sealed class ExpressionEqualityComparer : IEqualityComparer<Expression>
     {
         /// <summary>
         ///     Creates a new <see cref="ExpressionEqualityComparer" />.
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="obj"> The <see cref="Expression"/> obj to compute hash code for. </param>
         /// <returns> The hash code value for <paramref name="obj"/>. </returns>
-        public virtual int GetHashCode(Expression obj)
+        public int GetHashCode(Expression obj)
         {
             if (obj == null)
             {
@@ -279,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="x"> The left expression. </param>
         /// <param name="y"> The right expression. </param>
         /// <returns> <c>true</c> if the expressions are equal, <c>false</c> otherwise. </returns>
-        public virtual bool Equals(Expression x, Expression y) => new ExpressionComparer().Compare(x, y);
+        public bool Equals(Expression x, Expression y) => new ExpressionComparer().Compare(x, y);
 
         private struct ExpressionComparer
         {

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     // This is FirstOrDefault ending so we need to push down properties.
                     var temporaryParameter = Expression.Parameter(root.Type);
-                    var temporaryKey = temporaryParameter.CreateKeyValueReadExpression(
+                    var temporaryKey = temporaryParameter.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? navigation.ForeignKey.Properties
                             : navigation.ForeignKey.PrincipalKey.Properties,
@@ -184,14 +184,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
                 else
                 {
-                    outerKey = root.CreateKeyValueReadExpression(
+                    outerKey = root.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? navigation.ForeignKey.Properties
                             : navigation.ForeignKey.PrincipalKey.Properties,
                         makeNullable: true);
                 }
 
-                var innerKey = innerParameter.CreateKeyValueReadExpression(
+                var innerKey = innerParameter.CreateKeyValuesExpression(
                     navigation.IsOnDependent
                         ? navigation.ForeignKey.PrincipalKey.Properties
                         : navigation.ForeignKey.Properties,

--- a/src/EFCore/Query/ReplacingExpressionVisitor.cs
+++ b/src/EFCore/Query/ReplacingExpressionVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,8 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class ReplacingExpressionVisitor : ExpressionVisitor
     {
-        private readonly Expression[] _originals;
-        private readonly Expression[] _replacements;
+        private readonly IReadOnlyList<Expression> _originals;
+        private readonly IReadOnlyList<Expression> _replacements;
 
         public static Expression Replace([NotNull] Expression original, [NotNull] Expression replacement, [NotNull] Expression tree)
         {
@@ -24,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return new ReplacingExpressionVisitor(new[] { original }, new[] { replacement }).Visit(tree);
         }
 
-        public ReplacingExpressionVisitor([NotNull] Expression[] originals, [NotNull] Expression[] replacements)
+        public ReplacingExpressionVisitor([NotNull] IReadOnlyList<Expression> originals, [NotNull] IReadOnlyList<Expression> replacements)
         {
             Check.NotNull(originals, nameof(originals));
             Check.NotNull(replacements, nameof(replacements));
@@ -42,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             // We use two arrays rather than a dictionary because hash calculation here can be prohibitively expensive
             // for deep trees. Locality of reference makes arrays better for the small number of replacements anyway.
-            for (var i = 0; i < _originals.Length; i++)
+            for (var i = 0; i < _originals.Count; i++)
             {
                 if (expression.Equals(_originals[i]))
                 {

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -333,5 +333,16 @@ namespace System
                 return ex.Types.Where(t => t != null).Select(IntrospectionExtensions.GetTypeInfo);
             }
         }
+
+        public static bool IsQueryableType(this Type type)
+        {
+            if (type.IsGenericType
+                && type.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                return true;
+            }
+
+            return type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryable<>));
+        }
     }
 }

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                     b =>
                     {
                         b.HasKey(c => c.Id);
-                        b.Property(c => c.ETag).IsEtagConcurrency();
+                        b.Property(c => c.ETag).IsETagConcurrency();
                     });
             }
         }

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .IsConcurrencyToken();
 
             var model = modelBuilder.Model;
-            VerifyError(CosmosStrings.NonEtagConcurrencyToken(typeof(Customer).Name, "_not_etag"), model);
+            VerifyError(CosmosStrings.NonETagConcurrencyToken(typeof(Customer).Name, "_not_etag"), model);
         }
 
         protected override TestHelpers TestHelpers => CosmosTestHelpers.Instance;

--- a/test/EFCore.Cosmos.Tests/Metadata/CosmosBuilderExtensionsTest.cs
+++ b/test/EFCore.Cosmos.Tests/Metadata/CosmosBuilderExtensionsTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public void Can_set_etag_concurrency_entity()
         {
             var modelBuilder = CreateConventionModelBuilder();
-            modelBuilder.Entity<Customer>().UseEtagConcurrency();
+            modelBuilder.Entity<Customer>().UseETagConcurrency();
             var model = modelBuilder.Model;
 
             var etagProperty = model.FindEntityType(typeof(Customer).FullName).FindProperty("_etag");
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public void Can_set_etag_concurrency_property()
         {
             var modelBuilder = CreateConventionModelBuilder();
-            modelBuilder.Entity<Customer>().Property(x => x.ETag).IsEtagConcurrency();
+            modelBuilder.Entity<Customer>().Property(x => x.ETag).IsETagConcurrency();
             var model = modelBuilder.Model;
 
             var etagProperty = model.FindEntityType(typeof(Customer).FullName).FindProperty("ETag");

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.Same(orderDateColumn, ordersView.FindColumn("OrderDateView"));
             Assert.Equal(new[] { orderDate, orderDetailsDate }, orderDateColumn.PropertyMappings.Select(m => m.Property));
             Assert.Equal("OrderDateView", orderDateColumn.Name);
-            Assert.Equal("default_datetime_mapping", orderDateColumn.Type);
+            Assert.Equal("default_datetime_mapping", orderDateColumn.StoreType);
             Assert.False(orderDateColumn.IsNullable);
             Assert.Same(ordersView, orderDateColumn.Table);
 
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.Same(orderDateColumn, ordersTable.FindColumn("OrderDate"));
             Assert.Equal(new[] { orderDate, orderDetailsDate }, orderDateColumn.PropertyMappings.Select(m => m.Property));
             Assert.Equal("OrderDate", orderDateColumn.Name);
-            Assert.Equal("default_datetime_mapping", orderDateColumn.Type);
+            Assert.Equal("default_datetime_mapping", orderDateColumn.StoreType);
             Assert.False(orderDateColumn.IsNullable);
             Assert.Same(ordersTable, orderDateColumn.Table);
 

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -1983,8 +1983,8 @@ namespace Microsoft.EntityFrameworkCore
                         b.HasMany(e => e.Posts).WithOne(e => e.Blog).HasForeignKey(e => e.BlogId);
                     });
 
-                modelBuilder.Entity<PostFullExplicit>().Metadata.FindNavigation("Blog").SetFieldInfo("_myblog");
-                modelBuilder.Entity<BlogFullExplicit>().Metadata.FindNavigation("Posts").SetFieldInfo("_myposts");
+                modelBuilder.Entity<PostFullExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
+                modelBuilder.Entity<BlogFullExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
 
                 modelBuilder.Entity<LoginSession>().UsePropertyAccessMode(PropertyAccessMode.Field);
 
@@ -2052,8 +2052,8 @@ namespace Microsoft.EntityFrameworkCore
                             b.HasMany(e => e.Posts).WithOne(e => e.Blog).HasForeignKey(e => e.BlogId);
                         });
 
-                    modelBuilder.Entity<PostReadOnlyExplicit>().Metadata.FindNavigation("Blog").SetFieldInfo("_myblog");
-                    modelBuilder.Entity<BlogReadOnlyExplicit>().Metadata.FindNavigation("Posts").SetFieldInfo("_myposts");
+                    modelBuilder.Entity<PostReadOnlyExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
+                    modelBuilder.Entity<BlogReadOnlyExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
 
                     modelBuilder.Entity<PostWriteOnly>(
                         b =>
@@ -2089,8 +2089,8 @@ namespace Microsoft.EntityFrameworkCore
                             b.HasMany(typeof(PostWriteOnlyExplicit).DisplayName(), "Posts").WithOne("Blog").HasForeignKey("BlogId");
                         });
 
-                    modelBuilder.Entity<PostWriteOnlyExplicit>().Metadata.FindNavigation("Blog").SetFieldInfo("_myblog");
-                    modelBuilder.Entity<BlogWriteOnlyExplicit>().Metadata.FindNavigation("Posts").SetFieldInfo("_myposts");
+                    modelBuilder.Entity<PostWriteOnlyExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
+                    modelBuilder.Entity<BlogWriteOnlyExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
 
                     modelBuilder.Entity<PostFields>(
                         b =>

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -105,6 +105,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } = new HashSet<MethodInfo>
             {
+                typeof(IConventionPropertyBase).GetMethod(nameof(IConventionPropertyBase.SetField)),
                 typeof(IAnnotatable).GetMethod(nameof(IAnnotatable.FindAnnotation)),
                 typeof(IAnnotatable).GetMethod(nameof(IAnnotatable.GetAnnotations)),
                 typeof(IMutableAnnotatable).GetMethod("set_Item"),

--- a/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             RunConvention(property);
 
-            property.SetFieldInfo("m_onTheRun");
+            property.SetField("m_onTheRun");
 
             Validate(property);
 
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             RunConvention((IMutableProperty)property);
 
-            property.SetFieldInfo("m_onTheRun", fromDataAnnotation: true);
+            property.SetField("m_onTheRun", fromDataAnnotation: true);
 
             Validate((IMutableProperty)property);
 
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             Assert.Equal(
                 CoreStrings.BackingFieldOnIndexer("nation", entityType.DisplayName(), "Nation"),
-                Assert.Throws<InvalidOperationException>(() => property.SetFieldInfo("nation")).Message);
+                Assert.Throws<InvalidOperationException>(() => property.SetField("nation")).Message);
         }
 
         private void RunConvention(IMutableProperty property)

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -3179,7 +3179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
             else
             {
-                propertyBuilder.Metadata.SetFieldInfo(nameof(Order.IntField),
+                propertyBuilder.Metadata.SetField(nameof(Order.IntField),
                     ConfigurationSource.Convention);
             }
 
@@ -3200,7 +3200,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
             else
             {
-                propertyBuilder.Metadata.SetFieldInfo(nameof(Order.IntField),
+                propertyBuilder.Metadata.SetField(nameof(Order.IntField),
                     ConfigurationSource.Convention);
             }
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
@@ -212,11 +212,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Can_create_materializer_for_entity_with_fields()
         {
             var entityType = ((IMutableModel)new Model()).AddEntityType(typeof(SomeEntityWithFields));
-            entityType.AddProperty(SomeEntityWithFields.EnumProperty).SetFieldInfo("_enum");
-            entityType.AddProperty(SomeEntityWithFields.FooProperty).SetFieldInfo("_foo");
-            entityType.AddProperty(SomeEntityWithFields.GooProperty).SetFieldInfo("_goo");
-            entityType.AddProperty(SomeEntityWithFields.IdProperty).SetFieldInfo("_id");
-            entityType.AddProperty(SomeEntityWithFields.MaybeEnumProperty).SetFieldInfo("_maybeEnum");
+            entityType.AddProperty(SomeEntityWithFields.EnumProperty).SetField("_enum");
+            entityType.AddProperty(SomeEntityWithFields.FooProperty).SetField("_foo");
+            entityType.AddProperty(SomeEntityWithFields.GooProperty).SetField("_goo");
+            entityType.AddProperty(SomeEntityWithFields.IdProperty).SetField("_id");
+            entityType.AddProperty(SomeEntityWithFields.MaybeEnumProperty).SetField("_maybeEnum");
             ((Model)entityType.Model).FinalizeModel();
 
             var factory = GetMaterializer(new EntityMaterializerSource(new EntityMaterializerSourceDependencies()), entityType);

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2037,7 +2037,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void AddIndexedProperty_throws_when_entitytype_does_not_have_indexer()
+        public void AddIndexerProperty_throws_when_entitytype_does_not_have_indexer()
         {
             var model = CreateModel();
             var entityType = model.AddEntityType(typeof(Order));
@@ -2053,7 +2053,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void AddIndexedProperty_throws_when_entitytype_have_property_with_same_name()
+        public void AddIndexerProperty_throws_when_entitytype_have_property_with_same_name()
         {
             var model = CreateModel();
             var entityType = model.AddEntityType(typeof(Customer));

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1427,7 +1427,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
             var propertyBuilder = entityBuilder.IndexerProperty(
-                typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.DataAnnotation);
+                typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(propertyBuilder);
         }
@@ -1439,18 +1439,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
             var propertyBuilder = entityBuilder.IndexerProperty(
-                typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.DataAnnotation);
+                typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(propertyBuilder);
             Assert.Same(
                 propertyBuilder,
-                entityBuilder.Property(typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.Convention));
+                entityBuilder.Property(typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention));
 
             Assert.Same(
                 propertyBuilder,
-                entityBuilder.Property(IndexedClass.IndexedPropertyName, ConfigurationSource.Convention));
+                entityBuilder.Property(IndexedClass.IndexerPropertyName, ConfigurationSource.Convention));
 
-            Assert.Null(entityBuilder.Property(typeof(int), IndexedClass.IndexedPropertyName, ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.Property(typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention));
         }
 
         [ConditionalFact]
@@ -1460,12 +1460,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
             var propertyBuilder = entityBuilder.IndexerProperty(
-                typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.Convention);
+                typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention);
 
             Assert.NotNull(propertyBuilder);
 
             var replacedPropertyBuilder = entityBuilder.Property(
-                typeof(int), IndexedClass.IndexedPropertyName, ConfigurationSource.DataAnnotation);
+                typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(replacedPropertyBuilder);
             Assert.NotSame(propertyBuilder, replacedPropertyBuilder);
@@ -1480,13 +1480,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
             var shadowPropertyBuilder = entityBuilder.Property(
-                typeof(int), IndexedClass.IndexedPropertyName, ConfigurationSource.Convention);
+                typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention);
 
             Assert.NotNull(shadowPropertyBuilder);
             Assert.True(shadowPropertyBuilder.Metadata.IsShadowProperty());
 
             var replacedPropertyBuilder = entityBuilder.IndexerProperty(
-                typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.DataAnnotation);
+                typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(replacedPropertyBuilder);
             Assert.NotSame(shadowPropertyBuilder, replacedPropertyBuilder);
@@ -1501,10 +1501,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             Assert.Equal(
-                CoreStrings.NonIndexerEntityType(IndexedClass.IndexedPropertyName, nameof(Order), typeof(string).ShortDisplayName()),
+                CoreStrings.NonIndexerEntityType(IndexedClass.IndexerPropertyName, nameof(Order), typeof(string).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(
                     () => entityBuilder.IndexerProperty(
-                        typeof(string), IndexedClass.IndexedPropertyName, ConfigurationSource.Convention)).Message);
+                        typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention)).Message);
         }
 
         [ConditionalFact]
@@ -3170,7 +3170,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private class IndexedClass
         {
-            public static readonly string IndexedPropertyName = "Indexer";
+            public static readonly string IndexerPropertyName = "Indexer";
 
             public object this[string name] => null;
         }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -737,7 +737,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .Property<int>(propertyName)
                 .Metadata;
 
-            property.SetFieldInfo(fieldName);
+            property.SetField(fieldName);
             Assert.False(property.IsShadowProperty());
 
             return property;
@@ -755,7 +755,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .WithMany();
 
             var navigation = relationship.Metadata.DependentToPrincipal;
-            navigation.SetFieldInfo(fieldName);
+            navigation.SetField(fieldName);
 
             return navigation;
         }
@@ -772,7 +772,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .WithOne();
 
             var navigation = relationship.Metadata.PrincipalToDependent;
-            navigation.SetFieldInfo(fieldName);
+            navigation.SetField(fieldName);
 
             return navigation;
         }
@@ -908,7 +908,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.FieldNameMismatch(null, nameof(FieldOnly), "_foo"),
-                Assert.Throws<InvalidOperationException>(() => propertyBase.SetFieldInfo(null)).Message);
+                Assert.Throws<InvalidOperationException>(() => propertyBase.SetField(null)).Message);
         }
 
         [ConditionalFact]
@@ -931,14 +931,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Null(propertyBase.FieldInfo);
             Assert.Same(propertyInfo, propertyBase.GetIdentifyingMemberInfo());
 
-            propertyBase.SetFieldInfo(fieldName);
+            propertyBase.SetField(fieldName);
 
             Assert.Equal(fieldName, propertyBase.GetFieldName());
             var fieldInfo = propertyBase.FieldInfo;
             Assert.Equal(fieldName, fieldInfo.Name);
             Assert.Same(propertyInfo ?? (MemberInfo)fieldInfo, propertyBase.GetIdentifyingMemberInfo());
 
-            propertyBase.SetFieldInfo(null);
+            propertyBase.SetField(null);
 
             Assert.Null(propertyBase.GetFieldName());
             Assert.Null(propertyBase.FieldInfo);
@@ -966,7 +966,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.FieldNameMismatch("_foo", nameof(FullProp), "shadow"),
-                Assert.Throws<InvalidOperationException>(() => property.SetFieldInfo("_foo")).Message);
+                Assert.Throws<InvalidOperationException>(() => property.SetField("_foo")).Message);
         }
 
         private class AutoProp


### PR DESCRIPTION
Part of #20409

- Use Field instead of FieldInfo in model building
- Change entityTypeName for `IDbSetCache.GetOrAddSet` and similar
- Rename CreateKeyValueReadExpression to CreateKeyValuesExpression
- Make IsQueryableType real internal
- Rename IndexedProperty to IndexerProperty and related
- Seal ExpressionEqualityComparer
- Change ReplacingExpressionVisitor to use `IReadOnlyList<Expression>`
- Use `ETag` instead of `Etag`
- Remove `GetViewOrTableColumnMappings`
- Rename IColumnBase.Type to StoreType
