### PR TITLE
Use existing transaction identifier in RelationalConnection.UseTransaction 

### DIFF
--- a/src/EFCore.Relational/Diagnostics/DbTransactionInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/DbTransactionInterceptor.cs
@@ -120,17 +120,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         Called immediately after <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" /> is called.
+        ///         Called immediately after <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" /> is called.
         ///     </para>
         /// </summary>
         /// <param name="connection"> The connection. </param>
         /// <param name="eventData"> Contextual information about connection and transaction. </param>
         /// <param name="result">
-        ///     The <see cref="DbTransaction" /> that was passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" />.
+        ///     The <see cref="DbTransaction" /> that was passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" />.
         ///     This value is typically used as the return value for the implementation of this method.
         /// </param>
         /// <returns>
-        ///     The value that will be used as the effective value passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" />
+        ///     The value that will be used as the effective value passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" />
         ///     A normal implementation of this method for any interceptor that is not attempting to change the result
         ///     is to return the <paramref name="result" /> value passed in.
         /// </returns>
@@ -142,19 +142,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         Called immediately after <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" /> is called.
+        ///         Called immediately after <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" /> is called.
         ///     </para>
         /// </summary>
         /// <param name="connection"> The connection. </param>
         /// <param name="eventData"> Contextual information about connection and transaction. </param>
         /// <param name="result">
-        ///     The <see cref="DbTransaction" /> that was passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" />.
+        ///     The <see cref="DbTransaction" /> that was passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" />.
         ///     This value is typically used as the return value for the implementation of this method.
         /// </param>
         /// <param name="cancellationToken"> The cancellation token. </param>
         /// <returns>
         ///     A <see cref="Task" />  containing the value that will be used as the effective value passed
-        ///     to <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" />
+        ///     to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" />
         ///     A normal implementation of this method for any interceptor that is not attempting to change the result
         ///     is to return the <paramref name="result" /> value passed in, often using <see cref="Task.FromResult{TResult}" />
         /// </returns>

--- a/src/EFCore.Relational/Diagnostics/IDbTransactionInterceptor.cs
+++ b/src/EFCore.Relational/Diagnostics/IDbTransactionInterceptor.cs
@@ -137,17 +137,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         Called immediately after <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" /> is called.
+        ///         Called immediately after <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" /> is called.
         ///     </para>
         /// </summary>
         /// <param name="connection"> The connection. </param>
         /// <param name="eventData"> Contextual information about connection and transaction. </param>
         /// <param name="result">
-        ///     The <see cref="DbTransaction" /> that was passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" />.
+        ///     The <see cref="DbTransaction" /> that was passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" />.
         ///     This value is typically used as the return value for the implementation of this method.
         /// </param>
         /// <returns>
-        ///     The value that will be used as the effective value passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransaction" />
+        ///     The value that will be used as the effective value passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransaction" />
         ///     A normal implementation of this method for any interceptor that is not attempting to change the result
         ///     is to return the <paramref name="result" /> value passed in.
         /// </returns>
@@ -158,19 +158,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         Called immediately after <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" /> is called.
+        ///         Called immediately after <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" /> is called.
         ///     </para>
         /// </summary>
         /// <param name="connection"> The connection. </param>
         /// <param name="eventData"> Contextual information about connection and transaction. </param>
         /// <param name="result">
-        ///     The <see cref="DbTransaction" /> that was passed to <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" />.
+        ///     The <see cref="DbTransaction" /> that was passed to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" />.
         ///     This value is typically used as the return value for the implementation of this method.
         /// </param>
         /// <param name="cancellationToken"> The cancellation token. </param>
         /// <returns>
         ///     A <see cref="Task" />  containing the value that will be used as the effective value passed
-        ///     to <see cref="RelationalDatabaseFacadeExtensions.UseTransactionAsync" />
+        ///     to <see cref="M:RelationalDatabaseFacadeExtensions.UseTransactionAsync" />
         ///     A normal implementation of this method for any interceptor that is not attempting to change the result
         ///     is to return the <paramref name="result" /> value passed in, often using <see cref="Task.FromResult{TResult}" />
         /// </returns>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -144,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -288,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method
