### PR TITLE
Query: Consistency issues

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -565,6 +565,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="sql"> A custom SQL for the table source. </param>
         /// <param name="sqlArguments"> An expression representing parameters passed to the custom SQL. </param>
         /// <returns> An expression representing a SELECT in a SQL tree. </returns>
+        [Obsolete("Use overload which takes TableExpressionBase by passing FromSqlExpression directly.")]
         SelectExpression Select([NotNull] IEntityType entityType, [NotNull] string sql, [NotNull] Expression sqlArguments);
     }
 }

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -449,7 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 _relationalCommandBuilder.Append(")");
             }
 
-            _relationalCommandBuilder.Append(GenerateOperator(sqlBinaryExpression));
+            _relationalCommandBuilder.Append(GetOperator(sqlBinaryExpression));
 
             requiresBrackets = RequiresBrackets(sqlBinaryExpression.Right);
 
@@ -730,7 +730,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="binaryExpression"> A SQL binary operation. </param>
         /// <returns> A string representation of the binary operator. </returns>
+        [Obsolete("Use GetOperator instead.")]
         protected virtual string GenerateOperator([NotNull] SqlBinaryExpression binaryExpression)
+        {
+            Check.NotNull(binaryExpression, nameof(binaryExpression));
+
+            return _operatorMap[binaryExpression.OperatorType];
+        }
+
+        /// <summary>
+        ///     Gets a SQL operator for a SQL binary operation.
+        /// </summary>
+        /// <param name="binaryExpression"> A SQL binary operation. </param>
+        /// <returns> A string representation of the binary operator. </returns>
+        protected virtual string GetOperator([NotNull] SqlBinaryExpression binaryExpression)
         {
             Check.NotNull(binaryExpression, nameof(binaryExpression));
 

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -87,8 +87,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                         fromSqlQueryRootExpression.EntityType,
                         _sqlExpressionFactory.Select(
                             fromSqlQueryRootExpression.EntityType,
-                            fromSqlQueryRootExpression.Sql,
-                            fromSqlQueryRootExpression.Argument));
+                            new FromSqlExpression(
+                                (fromSqlQueryRootExpression.EntityType.GetViewOrTableMappings().SingleOrDefault()?.Table.Name
+                                ?? fromSqlQueryRootExpression.EntityType.ShortName()).Substring(0, 1).ToLower(),
+                                fromSqlQueryRootExpression.Sql,
+                                fromSqlQueryRootExpression.Argument)));
 
                 case TableValuedFunctionQueryRootExpression tableValuedFunctionQueryRootExpression:
                     var function = tableValuedFunctionQueryRootExpression.Function;

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -37,26 +37,22 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <inheritdoc />
         public virtual SqlExpression ApplyDefaultTypeMapping(SqlExpression sqlExpression)
         {
-            if (sqlExpression == null
-                || sqlExpression.TypeMapping != null)
-            {
-                return sqlExpression;
-            }
-
-            if (sqlExpression is SqlUnaryExpression sqlUnaryExpression
-                && sqlUnaryExpression.OperatorType == ExpressionType.Convert
-                && sqlUnaryExpression.Type == typeof(object))
-            {
-                return sqlUnaryExpression.Operand;
-            }
-
-            return ApplyTypeMapping(sqlExpression, _typeMappingSource.FindMapping(sqlExpression.Type));
+            return sqlExpression == null
+                || sqlExpression.TypeMapping != null
+                ? sqlExpression
+                : sqlExpression is SqlUnaryExpression sqlUnaryExpression
+                    && sqlUnaryExpression.OperatorType == ExpressionType.Convert
+                    && sqlUnaryExpression.Type == typeof(object)
+                    ? sqlUnaryExpression.Operand
+                    : ApplyTypeMapping(sqlExpression, _typeMappingSource.FindMapping(sqlExpression.Type));
         }
 
         /// <inheritdoc />
         public virtual SqlExpression ApplyTypeMapping(SqlExpression sqlExpression, RelationalTypeMapping typeMapping)
         {
+#pragma warning disable IDE0046 // Convert to conditional expression
             if (sqlExpression == null
+#pragma warning restore IDE0046 // Convert to conditional expression
                 || sqlExpression.TypeMapping != null)
             {
                 return sqlExpression;
@@ -404,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 typeMappedArguments,
                 nullable: true,
                 // COALESCE is handled separately since it's only nullable if *both* arguments are null
-                argumentsPropagateNullability: new[] { false, false},
+                argumentsPropagateNullability: new[] { false, false },
                 resultType,
                 inferredTypeMapping);
         }
