### PR TITLE
Benchmark cleanup

### DIFF
--- a/benchmark/EF6.SqlServer.Benchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/benchmark/EF6.SqlServer.Benchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -117,26 +117,22 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
         }
 
         [SingleRunJob]
-        [Description("AutoDetectChanges=True")]
         public class AddDataVariationsWithAutoDetectChangesOn : AddDataVariations
         {
             protected override bool AutoDetectChanges => true;
         }
 
         [SingleRunJob]
-        [Description("AutoDetectChanges=True")]
         public class ExistingDataVariationsWithAutoDetectChangesOn : ExistingDataVariations
         {
             protected override bool AutoDetectChanges => true;
         }
 
-        [Description("AutoDetectChanges=False")]
         public class AddDataVariationsWithAutoDetectChangesOff : AddDataVariations
         {
             protected override bool AutoDetectChanges => false;
         }
 
-        [Description("AutoDetectChanges=False")]
         public class ExistingDataVariationsWithAutoDetectChangesOff : ExistingDataVariations
         {
             protected override bool AutoDetectChanges => false;

--- a/benchmark/EF6.SqlServer.Benchmarks/ChangeTracker/FixupTests.cs
+++ b/benchmark/EF6.SqlServer.Benchmarks/ChangeTracker/FixupTests.cs
@@ -123,26 +123,22 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
         }
 
         [SingleRunJob]
-        [Description("AutoDetectChanges=True")]
         public class ChildVariationsWithAutoDetectChangesOn : ChildVariations
         {
             protected override bool AutoDetectChanges => true;
         }
 
         [SingleRunJob]
-        [Description("AutoDetectChanges=True")]
         public class ParentVariationsWithAutoDetectChangesOn : ParentVariations
         {
             protected override bool AutoDetectChanges => true;
         }
 
-        [Description("AutoDetectChanges=False")]
         public class ChildVariationsWithAutoDetectChangesOff : ChildVariations
         {
             protected override bool AutoDetectChanges => false;
         }
 
