### PR TITLE
Query: Introduce identity resolution in no tracking query

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -87,7 +87,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(shaperLambda.Compile()),
                         Expression.Constant(_contextType),
                         Expression.Constant(_partitionKeyFromExtension, typeof(string)),
-                        Expression.Constant(_logger));
+                        Expression.Constant(_logger),
+                        Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
 
                 case ReadItemExpression readItemExpression:
 
@@ -108,7 +109,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(readItemExpression),
                         Expression.Constant(shaperReadItemLambda.Compile()),
                         Expression.Constant(_contextType),
-                        Expression.Constant(_logger));
+                        Expression.Constant(_logger),
+                        Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
 
                 default:
                     throw new NotImplementedException();

--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         public virtual Expression GetMappedProjection([NotNull] ProjectionMember projectionMember)
             => _projectionMapping[projectionMember];
 
-        
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -29,19 +29,22 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             private readonly Func<QueryContext, ValueBuffer, T> _shaper;
             private readonly Type _contextType;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly bool _performIdentityResolution;
 
             public QueryingEnumerable(
                 QueryContext queryContext,
                 IEnumerable<ValueBuffer> innerEnumerable,
                 Func<QueryContext, ValueBuffer, T> shaper,
                 Type contextType,
-                IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+                IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+                bool performIdentityResolution)
             {
                 _queryContext = queryContext;
                 _innerEnumerable = innerEnumerable;
                 _shaper = shaper;
                 _contextType = contextType;
                 _logger = logger;
+                _performIdentityResolution = performIdentityResolution;
             }
 
             public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -61,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 private readonly Func<QueryContext, ValueBuffer, T> _shaper;
                 private readonly Type _contextType;
                 private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+                private readonly bool _performIdentityResolution;
                 private readonly CancellationToken _cancellationToken;
 
                 public Enumerator(QueryingEnumerable<T> queryingEnumerable, CancellationToken cancellationToken = default)
@@ -70,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     _shaper = queryingEnumerable._shaper;
                     _contextType = queryingEnumerable._contextType;
                     _logger = queryingEnumerable._logger;
+                    _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                     _cancellationToken = cancellationToken;
                 }
 
@@ -118,6 +123,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     if (_enumerator == null)
                     {
                         _enumerator = _innerEnumerable.GetEnumerator();
+                        _queryContext.InitializeStateManager(_performIdentityResolution);
                     }
 
                     var hasNext = _enumerator.MoveNext();

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
@@ -92,7 +92,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 innerEnumerable,
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
-                Expression.Constant(_logger));
+                Expression.Constant(_logger),
+                Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
         }
 
         private static readonly MethodInfo _tableMethodInfo

--- a/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
         private readonly Type _contextType;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly bool _performIdentityResolution;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IReadOnlyList<ReaderColumn> readerColumns,
             [NotNull] Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> shaper,
             [NotNull] Type contextType,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            bool performIdentityResolution)
         {
             _relationalQueryContext = relationalQueryContext;
             _relationalCommandCache = relationalCommandCache;
@@ -52,6 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _shaper = shaper;
             _contextType = contextType;
             _logger = logger;
+            _performIdentityResolution = performIdentityResolution;
         }
 
         /// <summary>
@@ -148,6 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
             private readonly Type _contextType;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly bool _performIdentityResolution;
 
             private RelationalDataReader _dataReader;
             private int[] _indexMap;
@@ -163,6 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _shaper = queryingEnumerable._shaper;
                 _contextType = queryingEnumerable._contextType;
                 _logger = queryingEnumerable._logger;
+                _performIdentityResolution = queryingEnumerable._performIdentityResolution;
             }
 
             public T Current { get; private set; }
@@ -246,6 +251,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 _resultCoordinator = new ResultCoordinator();
 
+                _relationalQueryContext.InitializeStateManager(_performIdentityResolution);
+
                 return result;
             }
 
@@ -267,6 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
             private readonly Type _contextType;
             private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly bool _performIdentityResolution;
             private readonly CancellationToken _cancellationToken;
 
             private RelationalDataReader _dataReader;
