### PR TITLE
Fix for 11410. Updating ModelBuilder APIs to use GetMemberAccess()

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeBuilderExtensions.cs
@@ -209,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(propertyExpression.GetPropertyAccess().GetSimpleMemberName());
+            entityTypeBuilder.Metadata.SetPartitionKeyPropertyName(propertyExpression.GetMemberAccess().GetSimpleMemberName());
 
             return entityTypeBuilder;
         }

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -755,7 +755,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var columnsBuilder = new ColumnsBuilder(createTableOperation);
             var columnsObject = columns(columnsBuilder);
-            var columnMap = new Dictionary<PropertyInfo, AddColumnOperation>();
+            var columnMap = new Dictionary<MemberInfo, AddColumnOperation>();
             foreach (var property in typeof(TColumns).GetTypeInfo().DeclaredProperties)
             {
                 var addColumnOperation = ((IInfrastructure<AddColumnOperation>)property.GetMethod.Invoke(columnsObject, null)).Instance;

--- a/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
     /// <typeparam name="TColumns"> Type of a typically anonymous type for building columns. </typeparam>
     public class CreateTableBuilder<TColumns> : OperationBuilder<CreateTableOperation>
     {
-        private readonly IReadOnlyDictionary<PropertyInfo, AddColumnOperation> _columnMap;
+        private readonly IReadOnlyDictionary<MemberInfo, AddColumnOperation> _columnMap;
 
         /// <summary>
         ///     Constructs a new builder for the given <see cref="CreateTableOperation" /> and
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <param name="columnMap"> The map of CLR properties to <see cref="AddColumnOperation" />s. </param>
         public CreateTableBuilder(
             [NotNull] CreateTableOperation operation,
-            [NotNull] IReadOnlyDictionary<PropertyInfo, AddColumnOperation> columnMap)
+            [NotNull] IReadOnlyDictionary<MemberInfo, AddColumnOperation> columnMap)
             : base(operation)
         {
             Check.NotNull(columnMap, nameof(columnMap));
@@ -191,6 +191,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
             => (CreateTableBuilder<TColumns>)base.Annotation(name, value);
 
         private string[] Map(LambdaExpression columns)
-            => columns.GetPropertyAccessList().Select(c => _columnMap[c].Name).ToArray();
+            => columns.GetMemberAccessList().Select(c => _columnMap[c].Name).ToArray();
     }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore
 
             IncludeProperties(
                 indexBuilder,
-                includeExpression.GetPropertyAccessList().Select(MemberInfoExtensions.GetSimpleMemberName).ToArray());
+                includeExpression.GetMemberAccessList().Select(MemberInfoExtensions.GetSimpleMemberName).ToArray());
 
             return indexBuilder;
         }

--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            return new PropertyEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().GetSimpleMemberName());
+            return new PropertyEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetMemberAccess().GetSimpleMemberName());
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            return new ReferenceEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().GetSimpleMemberName());
+            return new ReferenceEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetMemberAccess().GetSimpleMemberName());
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            return new CollectionEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetPropertyAccess().GetSimpleMemberName());
+            return new CollectionEntry<TEntity, TProperty>(InternalEntry, propertyExpression.GetMemberAccess().GetSimpleMemberName());
         }
 
         /// <summary>

--- a/src/EFCore/Infrastructure/ExpressionExtensions.cs
+++ b/src/EFCore/Infrastructure/ExpressionExtensions.cs
@@ -149,28 +149,46 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="propertyAccessExpression"> The expression. </param>
         /// <returns> The <see cref="PropertyInfo" />. </returns>
         public static PropertyInfo GetPropertyAccess([NotNull] this LambdaExpression propertyAccessExpression)
+            => GetInternalMemberAccess<PropertyInfo>(propertyAccessExpression);
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="MemberInfo" /> represented by a simple member-access expression.
+        ///     </para>
+        ///     <para>
+        ///         This method is typically used to parse member access lambdas from fluent APIs.
+        ///     </para>
+        /// </summary>
+        /// <param name="memberAccessExpression"> The expression. </param>
+        /// <returns> The <see cref="MemberInfo" />. </returns>
+        public static MemberInfo GetMemberAccess([NotNull] this LambdaExpression memberAccessExpression)
+            => GetInternalMemberAccess<MemberInfo>(memberAccessExpression);
+
+        private static TMemberInfo GetInternalMemberAccess<TMemberInfo>([NotNull] this LambdaExpression memberAccessExpression)
+            where TMemberInfo : MemberInfo
         {
             Check.DebugAssert(
-                propertyAccessExpression.Parameters.Count == 1,
-                $"Parameters.Count is {propertyAccessExpression.Parameters.Count}");
+                memberAccessExpression.Parameters.Count == 1,
+                $"Parameters.Count is {memberAccessExpression.Parameters.Count}");
 
-            var parameterExpression = propertyAccessExpression.Parameters.Single();
-            var propertyInfo = parameterExpression.MatchSimplePropertyAccess(propertyAccessExpression.Body);
+            var parameterExpression = memberAccessExpression.Parameters[0];
+            var memberInfo = parameterExpression.MatchSimpleMemberAccess<TMemberInfo>(memberAccessExpression.Body);
 
-            if (propertyInfo == null)
+            if (memberInfo == null)
             {
                 throw new ArgumentException(
-                    CoreStrings.InvalidPropertyExpression(propertyAccessExpression),
-                    nameof(propertyAccessExpression));
+                    CoreStrings.InvalidMemberExpression(memberAccessExpression),
+                    nameof(memberAccessExpression));
             }
 
-            var declaringType = propertyInfo.DeclaringType;
+            var declaringType = memberInfo.DeclaringType;
             var parameterType = parameterExpression.Type;
 
             if (declaringType != null
                 && declaringType != parameterType
                 && declaringType.IsInterface
-                && declaringType.IsAssignableFrom(parameterType))
+                && declaringType.IsAssignableFrom(parameterType)
+                && memberInfo is PropertyInfo propertyInfo)
             {
                 var propertyGetter = propertyInfo.GetMethod;
                 var interfaceMapping = parameterType.GetTypeInfo().GetRuntimeInterfaceMap(declaringType);
@@ -180,12 +198,12 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     if (targetMethod.Equals(runtimeProperty.GetMethod))
                     {
-                        return runtimeProperty;
+                        return runtimeProperty as TMemberInfo;
                     }
                 }
             }
 
-            return propertyInfo;
+            return memberInfo;
         }
 
         /// <summary>
@@ -195,8 +213,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     </para>
         ///     <para>
         ///         Only simple expressions are supported, such as those used to reference a property.
-        ///         This type is typically used by database providers (and other extensions). It is generally
-        ///         not used in application code.
         ///     </para>
         ///     <para>
         ///         This method is typically used by database providers (and other extensions). It is generally
@@ -212,21 +228,53 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             if (propertyAccessExpression.Parameters.Count != 1)
             {
                 throw new ArgumentException(
-                    CoreStrings.InvalidPropertiesExpression(propertyAccessExpression),
+                    CoreStrings.InvalidMembersExpression(propertyAccessExpression),
                     nameof(propertyAccessExpression));
             }
 
-            var propertyPaths
-                = propertyAccessExpression.MatchPropertyAccessList((p, e) => e.MatchSimplePropertyAccess(p));
+            var propertyPaths = propertyAccessExpression
+                .MatchMemberAccessList((p, e) => e.MatchSimpleMemberAccess<PropertyInfo>(p));
 
             if (propertyPaths == null)
             {
                 throw new ArgumentException(
-                    CoreStrings.InvalidPropertiesExpression(propertyAccessExpression),
+                    CoreStrings.InvalidMembersExpression(propertyAccessExpression),
                     nameof(propertyAccessExpression));
             }
 
             return propertyPaths;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Returns a list of <see cref="MemberInfo" /> extracted from the given simple
