### PR TITLE
Add savepoint support

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual Task CommitTransactionAsync(CancellationToken cancellationToken = default)
-                    => throw new NotSupportedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -114,6 +114,42 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             return Task.CompletedTask;
         }
 
+        /// <inheritdoc />
+        public virtual void CreateSavepoint(string savepointName)
+            => _logger.TransactionIgnoredWarning();
+
+        /// <inheritdoc />
+        public virtual Task CreateSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            _logger.TransactionIgnoredWarning();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual void RollbackSavepoint(string savepointName)
+            => _logger.TransactionIgnoredWarning();
+
+        /// <inheritdoc />
+        public virtual Task RollbackSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            _logger.TransactionIgnoredWarning();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual void ReleaseSavepoint(string savepointName)
+            => _logger.TransactionIgnoredWarning();
+
+        /// <inheritdoc />
+        public virtual Task ReleaseSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            _logger.TransactionIgnoredWarning();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual bool AreSavepointsSupported => true;
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -509,6 +509,86 @@ namespace Microsoft.EntityFrameworkCore.Storage
             return CurrentTransaction.RollbackAsync(cancellationToken);
         }
 
+        /// <inheritdoc />
+        public virtual void CreateSavepoint(string savepointName)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            CurrentTransaction.Save(savepointName);
+        }
+
+        /// <inheritdoc />
+        public virtual Task CreateSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            return CurrentTransaction.SaveAsync(savepointName, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual void RollbackSavepoint(string savepointName)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            CurrentTransaction.Rollback(savepointName);
+        }
+
+        /// <inheritdoc />
+        public virtual Task RollbackSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            return CurrentTransaction.RollbackAsync(savepointName, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual void ReleaseSavepoint(string savepointName)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            CurrentTransaction.Release(savepointName);
+        }
+
+        /// <inheritdoc />
+        public virtual Task ReleaseSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            if (CurrentTransaction == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+            }
+
+            return CurrentTransaction.ReleaseAsync(savepointName, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual bool AreSavepointsSupported
+        {
+            get
+            {
+                if (CurrentTransaction == null)
+                {
+                    throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
+                }
+
+                return CurrentTransaction.AreSavepointsSupported;
+            }
+        }
+
         /// <summary>
         ///     Opens the connection to the database.
         /// </summary>

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModelValidator, SqlServerModelValidator>()
                 .TryAdd<IProviderConventionSetBuilder, SqlServerConventionSetBuilder>()
                 .TryAdd<IUpdateSqlGenerator>(p => p.GetService<ISqlServerUpdateSqlGenerator>())
+                .TryAdd<IRelationalTransactionFactory, SqlServerTransactionFactory>()
                 .TryAdd<IModificationCommandBatchFactory, SqlServerModificationCommandBatchFactory>()
                 .TryAdd<IValueGeneratorSelector, SqlServerValueGeneratorSelector>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISqlServerConnection>())

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
+{
+    public class SqlServerTransaction : RelationalTransaction, IDbContextTransaction
+    {
+        private readonly DbTransaction _dbTransaction;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqlServerTransaction(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] DbTransaction transaction,
+            Guid transactionId,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned)
+            : base(connection, transaction, transactionId, logger, transactionOwned)
+            => _dbTransaction = transaction;
+
+        /// <inheritdoc />
+        public virtual void Save(string savepointName)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "SAVE TRANSACTION " + savepointName;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public virtual async Task SaveAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "SAVE TRANSACTION " + savepointName;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual void Rollback(string savepointName)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "ROLLBACK TRANSACTION " + savepointName;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public virtual async Task RollbackAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "ROLLBACK TRANSACTION " + savepointName;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual bool AreSavepointsSupported => true;
+    }
+}

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransactionFactory.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransactionFactory.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
+{
+    public class SqlServerTransactionFactory : IRelationalTransactionFactory
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual RelationalTransaction Create(
+            IRelationalConnection connection, DbTransaction transaction, Guid transactionId, IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger, bool transactionOwned)
+            => new SqlServerTransaction(connection, transaction, transactionId, logger, transactionOwned);
+    }
+}

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModelValidator, SqliteModelValidator>()
                 .TryAdd<IProviderConventionSetBuilder, SqliteConventionSetBuilder>()
                 .TryAdd<IUpdateSqlGenerator, SqliteUpdateSqlGenerator>()
