### PR TITLE
Output [Obsolete] for string resources.

### DIFF
--- a/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
+++ b/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
                 entityType, keyValue, conflictingValues, databaseValues);
 
         /// <summary>
-        ///      Invalid {state} encountered.
+        ///     Invalid {state} encountered.
         /// </summary>
         public static string InvalidStateEncountered([CanBeNull] object state)
             => string.Format(
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
                 state);
 
         /// <summary>
-        ///      Cannot apply DefaultIfEmpty after a client-evaluated projection.
+        ///     Cannot apply DefaultIfEmpty after a client-evaluated projection.
         /// </summary>
         public static string DefaultIfEmptyAppliedAfterProjection
             => GetString("DefaultIfEmptyAppliedAfterProjection");

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -354,7 +354,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}
+        ///     Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}, computed value is stored: {computedValueIsStored}
         /// </summary>
         public static FallbackEventDefinition LogFoundColumn([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -87,6 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.
         /// </summary>
+        [Obsolete]
         public static string InvalidPropertiesExpression([CanBeNull] object expression)
             => string.Format(
                 GetString("InvalidPropertiesExpression", nameof(expression)),
@@ -95,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     The expression '{expression}' is not a valid property expression. The expression should represent a simple property access: 't =&gt; t.MyProperty'.
         /// </summary>
+        [Obsolete]
         public static string InvalidPropertyExpression([CanBeNull] object expression)
             => string.Format(
                 GetString("InvalidPropertyExpression", nameof(expression)),

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -88,6 +88,13 @@ namespace <#= model.Namespace #>
 #>
         /// </summary>
 <#
+            if (resource.Obsolete)
+            {
+#>
+        [Obsolete]
+<#
+            }
+
             if (resource.Parameters.Any())
             {
 #>


### PR DESCRIPTION
Update `Resources.tt` to output `[Obsolete]` for string resources, not just for event definitions. Also some .Designer.cs files were not up to date.

Note: Obsolete originally added due to comment [here](https://github.com/dotnet/efcore/pull/20726#discussion_r414114742).