+        ///         <see cref="LambdaExpression" />.
+        ///     </para>
+        ///     <para>
+        ///         Only simple expressions are supported, such as those used to reference a member.
+        ///     </para>
+        ///     <para>
+        ///         This method is typically used by database providers (and other extensions). It is generally
+        ///         not used in application code.
+        ///     </para>
+        /// </summary>
+        /// <param name="memberAccessExpression"> The expression. </param>
+        /// <returns> The list of referenced members. </returns>
+        public static IReadOnlyList<MemberInfo> GetMemberAccessList([NotNull] this LambdaExpression memberAccessExpression)
+        {
+            Check.NotNull(memberAccessExpression, nameof(memberAccessExpression));
+
+            var memberPaths = memberAccessExpression
+                .MatchMemberAccessList((p, e) => e.MatchSimpleMemberAccess<MemberInfo>(p));
+
+            if (memberPaths == null)
+            {
+                throw new ArgumentException(
+                    CoreStrings.InvalidMembersExpression(memberAccessExpression),
+                    nameof(memberAccessExpression));
+            }
+
+            return memberPaths;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,
-                WithOneBuilder(navigationExpression?.GetPropertyAccess()).Metadata);
+                WithOneBuilder(navigationExpression?.GetMemberAccess()).Metadata);
 
         /// <summary>
         ///     Configures this as a many-to-many relationship.
@@ -129,8 +129,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             return new CollectionCollectionBuilder<TRelatedEntity, TEntity>(
                            RelatedEntityType,
                            DeclaringEntityType,
-                           WithLeftManyNavigation(navigationExpression.GetPropertyAccess()),
-                           WithRightManyNavigation(navigationExpression.GetPropertyAccess(), leftName));
+                           WithLeftManyNavigation(navigationExpression.GetMemberAccess()),
+                           WithRightManyNavigation(navigationExpression.GetMemberAccess(), leftName));
         }
     }
 }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual KeyBuilder HasKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
             => new KeyBuilder<TEntity>(
                 Builder.PrimaryKey(
-                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(),
+                    Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList(),
                     ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual KeyBuilder<TEntity> HasAlternateKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
             => new KeyBuilder<TEntity>(
                 Builder.HasKey(
-                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(),
+                    Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList(),
                     ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
             => new PropertyBuilder<TProperty>(
                 Builder.Property(
-                        Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(), ConfigurationSource.Explicit)
+                        Check.NotNull(propertyExpression, nameof(propertyExpression)).GetMemberAccess(), ConfigurationSource.Explicit)
                     .Metadata);
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual NavigationBuilder Navigation<TNavigation>([NotNull] Expression<Func<TEntity, TNavigation>> navigationExpression)
             => new NavigationBuilder(
                 Builder.Navigation(
-                        Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                        Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         public virtual EntityTypeBuilder<TEntity> Ignore([NotNull] Expression<Func<TEntity, object>> propertyExpression)
             => (EntityTypeBuilder<TEntity>)base.Ignore(
-                Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess().GetSimpleMemberName());
+                Check.NotNull(propertyExpression, nameof(propertyExpression)).GetMemberAccess().GetSimpleMemberName());
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual IndexBuilder<TEntity> HasIndex([NotNull] Expression<Func<TEntity, object>> indexExpression)
             => new IndexBuilder<TEntity>(
                 Builder.HasIndex(
-                    Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(),
+                    Check.NotNull(indexExpression, nameof(indexExpression)).GetMemberAccessList(),
                     ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
             where TRelatedEntity : class
             => OwnsOneBuilder<TRelatedEntity>(
-                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     <para>
@@ -371,7 +371,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new MemberIdentity(navigationExpression.GetPropertyAccess())));
+            buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new MemberIdentity(navigationExpression.GetMemberAccess())));
             return this;
         }
 
@@ -383,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             {
                 relationship = navigation.MemberInfo == null
                     ? Builder.HasOwnership(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : Builder.HasOwnership(typeof(TRelatedEntity), (PropertyInfo)navigation.MemberInfo, ConfigurationSource.Explicit);
+                    : Builder.HasOwnership(typeof(TRelatedEntity), navigation.MemberInfo, ConfigurationSource.Explicit);
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
                 relationship = (InternalForeignKeyBuilder)batch.Run(relationship.Metadata).Builder;
             }
@@ -448,7 +448,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
             where TRelatedEntity : class
             => OwnsManyBuilder<TRelatedEntity>(
-                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     <para>
@@ -517,7 +517,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            buildAction.Invoke(OwnsManyBuilder<TRelatedEntity>(new MemberIdentity(navigationExpression.GetPropertyAccess())));
+            buildAction.Invoke(OwnsManyBuilder<TRelatedEntity>(new MemberIdentity(navigationExpression.GetMemberAccess())));
             return this;
         }
 
@@ -613,7 +613,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
             where TRelatedEntity : class
         {
-            var navigationMember = navigationExpression?.GetPropertyAccess();
+            var navigationMember = navigationExpression?.GetMemberAccess();
             var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationMember?.GetSimpleMemberName());
             var foreignKey = HasOneBuilder(
                 MemberIdentity.Create(navigationMember), relatedEntityType);
@@ -704,7 +704,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
             where TRelatedEntity : class
         {
-            var navigationMember = navigationExpression?.GetPropertyAccess();
+            var navigationMember = navigationExpression?.GetMemberAccess();
             var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationMember?.GetSimpleMemberName());
             var skipNavigation = navigationMember != null ? Builder.Metadata.FindSkipNavigation(navigationMember) : null;
 
@@ -812,7 +812,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
             return new DiscriminatorBuilder<TDiscriminator>(
-                Builder.HasDiscriminator(propertyExpression.GetPropertyAccess(), ConfigurationSource.Explicit));
+                Builder.HasDiscriminator(propertyExpression.GetMemberAccess(), ConfigurationSource.Explicit));
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual KeyBuilder<TDependentEntity> HasKey([NotNull] Expression<Func<TDependentEntity, object>> keyExpression)
             => new KeyBuilder<TDependentEntity>(
                 DependentEntityType.Builder.PrimaryKey(
-                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit).Metadata);
+                    Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList(), ConfigurationSource.Explicit).Metadata);
 
         /// <summary>
         ///     Sets the properties that make up the primary key for this owned entity type.
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => UpdateBuilder(
                 () => new PropertyBuilder<TProperty>(
                     DependentEntityType.Builder.Property(
-                        Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(),
+                        Check.NotNull(propertyExpression, nameof(propertyExpression)).GetMemberAccess(),
                         ConfigurationSource.Explicit).Metadata));
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual NavigationBuilder Navigation<TNavigation>(
             [NotNull] Expression<Func<TDependentEntity, TNavigation>> navigationExpression)
             => new NavigationBuilder(DependentEntityType.Builder.Navigation(
-                Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (OwnedNavigationBuilder<TEntity, TDependentEntity>)
                 base.Ignore(
                     Check.NotNull(propertyExpression, nameof(propertyExpression))
-                        .GetPropertyAccess().GetSimpleMemberName());
+                        .GetMemberAccess().GetSimpleMemberName());
 
         /// <summary>
         ///     Configures an index on the specified properties. If there is an existing index on the given
@@ -159,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual IndexBuilder<TEntity> HasIndex([NotNull] Expression<Func<TDependentEntity, object>> indexExpression)
             => new IndexBuilder<TEntity>(
                 DependentEntityType.Builder.HasIndex(
-                        Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit)
+                        Check.NotNull(indexExpression, nameof(indexExpression)).GetMemberAccessList(), ConfigurationSource.Explicit)
                     .Metadata);
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 PrincipalEntityType,
                 DependentEntityType,
                 Builder.HasNavigation(
-                    referenceExpression?.GetPropertyAccess(),
+                    referenceExpression?.GetMemberAccess(),
                     pointsToPrincipal: true,
                     ConfigurationSource.Explicit).Metadata);
 
