### PR TITLE
Fix for 18063. Add missing concurrency token properties for table splitting

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/AddConcurrencyTokenPropertiesConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/AddConcurrencyTokenPropertiesConvention.cs
@@ -1,0 +1,189 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that finds entity types which share a table
+    ///     which has a concurrency token column where those entity types
+    ///     do not have a property mapped to that column. It then
+    ///     creates a shadow concurrency property mapped to that column
+    ///     on the base-most entity type(s).
+    /// </summary>
+    public class AddConcurrencyTokenPropertiesConvention : IModelFinalizingConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="AddConcurrencyTokenPropertiesConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies">  Parameter object containing relational dependencies for this convention. </param>
+        public AddConcurrencyTokenPropertiesConvention(
+            [NotNull] ProviderConventionSetBuilderDependencies dependencies,
+            [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
+        {
+            Dependencies = dependencies;
+        }
+
+        /// <summary>
+        ///     Parameter object containing service dependencies.
+        /// </summary>
+        protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+        public static readonly string ConcurrencyPropertyPrefix = "_concurrency_";
+
+        /// <inheritdoc />
+        public virtual void ProcessModelFinalizing(
+            IConventionModelBuilder modelBuilder,
+            IConventionContext<IConventionModelBuilder> context)
+        {
+            var maxIdentifierLength = modelBuilder.Metadata.GetMaxIdentifierLength();
+
+            GetMappings(modelBuilder.Metadata,
+                out var tableToEntityTypes, out var concurrencyColumnsToProperties);
+
+            foreach (var table in tableToEntityTypes)
+            {
+                var tableName = table.Key;
+                if (!concurrencyColumnsToProperties.TryGetValue(tableName, out var concurrencyColumns))
+                {
+                    continue; // this table has no mapped concurrency columns
+                }
+
+                var entityTypesMappedToTable = table.Value;
+
+                foreach (var concurrencyColumn in concurrencyColumns)
+                {
+                    var concurrencyColumnName = concurrencyColumn.Key;
+                    var propertiesMappedToConcurrencyColumn = concurrencyColumn.Value;
+
+                    var entityTypesMissingConcurrencyColumn =
+                        new Dictionary<IConventionEntityType, IProperty>();
+                    foreach (var entityType in entityTypesMappedToTable)
+                    {
+                        var foundMappedProperty = false;
+                        foreach (var mappedProperty in propertiesMappedToConcurrencyColumn)
+                        {
+                            var declaringEntityType = mappedProperty.DeclaringEntityType;
+                            if (declaringEntityType.IsAssignableFrom(entityType)
+                                || declaringEntityType.IsInOwnershipPath(entityType)
+                                || entityType.IsInOwnershipPath(declaringEntityType))
+                            {
+                                foundMappedProperty = true;
+                                break;
+                            }
+                        }
+
+                        foundMappedProperty = foundMappedProperty
+                            || entityType.GetAllBaseTypes().SelectMany(t => t.GetDeclaredProperties())
+                                .Any(p => p.GetColumnName() == concurrencyColumnName);
+
+                        if (!foundMappedProperty)
+                        {
+                            // store the entity type which is missing the
+                            // concurrency token property, mapped to an example
+                            // property which _is_ mapped to this concurrency token
+                            // column and which will be used later as a template
+                            entityTypesMissingConcurrencyColumn.Add(
+                                entityType, propertiesMappedToConcurrencyColumn.First());
+                        }
+                    }
+
+                    foreach(var entityTypeToExampleProperty in
+                        BasestEntities(entityTypesMissingConcurrencyColumn))
+                    {
+                        var entityType = entityTypeToExampleProperty.Key;
+                        var exampleProperty = entityTypeToExampleProperty.Value;
+                        var allExistingProperties =
+                            entityType.GetProperties().Select(p => p.Name)
+                            .Union(entityType.GetNavigations().Select(p => p.Name))
+                            .ToDictionary(s => s, s => 0);
+                        var concurrencyShadowPropertyName =
+                            Uniquifier.Uniquify(ConcurrencyPropertyPrefix + concurrencyColumnName, allExistingProperties, maxIdentifierLength);
+                        var concurrencyShadowProperty =
+                            entityType.AddProperty(concurrencyShadowPropertyName, exampleProperty.ClrType, null);
+                        concurrencyShadowProperty.SetColumnName(concurrencyColumnName);
+                        concurrencyShadowProperty.SetIsConcurrencyToken(true);
+                        concurrencyShadowProperty.SetValueGenerated(exampleProperty.ValueGenerated);
+                    }
+                }
+            }
+        }
+
+        private void GetMappings(IConventionModel model,
+            out Dictionary<string, IList<IConventionEntityType>> tableToEntityTypes,
+            out Dictionary<string, Dictionary<string, IList<IProperty>>> concurrencyColumnsToProperties)
+        {
+            tableToEntityTypes = new Dictionary<string, IList<IConventionEntityType>>();
+            concurrencyColumnsToProperties = new Dictionary<string, Dictionary<string, IList<IProperty>>>();
+            foreach (var entityType in model.GetEntityTypes())
+            {
+                var tableName = entityType.GetSchemaQualifiedTableName();
+                if (tableName == null)
+                {
+                    continue; // unmapped entityType
+                }
+
+                if (!tableToEntityTypes.TryGetValue(tableName, out var mappedTypes))
+                {
+                    mappedTypes = new List<IConventionEntityType>();
+                    tableToEntityTypes[tableName] = mappedTypes;
+                }
+
+                mappedTypes.Add(entityType);
+
+                foreach (var property in entityType.GetDeclaredProperties())
+                {
+                    if (property.IsConcurrencyToken
+                        && (property.ValueGenerated & ValueGenerated.OnUpdate) != 0)
+                    {
+                        if (!concurrencyColumnsToProperties.TryGetValue(tableName, out var columnToProperties))
+                        {
+                            columnToProperties = new Dictionary<string, IList<IProperty>>();
+                            concurrencyColumnsToProperties[tableName] = columnToProperties;
+                        }
+
+                        var columnName = property.GetColumnName();
+                        if (!columnToProperties.TryGetValue(columnName, out var properties))
+                        {
+                            properties = new List<IProperty>();
+                            columnToProperties[columnName] = properties;
+                        }
+
+                        properties.Add(property);
+                    }
+                }
+            }
+        }
+
+        // Given a (distinct) IEnumerable of EntityTypes (mapped to T),
+        // return only the mappings where the EntityType does not inherit
+        // from any other EntityType in the list.
+        private static IEnumerable<KeyValuePair<IConventionEntityType, T>> BasestEntities<T>(
+            IEnumerable<KeyValuePair<IConventionEntityType, T>> entityTypeDictionary)
+        {
+            var toRemove = new HashSet<KeyValuePair<IConventionEntityType, T>>();
+            foreach (var entityType in entityTypeDictionary)
+            {
+                var otherEntityTypes = entityTypeDictionary
+                    .Except(new[] { entityType }).Except(toRemove);
+                foreach (var otherEntityType in otherEntityTypes)
+                {
+                    if (otherEntityType.Key.IsAssignableFrom(entityType.Key))
+                    {
+                        toRemove.Add(entityType);
+                        break;
+                    }
+                }
+            }
+
+            return entityTypeDictionary.Except(toRemove);
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -92,6 +92,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var dbFunctionAttributeConvention = new RelationalDbFunctionAttributeConvention(Dependencies, RelationalDependencies);
             conventionSet.ModelInitializedConventions.Add(dbFunctionAttributeConvention);
 
+            // Use TypeMappingConvention to add the relational store type mapping
+            // to the generated concurrency token property
+            ConventionSet.AddBefore(
+                conventionSet.ModelFinalizingConventions,
+                new AddConcurrencyTokenPropertiesConvention(Dependencies, RelationalDependencies),
+                typeof(TypeMappingConvention));
             // ModelCleanupConvention would remove the entity types added by QueryableDbFunctionConvention #15898
             ConventionSet.AddAfter(
                 conventionSet.ModelFinalizingConventions,

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             // to the generated concurrency token property
             ConventionSet.AddBefore(
                 conventionSet.ModelFinalizingConventions,
-                new AddConcurrencyTokenPropertiesConvention(Dependencies, RelationalDependencies),
+                new TableSharingConcurrencyTokenConvention(Dependencies, RelationalDependencies),
                 typeof(TypeMappingConvention));
             // ModelCleanupConvention would remove the entity types added by QueryableDbFunctionConvention #15898
             ConventionSet.AddAfter(

--- a/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SharedTableConvention.cs
@@ -167,7 +167,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 var usePrefix = property.DeclaringEntityType != otherProperty.DeclaringEntityType
                     || property.IsPrimaryKey()
                     || otherProperty.IsPrimaryKey();
-                if (!property.IsPrimaryKey())
+                if (!property.IsPrimaryKey()
+                    && !property.IsConcurrencyToken)
                 {
                     var newColumnName = TryUniquify(property, columnName, properties, usePrefix, maxLength);
                     if (newColumnName != null)
@@ -177,7 +178,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     }
                 }
 
-                if (!otherProperty.IsPrimaryKey())
+                if (!otherProperty.IsPrimaryKey()
+                    && !otherProperty.IsConcurrencyToken)
                 {
                     var newColumnName = TryUniquify(otherProperty, columnName, properties, usePrefix, maxLength);
                     if (newColumnName != null)

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -962,82 +962,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
-        public virtual void Missing_concurrency_token_property_is_created_on_the_base_type()
-        {
-            var modelBuilder = CreateConventionalModelBuilder();
-            modelBuilder.Entity<Person>().ToTable(nameof(Animal))
-                .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
-            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
-            modelBuilder.Entity<Cat>()
-                .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
-
-            var model = modelBuilder.Model;
-            Validate(model);
-
-            var animal = model.FindEntityType(typeof(Animal));
-            var concurrencyProperty = animal.FindProperty("_concurrency_Version");
-            Assert.True(concurrencyProperty.IsConcurrencyToken);
-            Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
-        }
-
-        [ConditionalFact]
-        public virtual void Missing_concurrency_token_properties_are_created_on_the_base_most_types()
-        {
-            var modelBuilder = CreateConventionalModelBuilder();
-            modelBuilder.Entity<Person>().ToTable(nameof(Animal)).Property<byte[]>("Version")
-                .HasColumnName("Version").ValueGeneratedOnUpdate().IsConcurrencyToken(true);
-            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
-            modelBuilder.Entity<Animal>().HasOne(a => a.Dwelling).WithOne().HasForeignKey<AnimalHouse>(p => p.Id);
-            modelBuilder.Entity<Cat>();
-            modelBuilder.Entity<AnimalHouse>().ToTable(nameof(Animal));
-            modelBuilder.Entity<TheMovie>();
-
-            var model = modelBuilder.Model;
-            Validate(model);
-
-            var animal = model.FindEntityType(typeof(Animal));
-            var concurrencyProperty = animal.FindProperty("_concurrency_Version");
-            Assert.True(concurrencyProperty.IsConcurrencyToken);
-            Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
-            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
-
-            var cat = model.FindEntityType(typeof(Cat));
-            Assert.DoesNotContain(cat.GetDeclaredProperties(), p => p.Name == "_concurrency_Version");
-
-            var animalHouse = model.FindEntityType(typeof(AnimalHouse));
-            concurrencyProperty = animalHouse.FindProperty("_concurrency_Version");
-            Assert.True(concurrencyProperty.IsConcurrencyToken);
-            Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
-            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
-
-            var theMovie = model.FindEntityType(typeof(TheMovie));
-            Assert.DoesNotContain(theMovie.GetDeclaredProperties(), p => p.Name == "_concurrency_Version");
-        }
-
-        [ConditionalFact]
-        public virtual void Missing_concurrency_token_property_is_created_on_the_sharing_type()
-        {
-            var modelBuilder = CreateConventionalModelBuilder();
-            modelBuilder.Entity<Person>().ToTable(nameof(Animal));
-            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
-            modelBuilder.Entity<Animal>().Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
-
-            var model = modelBuilder.Model;
-            Validate(model);
-
-            var personEntityType = model.FindEntityType(typeof(Person));
-            var concurrencyProperty = personEntityType.FindProperty("_concurrency_Version");
-            Assert.True(concurrencyProperty.IsConcurrencyToken);
-            Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
-        }
-
-        [ConditionalFact]
         public virtual void Passes_for_correctly_mapped_concurrency_tokens_with_table_sharing()
         {
             var modelBuilder = CreateConventionalModelBuilder();
@@ -1164,7 +1088,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public string Name { get; set; }
 
             public Person FavoritePerson { get; set; }
-            public AnimalHouse Dwelling { get; set; }
         }
 
         protected class Cat : Animal
@@ -1185,16 +1108,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public int Type { get; set; }
 
             public int Identity { get; set; }
-        }
-
-        protected class AnimalHouse
-        {
-            public int Id { get; set; }
-        }
-
-        protected class TheMovie : AnimalHouse
-        {
-            public bool CanHaveAnother { get; set; }
         }
 
         protected class Person

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -962,7 +962,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
-        public virtual void Detects_missing_concurrency_token_on_the_base_type()
+        public virtual void Missing_concurrency_token_property_is_created_on_the_base_type()
         {
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Person>().ToTable(nameof(Animal))
@@ -971,22 +971,70 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.Entity<Cat>()
                 .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
 
-            VerifyError(
-                RelationalStrings.MissingConcurrencyColumn(nameof(Animal), "Version", nameof(Animal)),
-                modelBuilder.Model);
+            var model = modelBuilder.Model;
+            Validate(model);
+
+            var animal = model.FindEntityType(typeof(Animal));
+            var concurrencyProperty = animal.FindProperty("_concurrency_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
         }
 
         [ConditionalFact]
-        public virtual void Detects_missing_concurrency_token_on_the_sharing_type()
+        public virtual void Missing_concurrency_token_properties_are_created_on_the_base_most_types()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Person>().ToTable(nameof(Animal)).Property<byte[]>("Version")
+                .HasColumnName("Version").ValueGeneratedOnUpdate().IsConcurrencyToken(true);
+            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
+            modelBuilder.Entity<Animal>().HasOne(a => a.Dwelling).WithOne().HasForeignKey<AnimalHouse>(p => p.Id);
+            modelBuilder.Entity<Cat>();
+            modelBuilder.Entity<AnimalHouse>().ToTable(nameof(Animal));
+            modelBuilder.Entity<TheMovie>();
+
+            var model = modelBuilder.Model;
+            Validate(model);
+
+            var animal = model.FindEntityType(typeof(Animal));
+            var concurrencyProperty = animal.FindProperty("_concurrency_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
+
+            var cat = model.FindEntityType(typeof(Cat));
+            Assert.DoesNotContain(cat.GetDeclaredProperties(), p => p.Name == "_concurrency_Version");
+
+            var animalHouse = model.FindEntityType(typeof(AnimalHouse));
+            concurrencyProperty = animalHouse.FindProperty("_concurrency_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
+
+            var theMovie = model.FindEntityType(typeof(TheMovie));
+            Assert.DoesNotContain(theMovie.GetDeclaredProperties(), p => p.Name == "_concurrency_Version");
+        }
+
+        [ConditionalFact]
+        public virtual void Missing_concurrency_token_property_is_created_on_the_sharing_type()
         {
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Person>().ToTable(nameof(Animal));
             modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
             modelBuilder.Entity<Animal>().Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
 
-            VerifyError(
-                RelationalStrings.MissingConcurrencyColumn(nameof(Person), "Version", nameof(Animal)),
-                modelBuilder.Model);
+            var model = modelBuilder.Model;
+            Validate(model);
+
+            var personEntityType = model.FindEntityType(typeof(Person));
+            var concurrencyProperty = personEntityType.FindProperty("_concurrency_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
         }
 
         [ConditionalFact]
@@ -1116,6 +1164,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public string Name { get; set; }
 
             public Person FavoritePerson { get; set; }
+            public AnimalHouse Dwelling { get; set; }
         }
 
         protected class Cat : Animal
@@ -1136,6 +1185,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public int Type { get; set; }
 
             public int Identity { get; set; }
+        }
+
+        protected class AnimalHouse
+        {
+            public int Id { get; set; }
+        }
+
+        protected class TheMovie : AnimalHouse
+        {
+            public bool CanHaveAnother { get; set; }
         }
 
         protected class Person

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/TableSharingConcurrencyTokenConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/TableSharingConcurrencyTokenConventionTest.cs
@@ -1,0 +1,159 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    public class TableSharingConcurrencyTokenConventionTest
+    {
+        [ConditionalFact]
+        public virtual void Missing_concurrency_token_property_is_created_on_the_base_type()
+        {
+            var modelBuilder = GetModelBuilder();
+            modelBuilder.Entity<Person>().ToTable(nameof(Animal))
+                .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
+            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
+            modelBuilder.Entity<Cat>()
+                .Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
+
+            var model = modelBuilder.Model;
+            model.FinalizeModel();
+
+            var animal = model.FindEntityType(typeof(Animal));
+            var concurrencyProperty = animal.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
+        }
+
+        [ConditionalFact]
+        public virtual void Missing_concurrency_token_properties_are_created_on_the_base_most_types()
+        {
+            var modelBuilder = GetModelBuilder();
+            modelBuilder.Entity<Person>().ToTable(nameof(Animal)).Property<byte[]>("Version")
+                .HasColumnName("Version").ValueGeneratedOnUpdate().IsConcurrencyToken(true);
+            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
+            modelBuilder.Entity<Animal>().HasOne(a => a.Dwelling).WithOne().HasForeignKey<AnimalHouse>(p => p.Id);
+            modelBuilder.Entity<Cat>();
+            modelBuilder.Entity<AnimalHouse>().ToTable(nameof(Animal));
+            modelBuilder.Entity<TheMovie>();
+
+            var model = modelBuilder.Model;
+            model.FinalizeModel();
+
+            var animal = model.FindEntityType(typeof(Animal));
+            var concurrencyProperty = animal.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
+
+            var cat = model.FindEntityType(typeof(Cat));
+            Assert.DoesNotContain(cat.GetDeclaredProperties(), p => p.Name == "_TableSharingConcurrencyTokenConvention_Version");
+
+            var animalHouse = model.FindEntityType(typeof(AnimalHouse));
+            concurrencyProperty = animalHouse.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
+
+            var theMovie = model.FindEntityType(typeof(TheMovie));
+            Assert.DoesNotContain(theMovie.GetDeclaredProperties(), p => p.Name == "_TableSharingConcurrencyTokenConvention_Version");
+        }
+
+        [ConditionalFact]
+        public virtual void Missing_concurrency_token_property_is_created_on_the_sharing_type()
+        {
+            var modelBuilder = GetModelBuilder();
+            modelBuilder.Entity<Person>().ToTable(nameof(Animal));
+            modelBuilder.Entity<Animal>().HasOne(a => a.FavoritePerson).WithOne().HasForeignKey<Person>(p => p.Id);
+            modelBuilder.Entity<Animal>().Property<byte[]>("Version").IsRowVersion().HasColumnName("Version");
+
+            var model = modelBuilder.Model;
+            model.FinalizeModel();
+
+            var personEntityType = model.FindEntityType(typeof(Person));
+            var concurrencyProperty = personEntityType.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
+            Assert.True(concurrencyProperty.IsConcurrencyToken);
+            Assert.True(concurrencyProperty.IsShadowProperty());
+            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
+        }
+
+        protected class Animal
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public Person FavoritePerson { get; set; }
+            public AnimalHouse Dwelling { get; set; }
+        }
+
+        protected class Cat : Animal
+        {
+            public string Breed { get; set; }
+
+            [NotMapped]
+            public string Type { get; set; }
+
+            public int Identity { get; set; }
+        }
+
+        protected class Dog : Animal
+        {
+            public string Breed { get; set; }
+
+            [NotMapped]
+            public int Type { get; set; }
+
+            public int Identity { get; set; }
+        }
+
+        protected class AnimalHouse
+        {
+            public int Id { get; set; }
+        }
+
+        protected class TheMovie : AnimalHouse
+        {
+            public bool CanHaveAnother { get; set; }
+        }
+
+        protected class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string FavoriteBreed { get; set; }
+        }
+
+        private ModelBuilder GetModelBuilder(DbContext dbContext = null)
+        {
+            var conventionSet = new ConventionSet();
+
+            var dependencies = CreateDependencies()
+                .With(new CurrentDbContext(dbContext ?? new DbContext(new DbContextOptions<DbContext>())));
+            var relationalDependencies = CreateRelationalDependencies();
+            var tableSharingConcurrencyTokenConvention = new TableSharingConcurrencyTokenConvention(dependencies, relationalDependencies);
+            conventionSet.ModelFinalizingConventions.Add(tableSharingConcurrencyTokenConvention);
+
+            return new ModelBuilder(conventionSet);
+        }
+
+        private ProviderConventionSetBuilderDependencies CreateDependencies()
+            => RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
+
+        private RelationalConventionSetBuilderDependencies CreateRelationalDependencies()
+            => RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<RelationalConventionSetBuilderDependencies>();
+    }
+}

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -155,15 +155,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public ModelBuilder CreateConventionBuilder(
             DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
             DiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
+                => new ModelBuilder(CreateConventionalConventionSet(modelLogger, validationLogger));
+
+        public ConventionSet CreateConventionalConventionSet(
+            DiagnosticsLogger<DbLoggerCategory.Model> modelLogger,
+            DiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
         {
             var contextServices = CreateContextServices(
                 new ServiceCollection()
                     .AddScoped<IDiagnosticsLogger<DbLoggerCategory.Model>>(_ => modelLogger)
                     .AddScoped<IDiagnosticsLogger<DbLoggerCategory.Model.Validation>>(_ => validationLogger));
 
-            var conventionSet = contextServices.GetRequiredService<IConventionSetBuilder>().CreateConventionSet();
-
-            return new ModelBuilder(conventionSet);
+            return contextServices.GetRequiredService<IConventionSetBuilder>().CreateConventionSet();
         }
 
         public virtual LoggingDefinitions LoggingDefinitions { get; } = new TestLoggingDefinitions();


### PR DESCRIPTION
Fixes #18063 . Previously if the user was table-splitting and one or more entity types did not map to a concurrency column, we used to throw warning the user to configure the property. Now we simply add it ourselves in shadow state.