### PR TITLE
Update link to release planning process

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See also
 * [Documentation](https://docs.microsoft.com/ef/core/)
 * [Roadmap](https://docs.microsoft.com/ef/core/what-is-new/roadmap)
 * [Weekly status updates](https://github.com/dotnet/efcore/issues/15403)
-* [Release planning process](https://docs.microsoft.com/en-us/ef/core/what-is-new/release-planning)
+* [Release planning process](https://docs.microsoft.com/ef/core/what-is-new/release-planning)
 * [How to write an EF Core provider](https://docs.microsoft.com/ef/core/providers/writing-a-provider)
 * [Security](./docs/security.md)
 * [Code of conduct](.github/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See also
 * [Documentation](https://docs.microsoft.com/ef/core/)
 * [Roadmap](https://docs.microsoft.com/ef/core/what-is-new/roadmap)
 * [Weekly status updates](https://github.com/dotnet/efcore/issues/15403)
-* [Release planning process](https://docs.microsoft.com/ef/core/what-is-new/#release-planning-process)
+* [Release planning process](https://docs.microsoft.com/en-us/ef/core/what-is-new/release-planning)
 * [How to write an EF Core provider](https://docs.microsoft.com/ef/core/providers/writing-a-provider)
 * [Security](./docs/security.md)
 * [Code of conduct](.github/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
The link to release planning process is pointing to https://docs.microsoft.com/ef/core/what-is-new/#release-planning-process instead of https://docs.microsoft.com/en-us/ef/core/what-is-new/release-planning.