@@ -285,7 +285,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             where TNewDependentEntity : class
             => OwnsOneBuilder<TNewDependentEntity>(
                 new MemberIdentity(
-                    Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                    Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     <para>
@@ -356,7 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            buildAction.Invoke(OwnsOneBuilder<TNewDependentEntity>(new MemberIdentity(navigationExpression.GetPropertyAccess())));
+            buildAction.Invoke(OwnsOneBuilder<TNewDependentEntity>(new MemberIdentity(navigationExpression.GetMemberAccess())));
             return this;
         }
 
@@ -435,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression)
             where TNewDependentEntity : class
             => OwnsManyBuilder<TNewDependentEntity>(
-                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+                new MemberIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetMemberAccess()));
 
         /// <summary>
         ///     <para>
@@ -509,7 +509,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             using (DependentEntityType.Model.ConventionDispatcher.DelayConventions())
             {
-                buildAction.Invoke(OwnsManyBuilder<TNewDependentEntity>(new MemberIdentity(navigationExpression.GetPropertyAccess())));
+                buildAction.Invoke(OwnsManyBuilder<TNewDependentEntity>(new MemberIdentity(navigationExpression.GetMemberAccess())));
                 return this;
             }
         }
@@ -607,7 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] Expression<Func<TDependentEntity, TNewRelatedEntity>> navigationExpression = null)
             where TNewRelatedEntity : class
         {
-            var navigation = navigationExpression?.GetPropertyAccess();
+            var navigation = navigationExpression?.GetMemberAccess();
             var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigation?.GetSimpleMemberName());
 
             return new ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(

--- a/src/EFCore/Metadata/Builders/OwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnershipBuilder`.cs
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
         {
             Builder = Builder.HasForeignKey(
-                Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList(),
+                Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetMemberAccessList(),
                 (EntityType)DependentEntityType,
                 ConfigurationSource.Explicit);
             return new OwnershipBuilder<TEntity, TDependentEntity>(
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Expression<Func<TEntity, object>> keyExpression)
         {
             Builder = Builder.HasPrincipalKey(
-                Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(),
+                Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList(),
                 ConfigurationSource.Explicit);
             return new OwnershipBuilder<TEntity, TDependentEntity>(
                 Builder,

--- a/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -117,8 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        protected virtual InternalForeignKeyBuilder HasForeignKeyBuilder([NotNull] IReadOnlyList<MemberInfo> foreignKeyProperties)
-            => Builder.HasForeignKey(foreignKeyProperties, (EntityType)DependentEntityType, ConfigurationSource.Explicit);
+        protected virtual InternalForeignKeyBuilder HasForeignKeyBuilder([NotNull] IReadOnlyList<MemberInfo> foreignKeyMembers)
+            => Builder.HasForeignKey(foreignKeyMembers, (EntityType)DependentEntityType, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
@@ -151,8 +151,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        protected virtual InternalForeignKeyBuilder HasPrincipalKeyBuilder([NotNull] IReadOnlyList<MemberInfo> keyProperties)
-            => Builder.HasPrincipalKey(keyProperties, ConfigurationSource.Explicit);
+        protected virtual InternalForeignKeyBuilder HasPrincipalKeyBuilder([NotNull] IReadOnlyList<MemberInfo> keyMembers)
+            => Builder.HasPrincipalKey(keyMembers, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Configures whether this is a required relationship (i.e. whether the foreign key property(s) can

--- a/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasForeignKey(
             [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
             => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                HasForeignKeyBuilder(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
+                HasForeignKeyBuilder(Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetMemberAccessList()),
                 this,
                 foreignKeySet: true);
 
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasPrincipalKey(
             [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
             => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                HasPrincipalKeyBuilder(Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList()),
+                HasPrincipalKeyBuilder(Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList()),
                 this,
                 principalKeySet: true);
 

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             return new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                 RelatedEntityType,
                 DeclaringEntityType,
-                WithManyBuilder(navigationExpression?.GetPropertyAccess()).Metadata);
+                WithManyBuilder(navigationExpression?.GetMemberAccess()).Metadata);
         }
 
         /// <summary>
@@ -153,6 +153,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                 DeclaringEntityType,
                 RelatedEntityType,
-                WithOneBuilder(navigationExpression?.GetPropertyAccess()).Metadata);
+                WithOneBuilder(navigationExpression?.GetMemberAccess()).Metadata);
     }
 }

--- a/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -172,10 +172,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         protected virtual InternalForeignKeyBuilder HasForeignKeyBuilder(
             [NotNull] EntityType dependentEntityType,
             [NotNull] string dependentEntityTypeName,
-            [NotNull] IReadOnlyList<MemberInfo> foreignKeyProperties)
+            [NotNull] IReadOnlyList<MemberInfo> foreignKeyMembers)
             => HasForeignKeyBuilder(
                 dependentEntityType, dependentEntityTypeName,
-                (b, d) => b.HasForeignKey(foreignKeyProperties, d, ConfigurationSource.Explicit));
+                (b, d) => b.HasForeignKey(foreignKeyMembers, d, ConfigurationSource.Explicit));
 
         private InternalForeignKeyBuilder HasForeignKeyBuilder(
             EntityType dependentEntityType,
@@ -282,10 +282,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         protected virtual InternalForeignKeyBuilder HasPrincipalKeyBuilder(
             [NotNull] EntityType principalEntityType,
             [NotNull] string principalEntityTypeName,
-            [NotNull] IReadOnlyList<MemberInfo> foreignKeyProperties)
+            [NotNull] IReadOnlyList<MemberInfo> foreignKeyMembers)
             => HasPrincipalKeyBuilder(
                 principalEntityType, principalEntityTypeName,
-                b => b.HasPrincipalKey(foreignKeyProperties, ConfigurationSource.Explicit));
+                b => b.HasPrincipalKey(foreignKeyMembers, ConfigurationSource.Explicit));
 
         private InternalForeignKeyBuilder HasPrincipalKeyBuilder(
             EntityType principalEntityType,

--- a/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -211,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 HasForeignKeyBuilder(
                     ResolveEntityType(typeof(TDependentEntity)),
                     typeof(TDependentEntity).ShortDisplayName(),
-                    Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
+                    Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetMemberAccessList()),
                 this,
                 inverted: Builder.Metadata.DeclaringEntityType.ClrType != typeof(TDependentEntity),
                 foreignKeySet: true);
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 HasPrincipalKeyBuilder(
                     ResolveEntityType(typeof(TPrincipalEntity)),
                     typeof(TPrincipalEntity).ShortDisplayName(),
-                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList()),
+                    Check.NotNull(keyExpression, nameof(keyExpression)).GetMemberAccessList()),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.ClrType != typeof(TPrincipalEntity),
                 principalKeySet: true);

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -173,8 +173,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalKeyBuilder HasKey([NotNull] IReadOnlyList<MemberInfo> clrProperties, ConfigurationSource configurationSource)
-            => HasKeyInternal(GetOrCreateProperties(clrProperties, configurationSource), configurationSource);
+        public virtual InternalKeyBuilder HasKey([NotNull] IReadOnlyList<MemberInfo> clrMembers, ConfigurationSource configurationSource)
+            => HasKeyInternal(GetOrCreateProperties(clrMembers, configurationSource), configurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2475,12 +2475,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalForeignKeyBuilder HasRelationship(
             [NotNull] EntityType targetEntityType,
-            [CanBeNull] MemberInfo navigationProperty,
+            [CanBeNull] MemberInfo navigationMember,
             ConfigurationSource configurationSource,
             bool? targetIsPrincipal = null)
             => HasRelationship(
                 Check.NotNull(targetEntityType, nameof(targetEntityType)),
-                MemberIdentity.Create(navigationProperty),
+                MemberIdentity.Create(navigationMember),
                 null,
                 targetIsPrincipal,
                 configurationSource);
@@ -2888,10 +2888,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalForeignKeyBuilder HasOwnership(
             [NotNull] Type targetEntityType,
-            [NotNull] MemberInfo navigationProperty,
+            [NotNull] MemberInfo navigationMember,
             ConfigurationSource configurationSource)
             => HasOwnership(
-                new TypeIdentity(targetEntityType, Metadata.Model), MemberIdentity.Create(navigationProperty),
+                new TypeIdentity(targetEntityType, Metadata.Model), MemberIdentity.Create(navigationMember),
                 inverse: null, configurationSource);
 
         /// <summary>
@@ -2919,13 +2919,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalForeignKeyBuilder HasOwnership(
             [NotNull] Type targetEntityType,
-            [NotNull] MemberInfo navigationProperty,
-            [CanBeNull] MemberInfo inverseProperty,
+            [NotNull] MemberInfo navigationMember,
+            [CanBeNull] MemberInfo inverseMember,
             ConfigurationSource configurationSource)
             => HasOwnership(
                 new TypeIdentity(targetEntityType, Metadata.Model),
-                MemberIdentity.Create(navigationProperty),
-                MemberIdentity.Create(inverseProperty),
+                MemberIdentity.Create(navigationMember),
+                MemberIdentity.Create(inverseMember),
                 configurationSource);
 
         private InternalForeignKeyBuilder HasOwnership(

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -867,7 +867,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         && (overrideSameSource || configurationSource != Metadata.GetPrincipalToDependentConfigurationSource()));
 
         private static bool IsCompatible(
-            [NotNull] MemberInfo navigationProperty,
+            [NotNull] MemberInfo navigationMember,
             bool pointsToPrincipal,
             [NotNull] Type dependentType,
             [NotNull] Type principalType,
@@ -878,13 +878,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!pointsToPrincipal)
             {
                 var canBeUnique = Navigation.IsCompatible(
-                    navigationProperty,
+                    navigationMember,
                     principalType,
                     dependentType,
                     shouldBeCollection: false,
                     shouldThrow: false);
                 var canBeNonUnique = Navigation.IsCompatible(
-                    navigationProperty,
+                    navigationMember,
                     principalType,
                     dependentType,
                     shouldBeCollection: true,
@@ -899,7 +899,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (shouldThrow)
                     {
                         Navigation.IsCompatible(
-                            navigationProperty,
+                            navigationMember,
                             principalType,
                             dependentType,
                             shouldBeCollection: null,
@@ -910,7 +910,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
             else if (!Navigation.IsCompatible(
-                navigationProperty,
+                navigationMember,
                 dependentType,
                 principalType,
                 shouldBeCollection: false,
@@ -2061,10 +2061,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual InternalForeignKeyBuilder HasPrincipalKey(
-            [NotNull] IReadOnlyList<MemberInfo> properties,
+            [NotNull] IReadOnlyList<MemberInfo> members,
             ConfigurationSource configurationSource)
             => HasPrincipalKey(
-                Metadata.PrincipalEntityType.Builder.GetOrCreateProperties(properties, configurationSource),
+                Metadata.PrincipalEntityType.Builder.GetOrCreateProperties(members, configurationSource),
                 configurationSource);
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -85,6 +85,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
+        ///     The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.
+        /// </summary>
+        public static string InvalidPropertiesExpression([CanBeNull] object expression)
+            => string.Format(
+                GetString("InvalidPropertiesExpression", nameof(expression)),
+                expression);
+
+        /// <summary>
+        ///     The expression '{expression}' is not a valid property expression. The expression should represent a simple property access: 't =&gt; t.MyProperty'.
+        /// </summary>
+        public static string InvalidPropertyExpression([CanBeNull] object expression)
+            => string.Format(
+                GetString("InvalidPropertyExpression", nameof(expression)),
+                expression);
+
+        /// <summary>
         ///     The expression '{expression}' is not a valid members access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'. When specifying multiple properties or fields use an anonymous type: 't =&gt; new {{ t.MyProperty, t.MyField }}'.
         /// </summary>
         public static string InvalidMembersExpression([CanBeNull] object expression)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -85,19 +85,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
-        ///     The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.
+        ///     The expression '{expression}' is not a valid members access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'. When specifying multiple properties or fields use an anonymous type: 't =&gt; new {{ t.MyProperty, t.MyField }}'.
         /// </summary>
-        public static string InvalidPropertiesExpression([CanBeNull] object expression)
+        public static string InvalidMembersExpression([CanBeNull] object expression)
             => string.Format(
-                GetString("InvalidPropertiesExpression", nameof(expression)),
+                GetString("InvalidMembersExpression", nameof(expression)),
                 expression);
 
         /// <summary>
-        ///     The expression '{expression}' is not a valid property expression. The expression should represent a simple property access: 't =&gt; t.MyProperty'.
+        ///     The expression '{expression}' is not a valid member access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'.
         /// </summary>
-        public static string InvalidPropertyExpression([CanBeNull] object expression)
+        public static string InvalidMemberExpression([CanBeNull] object expression)
             => string.Format(
-                GetString("InvalidPropertyExpression", nameof(expression)),
+                GetString("InvalidMemberExpression", nameof(expression)),
                 expression);
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -141,6 +141,14 @@
   <data name="LiteralGenerationNotSupported" xml:space="preserve">
     <value>The type mapping for '{type}' has not implemented code literal generation.</value>
   </data>
+  <data name="InvalidPropertiesExpression" xml:space="preserve">
+    <value>The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.</value>
+    <comment>Obsolete</comment>
+  </data>
+  <data name="InvalidPropertyExpression" xml:space="preserve">
+    <value>The expression '{expression}' is not a valid property expression. The expression should represent a simple property access: 't =&gt; t.MyProperty'.</value>
+    <comment>Obsolete</comment>
+  </data>
   <data name="InvalidMembersExpression" xml:space="preserve">
     <value>The expression '{expression}' is not a valid members access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'. When specifying multiple properties or fields use an anonymous type: 't =&gt; new {{ t.MyProperty, t.MyField }}'.</value>
   </data>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -141,11 +141,11 @@
   <data name="LiteralGenerationNotSupported" xml:space="preserve">
     <value>The type mapping for '{type}' has not implemented code literal generation.</value>
   </data>
-  <data name="InvalidPropertiesExpression" xml:space="preserve">
-    <value>The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.</value>
+  <data name="InvalidMembersExpression" xml:space="preserve">
+    <value>The expression '{expression}' is not a valid members access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'. When specifying multiple properties or fields use an anonymous type: 't =&gt; new {{ t.MyProperty, t.MyField }}'.</value>
   </data>
-  <data name="InvalidPropertyExpression" xml:space="preserve">
-    <value>The expression '{expression}' is not a valid property expression. The expression should represent a simple property access: 't =&gt; t.MyProperty'.</value>
+  <data name="InvalidMemberExpression" xml:space="preserve">
+    <value>The expression '{expression}' is not a valid member access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'.</value>
   </data>
   <data name="IdentityConflict" xml:space="preserve">
     <value>The instance of entity type '{entityType}' cannot be tracked because another instance with the same key value for {keyProperties} is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting key values.</value>
@@ -904,7 +904,7 @@
   </data>
   <data name="LogInvalidIncludePath" xml:space="preserve">
     <value>Invalid include path '{navigationChain}', couldn't find navigation for '{navigationName}'.</value>
-    <comment>Error CoreEventId.InvalidIncludePathError object object</comment>    
+    <comment>Error CoreEventId.InvalidIncludePathError object object</comment>
   </data>
   <data name="LogDuplicateDependentEntityTypeInstance" xml:space="preserve">
     <value>The same entity is being tracked as different weak entity types '{dependent1}' and '{dependent2}'. If a property value changes it will result in two store changes, which might not be the desired outcome.</value>

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -60,6 +60,71 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Finds_existing_navigations_and_uses_associated_FK_with_fields()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyPrincipalWithField>(e =>
+                {
+                    e.Property(p => p.Id);
+                    e.Property(p => p.AlternateKey);
+                    e.Property(p => p.Name);
+                    e.HasKey(p => p.Id);
+                });
+                modelBuilder.Entity<DependentWithField>(e =>
+                {
+                    e.Property(d => d.DependentWithFieldId);
+                    e.Property(d => d.OneToManyPrincipalId);
+                    e.Property(d => d.AnotherOneToManyPrincipalId);
+                    e.Ignore(d => d.ManyToManyPrincipals);
+                    e.Ignore(d => d.OneToOnePrincipal);
+                    e.HasKey(d => d.DependentWithFieldId);
+                });
+
+                modelBuilder.Entity<OneToManyPrincipalWithField>()
+                    .HasMany(p => p.Dependents)
+                    .WithOne(d => d.OneToManyPrincipal)
+                    .HasForeignKey(d => d.OneToManyPrincipalId);
+
+                var dependentType = model.FindEntityType(typeof(DependentWithField));
+                var principalType = model.FindEntityType(typeof(OneToManyPrincipalWithField));
+                var fk = dependentType.GetForeignKeys().Single();
+
+                var navToPrincipal = dependentType.FindNavigation("OneToManyPrincipal");
+                var navToDependent = principalType.FindNavigation("Dependents");
+
+                var principalKey = principalType.GetKeys().Single();
+                var dependentKey = dependentType.GetKeys().Single();
+
+                modelBuilder.Entity<OneToManyPrincipalWithField>()
+                    .HasMany(p => p.Dependents)
+                    .WithOne(d => d.OneToManyPrincipal);
+
+                modelBuilder.FinalizeModel();
+
+                Assert.Same(fk, dependentType.GetForeignKeys().Single());
+                Assert.Equal(navToPrincipal.Name, dependentType.GetNavigations().Single().Name);
+                Assert.Same(navToDependent, principalType.GetNavigations().Single());
+                Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
+                Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
+                AssertEqual(
+                    new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" },
+                    principalType.GetProperties().Select(p => p.Name));
+                AssertEqual(
+                    new[] { "AnotherOneToManyPrincipalId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name },
+                    dependentType.GetProperties().Select(p => p.Name));
+                Assert.Empty(principalType.GetForeignKeys());
+                Assert.Same(principalKey, principalType.GetKeys().Single());
+                Assert.Same(dependentKey, dependentType.GetKeys().Single());
+                Assert.Same(principalKey, principalType.FindPrimaryKey());
+                Assert.Same(dependentKey, dependentType.FindPrimaryKey());
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+                Assert.Empty(principalType.GetIndexes());
+            }
+
+            [ConditionalFact]
             public virtual void Finds_existing_navigation_to_principal_and_uses_associated_FK()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipStringTest.cs
@@ -82,40 +82,40 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 => new GenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.OwnsOne<TRelatedEntity>(navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName()));
+                    EntityTypeBuilder.OwnsOne<TRelatedEntity>(navigationExpression?.GetMemberAccess()?.GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression,
                 Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
                 => Wrap(
                     EntityTypeBuilder.OwnsOne<TRelatedEntity>(
-                        navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName(),
+                        navigationExpression?.GetMemberAccess()?.GetSimpleMemberName(),
                         r => buildAction(new GenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
                 => new GenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.OwnsMany<TRelatedEntity>(navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName()));
+                    EntityTypeBuilder.OwnsMany<TRelatedEntity>(navigationExpression?.GetMemberAccess()?.GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
                 Action<TestOwnedNavigationBuilder<TEntity, TRelatedEntity>> buildAction)
                 => Wrap(
                     EntityTypeBuilder.OwnsMany<TRelatedEntity>(
-                        navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName(),
+                        navigationExpression?.GetMemberAccess()?.GetSimpleMemberName(),
                         r => buildAction(new GenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
                 => new GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne<TRelatedEntity>(
-                        navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess()?.GetSimpleMemberName()));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
                 => new GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany<TRelatedEntity>(
-                        navigationExpression?.GetPropertyAccess()?.GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess()?.GetSimpleMemberName()));
         }
 
         private class GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity> :
@@ -133,13 +133,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null)
                 => new GenericStringTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new GenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         private class GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity>
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         private class GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>
@@ -179,13 +179,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, object>> foreignKeyExpression)
                 => Wrap(
                     ReferenceCollectionBuilder.HasForeignKey(
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
                 Expression<Func<TEntity, object>> keyExpression)
                 => Wrap(
                     ReferenceCollectionBuilder.HasPrincipalKey(
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
         }
 
         private class GenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasForeignKey(
                         typeof(TDependentEntity).FullName,
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
                 params string[] foreignKeyPropertyNames)
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasPrincipalKey(
                         typeof(TPrincipalEntity).FullName,
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
                 params string[] keyPropertyNames)
@@ -246,38 +246,38 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression)
                 => new GenericTestOwnershipBuilder<TEntity, TDependentEntity>(
-                    OwnedNavigationBuilder.WithOwner(referenceExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.WithOwner(referenceExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression)
                 => Wrap(
-                    OwnedNavigationBuilder.OwnsOne<TNewDependentEntity>(navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.OwnsOne<TNewDependentEntity>(navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression,
                 Action<TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
                 => Wrap(
                     OwnedNavigationBuilder.OwnsOne<TNewDependentEntity>(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(Wrap(r))));
 
             public override TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression)
                 => Wrap(
-                    OwnedNavigationBuilder.OwnsMany<TNewDependentEntity>(navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.OwnsMany<TNewDependentEntity>(navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression,
                 Action<TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
                 => Wrap(
                     OwnedNavigationBuilder.OwnsMany<TNewDependentEntity>(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(Wrap(r))));
 
             public override TestReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
                 Expression<Func<TDependentEntity, TNewRelatedEntity>> navigationExpression = null)
                 => new GenericStringTestReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
-                    OwnedNavigationBuilder.HasOne<TNewRelatedEntity>(navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.HasOne<TNewRelatedEntity>(navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericRelationshipTypeTest.cs
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasForeignKey(
                         typeof(TDependentEntity),
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
                 params string[] foreignKeyPropertyNames)
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasPrincipalKey(
                         typeof(TPrincipalEntity),
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
                 params string[] keyPropertyNames)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 => new NonGenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsOne(
-                        typeof(TRelatedEntity).FullName, navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TRelatedEntity).FullName, navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression,
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsOne(
                         typeof(TRelatedEntity).FullName,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsMany(
                         typeof(TRelatedEntity).FullName,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsMany(
                         typeof(TRelatedEntity).FullName,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
@@ -148,14 +148,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(
                         typeof(TRelatedEntity).FullName,
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany(
                         typeof(TRelatedEntity).FullName,
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         private class NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         private class NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -194,14 +194,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasForeignKey(
                         typeof(TDependentEntity).FullName,
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
                 Expression<Func<TPrincipalEntity, object>> keyExpression)
                 => Wrap(
                     ReferenceReferenceBuilder.HasPrincipalKey(
                         typeof(TPrincipalEntity).FullName,
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
                 params string[] foreignKeyPropertyNames)
@@ -262,7 +262,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression)
                 => new NonGenericStringTestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.OwnsOne(
-                        typeof(TNewDependentEntity).FullName, navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity).FullName, navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression,
@@ -270,14 +270,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap<TEntity, TDependentEntity>(
                     OwnedNavigationBuilder.OwnsOne(
                         typeof(TNewDependentEntity).FullName,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericStringTestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression)
                 => Wrap<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.OwnsMany(
-                        typeof(TNewDependentEntity).FullName, navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity).FullName, navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression,
@@ -285,14 +285,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap<TEntity, TDependentEntity>(
                     OwnedNavigationBuilder.OwnsMany(
                         typeof(TNewDependentEntity).FullName,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(Wrap<TDependentEntity, TNewDependentEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity> HasOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression = null)
                 => new NonGenericStringTestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.HasOne(
-                        typeof(TNewDependentEntity).FullName, navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity).FullName, navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestKeyBuilder<TEntity> HasKey(Expression<Func<TEntity, object>> keyExpression)
                 => new NonGenericTestKeyBuilder<TEntity>(
-                    EntityTypeBuilder.HasKey(keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                    EntityTypeBuilder.HasKey(keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestKeyBuilder<TEntity> HasKey(params string[] propertyNames)
                 => new NonGenericTestKeyBuilder<TEntity>(EntityTypeBuilder.HasKey(propertyNames));
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestKeyBuilder<TEntity> HasAlternateKey(Expression<Func<TEntity, object>> keyExpression)
                 => new NonGenericTestKeyBuilder<TEntity>(
                     EntityTypeBuilder.HasAlternateKey(
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestKeyBuilder<TEntity> HasAlternateKey(params string[] propertyNames)
                 => new NonGenericTestKeyBuilder<TEntity>(EntityTypeBuilder.HasAlternateKey(propertyNames));
@@ -136,9 +136,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
             {
-                var propertyInfo = propertyExpression.GetPropertyAccess();
+                var memberInfo = propertyExpression.GetMemberAccess();
                 return new NonGenericTestPropertyBuilder<TProperty>(
-                    EntityTypeBuilder.Property(propertyInfo.PropertyType, propertyInfo.GetSimpleMemberName()));
+                    EntityTypeBuilder.Property(memberInfo.GetMemberType(), memberInfo.GetSimpleMemberName()));
             }
 
             public override TestPropertyBuilder<TProperty> Property<TProperty>(string propertyName)
@@ -148,24 +148,21 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.IndexerProperty<TProperty>(propertyName));
 
             public override TestNavigationBuilder Navigation<TNavigation>(Expression<Func<TEntity, TNavigation>> navigationExpression)
-            {
-                var navigationInfo = navigationExpression.GetPropertyAccess();
-                return new NonGenericTestNavigationBuilder(
-                    EntityTypeBuilder.Navigation(navigationInfo.GetSimpleMemberName()));
-            }
+                => new NonGenericTestNavigationBuilder(
+                    EntityTypeBuilder.Navigation(navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestNavigationBuilder Navigation(string propertyName)
                 => new NonGenericTestNavigationBuilder(EntityTypeBuilder.Navigation(propertyName));
 
             public override TestEntityTypeBuilder<TEntity> Ignore(Expression<Func<TEntity, object>> propertyExpression)
-                => Wrap(EntityTypeBuilder.Ignore(propertyExpression.GetPropertyAccess().GetSimpleMemberName()));
+                => Wrap(EntityTypeBuilder.Ignore(propertyExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> Ignore(string propertyName)
                 => Wrap(EntityTypeBuilder.Ignore(propertyName));
 
             public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object>> indexExpression)
                 => new NonGenericTestIndexBuilder<TEntity>(
-                    EntityTypeBuilder.HasIndex(indexExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                    EntityTypeBuilder.HasIndex(indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestIndexBuilder<TEntity> HasIndex(params string[] propertyNames)
                 => new NonGenericTestIndexBuilder<TEntity>(EntityTypeBuilder.HasIndex(propertyNames));
@@ -185,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.OwnsOne(typeof(TRelatedEntity), navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                    EntityTypeBuilder.OwnsOne(typeof(TRelatedEntity), navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression,
@@ -193,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsOne(
                         typeof(TRelatedEntity),
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(string navigationName)
@@ -211,7 +208,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                    EntityTypeBuilder.OwnsMany(typeof(TRelatedEntity), navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                    EntityTypeBuilder.OwnsMany(typeof(TRelatedEntity), navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
@@ -219,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsMany(
                         typeof(TRelatedEntity),
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(string navigationName)
@@ -231,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasOne(
                         typeof(TRelatedEntity),
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(string navigationName)
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
@@ -242,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.HasMany(
                         typeof(TRelatedEntity),
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> HasQueryFilter(Expression<Func<TEntity, bool>> filter)
                 => Wrap(EntityTypeBuilder.HasQueryFilter(filter));
@@ -281,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TEntity, TDiscriminator>> propertyExpression)
                 => new NonGenericTestDiscriminatorBuilder<TDiscriminator>(
                     EntityTypeBuilder.HasDiscriminator(
-                        propertyExpression?.GetPropertyAccess().GetSimpleMemberName(), typeof(TDiscriminator)));
+                        propertyExpression?.GetMemberAccess().GetSimpleMemberName(), typeof(TDiscriminator)));
 
             public override TestDiscriminatorBuilder<TDiscriminator> HasDiscriminator<TDiscriminator>(string propertyName)
                 => new NonGenericTestDiscriminatorBuilder<TDiscriminator>(
@@ -485,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression = null)
                 => new NonGenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(
                     ReferenceNavigationBuilder.WithMany(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(string navigationName)
                 => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
@@ -495,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         protected class NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>
@@ -519,7 +516,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     CollectionNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 string navigationName)
@@ -529,7 +526,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestCollectionCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> navigationExpression)
                 => new NonGenericTestCollectionCollectionBuilder<TRelatedEntity, TEntity>(
-                    CollectionNavigationBuilder.WithMany(navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                    CollectionNavigationBuilder.WithMany(navigationExpression.GetMemberAccess().GetSimpleMemberName()));
         }
 
         protected class NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>
@@ -550,13 +547,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, object>> foreignKeyExpression)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     ReferenceCollectionBuilder.HasForeignKey(
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
                 Expression<Func<TEntity, object>> keyExpression)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
                     ReferenceCollectionBuilder.HasPrincipalKey(
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> HasForeignKey(params string[] foreignKeyPropertyNames)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(
@@ -603,12 +600,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TDependentEntity, object>> foreignKeyExpression)
                 => Wrap(ReferenceReferenceBuilder.HasForeignKey(
                     typeof(TDependentEntity),
-                    foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                    foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
                 Expression<Func<TPrincipalEntity, object>> keyExpression)
                 => Wrap(ReferenceReferenceBuilder.HasPrincipalKey(
-                    typeof(TPrincipalEntity), keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                    typeof(TPrincipalEntity), keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
                 params string[] foreignKeyPropertyNames)
@@ -696,7 +693,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, object>> foreignKeyExpression)
                 => Wrap<TEntity, TRelatedEntity>(
                     OwnershipBuilder.HasForeignKey(
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestOwnershipBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
                 params string[] keyPropertyNames)
@@ -706,7 +703,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TEntity, object>> keyExpression)
                 => Wrap<TEntity, TRelatedEntity>(
                     OwnershipBuilder.HasPrincipalKey(
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             OwnershipBuilder IInfrastructure<OwnershipBuilder>.Instance => OwnershipBuilder;
         }
@@ -739,7 +736,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestKeyBuilder<TDependentEntity> HasKey(Expression<Func<TDependentEntity, object>> keyExpression)
                 => new NonGenericTestKeyBuilder<TDependentEntity>(
                     OwnedNavigationBuilder.HasKey(
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestKeyBuilder<TDependentEntity> HasKey(params string[] propertyNames)
                 => new NonGenericTestKeyBuilder<TDependentEntity>(OwnedNavigationBuilder.HasKey(propertyNames));
@@ -753,9 +750,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestPropertyBuilder<TProperty> Property<TProperty>(
                 Expression<Func<TDependentEntity, TProperty>> propertyExpression)
             {
-                var propertyInfo = propertyExpression.GetPropertyAccess();
+                var memberInfo = propertyExpression.GetMemberAccess();
                 return new NonGenericTestPropertyBuilder<TProperty>(
-                    OwnedNavigationBuilder.Property(propertyInfo.PropertyType, propertyInfo.GetSimpleMemberName()));
+                    OwnedNavigationBuilder.Property(memberInfo.GetMemberType(), memberInfo.GetSimpleMemberName()));
             }
 
             public override TestNavigationBuilder Navigation<TNavigation>(string navigationName)
@@ -763,7 +760,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestNavigationBuilder Navigation<TNavigation>(
                 Expression<Func<TDependentEntity, TNavigation>> navigationExpression)
                 => new NonGenericTestNavigationBuilder(
-                    OwnedNavigationBuilder.Navigation(navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.Navigation(navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(string propertyName)
                 => Wrap<TEntity, TDependentEntity>(OwnedNavigationBuilder.Ignore(propertyName));
@@ -771,7 +768,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> Ignore(
                 Expression<Func<TDependentEntity, object>> propertyExpression)
                 => Wrap<TEntity, TDependentEntity>(
-                    OwnedNavigationBuilder.Ignore(propertyExpression.GetPropertyAccess().GetSimpleMemberName()));
+                    OwnedNavigationBuilder.Ignore(propertyExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestIndexBuilder<TEntity> HasIndex(params string[] propertyNames)
                 => new NonGenericTestIndexBuilder<TEntity>(OwnedNavigationBuilder.HasIndex(propertyNames));
@@ -779,7 +776,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TDependentEntity, object>> indexExpression)
                 => new NonGenericTestIndexBuilder<TEntity>(
                     OwnedNavigationBuilder.HasIndex(
-                        indexExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(string ownerReference)
                 => new NonGenericTestOwnershipBuilder<TEntity, TDependentEntity>(
@@ -788,13 +785,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestOwnershipBuilder<TEntity, TDependentEntity> WithOwner(
                 Expression<Func<TDependentEntity, TEntity>> referenceExpression)
                 => new NonGenericTestOwnershipBuilder<TEntity, TDependentEntity>(
-                    OwnedNavigationBuilder.WithOwner(referenceExpression?.GetPropertyAccess()?.GetSimpleMemberName()));
+                    OwnedNavigationBuilder.WithOwner(referenceExpression?.GetMemberAccess()?.GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression)
                 => Wrap<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.OwnsOne(
-                        typeof(TNewDependentEntity), navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity), navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression,
@@ -802,14 +799,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap<TEntity, TDependentEntity>(
                     OwnedNavigationBuilder.OwnsOne(
                         typeof(TNewDependentEntity),
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression)
                 => Wrap<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.OwnsMany(
-                        typeof(TNewDependentEntity), navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity), navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression,
@@ -817,14 +814,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap<TEntity, TDependentEntity>(
                     OwnedNavigationBuilder.OwnsMany(
                         typeof(TNewDependentEntity),
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(Wrap<TDependentEntity, TNewDependentEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity> HasOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression = null)
                 => new NonGenericTestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity>(
                     OwnedNavigationBuilder.HasOne(
-                        typeof(TNewDependentEntity), navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TNewDependentEntity), navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestOwnedNavigationBuilder<TEntity, TDependentEntity> HasChangeTrackingStrategy(
                 ChangeTrackingStrategy changeTrackingStrategy)

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
                 => new NonGenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsOne(
-                        typeof(TRelatedEntity).Name, navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        typeof(TRelatedEntity).Name, navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression,
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsOne(
                         typeof(TRelatedEntity).Name,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericStringTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(
                     EntityTypeBuilder.OwnsMany(
                         typeof(TRelatedEntity).Name,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName()));
 
             public override TestEntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
@@ -87,13 +87,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     EntityTypeBuilder.OwnsMany(
                         typeof(TRelatedEntity).Name,
-                        navigationExpression.GetPropertyAccess().GetSimpleMemberName(),
+                        navigationExpression.GetMemberAccess().GetSimpleMemberName(),
                         r => buildAction(new NonGenericTestOwnedNavigationBuilder<TEntity, TRelatedEntity>(r))));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
             {
-                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+                var navigationName = navigationExpression?.GetMemberAccess().GetSimpleMemberName();
 
                 return new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                     navigationName == null
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
             {
-                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+                var navigationName = navigationExpression?.GetMemberAccess().GetSimpleMemberName();
 
                 return new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(
                     navigationName == null
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Expression<Func<TRelatedEntity, TEntity>> navigationExpression = null)
                 => new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(
                     ReferenceNavigationBuilder.WithOne(
-                        navigationExpression?.GetPropertyAccess().GetSimpleMemberName()));
+                        navigationExpression?.GetMemberAccess().GetSimpleMemberName()));
         }
 
         private class NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : NonGenericTestReferenceReferenceBuilder<
@@ -149,14 +149,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 => Wrap(
                     ReferenceReferenceBuilder.HasForeignKey(
                         typeof(TDependentEntity).Name,
-                        foreignKeyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        foreignKeyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey<TPrincipalEntity>(
                 Expression<Func<TPrincipalEntity, object>> keyExpression)
                 => Wrap(
                     ReferenceReferenceBuilder.HasPrincipalKey(
                         typeof(TPrincipalEntity).Name,
-                        keyExpression.GetPropertyAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+                        keyExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
                 params string[] foreignKeyPropertyNames)
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity> HasOne<TNewDependentEntity>(
                 Expression<Func<TDependentEntity, TNewDependentEntity>> navigationExpression = null)
             {
-                var navigationName = navigationExpression?.GetPropertyAccess().GetSimpleMemberName();
+                var navigationName = navigationExpression?.GetMemberAccess().GetSimpleMemberName();
 
                 return new NonGenericStringTestReferenceNavigationBuilder<TDependentEntity, TNewDependentEntity>(
                     navigationName == null

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
@@ -1248,6 +1249,160 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<EntityBase>().Ignore(e => ((IEntityBase)e).Target);
 
                 Assert.Empty(modelBuilder.Model.FindEntityType(typeof(EntityBase)).GetProperties());
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_key_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasKey(e => e.Id);
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(EntityWithFields));
+                var primaryKey = entity.FindPrimaryKey();
+                Assert.NotNull(primaryKey);
+                var property = Assert.Single(primaryKey.Properties);
+                Assert.Equal(nameof(EntityWithFields.Id), property.Name);
+                Assert.Null(property.PropertyInfo);
+                Assert.NotNull(property.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_composite_key_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasKey(e => new { e.TenantId, e.CompanyId });
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(EntityWithFields));
+                var primaryKeyProperties = entity.FindPrimaryKey().Properties;
+                Assert.Equal(2, primaryKeyProperties.Count);
+                var first = primaryKeyProperties[0];
+                var second = primaryKeyProperties[1];
+                Assert.Equal(nameof(EntityWithFields.TenantId), first.Name);
+                Assert.Null(first.PropertyInfo);
+                Assert.NotNull(first.FieldInfo);
+                Assert.Equal(nameof(EntityWithFields.CompanyId), second.Name);
+                Assert.Null(second.PropertyInfo);
+                Assert.NotNull(second.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_alternate_key_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasAlternateKey(e => e.CompanyId);
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(EntityWithFields));
+                var properties = modelBuilder.Model.FindEntityType(typeof(EntityWithFields)).GetProperties();
+                Assert.Single(properties);
+                var property = properties.Single();
+                Assert.Equal(nameof(EntityWithFields.CompanyId), property.Name);
+                Assert.Null(property.PropertyInfo);
+                Assert.NotNull(property.FieldInfo);
+                var keys = entity.GetKeys();
+                var key = Assert.Single(keys);
+                Assert.Equal(properties, key.Properties);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_composite_alternate_key_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasAlternateKey(e => new { e.TenantId, e.CompanyId });
+
+                var keys = modelBuilder.Model.FindEntityType(typeof(EntityWithFields)).GetKeys();
+                Assert.Single(keys);
+                var properties = keys.Single().Properties;
+                Assert.Equal(2, properties.Count);
+                var first = properties[0];
+                var second = properties[1];
+                Assert.Equal(nameof(EntityWithFields.TenantId), first.Name);
+                Assert.Null(first.PropertyInfo);
+                Assert.NotNull(first.FieldInfo);
+                Assert.Equal(nameof(EntityWithFields.CompanyId), second.Name);
+                Assert.Null(second.PropertyInfo);
+                Assert.NotNull(second.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_call_Property_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().Property(e => e.Id);
+
+                var properties = modelBuilder.Model.FindEntityType(typeof(EntityWithFields)).GetProperties();
+                var property = Assert.Single(properties);
+                Assert.Equal(nameof(EntityWithFields.Id), property.Name);
+                Assert.Null(property.PropertyInfo);
+                Assert.NotNull(property.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_index_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasIndex(e => e.CompanyId);
+
+                var indexes = modelBuilder.Model.FindEntityType(typeof(EntityWithFields)).GetIndexes();
+                var index = Assert.Single(indexes);
+                var property = Assert.Single(index.Properties);
+                Assert.Null(property.PropertyInfo);
+                Assert.NotNull(property.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_set_composite_index_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>().HasIndex(e => new { e.TenantId, e.CompanyId });
+
+                var indexes = modelBuilder.Model.FindEntityType(typeof(EntityWithFields)).GetIndexes();
+                var index = Assert.Single(indexes);
+                Assert.Equal(2, index.Properties.Count);
+                var properties = index.Properties;
+                var first = properties[0];
+                var second = properties[1];
+                Assert.Equal(nameof(EntityWithFields.TenantId), first.Name);
+                Assert.Null(first.PropertyInfo);
+                Assert.NotNull(first.FieldInfo);
+                Assert.Equal(nameof(EntityWithFields.CompanyId), second.Name);
+                Assert.Null(second.PropertyInfo);
+                Assert.NotNull(second.FieldInfo);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_ignore_a_field_on_an_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<EntityWithFields>()
+                    .Ignore(e => e.CompanyId)
+                    .HasKey(e => e.Id);
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(EntityWithFields));
+                var property = Assert.Single(entity.GetProperties());
+                Assert.Equal(nameof(EntityWithFields.Id), property.Name);
+            }
+
+            [ConditionalFact]
+            public virtual void Can_ignore_a_field_on_a_keyless_entity_with_fields()
+            {
+                var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                modelBuilder.Entity<KeylessEntityWithFields>()
+                    .HasNoKey()
+                    .Ignore(e => e.FirstName)
+                   .Property(e => e.LastName);
+
+                var entity = modelBuilder.Model.FindEntityType(typeof(KeylessEntityWithFields));
+                var property = Assert.Single(entity.GetProperties());
+                Assert.Equal(nameof(KeylessEntityWithFields.LastName), property.Name);
             }
 
             [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -68,6 +68,71 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Finds_existing_navigations_and_uses_associated_FK_with_fields()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<OneToManyPrincipalWithField>(e =>
+                    {
+                        e.Property(p => p.Id);
+                        e.Property(p => p.AlternateKey);
+                        e.Property(p => p.Name);
+                        e.HasKey(p => p.Id);
+                    });
+                modelBuilder.Entity<DependentWithField>(e =>
+                    {
+                        e.Property(d => d.DependentWithFieldId);
+                        e.Property(d => d.OneToManyPrincipalId);
+                        e.Property(d => d.AnotherOneToManyPrincipalId);
+                        e.Ignore(d => d.ManyToManyPrincipals);
+                        e.Ignore(d => d.OneToOnePrincipal);
+                        e.HasKey(d => d.DependentWithFieldId);
+                    });
+
+                modelBuilder.Entity<DependentWithField>()
+                    .HasOne(d => d.OneToManyPrincipal)
+                    .WithMany(p => p.Dependents)
+                    .HasForeignKey(d => d.OneToManyPrincipalId);
+
+                var dependentType = model.FindEntityType(typeof(DependentWithField));
+                var principalType = model.FindEntityType(typeof(OneToManyPrincipalWithField));
+                var fk = dependentType.GetForeignKeys().Single();
+
+                var navToPrincipal = dependentType.FindNavigation("OneToManyPrincipal");
+                var navToDependent = principalType.FindNavigation("Dependents");
+
+                var principalKey = principalType.GetKeys().Single();
+                var dependentKey = dependentType.GetKeys().Single();
+
+                modelBuilder.Entity<DependentWithField>()
+                    .HasOne(d => d.OneToManyPrincipal)
+                    .WithMany(p => p.Dependents);
+
+                modelBuilder.FinalizeModel();
+
+                Assert.Same(fk, dependentType.GetForeignKeys().Single());
+                Assert.Equal(navToPrincipal.Name, dependentType.GetNavigations().Single().Name);
+                Assert.Same(navToDependent, principalType.GetNavigations().Single());
+                Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
+                Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
+                AssertEqual(
+                    new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" },
+                    principalType.GetProperties().Select(p => p.Name));
+                AssertEqual(
+                    new[] { "AnotherOneToManyPrincipalId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name },
+                    dependentType.GetProperties().Select(p => p.Name));
+                Assert.Empty(principalType.GetForeignKeys());
+                Assert.Same(principalKey, principalType.GetKeys().Single());
+                Assert.Same(dependentKey, dependentType.GetKeys().Single());
+                Assert.Same(principalKey, principalType.FindPrimaryKey());
+                Assert.Same(dependentKey, dependentType.FindPrimaryKey());
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+                Assert.Empty(principalType.GetIndexes());
+            }
+
+            [ConditionalFact]
             public virtual void Finds_existing_navigation_to_principal_and_uses_associated_FK()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -687,6 +687,20 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public IList<Friendship> Friendships { get; set; }
         }
 
+        public class EntityWithFields
+        {
+            public long Id;
+            public int CompanyId;
+            public int TenantId;
+            public KeylessEntityWithFields KeylessEntity;
+        }
+
+        public class KeylessEntityWithFields
+        {
+            public string FirstName;
+            public string LastName;
+        }
+
         protected class QueryResult
         {
             public int ValueFk { get; set; }
@@ -937,6 +951,89 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public class Ownee3
         {
             public string Name { get; private set; }
+        }
+
+        public class OneToManyPrincipalWithField
+        {
+            public int Id;
+            public Guid AlternateKey;
+            public string Name;
+
+            public IEnumerable<DependentWithField> Dependents;
+        }
+
+        public class OneToOnePrincipalWithField
+        {
+            public int Id;
+            public string Name;
+
+            public DependentWithField Dependent;
+        }
+
+        public class ManyToManyPrincipalWithField
+        {
+            public int Id;
+            public string Name;
+
+            public List<DependentWithField> Dependents;
+        }
+
+        protected class ManyToManyJoinWithFields
+        {
+            public int ManyToManyPrincipalWithFieldId;
+            public int DependentWithFieldId;
+
+            public ManyToManyPrincipalWithField ManyToManyPrincipalWithField { get; set; }
+            public DependentWithField DependentWithField { get; set; }
+        }
+
+        public class DependentWithField
+        {
+            public int DependentWithFieldId;
+
+            public int? OneToManyPrincipalId;
+            public Guid AnotherOneToManyPrincipalId;
+            public OneToManyPrincipalWithField OneToManyPrincipal { get; set; }
+            public int OneToOnePrincipalId;
+            public OneToOnePrincipalWithField OneToOnePrincipal { get; set; }
+            public List<ManyToManyPrincipalWithField> ManyToManyPrincipals { get; set; }
+        }
+
+        public class OneToManyOwnerWithField
+        {
+            public int Id;
+            public Guid AlternateKey;
+            public string Description;
+
+            public List<OneToManyOwnedWithField> OwnedDependents { get; set; }
+        }
+
+        public class OneToManyOwnedWithField
+        {
+            public string FirstName;
+            public string LastName;
+
+            public int OneToManyOwnerId;
+            public OneToManyOwnerWithField OneToManyOwner { get; set; }
+        }
+
+        public class OneToOneOwnerWithField
+        {
+            public int Id;
+            public Guid AlternateKey;
+            public string Description;
+
+            public OneToOneOwnedWithField OwnedDependent { get; set; }
+        }
+
+        public class OneToOneOwnedWithField
+        {
+            public string FirstName;
+            public string LastName;
+
+            public int OneToOneOwnerId;
+            public OneToOneOwnerWithField OneToOneOwner { get; set; }
+
         }
     }
 }


### PR DESCRIPTION
Fixes #11410

Updating ModelBuilder APIs to use GetMemberAccess() instead of GetPropertyAccess().
