### PR TITLE
Fix for 19608. Truncate/Uniquify Sequence Names.

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -106,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizingConventions.Add(dbFunctionAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(tableNameFromDbSetConvention);
             conventionSet.ModelFinalizingConventions.Add(storeGenerationConvention);
+            conventionSet.ModelFinalizingConventions.Add(new SequenceUniquificationConvention(Dependencies, RelationalDependencies));
             conventionSet.ModelFinalizingConventions.Add(new SharedTableConvention(Dependencies, RelationalDependencies));
             conventionSet.ModelFinalizingConventions.Add(new DbFunctionTypeMappingConvention(Dependencies, RelationalDependencies));
             ReplaceConvention(

--- a/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention which ensures that all sequences in the model have unique names
+    ///     within a schema when truncated to the maximum identifier length for the model.
+    /// </summary>
+    public class SequenceUniquificationConvention : IModelFinalizingConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="SequenceUniquificationConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies"> Parameter object containing relational dependencies for this convention. </param>
+        public SequenceUniquificationConvention(
+            [NotNull] ProviderConventionSetBuilderDependencies dependencies,
+            [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
+        {
+            Dependencies = dependencies;
+        }
+
+        /// <summary>
+        ///     Parameter object containing service dependencies.
+        /// </summary>
+        protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+        /// <inheritdoc />
+        public virtual void ProcessModelFinalizing(IConventionModelBuilder modelBuilder, IConventionContext<IConventionModelBuilder> context)
+        {
+            var model = modelBuilder.Metadata;
+            var modelSequences =
+                (SortedDictionary<(string Name, string Schema), Sequence>)model[RelationalAnnotationNames.Sequences];
+
+            if (modelSequences != null)
+            {
+                var schemaToSequenceNameToSequences = new Dictionary<string, Dictionary<string, Sequence>>();
+                var nullSchemaSequenceNameToSequences = new Dictionary<string, Sequence>();
+                foreach (var sequenceTupleToSequence in modelSequences)
+                {
+                    var schemaName = sequenceTupleToSequence.Key.Schema;
+                    if (schemaName == null)
+                    {
+                        nullSchemaSequenceNameToSequences.Add(
+                            sequenceTupleToSequence.Key.Name, sequenceTupleToSequence.Value);
+                    }
+                    else
+                    {
+                        if (!schemaToSequenceNameToSequences.TryGetValue(schemaName, out var sequenceNameToSequences))
+                        {
+                            sequenceNameToSequences = new Dictionary<string, Sequence>();
+                            schemaToSequenceNameToSequences[schemaName] = sequenceNameToSequences;
+                        }
+
+                        sequenceNameToSequences.Add(sequenceTupleToSequence.Key.Name, sequenceTupleToSequence.Value);
+                    }
+                }
+
+                var maxLength = model.GetMaxIdentifierLength();
+                UniquifySequenceNamesInSchema(
+                    null, nullSchemaSequenceNameToSequences, maxLength, ref modelSequences);
+                foreach (var schemaToSequenceNameToSequence in schemaToSequenceNameToSequences)
+                {
+                    UniquifySequenceNamesInSchema(schemaToSequenceNameToSequence.Key,
+                        schemaToSequenceNameToSequence.Value, maxLength, ref modelSequences);
+                }
+            }
+        }
+
+        private static void UniquifySequenceNamesInSchema(
+            string schemaName, Dictionary<string, Sequence> sequenceNameToSequences, int maxLength,
+            ref SortedDictionary<(string Name, string Schema), Sequence> modelSequences)
+        {
+            var sequenceNamesInSchema = new Dictionary<string, int>();
+            var sequencesToRemove = new List<(string Name, string Schema)>();
+            var sequencesToAdd = new Dictionary<(string Name, string Schema), Sequence>();
+            foreach (var sequenceNameToSequence in sequenceNameToSequences)
+            {
+                var originalSequenceName = sequenceNameToSequence.Key;
+                var newSequenceName =
+                    Uniquifier.Uniquify(originalSequenceName, sequenceNamesInSchema, maxLength);
+                sequenceNamesInSchema.Add(newSequenceName, 0);
+                if (!string.Equals(newSequenceName, originalSequenceName, StringComparison.Ordinal))
+                {
+                    // do not just remove the old and immediately add the new sequence
+                    // here in case the new name clashes with a different old, but
+                    // not yet removed sequence
+                    sequencesToRemove.Add((originalSequenceName, schemaName));
+                    sequencesToAdd.Add((newSequenceName, schemaName),
+                        Sequence.WithNewName(sequenceNameToSequence.Value, newSequenceName));
+                }
+            }
+
+            foreach (var sequenceToRemove in sequencesToRemove)
+            {
+                modelSequences.Remove(sequenceToRemove);
+            }
+
+            foreach (var sequenceToAdd in sequencesToAdd)
+            {
+                modelSequences.Add(sequenceToAdd.Key, sequenceToAdd.Value);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/SequenceUniquificationConvention.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     var newSequenceName = Uniquifier.Uniquify(
                         sequence.Key.Name, modelSequences,
                         sequenceName => (sequenceName, schemaName), maxLength);
-                    Sequence.UpdateSequence((IMutableModel)model, sequence.Value, newSequenceName);
+                    Sequence.SetName((IMutableModel)model, sequence.Value, newSequenceName);
                 }
             }
         }

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -192,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static Sequence UpdateSequence(
+        public static Sequence SetName(
             [NotNull] IMutableModel model, [NotNull] Sequence sequence, [NotNull] string name)
         {
             Check.NotNull(model, nameof(model));

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -144,6 +144,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static Sequence WithNewName([NotNull] Sequence sequence, [NotNull] string name)
+        {
+            Check.NotNull(sequence, nameof(sequence));
+            Check.NotEmpty(name, nameof(name));
+
+            var newSequence = new Sequence(name, sequence.Schema, sequence._model, sequence._configurationSource);
+
+            newSequence._startValue = sequence.StartValue;
+            newSequence._incrementBy = sequence.IncrementBy;
+            newSequence._minValue = sequence.MinValue;
+            newSequence._maxValue = sequence.MaxValue;
+            newSequence._clrType = sequence.ClrType;
+            newSequence._isCyclic = sequence.IsCyclic;
+            newSequence._startValueConfigurationSource = sequence._startValueConfigurationSource;
+            newSequence._incrementByConfigurationSource = sequence._incrementByConfigurationSource;
+            newSequence._minValueConfigurationSource = sequence._minValueConfigurationSource;
+            newSequence._maxValueConfigurationSource = sequence._maxValueConfigurationSource;
+            newSequence._clrTypeConfigurationSource = sequence._clrTypeConfigurationSource;
+            newSequence._isCyclicConfigurationSource = sequence._isCyclicConfigurationSource;
+
+            return newSequence;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static IEnumerable<Sequence> GetSequences([NotNull] IModel model)
             => ((SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences])
                 ?.Values ?? Enumerable.Empty<Sequence>();

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
@@ -14,15 +14,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     public class SequenceUniquificationConventionTest
     {
         [ConditionalFact]
-        public virtual void Sequence_names_are_uniquified_and_truncated()
+        public virtual void Sequence_names_are_truncated_and_uniquified()
         {
             var modelBuilder = GetModelBuilder();
             modelBuilder.GetInfrastructure().HasMaxIdentifierLength(10);
-            modelBuilder.HasSequence("UniquifyMe", (string)null);
+            modelBuilder.HasSequence("UniquifyMeToo", (string)null);
+            modelBuilder.HasSequence("UniquifyMeToo", "TestSchema");
             modelBuilder.HasSequence("UniquifyM!Too", (string)null);
-            modelBuilder.HasSequence("UniquifyM~", (string)null);
-            modelBuilder.HasSequence("UniquifyMe", "TestSchema");
             modelBuilder.HasSequence("UniquifyM!Too", "TestSchema");
+            // the below ensure we deal with clashes with existing
+            // sequence names that look like candidate uniquified names
+            modelBuilder.HasSequence("UniquifyM~", (string)null);
             modelBuilder.HasSequence("UniquifyM~", "TestSchema");
 
             var model = modelBuilder.Model;
@@ -41,22 +43,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 },
                 s2 =>
                 {
-                    Assert.Equal("UniquifyM~", s2.Name);
+                    Assert.Equal("Uniquify~2", s2.Name);
                     Assert.Null(s2.Schema);
                 },
                 s3 =>
                 {
-                    Assert.Equal("UniquifyM~", s3.Name);
+                    Assert.Equal("Uniquify~2", s3.Name);
                     Assert.Equal("TestSchema", s3.Schema);
                 },
                 s4 =>
                 {
-                    Assert.Equal("UniquifyMe", s4.Name);
+                    Assert.Equal("UniquifyM~", s4.Name);
                     Assert.Null(s4.Schema);
                 },
                 s5 =>
                 {
-                    Assert.Equal("UniquifyMe", s5.Name);
+                    Assert.Equal("UniquifyM~", s5.Name);
                     Assert.Equal("TestSchema", s5.Schema);
                 });
         }

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
@@ -19,11 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var modelBuilder = GetModelBuilder();
             modelBuilder.GetInfrastructure().HasMaxIdentifierLength(10);
             modelBuilder.HasSequence("UniquifyMe", (string)null);
-            modelBuilder.HasSequence("UniquifyMeToo", (string)null);
-            modelBuilder.HasSequence("UniquifyMeAsWell", (string)null);
+            modelBuilder.HasSequence("UniquifyM!Too", (string)null);
+            modelBuilder.HasSequence("UniquifyM~", (string)null);
             modelBuilder.HasSequence("UniquifyMe", "TestSchema");
-            modelBuilder.HasSequence("UniquifyMeToo", "TestSchema");
-            modelBuilder.HasSequence("UniquifyMeAsWell", "TestSchema");
+            modelBuilder.HasSequence("UniquifyM!Too", "TestSchema");
+            modelBuilder.HasSequence("UniquifyM~", "TestSchema");
 
             var model = modelBuilder.Model;
             model.FinalizeModel();

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/SequenceUniquificationConventionTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    public class SequenceUniquificationConventionTest
+    {
+        [ConditionalFact]
+        public virtual void Sequence_names_are_uniquified_and_truncated()
+        {
+            var modelBuilder = GetModelBuilder();
+            modelBuilder.GetInfrastructure().HasMaxIdentifierLength(10);
+            modelBuilder.HasSequence("UniquifyMe", (string)null);
+            modelBuilder.HasSequence("UniquifyMeToo", (string)null);
+            modelBuilder.HasSequence("UniquifyMeAsWell", (string)null);
+            modelBuilder.HasSequence("UniquifyMe", "TestSchema");
+            modelBuilder.HasSequence("UniquifyMeToo", "TestSchema");
+            modelBuilder.HasSequence("UniquifyMeAsWell", "TestSchema");
+
+            var model = modelBuilder.Model;
+            model.FinalizeModel();
+
+            Assert.Collection(model.GetSequences(),
+                s0 =>
+                {
+                    Assert.Equal("Uniquify~1", s0.Name);
+                    Assert.Null(s0.Schema);
+                },
+                s1 =>
+                {
+                    Assert.Equal("Uniquify~1", s1.Name);
+                    Assert.Equal("TestSchema", s1.Schema);
+                },
+                s2 =>
+                {
+                    Assert.Equal("UniquifyM~", s2.Name);
+                    Assert.Null(s2.Schema);
+                },
+                s3 =>
+                {
+                    Assert.Equal("UniquifyM~", s3.Name);
+                    Assert.Equal("TestSchema", s3.Schema);
+                },
+                s4 =>
+                {
+                    Assert.Equal("UniquifyMe", s4.Name);
+                    Assert.Null(s4.Schema);
+                },
+                s5 =>
+                {
+                    Assert.Equal("UniquifyMe", s5.Name);
+                    Assert.Equal("TestSchema", s5.Schema);
+                });
+        }
+
+        private ModelBuilder GetModelBuilder()
+        {
+            var conventionSet = new ConventionSet();
+
+            var dependencies = CreateDependencies()
+                .With(new CurrentDbContext(new DbContext(new DbContextOptions<DbContext>())));
+            var relationalDependencies = CreateRelationalDependencies();
+            conventionSet.ModelFinalizingConventions.Add(
+                new SequenceUniquificationConvention(dependencies, relationalDependencies));
+
+            return new ModelBuilder(conventionSet);
+        }
+
+        private ProviderConventionSetBuilderDependencies CreateDependencies()
+            => RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
+
+        private RelationalConventionSetBuilderDependencies CreateRelationalDependencies()
+            => RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<RelationalConventionSetBuilderDependencies>();
+    }
+}


### PR DESCRIPTION
Fixes #19608 

Truncate and uniquify Sequence Names within each schema.