### PR TITLE
Obsolete key comparers on properties

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -613,8 +613,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.AfterSaveBehavior,
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueComparer,
-                CoreAnnotationNames.KeyValueComparer,
 #pragma warning disable 618
+                CoreAnnotationNames.KeyValueComparer,
                 CoreAnnotationNames.StructuralValueComparer,
 #pragma warning restore 618
                 CoreAnnotationNames.ValueConverter,

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -229,8 +229,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.AfterSaveBehavior,
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueComparer,
-                CoreAnnotationNames.KeyValueComparer,
 #pragma warning disable 618
+                CoreAnnotationNames.KeyValueComparer,
                 CoreAnnotationNames.StructuralValueComparer,
 #pragma warning restore 618
                 CoreAnnotationNames.ConstructorBinding,

--- a/src/EFCore/Extensions/ConventionPropertyExtensions.cs
+++ b/src/EFCore/Extensions/ConventionPropertyExtensions.cs
@@ -345,11 +345,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
+        [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static ValueComparer SetKeyValueComparer(
             [NotNull] this IConventionProperty property,
             [CanBeNull] ValueComparer comparer,
             bool fromDataAnnotation = false)
-            => property.AsProperty().SetKeyValueComparer(
+            => property.AsProperty().SetValueComparer(
                 comparer, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -357,6 +358,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property to find configuration source for. </param>
         /// <returns> The configuration source for <see cref="PropertyExtensions.GetKeyValueComparer" />. </returns>
+        [Obsolete("Use GetValueComparerConfigurationSource. Only a single value comparer is allowed for a given property.")]
         public static ConfigurationSource? GetKeyValueComparerConfigurationSource([NotNull] this IConventionProperty property)
             => property.FindAnnotation(CoreAnnotationNames.KeyValueComparer)?.GetConfigurationSource();
 
@@ -366,7 +368,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        [Obsolete("Use SetKeyValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static ValueComparer SetStructuralValueComparer(
             [NotNull] this IConventionProperty property,
             [CanBeNull] ValueComparer comparer,
@@ -378,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property to find configuration source for. </param>
         /// <returns> The configuration source for <see cref="PropertyExtensions.GetStructuralValueComparer" />. </returns>
-        [Obsolete("Use GetKeyValueComparerConfigurationSource. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use GetValueComparerConfigurationSource. Only a single value comparer is allowed for a given property.")]
         public static ConfigurationSource? GetStructuralValueComparerConfigurationSource([NotNull] this IConventionProperty property)
             => property.GetKeyValueComparerConfigurationSource();
     }

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -211,16 +211,17 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
+        [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static void SetKeyValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
-            => property.AsProperty().SetKeyValueComparer(comparer, ConfigurationSource.Explicit);
+            => property.AsProperty().SetValueComparer(comparer, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Sets the custom <see cref="ValueComparer" /> for structural copies for this property.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
-        [Obsolete("Use SetKeyValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static void SetStructuralValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
-            => property.SetKeyValueComparer(comparer);
+            => property.SetValueComparer(comparer);
     }
 }

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -320,49 +320,36 @@ namespace Microsoft.EntityFrameworkCore
         ///     Gets the <see cref="ValueComparer" /> for this property, or null if none is set.
         /// </summary>
         /// <param name="property"> The property. </param>
-        /// <param name="fallback"> If true, then the default comparer is returned when the explicit comparer is not set. </param>
         /// <returns> The comparer, or null if none has been set. </returns>
-        public static ValueComparer GetValueComparer([NotNull] this IProperty property, bool fallback = true)
+        public static ValueComparer GetValueComparer([NotNull] this IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
-            var comparer = (ValueComparer)property[CoreAnnotationNames.ValueComparer];
-
-            return comparer == null
-                && fallback
-                    ? property.FindTypeMapping()?.Comparer
-                    : comparer;
+            return (ValueComparer)property[CoreAnnotationNames.ValueComparer]
+                ?? property.FindTypeMapping()?.Comparer;
         }
 
         /// <summary>
         ///     Gets the <see cref="ValueComparer" /> to use with keys for this property, or null if none is set.
         /// </summary>
         /// <param name="property"> The property. </param>
-        /// <param name="fallback"> If true, then the regular comparer is returned when the key comparer is not set. </param>
         /// <returns> The comparer, or null if none has been set. </returns>
-        public static ValueComparer GetKeyValueComparer([NotNull] this IProperty property, bool fallback = true)
+        public static ValueComparer GetKeyValueComparer([NotNull] this IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
-            var comparer = (ValueComparer)property[CoreAnnotationNames.KeyValueComparer];
-
-            return fallback
-                ? comparer
-                ?? (ValueComparer)property[CoreAnnotationNames.ValueComparer]
-                ?? property.FindTypeMapping()?.KeyComparer
-                : comparer;
+            return (ValueComparer)property[CoreAnnotationNames.ValueComparer]
+                ?? property.FindTypeMapping()?.KeyComparer;
         }
 
         /// <summary>
         ///     Gets the <see cref="ValueComparer" /> to use for structural copies for this property, or null if none is set.
         /// </summary>
         /// <param name="property"> The property. </param>
-        /// <param name="fallback"> If true, then the key comparer is returned when the structural comparer is not set. </param>
         /// <returns> The comparer, or null if none has been set. </returns>
-        [Obsolete(
-            "Use GetKeyValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
-        public static ValueComparer GetStructuralValueComparer([NotNull] this IProperty property, bool fallback = true)
-            => property.GetKeyValueComparer(fallback);
+        [Obsolete("Use GetKeyValueComparer. A separate structural comparer is no longer supported.")]
+        public static ValueComparer GetStructuralValueComparer([NotNull] this IProperty property)
+            => property.GetKeyValueComparer();
 
         /// <summary>
         ///     Creates an <see cref="IEqualityComparer{T}" /> for values of the given property type.

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -879,7 +879,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     var converter = property.GetValueConverter();
                     if (converter != null
-                        && property.GetValueComparer(fallback: false) == null)
+                        && property[CoreAnnotationNames.ValueComparer] == null)
                     {
                         var type = converter.ModelClrType;
                         if (type != typeof(string)

--- a/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
@@ -381,6 +381,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The same builder instance if the configuration was applied,
         ///     <c>null</c> otherwise.
         /// </returns>
+        [Obsolete("Use HasValueComparer. Only a single value comparer is allowed for a given property.")]
         IConventionPropertyBuilder HasKeyValueComparer([CanBeNull] ValueComparer comparer, bool fromDataAnnotation = false);
 
         /// <summary>
@@ -392,6 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns>
         ///     <c>true</c> if the given <see cref="ValueComparer" /> can be configured for this property.
         /// </returns>
+        [Obsolete("Use CanSetValueComparer. Only a single value comparer is allowed for a given property.")]
         bool CanSetKeyValueComparer([CanBeNull] ValueComparer comparer, bool fromDataAnnotation = false);
 
         /// <summary>
@@ -403,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The same builder instance if the configuration was applied,
         ///     <c>null</c> otherwise.
         /// </returns>
-        [Obsolete("Use HasKeyValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use HasValueComparer. Only a single value comparer is allowed for a given property.")]
         IConventionPropertyBuilder HasStructuralValueComparer([CanBeNull] ValueComparer comparer, bool fromDataAnnotation = false);
 
         /// <summary>
@@ -415,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns>
         ///     <c>true</c> if the given <see cref="ValueComparer" /> can be configured for this property.
         /// </returns>
-        [Obsolete("Use CanSetStructuralValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use CanSetValueComparer. Only a single value comparer is allowed for a given property.")]
         bool CanSetStructuralValueComparer([CanBeNull] ValueComparer comparer, bool fromDataAnnotation = false);
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -156,6 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [Obsolete("Use ValueComparer. Only a single value comparer is allowed for a given property.")]
         public const string KeyValueComparer = "KeyValueComparer";
 
         /// <summary>
@@ -164,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        [Obsolete("Use KeyValueComparer. Starting with EF Core 5.0, key comparers must implement structural comparisons and deep copies.")]
+        [Obsolete("Use ValueComparer. Only a single value comparer is allowed for a given property.")]
         public const string StructuralValueComparer = "StructuralValueComparer";
 
         /// <summary>
@@ -288,8 +289,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             TypeMapping,
             ValueConverter,
             ValueComparer,
-            KeyValueComparer,
 #pragma warning disable 618
+            KeyValueComparer,
             StructuralValueComparer,
 #pragma warning restore 618
             AfterSaveBehavior,

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -504,7 +504,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] ValueComparer comparer, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetValueComparerConfigurationSource())
-                || Metadata.GetValueComparer(fallback: false) == comparer)
+                || Metadata[CoreAnnotationNames.ValueComparer] == comparer)
             {
                 Metadata.SetValueComparer(comparer, configurationSource);
 
@@ -523,7 +523,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool CanSetValueComparer([CanBeNull] ValueComparer comparer, ConfigurationSource? configurationSource)
             => (configurationSource.Overrides(Metadata.GetValueComparerConfigurationSource())
                     && Metadata.CheckValueComparer(comparer) == null)
-                || Metadata.GetValueComparer(fallback: false) == comparer;
+                || Metadata[CoreAnnotationNames.ValueComparer] == comparer;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -533,17 +533,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalPropertyBuilder HasKeyValueComparer(
             [CanBeNull] ValueComparer comparer, ConfigurationSource configurationSource)
-        {
-            if (configurationSource.Overrides(Metadata.GetKeyValueComparerConfigurationSource())
-                || Metadata.GetKeyValueComparer(fallback: false) == comparer)
-            {
-                Metadata.SetKeyValueComparer(comparer, configurationSource);
-
-                return this;
-            }
-
-            return null;
-        }
+            => HasValueComparer(comparer, configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -552,9 +542,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CanSetKeyValueComparer([CanBeNull] ValueComparer comparer, ConfigurationSource? configurationSource)
-            => (configurationSource.Overrides(Metadata.GetKeyValueComparerConfigurationSource())
-                    && Metadata.CheckValueComparer(comparer) == null)
-                || Metadata.GetKeyValueComparer(fallback: false) == comparer;
+            => CanSetValueComparer(comparer, configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -478,25 +478,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ValueComparer SetKeyValueComparer([CanBeNull] ValueComparer comparer, ConfigurationSource configurationSource)
-        {
-            var errorString = CheckValueComparer(comparer);
-            if (errorString != null)
-            {
-                throw new InvalidOperationException(errorString);
-            }
-
-            this.SetOrRemoveAnnotation(CoreAnnotationNames.KeyValueComparer, comparer, configurationSource);
-
-            return comparer;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public virtual string CheckValueComparer([CanBeNull] ValueComparer comparer)
             => comparer != null
                 && comparer.Type != ClrType

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -51,8 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueConverter,
                 CoreAnnotationNames.ValueComparer,
-                CoreAnnotationNames.KeyValueComparer,
 #pragma warning disable 618
+                CoreAnnotationNames.KeyValueComparer,
                 CoreAnnotationNames.StructuralValueComparer,
 #pragma warning restore 618
                 CoreAnnotationNames.BeforeSaveBehavior,

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -922,7 +922,9 @@ namespace Microsoft.EntityFrameworkCore
                         var property = b.Property(e => e.Id)
                             .HasConversion(v => "KeyValue=" + v, v => v.Substring(9)).Metadata;
 
+#pragma warning disable 618
                         property.SetKeyValueComparer(caseInsensitiveComparer);
+#pragma warning restore 618
                     });
 
                 modelBuilder.Entity<StringForeignKeyDataType>(
@@ -931,7 +933,7 @@ namespace Microsoft.EntityFrameworkCore
                         var property = b.Property(e => e.StringKeyDataTypeId)
                             .HasConversion(v => "KeyValue=" + v, v => v.Substring(9)).Metadata;
 
-                        property.SetKeyValueComparer(caseInsensitiveComparer);
+                        property.SetValueComparer(caseInsensitiveComparer);
                     });
 
                 modelBuilder.Entity<MaxLengthDataTypes>(


### PR DESCRIPTION
Part of #20409

Type mappings need to be able to provide different comparers for key and non-key property. However, when a key comparer is being set on a specific property, then a key comparer can be set for key properties and a regular comparer can be set for non-key properties. We don't need to support setting both on the same property.

Also remove the fallback parameter, per API review.