@@ -322,7 +322,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         ///     <para>
         ///         Note that this method does not start a transaction. To use this method with
-        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="UseTransaction" />.
+        ///         a transaction, first call <see cref="BeginTransaction" /> or <see cref="M:UseTransaction" />.
         ///     </para>
         ///     <para>
         ///         Note that the current <see cref="ExecutionStrategy" /> is not used by this method

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -507,6 +507,17 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> A <see cref="IDbContextTransaction" /> that encapsulates the given transaction. </returns>
         public static IDbContextTransaction UseTransaction(
             [NotNull] this DatabaseFacade databaseFacade, [CanBeNull] DbTransaction transaction)
+            => databaseFacade.UseTransaction(transaction, Guid.NewGuid());
+
+        /// <summary>
+        ///     Sets the <see cref="DbTransaction" /> to be used by database operations on the <see cref="DbContext" />.
+        /// </summary>
+        /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
+        /// <param name="transaction"> The <see cref="DbTransaction" /> to use. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <returns> A <see cref="IDbContextTransaction" /> that encapsulates the given transaction. </returns>
+        public static IDbContextTransaction UseTransaction(
+            [NotNull] this DatabaseFacade databaseFacade, [CanBeNull] DbTransaction transaction, Guid transactionId)
         {
             var transactionManager = GetTransactionManager(databaseFacade);
 
@@ -515,7 +526,7 @@ namespace Microsoft.EntityFrameworkCore
                 throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
             }
 
-            return relationalTransactionManager.UseTransaction(transaction);
+            return relationalTransactionManager.UseTransaction(transaction, transactionId);
         }
 
         /// <summary>
@@ -529,6 +540,21 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this DatabaseFacade databaseFacade,
             [CanBeNull] DbTransaction transaction,
             CancellationToken cancellationToken = default)
+            => databaseFacade.UseTransactionAsync(transaction, Guid.NewGuid(), cancellationToken);
+
+        /// <summary>
+        ///     Sets the <see cref="DbTransaction" /> to be used by database operations on the <see cref="DbContext" />.
+        /// </summary>
+        /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
+        /// <param name="transaction"> The <see cref="DbTransaction" /> to use. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+        /// <returns> A <see cref="Task" /> containing the <see cref="IDbContextTransaction" /> for the given transaction. </returns>
+        public static Task<IDbContextTransaction> UseTransactionAsync(
+            [NotNull] this DatabaseFacade databaseFacade,
+            [CanBeNull] DbTransaction transaction,
+            Guid transactionId,
+            CancellationToken cancellationToken = default)
         {
             var transactionManager = GetTransactionManager(databaseFacade);
 
@@ -537,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore
                 throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
             }
 
-            return relationalTransactionManager.UseTransactionAsync(transaction, cancellationToken);
+            return relationalTransactionManager.UseTransactionAsync(transaction, transactionId, cancellationToken);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Storage/IRelationalTransactionManager.cs
+++ b/src/EFCore.Relational/Storage/IRelationalTransactionManager.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="transaction"> The transaction to be used. </param>
         /// <param name="transactionId"> The unique identifier for the transaction. </param>
         /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
-        IDbContextTransaction UseTransaction(DbTransaction transaction, Guid transactionId);
+        IDbContextTransaction UseTransaction([CanBeNull] DbTransaction transaction, Guid transactionId);
 
         /// <summary>
         ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.

--- a/src/EFCore.Relational/Storage/IRelationalTransactionManager.cs
+++ b/src/EFCore.Relational/Storage/IRelationalTransactionManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Threading;
@@ -53,10 +54,30 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
         /// </summary>
         /// <param name="transaction"> The transaction to be used. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