+                .TryAdd<IRelationalTransactionFactory, SqliteTransactionFactory>()
                 .TryAdd<IModificationCommandBatchFactory, SqliteModificationCommandBatchFactory>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISqliteRelationalConnection>())
                 .TryAdd<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator>()

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTransaction.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTransaction.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
+{
+    public class SqliteTransaction : RelationalTransaction, IDbContextTransaction
+    {
+        private readonly DbTransaction _dbTransaction;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqliteTransaction(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] DbTransaction transaction,
+            Guid transactionId,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned)
+            : base(connection, transaction, transactionId, logger, transactionOwned)
+            => _dbTransaction = transaction;
+
+        /// <inheritdoc />
+        public virtual void Save(string savepointName)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "SAVEPOINT " + savepointName;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public virtual async Task SaveAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "SAVEPOINT " + savepointName;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual void Rollback(string savepointName)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "ROLLBACK TO " + savepointName;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public virtual async Task RollbackAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "ROLLBACK TO " + savepointName;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual void Release(string savepointName)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "RELEASE " + savepointName;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public virtual async Task ReleaseAsync(string savepointName, CancellationToken cancellationToken = default)
+        {
+            using var command = Connection.DbConnection.CreateCommand();
+            command.Transaction = _dbTransaction;
+            command.CommandText = "RELEASE " + savepointName;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public virtual bool AreSavepointsSupported => true;
+    }
+}

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTransactionFactory.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTransactionFactory.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
+{
+    public class SqliteTransactionFactory : IRelationalTransactionFactory
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual RelationalTransaction Create(
+            IRelationalConnection connection, DbTransaction transaction, Guid transactionId, IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger, bool transactionOwned)
+            => new SqliteTransaction(connection, transaction, transactionId, logger, transactionOwned);
+    }
+}

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -183,6 +183,73 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => Dependencies.TransactionManager.RollbackTransactionAsync(cancellationToken);
 
         /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        public virtual void CreateSavepoint([NotNull] string savepointName)
+            => Dependencies.TransactionManager.CreateSavepoint(savepointName);
+
+        /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        public virtual Task CreateSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => Dependencies.TransactionManager.CreateSavepointAsync(savepointName, cancellationToken);
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        public virtual void RollbackSavepoint([NotNull] string savepointName)
+            => Dependencies.TransactionManager.RollbackSavepoint(savepointName);
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        public virtual Task RollbackSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => Dependencies.TransactionManager.RollbackSavepointAsync(savepointName, cancellationToken);
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        public virtual void ReleaseSavepoint([NotNull] string savepointName)
+            => Dependencies.TransactionManager.ReleaseSavepoint(savepointName);
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        public virtual Task ReleaseSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => Dependencies.TransactionManager.ReleaseSavepointAsync(savepointName, cancellationToken);
+
+        /// <summary>
+        ///     Gets a value that indicates whether this <see cref="DatabaseFacade"/> instance supports
+        ///     database savepoints. If <c>false</c>, the methods <see cref="CreateSavepointAsync"/>,
+        ///     <see cref="RollbackSavepointAsync"/>
+        ///     and <see cref="ReleaseSavepointAsync"/> as well as their synchronous counterparts are expected to throw
+        ///     <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="DatabaseFacade"/> instance supports database savepoints;
+        ///     otherwise, <c>false</c>.
+        /// </returns>
+        public virtual bool AreSavepointsSupported => Dependencies.TransactionManager.AreSavepointsSupported;
+
+        /// <summary>
         ///     Creates an instance of the configured <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <returns>An <see cref="IExecutionStrategy" /> instance.</returns>

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -47,5 +48,69 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="cancellationToken"> The cancellation token. </param>
         /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
         Task RollbackAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        void Save([NotNull] string savepointName) => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task SaveAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        void Rollback([NotNull] string savepointName) => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task RollbackAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        void Release([NotNull] string savepointName) { }
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task ReleaseAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        /// <summary>
+        ///     Gets a value that indicates whether this <see cref="IDbContextTransaction"/> instance supports
+        ///     database savepoints. If <c>false</c>, the methods <see cref="SaveAsync"/>,
+        ///     <see cref="RollbackAsync(string, System.Threading.CancellationToken)"/>
+        ///     and <see cref="ReleaseAsync"/> as well as their synchronous counterparts are expected to throw
+        ///     <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="IDbContextTransaction"/> instance supports database savepoints;
+        ///     otherwise, <c>false</c>.
+        /// </returns>
+        bool AreSavepointsSupported => false;
     }
 }

--- a/src/EFCore/Storage/IDbContextTransactionManager.cs
+++ b/src/EFCore/Storage/IDbContextTransactionManager.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -67,6 +69,70 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A task that represents the asynchronous operation.
         /// </returns>
         Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        void CreateSavepoint([NotNull] string savepointName) => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