@@ -762,14 +758,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
+        [Obsolete("Use overload which takes TableExpressionBase by passing FromSqlExpression directly.")]
         public virtual SelectExpression Select(IEntityType entityType, string sql, Expression sqlArguments)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(sql, nameof(sql));
 
-            var tableExpression = new FromSqlExpression(sql, sqlArguments,
-                (entityType.GetViewOrTableMappings().SingleOrDefault()?.Table.Name
-                ?? entityType.ShortName()).Substring(0, 1).ToLower());
+            var tableExpression = new FromSqlExpression(
+                (entityType.GetViewOrTableMappings().SingleOrDefault()?.Table.Name ?? entityType.ShortName()).Substring(0, 1).ToLower(),
+                sql, sqlArguments);
             var selectExpression = new SelectExpression(entityType, tableExpression);
             AddConditions(selectExpression, entityType);
 

--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -17,10 +17,31 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    // Class is sealed because there are no public/protected constructors. Can be unsealed if this is changed.
-    public sealed class FromSqlExpression : TableExpressionBase
+    public class FromSqlExpression : TableExpressionBase
     {
-        internal FromSqlExpression([NotNull] string sql, [NotNull] Expression arguments, [NotNull] string alias)
+        /// <summary>
+        ///     Creates a new instance of the <see cref="FromSqlExpression" /> class.
+        /// </summary>
+        /// <param name="sql"> A user-provided custom SQL for the table source. </param>
+        /// <param name="arguments"> A user-provided parameters to pass to the custom SQL. </param>
+        /// <param name="alias"> A string alias for the table source. </param>
+        [Obsolete("Use the constructor which takes alias as first argument.")]
+        public FromSqlExpression([NotNull] string sql, [NotNull] Expression arguments, [NotNull] string alias)
+            : base(alias)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(arguments, nameof(arguments));
+
+            Sql = sql;
+            Arguments = arguments;
+        }
+        /// <summary>
+        ///     Creates a new instance of the <see cref="FromSqlExpression" /> class.
+        /// </summary>
+        /// <param name="alias"> A string alias for the table source. </param>
+        /// <param name="sql"> A user-provided custom SQL for the table source. </param>
+        /// <param name="arguments"> A user-provided parameters to pass to the custom SQL. </param>
+        public FromSqlExpression([NotNull] string alias, [NotNull] string sql, [NotNull] Expression arguments)
             : base(alias)
         {
             Check.NotEmpty(sql, nameof(sql));
@@ -33,11 +54,11 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// <summary>
         ///     The user-provided custom SQL for the table source.
         /// </summary>
-        public string Sql { get; }
+        public virtual string Sql { get; }
         /// <summary>
         ///     The user-provided parameters passed to the custom SQL.
         /// </summary>
-        public Expression Arguments { get; }
+        public virtual Expression Arguments { get; }
 
         /// <summary>
         ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
@@ -45,12 +66,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// </summary>
         /// <param name="arguments"> The <see cref="Arguments"/> property of the result. </param>
         /// <returns> This expression if no children changed, or an expression with the updated children. </returns>
-        public FromSqlExpression Update([NotNull] Expression arguments)
+        public virtual FromSqlExpression Update([NotNull] Expression arguments)
         {
             Check.NotNull(arguments, nameof(arguments));
 
             return arguments != Arguments
-                ? new FromSqlExpression(Sql, arguments, Alias)
+                ? new FromSqlExpression(Alias, Sql, arguments)
                 : this;
         }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
@@ -19,9 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    /// <summary>
-    ///     Represents a SQL Table Valued Fuction in the sql generation tree.
-    /// </summary>
     public class TableValuedFunctionExpression : TableExpressionBase
     {
         /// <summary>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQuerySqlGenerator.cs
@@ -34,14 +34,14 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override string GenerateOperator(SqlBinaryExpression binaryExpression)
+        protected override string GetOperator(SqlBinaryExpression binaryExpression)
         {
             Check.NotNull(binaryExpression, nameof(binaryExpression));
 
             return binaryExpression.OperatorType == ExpressionType.Add
                 && binaryExpression.Type == typeof(string)
                     ? " || "
-                    : base.GenerateOperator(binaryExpression);
+                    : base.GetOperator(binaryExpression);
         }
 
         /// <summary>


### PR DESCRIPTION
- Table sources which takes alias should have alias as first argument.
- Single API to create select expression for all custom query roots-> custom table sources
- QuerySqlGenerator.Generate* methods are void and appends to command builder directly.