+        IDbContextTransaction UseTransaction(DbTransaction transaction, Guid transactionId);
+
+        /// <summary>
+        ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
+        /// </summary>
+        /// <param name="transaction"> The transaction to be used. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
         Task<IDbContextTransaction> UseTransactionAsync(
             [CanBeNull] DbTransaction transaction,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
+        /// </summary>
+        /// <param name="transaction"> The transaction to be used. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
+        Task<IDbContextTransaction> UseTransactionAsync(
+            [CanBeNull] DbTransaction transaction,
+            Guid transactionId,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -385,13 +385,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
         /// </summary>
         /// <param name="transaction"> The transaction to be used. </param>
+        /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
         public virtual IDbContextTransaction UseTransaction(DbTransaction transaction)
+            => UseTransaction(transaction, Guid.NewGuid());
+
+        /// <summary>
+        ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
+        /// </summary>
+        /// <param name="transaction"> The transaction to be used. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
+        public virtual IDbContextTransaction UseTransaction(DbTransaction transaction, Guid transactionId)
         {
             if (ShouldUseTransaction(transaction))
             {
                 Open();
-
-                var transactionId = Guid.NewGuid();
 
                 transaction = Dependencies.TransactionLogger.TransactionUsed(
                     this,
@@ -412,15 +420,26 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="transaction"> The transaction to be used. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
+        public virtual Task<IDbContextTransaction> UseTransactionAsync(
+            DbTransaction transaction,
+            CancellationToken cancellationToken = default)
+            => UseTransactionAsync(transaction, Guid.NewGuid(), cancellationToken);
+
+        /// <summary>
+        ///     Specifies an existing <see cref="DbTransaction" /> to be used for database operations.
+        /// </summary>
+        /// <param name="transaction"> The transaction to be used. </param>
+        /// <param name="transactionId"> The unique identifier for the transaction. </param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
+        /// <returns> An instance of <see cref="IDbTransaction" /> that wraps the provided transaction. </returns>
         public virtual async Task<IDbContextTransaction> UseTransactionAsync(
             DbTransaction transaction,
+            Guid transactionId,
             CancellationToken cancellationToken = default)
         {
             if (ShouldUseTransaction(transaction))
             {
                 await OpenAsync(cancellationToken);
-
-                var transactionId = Guid.NewGuid();
 
                 transaction = await Dependencies.TransactionLogger.TransactionUsedAsync(
                     this,

--- a/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalConnectionTest.cs
@@ -735,6 +735,28 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Null(connection.CurrentTransaction);
         }
 
+        [ConditionalFact]
+        public void Can_use_existing_transaction_identifier()
+        {
+            var dbConnection = new FakeDbConnection("Database=FrodoLives");
+
+            var dbTransaction = dbConnection.BeginTransaction(IsolationLevel.Unspecified);
+
+            using var connection = new FakeRelationalConnection(
+                CreateOptions(new FakeRelationalOptionsExtension().WithConnection(dbConnection)));
+            Assert.Null(connection.CurrentTransaction);
+
+            var transactionId = Guid.NewGuid();
+
+            using (var transaction = connection.UseTransaction(dbTransaction, transactionId))
+            {
+                Assert.Equal(dbTransaction, connection.CurrentTransaction.GetDbTransaction());
+                Assert.Equal(transactionId, transaction.TransactionId);
+            }
+
+            Assert.Null(connection.CurrentTransaction);
+        }
+
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -172,8 +172,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public IDbContextTransaction UseTransaction(DbTransaction transaction) => throw new NotImplementedException();
 
+            public IDbContextTransaction UseTransaction(DbTransaction transaction, Guid transactionId) =>
+                throw new NotImplementedException();
+
             public Task<IDbContextTransaction> UseTransactionAsync(
                 DbTransaction transaction, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public Task<IDbContextTransaction> UseTransactionAsync(
+                DbTransaction transaction, Guid transactionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
             public ValueTask DisposeAsync() => throw new NotImplementedException();
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -378,8 +378,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public IDbContextTransaction UseTransaction(DbTransaction transaction) => throw new NotImplementedException();
 
+            public IDbContextTransaction UseTransaction(DbTransaction transaction, Guid transactionId) =>
+                throw new NotImplementedException();
+
             public Task<IDbContextTransaction> UseTransactionAsync(
                 DbTransaction transaction, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public Task<IDbContextTransaction> UseTransactionAsync(
+                DbTransaction transaction, Guid transactionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
             public void Dispose()
             {


### PR DESCRIPTION
Add overload that takes a GUID to use for the transaction ID.

Fixes: #20828 

Please review
Thank you in advance 