+        ///     was established to be rolled back, restoring the transaction state to what it was at the time of the
+        ///     savepoint.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to be created. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task CreateSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        void RollbackSavepoint([NotNull] string savepointName) => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Rolls back all commands that were executed after the specified savepoint was established.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to roll back to. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task RollbackSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        void ReleaseSavepoint([NotNull] string savepointName) => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Destroys a savepoint previously defined in the current transaction. This allows the system to
+        ///     reclaim some resources before the transaction ends.
+        /// </summary>
+        /// <param name="savepointName"> The name of the savepoint to release. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
+        Task ReleaseSavepointAsync([NotNull] string savepointName, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        ///     Gets a value that indicates whether this <see cref="IDbContextTransactionManager"/> instance supports
+        ///     database savepoints. If <c>false</c>, the methods <see cref="CreateSavepointAsync"/>,
+        ///     <see cref="RollbackSavepointAsync"/>
+        ///     and <see cref="ReleaseSavepointAsync"/> as well as their synchronous counterparts are expected to throw
+        ///     <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this <see cref="IDbContextTransactionManager"/> instance supports database savepoints;
+        ///     otherwise, <c>false</c>.
+        /// </returns>
+        bool AreSavepointsSupported => false;
 
         /// <summary>
         ///     Gets the current transaction.

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -169,6 +169,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public void RollbackTransaction() => throw new NotImplementedException();
             public Task RollbackTransactionAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
             public IDbContextTransaction UseTransaction(DbTransaction transaction) => throw new NotImplementedException();
 
             public Task<IDbContextTransaction> UseTransactionAsync(

--- a/test/EFCore.Tests/DatabaseFacadeTest.cs
+++ b/test/EFCore.Tests/DatabaseFacadeTest.cs
@@ -151,6 +151,10 @@ namespace Microsoft.EntityFrameworkCore
 
             public int CommitCalls;
             public int RollbackCalls;
+            public int CreateSavepointCalls;
+            public int RollbackSavepointCalls;
+            public int ReleaseSavepointCalls;
+            public int AreSavepointsSupportedCalls;
 
             public IDbContextTransaction BeginTransaction()
                 => _transaction;
@@ -172,6 +176,39 @@ namespace Microsoft.EntityFrameworkCore
             {
                 RollbackCalls++;
                 return Task.CompletedTask;
+            }
+
+            public void CreateSavepoint(string savepointName) => CreateSavepointCalls++;
+
+            public Task CreateSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+            {
+                CreateSavepointCalls++;
+                return Task.CompletedTask;
+            }
+
+            public void RollbackSavepoint(string savepointName) => RollbackSavepointCalls++;
+
+            public Task RollbackSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+            {
+                RollbackSavepointCalls++;
+                return Task.CompletedTask;
+            }
+
+            public void ReleaseSavepoint(string savepointName) => ReleaseSavepointCalls++;
+
+            public Task ReleaseSavepointAsync(string savepointName, CancellationToken cancellationToken = default)
+            {
+                ReleaseSavepointCalls++;
+                return Task.CompletedTask;
+            }
+
+            public bool AreSavepointsSupported
+            {
+                get
+                {
+                    AreSavepointsSupportedCalls++;
+                    return true;
+                }
             }
 
             public IDbContextTransaction CurrentTransaction => _transaction;
@@ -243,6 +280,97 @@ namespace Microsoft.EntityFrameworkCore
             await context.Database.RollbackTransactionAsync();
 
             Assert.Equal(1, manager.RollbackCalls);
+        }
+
+        [ConditionalFact]
+        public void Can_create_savepoint()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            context.Database.CreateSavepoint("foo");
+
+            Assert.Equal(1, manager.CreateSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public async Task Can_create_savepoint_async()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            await context.Database.CreateSavepointAsync("foo");
+
+            Assert.Equal(1, manager.CreateSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public void Can_rollback_savepoint()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            context.Database.RollbackSavepoint("foo");
+
+            Assert.Equal(1, manager.RollbackSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public async Task Can_rollback_savepoint_async()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            await context.Database.RollbackSavepointAsync("foo");
+
+            Assert.Equal(1, manager.RollbackSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public void Can_release_savepoint()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            context.Database.ReleaseSavepoint("foo");
+
+            Assert.Equal(1, manager.ReleaseSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public async Task Can_release_savepoint_async()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            await context.Database.ReleaseSavepointAsync("foo");
+
+            Assert.Equal(1, manager.ReleaseSavepointCalls);
+        }
+
+        [ConditionalFact]
+        public void Can_check_if_checkpoints_are_supported()
+        {
+            var manager = new FakeDbContextTransactionManager(new FakeDbContextTransaction());
+
+            var context = InMemoryTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
+
+            _ = context.Database.AreSavepointsSupported;
+
+            Assert.Equal(1, manager.AreSavepointsSupportedCalls);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
* Add APIs for supporting transaction savepoints.
* Support is implemented at the EF level only, no System.Data support yet (this should come soon).
* Use savepoints in the update pipeline when a user-managed transaction is used, to roll back to before SaveChanges in case of exception.

Some notes:

* See SaveChanges_uses_explicit_transaction_with_failure_behavior for how savepoints help with SaveChanges failures.
* Another good example is Database_concurrency_token_value_is_discarded_for_non_conflicting_entities, which isn't needed anymore because the entire SaveChanges is rolled back if any conflict occurs. I wonder if we should still have a test for this - this may require an escape hatch flag that allows running without savepoints even if the provider supports them (but I'm not sure where someone would use that).
* This currently implements everything in EF Core, without any System.Data support (https://github.com/dotnet/runtime/issues/33397). When that makes it in, I'll replace the default implementation in RelationalTransaction to delegate to that.
* We should have logging for savepoints like other things, but we can wait for the System.Data implementation to put them into the default implementation. Same for interceptors.
* AFAICT ambient transactions (System.Transactions) don't support savepoints. You can have multiple nested scopes, but that's just a vote for committing the top-level scope.

Part of #20176