@@ -285,6 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _shaper = queryingEnumerable._shaper;
                 _contextType = queryingEnumerable._contextType;
                 _logger = queryingEnumerable._logger;
+                _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                 _cancellationToken = cancellationToken;
             }
 
@@ -367,6 +376,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _indexMap = BuildIndexMap(_columnNames, _dataReader.DbDataReader);
 
                 _resultCoordinator = new ResultCoordinator();
+
+                _relationalQueryContext.InitializeStateManager(_performIdentityResolution);
 
                 return result;
             }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -99,7 +99,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Expression.Constant(projectionColumns, typeof(IReadOnlyList<ReaderColumn>)),
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
-                Expression.Constant(_logger));
+                Expression.Constant(_logger),
+                Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
         }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2628,6 +2628,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("MissingInverseManyToManyNavigation", nameof(principalEntityType), nameof(declaringEntityType)),
                 principalEntityType, declaringEntityType);
 
+        /// <summary>
+        ///     InitializeStateManager method has been called multiple times on current query context. This method is intended to be called only once before query enumeration starts.
+        /// </summary>
+        public static string QueryContextAlreadyInitializedStateManager
+            => GetString("QueryContextAlreadyInitializedStateManager");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1387,4 +1387,7 @@
   <data name="MissingInverseManyToManyNavigation" xml:space="preserve">
     <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation property in the HasMany() call.</value>
   </data>
+  <data name="QueryContextAlreadyInitializedStateManager" xml:space="preserve">
+    <value>InitializeStateManager method has been called multiple times on current query context. This method is intended to be called only once before query enumeration starts.</value>
+  </data>
 </root>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -297,14 +297,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         private sealed class IncludeExpandingExpressionVisitor : ExpandingExpressionVisitor
         {
-            private readonly bool _isTracking;
+            private readonly bool _allowCycles;
 
             public IncludeExpandingExpressionVisitor(
                 NavigationExpandingExpressionVisitor navigationExpandingExpressionVisitor,
                 NavigationExpansionExpression source)
                 : base(navigationExpandingExpressionVisitor, source)
             {
-                _isTracking = navigationExpandingExpressionVisitor._queryCompilationContext.IsTracking;
+                _allowCycles = navigationExpandingExpressionVisitor._queryCompilationContext.IsTracking
+                    || navigationExpandingExpressionVisitor._queryCompilationContext.PerformIdentityResolution;
             }
 
             protected override Expression VisitExtension(Expression extensionExpression)
@@ -459,7 +460,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             private Expression ExpandInclude(Expression root, EntityReference entityReference)
             {
-                if (!_isTracking)
+                if (!_allowCycles)
                 {
                     VerifyNoCycles(entityReference.IncludePaths);
                 }

--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -135,6 +135,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return visitedExpression;
             }
 
+            if (genericMethodDefinition == EntityFrameworkQueryableExtensions.PerformIdentityResolutionMethodInfo)
+            {
+                var visitedExpression = Visit(methodCallExpression.Arguments[0]);
+                _queryCompilationContext.IsTracking = false;
+                _queryCompilationContext.PerformIdentityResolution = true;
+
+                return visitedExpression;
+            }
+
             if (genericMethodDefinition == EntityFrameworkQueryableExtensions.TagWithMethodInfo)
             {
                 var visitedExpression = Visit(methodCallExpression.Arguments[0]);

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -92,6 +92,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     A value indicating whether it is tracking query.
         /// </summary>
         public virtual bool IsTracking { get; internal set; }
+
+        /// <summary>
+        ///     <para>
+        ///         A value indicating whether query should perform identity resolution for the entities returned in the results.
+        ///     </para>
+        ///     <para>
+        ///         This value is only set when <see cref="IsTracking"/> is to <see langword="false"/>.
+        ///     </para>
+        /// </summary>
+        public virtual bool PerformIdentityResolution { get; internal set; }
         /// <summary>
         ///     A value indicating whether the underlying server query needs to pre-buffer all data.
         /// </summary>

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -21,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class QueryContext : IParameterValues
     {
         private readonly IDictionary<string, object> _parameterValues = new Dictionary<string, object>();
+        private IStateManager _stateManager;
 
         /// <summary>
         ///     <para>
@@ -51,16 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual QueryContextDependencies Dependencies { get; }
 
         /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
-        public virtual IStateManager StateManager
-            => Dependencies.StateManager;
-
-        /// <summary>
         ///     Sets the navigation as loaded.
         /// </summary>
         /// <param name="entity"> The entity instance. </param>
@@ -70,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(entity, nameof(entity));
             Check.NotNull(navigation, nameof(navigation));
 
-            Dependencies.StateManager.TryGetEntry(entity).SetIsLoaded(navigation);
+            _stateManager.TryGetEntry(entity).SetIsLoaded(navigation);
         }
 
         /// <summary>
@@ -145,6 +137,36 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        ///     Initializes the <see cref="IStateManager"/> to be used with this QueryContext.
+        /// </summary>
+        /// <param name="standAlone"> Whether a stand-alone <see cref="IStateManager"/> should be created to perform identity resolution. </param>
+        public virtual void InitializeStateManager(bool standAlone = false)
+        {
+            if (_stateManager != null)
+            {
+                throw new InvalidOperationException(CoreStrings.QueryContextAlreadyInitializedStateManager);
+            }
+
+            _stateManager = standAlone
+                ? new StateManager(Dependencies.StateManager.Dependencies)
+                : Dependencies.StateManager;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public virtual InternalEntityEntry TryGetEntry(
+            [NotNull] IKey key,
+            [NotNull] object[] keyValues,
+            bool throwOnNullKey,
+            out bool hasNullKey)
+            => _stateManager.TryGetEntry(key, keyValues, throwOnNullKey, out hasNullKey);
+
+        /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
@@ -155,6 +177,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IEntityType entityType,
             [NotNull] object entity,
             ValueBuffer valueBuffer)
-            => StateManager.StartTrackingFromQuery(entityType, entity, valueBuffer);
+            => _stateManager.StartTrackingFromQuery(entityType, entity, valueBuffer);
     }
 }

