### PR TITLE
Ignore NRT context metadata on generic types

### DIFF
--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -96,6 +96,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var type = memberInfo.DeclaringType;
             if (type != null)
             {
+                // We currently don't look at context information on generic types, #20718
+                if (type.IsGenericType)
+                {
+                    return false;
+                }
+
                 if (state.TypeCache.TryGetValue(type, out var cachedTypeNonNullable))
                 {
                     return cachedTypeNonNullable;

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -80,6 +81,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var entityTypeBuilder = modelBuilder.Entity(type);
 
             Assert.Equal(expectedNullable, entityTypeBuilder.Property(propertyName).Metadata.IsNullable);
+        }
+
+        [ConditionalFact]
+        public void Non_nullability_ignores_context_on_generic_types()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityTypeBuilder = modelBuilder.Entity<Dictionary<string, object>>();
+            entityTypeBuilder.IndexerProperty(typeof(int), "a");
+            entityTypeBuilder.IndexerProperty(typeof(string), "b");
+            Assert.True(entityTypeBuilder.Property("b").Metadata.IsNullable);
         }
 
         private void RunConvention(InternalPropertyBuilder propertyBuilder)


### PR DESCRIPTION
We don't have logic for correctly applying nullability context ןnformation on properties of generic types, so ignore them for now.

Note that this "fix" will completely ignore context information on generic types. This blocks some legitimate usage, i.e. where a user generic type has a non-generic property that needs to inherit the NRT context. We would ideally fix this by 5.0 by using a new API from dotnet/runtime#29723, or possibly by implementing the proper differentiation ourselves (ignoring only generic properties on the generic type).

Temporary fix for #20718