-        [Description("AutoDetectChanges=False")]
         public class ParentVariationsWithAutoDetectChangesOff : ParentVariations
         {
             protected override bool AutoDetectChanges => false;

--- a/benchmark/EFCore.Benchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/benchmark/EFCore.Benchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -15,6 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
     {
         public abstract class DbSetOperationBase
         {
+            public const int OperationsPerInvoke = 20000;
+
             private OrdersFixtureBase _fixture;
 
             protected List<Customer> _customersWithoutPk;
@@ -31,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
             {
                 _fixture = CreateFixture();
                 _fixture.Initialize(0, 0, 0, 0);
-                _customersWithoutPk = _fixture.CreateCustomers(20000, setPrimaryKeys: false);
-                _customersWithPk = _fixture.CreateCustomers(20000, setPrimaryKeys: true);
+                _customersWithoutPk = _fixture.CreateCustomers(OperationsPerInvoke, setPrimaryKeys: false);
+                _customersWithPk = _fixture.CreateCustomers(OperationsPerInvoke, setPrimaryKeys: true);
             }
 
             public virtual void InitializeContext()
@@ -56,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 base.InitializeContext();
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void Add()
             {
                 foreach (var customer in _customersWithoutPk)
@@ -65,13 +67,13 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void AddRange()
             {
                 _context.Customers.AddRange(_customersWithoutPk);
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void Attach()
             {
                 foreach (var customer in _customersWithPk)
@@ -80,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void AttachRange()
             {
                 _context.Customers.AttachRange(_customersWithPk);
@@ -96,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 _context.Customers.AttachRange(_customersWithPk);
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void Remove()
             {
                 foreach (var customer in _customersWithPk)
@@ -105,13 +107,13 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void RemoveRange()
             {
                 _context.Customers.RemoveRange(_customersWithPk);
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void Update()
             {
                 foreach (var customer in _customersWithPk)
@@ -120,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
             public virtual void UpdateRange()
             {
                 _context.Customers.UpdateRange(_customersWithPk);

--- a/benchmark/EFCore.Benchmarks/ChangeTracker/FixupTests.cs
+++ b/benchmark/EFCore.Benchmarks/ChangeTracker/FixupTests.cs
@@ -17,6 +17,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
     {
         public abstract class FixupBase
         {
+            protected const int Customers = 5000;
+            protected const int OrdersPerCustomer = 2;
+            protected const int TotalOrders = Customers * OrdersPerCustomer;
+
             private OrdersFixtureBase _fixture;
 
             protected List<Customer> _customers;
@@ -33,12 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
             public virtual void CheckData()
             {
                 _fixture = CreateFixture();
-                _fixture.Initialize(0, 5000, 2, 0);
+                _fixture.Initialize(0, Customers, OrdersPerCustomer, 0);
 
                 using (var context = _fixture.CreateContext())
                 {
-                    Assert.Equal(5000, context.Customers.Count());
-                    Assert.Equal(10000, context.Orders.Count());
+                    Assert.Equal(Customers, context.Customers.Count());
+                    Assert.Equal(TotalOrders, context.Orders.Count());
                 }
             }
 
@@ -47,9 +51,9 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 _context = _fixture.CreateContext();
                 _context.ChangeTracker.AutoDetectChangesEnabled = AutoDetectChanges;
 
-                _customers = _fixture.CreateCustomers(5000, setPrimaryKeys: true);
-                _ordersWithoutPk = _fixture.CreateOrders(_customers, ordersPerCustomer: 2, setPrimaryKeys: false);
-                _ordersWithPk = _fixture.CreateOrders(_customers, ordersPerCustomer: 2, setPrimaryKeys: true);
+                _customers = _fixture.CreateCustomers(Customers, setPrimaryKeys: true);
+                _ordersWithoutPk = _fixture.CreateOrders(_customers, ordersPerCustomer: OrdersPerCustomer, setPrimaryKeys: false);
+                _ordersWithPk = _fixture.CreateOrders(_customers, ordersPerCustomer: OrdersPerCustomer, setPrimaryKeys: true);
             }
 
             [IterationCleanup]
@@ -68,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 _context.Customers.AttachRange(_customers);
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = TotalOrders)]
             public virtual void AddChildren()
             {
                 foreach (var order in _ordersWithoutPk)
@@ -77,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = TotalOrders)]
             public virtual void AttachChildren()
             {
                 foreach (var order in _ordersWithPk)
@@ -86,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = TotalOrders)]
             public virtual void QueryChildren()
             {
                 _context.Orders.ToList();
@@ -102,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 _context.Orders.AttachRange(_ordersWithPk);
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = Customers)]
             public virtual void AddParents()
             {
                 foreach (var customer in _customers)
@@ -111,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = Customers)]
             public virtual void AttachParents()
             {
                 foreach (var customer in _customers)
@@ -120,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.ChangeTracker
                 }
             }
 
-            [Benchmark]
+            [Benchmark(OperationsPerInvoke = Customers)]
             public virtual void QueryParents()
             {
                 _context.Customers.ToList();

--- a/benchmark/EFCore.Benchmarks/Extensions/Extensions.cs
+++ b/benchmark/EFCore.Benchmarks/Extensions/Extensions.cs
@@ -3,16 +3,13 @@
 
 using System.Linq;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Benchmarks
 {
     public static class Extensions
     {
         public static IQueryable<TEntity> ApplyTracking<TEntity>(this IQueryable<TEntity> query, bool tracking)
             where TEntity : class
-        {
-            return tracking
-                ? query
-                : query.AsNoTracking();
-        }
+            => tracking ? query : query.AsNoTracking();
     }
 }

--- a/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
@@ -9,8 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
 {
-    [DisplayName("InitializationTests")]
-    public abstract class InitializationTests
+    public abstract class InitializationBase
     {
         protected abstract AdventureWorksContextBase CreateContext();
         protected abstract ConventionSet CreateConventionSet();

--- a/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
         protected abstract AdventureWorksContextBase CreateContext();
         protected abstract ConventionSet CreateConventionSet();
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = 10000)]
         public virtual void CreateAndDisposeUnusedContext()
         {
             for (var i = 0; i < 10000; i++)
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = 1000)]
         public virtual void InitializeAndQuery_AdventureWorks()
         {
             for (var i = 0; i < 1000; i++)
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = 100)]
         public virtual void InitializeAndSaveChanges_AdventureWorks()
         {
             for (var i = 0; i < 100; i++)

--- a/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
@@ -11,8 +11,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    [DisplayName(nameof(FuncletizationTests))]
-    public abstract class FuncletizationTests
+    public abstract class FuncletizationBase
     {
         private OrdersContextBase _context;
 

--- a/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
     {
         private OrdersContextBase _context;
 
-        protected virtual int FuncletizationIterationCount => 100;
+        public const int OperationsPerInvoke = 100;
+
         protected abstract OrdersFixtureBase CreateFixture();
 
         [GlobalSetup]
@@ -36,34 +37,34 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             _context.Dispose();
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void NewQueryInstance()
         {
             var val = 11;
-            for (var i = 0; i < FuncletizationIterationCount; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 _context.Products.Where(p => p.ProductId < val).ToList();
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void SameQueryInstance()
         {
             var val = 11;
             var query = _context.Products.Where(p => p.ProductId < val);
 
-            for (var i = 0; i < FuncletizationIterationCount; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 // ReSharper disable once PossibleMultipleEnumeration
                 query.ToList();
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void ValueFromObject()
         {
             var valueHolder = new ValueHolder();
-            for (var i = 0; i < FuncletizationIterationCount; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 _context.Products.Where(p => p.ProductId < valueHolder.SecondLevelProperty).ToList();
             }

--- a/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
@@ -10,8 +10,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    [DisplayName(nameof(NavigationsQueryTests))]
-    public abstract class NavigationsQueryTests
+    public abstract class NavigationsQueryBase
     {
         private AdventureWorksContextBase _context;
         private IQueryable<Store> _query;

--- a/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
@@ -16,8 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
         private AdventureWorksContextBase _context;
         private IQueryable<Store> _query;
 
-        protected virtual int QueriesPerIteration => 10;
-        protected virtual int UnfilteredCount => 466;
+        public const int OperationsPerInvoke = 10;
+        public const int UnfilteredCount = 466;
 
         [Params(true, false)]
         public bool Async { get; set; }
@@ -44,10 +44,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             _context.Dispose();
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual async Task PredicateAcrossOptionalNavigation()
         {
-            for (var i = 0; i < QueriesPerIteration; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 if (Async)
                 {

--- a/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
     [DisplayName(nameof(QueryCompilationTests))]
     public abstract class QueryCompilationTests
     {
+        public const int OperationsPerInvoke = 10;
+
         private OrdersContextBase _context;
         private IQueryable<Product> _simpleQuery;
         private IQueryable<DTO> _complexQuery;
@@ -70,28 +72,28 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             _context.Dispose();
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void ToList()
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 _simpleQuery.ToList();
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void FilterOrderProject()
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 _complexQuery.ToList();
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
         public virtual void MultipleJoins()
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < OperationsPerInvoke; i++)
             {
                 _multipleJoinQuery.ToList();
             }

--- a/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
@@ -16,8 +16,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    [DisplayName(nameof(QueryCompilationTests))]
-    public abstract class QueryCompilationTests
+    public abstract class QueryCompilationBase
     {
         public const int OperationsPerInvoke = 10;
 

--- a/benchmark/EFCore.Benchmarks/Query/RawSqlQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/RawSqlQueryTests.cs
@@ -13,8 +13,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    [DisplayName(nameof(RawSqlQueryTests))]
-    public abstract class RawSqlQueryTests
+    public abstract class RawSqlQueryBase
     {
         private OrdersContextBase _context;
 

--- a/benchmark/EFCore.Benchmarks/Query/SimpleQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/SimpleQueryTests.cs
@@ -12,8 +12,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    [DisplayName(nameof(SimpleQueryTests))]
-    public abstract class SimpleQueryTests
+    public abstract class SimpleQueryBase
     {
         private OrdersContextBase _context;
 

--- a/benchmark/EFCore.SqlServer.Benchmarks/Initialization/InitializationSqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Initialization/InitializationSqlServerTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
 {
-    public class InitializationSqlServerTests : InitializationTests
+    public class Initialization : InitializationBase
     {
         protected override AdventureWorksContextBase CreateContext() => AdventureWorksSqlServerFixture.CreateContext();
         protected override ConventionSet CreateConventionSet() => SqlServerConventionSetBuilder.Build();

--- a/benchmark/EFCore.SqlServer.Benchmarks/Query/FuncletizationSqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Query/FuncletizationSqlServerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class FuncletizationSqlServerTests : FuncletizationTests
+    public class Funcletization : FuncletizationBase
     {
         protected override OrdersFixtureBase CreateFixture()
         {

--- a/benchmark/EFCore.SqlServer.Benchmarks/Query/NavigationsQuerySqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Query/NavigationsQuerySqlServerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class NavigationsQuerySqlServerTests : NavigationsQueryTests
+    public class NavigationsQuery : NavigationsQueryBase
     {
         protected override AdventureWorksContextBase CreateContext()
         {

--- a/benchmark/EFCore.SqlServer.Benchmarks/Query/QueryCompilationSqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Query/QueryCompilationSqlServerTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class QueryCompilationSqlServerTests : QueryCompilationTests
+    public class QueryCompilation : QueryCompilationBase
     {
         public override IServiceCollection AddProviderServices(IServiceCollection services)
         {

--- a/benchmark/EFCore.SqlServer.Benchmarks/Query/RawSqlQuerySqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Query/RawSqlQuerySqlServerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class RawSqlQuerySqlServerTests : RawSqlQueryTests
+    public class RawSqlQuery : RawSqlQueryBase
     {
         protected override string StoredProcedureCreationScript
             => @"CREATE PROCEDURE dbo.SearchProducts

--- a/benchmark/EFCore.SqlServer.Benchmarks/Query/SimpleQuerySqlServerTests.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Query/SimpleQuerySqlServerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class SimpleQuerySqlServerTests : SimpleQueryTests
+    public class SimpleQuery : SimpleQueryBase
     {
         protected override OrdersFixtureBase CreateFixture()
         {

--- a/benchmark/EFCore.Sqlite.Benchmarks/Initialization/InitializationSqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Initialization/InitializationSqliteTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization
 {
-    public class InitializationSqliteTests : InitializationTests
+    public class Initialization : InitializationBase
     {
         protected override AdventureWorksContextBase CreateContext()=> AdventureWorksSqliteFixture.CreateContext();
         protected override ConventionSet CreateConventionSet() => SqliteConventionSetBuilder.Build();

--- a/benchmark/EFCore.Sqlite.Benchmarks/Query/FuncletizationSqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Query/FuncletizationSqliteTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class FuncletizationSqliteTests : FuncletizationTests
+    public class Funcletization : FuncletizationBase
     {
         protected override OrdersFixtureBase CreateFixture()
         {

--- a/benchmark/EFCore.Sqlite.Benchmarks/Query/NavigationsQuerySqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Query/NavigationsQuerySqliteTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class NavigationsQuerySqliteTests : NavigationsQueryTests
+    public class NavigationsQuery : NavigationsQueryBase
     {
         protected override AdventureWorksContextBase CreateContext()
         {

--- a/benchmark/EFCore.Sqlite.Benchmarks/Query/QueryCompilationSqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Query/QueryCompilationSqliteTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class QueryCompilationSqliteTests : QueryCompilationTests
+    public class QueryCompilationSqliteTests : QueryCompilationBase
     {
         public override IServiceCollection AddProviderServices(IServiceCollection services)
         {

--- a/benchmark/EFCore.Sqlite.Benchmarks/Query/RawSqlQuerySqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Query/RawSqlQuerySqliteTests.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class RawSqlQuerySqliteTests : RawSqlQueryTests
+    public class RawSqlQuery : RawSqlQueryBase
     {
         protected override string StoredProcedureCreationScript
             => @"";

--- a/benchmark/EFCore.Sqlite.Benchmarks/Query/SimpleQuerySqliteTests.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Query/SimpleQuerySqliteTests.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
-    public class SimpleQuerySqliteTests : SimpleQueryTests
+    public class SimpleQuery : SimpleQueryBase
     {
         protected override OrdersFixtureBase CreateFixture()
         {


### PR DESCRIPTION
This PR cleans up some benchmark stuff.

@sebastienros once this is merged, we'd need the corresponding cleanup to also occur in the database. I hope you can help us with that...

Benchmark name changes:

* InitializationSqliteTests -> Initialization
* FuncletizationSqliteTests -> Funcletization
* NavigationsQuerySqliteTests -> NavigationsQuery (does not appear in dashboard!)
* QueryCompilationSqliteTests -> QueryCompilation (does not appear in dashboard!)
* RawSqlQuerySqliteTests -> RawSqlQuery
* SimpleQuerySqliteTests -> SimpleQuery

For the following, I've configured BDN to always show the times for exactly one operation, even when the benchmark internally executes a loop. That means we'd need to multiply historical values in the database:

* AddDataVariations: multiply by 20000
* ExistingDataVariations: multiply by 20000
* ChildVariations: multiply by 10000
* ParentVariations: multiply by 5000
* InitializationTests.CreateAndDisposeUnusedContext: multiply by 10000
* InitializationTests.InitializeAndQuery_AdventureWorks: multiply by 1000
* InitializationTests.InitializeAndSaveChanges_AdventureWorks: multiply by 100
* FuncletizationTests: multiply by 100
* NavigationsQueryTests: multiply by 10
* QueryCompilation: multiply by 10