--- a/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore/Query/ShapedQueryCompilingExpressionVisitor.cs
@@ -64,7 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             _entityMaterializerInjectingExpressionVisitor =
                 new EntityMaterializerInjectingExpressionVisitor(
                     dependencies.EntityMaterializerSource,
-                    queryCompilationContext.IsTracking);
+                    queryCompilationContext.IsTracking,
+                    queryCompilationContext.PerformIdentityResolution);
 
             _constantVerifyingExpressionVisitor = new ConstantVerifyingExpressionVisitor(dependencies.TypeMappingSource);
 
@@ -288,9 +289,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             private static readonly PropertyInfo _dbContextMemberInfo
                 = typeof(QueryContext).GetProperty(nameof(QueryContext.Context));
 
-            private static readonly PropertyInfo _stateManagerMemberInfo
-                = typeof(QueryContext).GetProperty(nameof(QueryContext.StateManager));
-
             private static readonly PropertyInfo _entityMemberInfo
                 = typeof(InternalEntityEntry).GetProperty(nameof(InternalEntityEntry.Entity));
 
@@ -298,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 = typeof(InternalEntityEntry).GetProperty(nameof(InternalEntityEntry.EntityType));
 
             private static readonly MethodInfo _tryGetEntryMethodInfo
-                = typeof(IStateManager).GetTypeInfo().GetDeclaredMethods(nameof(IStateManager.TryGetEntry))
+                = typeof(QueryContext).GetTypeInfo().GetDeclaredMethods(nameof(QueryContext.TryGetEntry))
                     .Single(mi => mi.GetParameters().Length == 4);
 
             private static readonly MethodInfo _startTrackingMethodInfo
@@ -306,21 +304,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                     nameof(QueryContext.StartTracking), new[] { typeof(IEntityType), typeof(object), typeof(ValueBuffer) });
 
             private readonly IEntityMaterializerSource _entityMaterializerSource;
