### PR TITLE
Fix for 20741. Allow older versions of tools to pass null args.

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -46,13 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
-            Check.NotNull(args, nameof(args));
+            // Note: cannot assert that args is not null - as old versions of
+            // tools can still pass null.
 
             _reporter = reporter;
             _projectDir = projectDir;
             _rootNamespace = rootNamespace;
             _language = language;
-            _args = args;
+            _args = args ?? Array.Empty<string>();
 
             _servicesBuilder = new DesignTimeServicesBuilder(assembly, startupAssembly, reporter, _args);
         }

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -62,12 +62,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(assembly, nameof(assembly));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
-            Check.NotNull(args, nameof(args));
+            // Note: cannot assert that args is not null - as old versions of
+            // tools can still pass null.
 
             _reporter = reporter;
             _assembly = assembly;
             _startupAssembly = startupAssembly;
-            _args = args;
+            _args = args ?? Array.Empty<string>();
             _appServicesFactory = appServicesFactory;
         }
 

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -54,14 +54,15 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
-            Check.NotNull(args, nameof(args));
+            // Note: cannot assert that args is not null - as old versions of
+            // tools can still pass null.
 
             _reporter = reporter;
             _assembly = assembly;
             _projectDir = projectDir;
             _rootNamespace = rootNamespace;
             _language = language;
-            _args = args;
+            _args = args ?? Array.Empty<string>();
             _contextOperations = new DbContextOperations(
                 reporter,
                 assembly,

--- a/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public class DatabaseOperationsTest
+    {
+        [ConditionalFact]
+        public void Can_pass_null_args()
+        {
+            // Even though newer versions of the tools will pass an empty array
+            // older versions of the tools can pass null args.
+            var assembly = MockAssembly.Create(typeof(TestContext));
+            _ = new TestDatabaseOperations(
+                new TestOperationReporter(),
+                assembly,
+                assembly,
+                "projectDir",
+                "RootNamespace",
+                "C#",
+                args: null);
+        }
+
+        private class TestContext : DbContext
+        {
+            public TestContext()
+            {
+                throw new Exception("This isn't the constructor you're looking for.");
+            }
+
+            public TestContext(DbContextOptions<TestContext> options)
+                : base(options)
+            {
+            }
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DatabaseOperationsTest.cs
@@ -27,15 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         private class TestContext : DbContext
         {
-            public TestContext()
-            {
-                throw new Exception("This isn't the constructor you're looking for.");
-            }
-
-            public TestContext(DbContextOptions<TestContext> options)
-                : base(options)
-            {
-            }
         }
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -25,6 +25,20 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         }
 
         [ConditionalFact]
+        public void Can_pass_null_args()
+        {
+            // Even though newer versions of the tools will pass an empty array
+            // older versions of the tools can pass null args.
+            var assembly = MockAssembly.Create(typeof(BaseContext), typeof(DerivedContext), typeof(HierarchyContextFactory));
+            _ = new TestDbContextOperations(
+                new TestOperationReporter(),
+                assembly,
+                assembly,
+                args: null,
+                new TestAppServiceProviderFactory(assembly));
+        }
+
+        [ConditionalFact]
         public void CreateContext_uses_exact_factory_method()
         {
             var assembly = MockAssembly.Create(typeof(BaseContext), typeof(DerivedContext), typeof(HierarchyContextFactory));

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         {
             // Even though newer versions of the tools will pass an empty array
             // older versions of the tools can pass null args.
-            var assembly = MockAssembly.Create(typeof(BaseContext), typeof(DerivedContext), typeof(HierarchyContextFactory));
+            var assembly = MockAssembly.Create(typeof(TestContext));
             _ = new TestDbContextOperations(
                 new TestOperationReporter(),
                 assembly,

--- a/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Design.Internal
+{
+    public class MigrationsOperationsTest
+    {
+        [ConditionalFact]
+        public void Can_pass_null_args()
+        {
+            // Even though newer versions of the tools will pass an empty array
+            // older versions of the tools can pass null args.
+            var assembly = MockAssembly.Create(typeof(TestContext));
+            _ = new TestMigrationsOperations(
+                new TestOperationReporter(),
+                assembly,
+                assembly,
+                "projectDir",
+                "RootNamespace",
+                "C#",
+                args: null);
+        }
+
+        private class TestContext : DbContext
+        {
+            public TestContext()
+            {
+                throw new Exception("This isn't the constructor you're looking for.");
+            }
+
+            public TestContext(DbContextOptions<TestContext> options)
+                : base(options)
+            {
+            }
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/MigrationsOperationsTest.cs
@@ -27,15 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         private class TestContext : DbContext
         {
-            public TestContext()
-            {
-                throw new Exception("This isn't the constructor you're looking for.");
-            }
-
-            public TestContext(DbContextOptions<TestContext> options)
-                : base(options)
-            {
-            }
         }
     }
 }

--- a/test/EFCore.Design.Tests/TestUtilities/TestDatabaseOperations.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestDatabaseOperations.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestDatabaseOperations : DatabaseOperations
+    {
+        public TestDatabaseOperations(
+            IOperationReporter reporter,
+            Assembly assembly,
+            Assembly startupAssembly,
+            string projectDir,
+            string rootNamespace,
+            string language,
+            string[] args)
+            : base(reporter, assembly, startupAssembly, projectDir,rootNamespace, language, args)
+        {
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/TestUtilities/TestMigrationsOperations.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestMigrationsOperations.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestMigrationsOperations : MigrationsOperations
+    {
+        public TestMigrationsOperations(
+            IOperationReporter reporter,
+            Assembly assembly,
+            Assembly startupAssembly,
+            string projectDir,
+            string rootNamespace,
+            string language,
+            string[] args)
+            : base(reporter, assembly, startupAssembly, projectDir,rootNamespace, language, args)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #20741 

Allow older versions of tools to pass null args. This should fix @ajcvickers [comment](https://github.com/dotnet/efcore/issues/20741#issuecomment-620077080). There may still be underlying issues with `MigrationsModelDiffer`.