-            private readonly bool _trackQueryResults;
+            private readonly bool _trackingQuery;
+            private readonly bool _queryStateMananger;
             private readonly ISet<IEntityType> _visitedEntityTypes = new HashSet<IEntityType>();
             private int _currentEntityIndex;
 
             public EntityMaterializerInjectingExpressionVisitor(
-                IEntityMaterializerSource entityMaterializerSource, bool trackQueryResults)
+                IEntityMaterializerSource entityMaterializerSource,
+                bool trackingQuery,
+                bool performIdentityResolution)
             {
                 _entityMaterializerSource = entityMaterializerSource;
-                _trackQueryResults = trackQueryResults;
+                _trackingQuery = trackingQuery;
+                _queryStateMananger = trackingQuery || performIdentityResolution;
             }
 
             public Expression Inject(Expression expression)
             {
                 var result = Visit(expression);
-                if (_trackQueryResults)
+                if (_trackingQuery)
                 {
                     foreach (var entityType in _visitedEntityTypes)
                     {
@@ -386,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         instanceVariable,
                         Expression.Constant(null, entityType.ClrType)));
 
-                if (_trackQueryResults
+                if (_queryStateMananger
                     && primaryKey != null)
                 {
                     var entryVariable = Expression.Variable(typeof(InternalEntityEntry), "entry" + _currentEntityIndex);
@@ -398,9 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         Expression.Assign(
                             entryVariable,
                             Expression.Call(
-                                Expression.MakeMemberAccess(
-                                    QueryCompilationContext.QueryContextParameter,
-                                    _stateManagerMemberInfo),
+                                QueryCompilationContext.QueryContextParameter,
                                 _tryGetEntryMethodInfo,
                                 Expression.Constant(primaryKey),
                                 Expression.NewArrayInit(
@@ -513,7 +513,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 expressions.Add(Expression.Assign(instanceVariable, materializationExpression));
 
-                if (_trackQueryResults
+                if (_queryStateMananger
                     && entityType.FindPrimaryKey() != null)
                 {
                     foreach (var et in entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive()))
@@ -560,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var materializer = _entityMaterializerSource
                     .CreateMaterializeExpression(concreteEntityType, "instance", materializationContextVariable);
 
-                if (_trackQueryResults
+                if (_queryStateMananger
                     && concreteEntityType.ShadowPropertyCount() > 0)
                 {
                     var valueBufferExpression = Expression.Call(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4113,6 +4113,18 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"") OR (c[""CustomerID""] = null)))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Perform_identity_resolution_reuses_same_instances(bool async)
+        {
+            return base.Perform_identity_resolution_reuses_same_instances(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
+        public override Task Perform_identity_resolution_reuses_same_instances_across_joins(bool async)
+        {
+            return base.Perform_identity_resolution_reuses_same_instances_across_joins(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -451,6 +451,12 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
             AssertSql(" ");
         }
 
+        [ConditionalTheory(Skip = "No SelectMany, No Ability to Include navigation back to owner #17246")]
+        public override Task NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(bool async)
+        {
+            return base.NoTracking_Include_with_cycles_does_not_throw_when_performing_identity_resolution(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -184,7 +184,7 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
                     {
 #>
         [Obsolete]
-<#  
+<#
                     }
 #>
         public static EventDefinition<#= genericTypes #> <#= resource.Name #>([NotNull] IDiagnosticsLogger logger)
@@ -226,7 +226,7 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
         {
             result.AccessModifier = (string)Session["AccessModifier"];
         };
-        
+
         if (Session.ContainsKey("LoggingDefinitionsClass"))
         {
             result.LoggingDefinitionsClass = (string)Session["LoggingDefinitionsClass"];
@@ -266,7 +266,7 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
         result.Class = Path.GetFileNameWithoutExtension(resourceFile);
 
         result.DiagnosticsClass = result.Class.Replace("Strings", "Resources");
-        
+
         result.ResourceName = resourceNamespace + "." + result.Class;
 
         using (var reader = new ResXResourceReader(resourceFile))


### PR DESCRIPTION
- Uses an adhoc statemanager in the background which is different from statemanager in the context

Resolves #19877
