### PR TITLE
Query: MakeUnary/Binary should return null if invalid operator type

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -224,9 +224,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual SqlBinaryExpression MakeBinary(
             ExpressionType operatorType, SqlExpression left, SqlExpression right, RelationalTypeMapping typeMapping)
         {
-            Check.NotNull(operatorType, nameof(operatorType));
             Check.NotNull(left, nameof(left));
             Check.NotNull(right, nameof(right));
+
+            if (!SqlBinaryExpression.IsValidOperator(operatorType))
+            {
+                return null;
+            }
 
             var returnType = left.Type;
             switch (operatorType)
@@ -416,6 +420,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(operatorType, nameof(operand));
             Check.NotNull(operand, nameof(operand));
             Check.NotNull(type, nameof(type));
+
+            if (!SqlUnaryExpression.IsValidOperator(operatorType))
+            {
+                return null;
+            }
 
             return (SqlUnaryExpression)ApplyTypeMapping(new SqlUnaryExpression(operatorType, operand, type, null), typeMapping);
         }

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
@@ -46,10 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             //ExpressionType.LeftShift,
         };
 
-        private static ExpressionType VerifyOperator(ExpressionType operatorType)
-            => _allowedOperators.Contains(operatorType)
-                ? operatorType
-                : throw new InvalidOperationException(CoreStrings.UnsupportedBinaryOperator);
+        internal static bool IsValidOperator(ExpressionType operatorType)
+            => _allowedOperators.Contains(operatorType);
 
         /// <summary>
         ///     Creates a new instance of the <see cref="SqlBinaryExpression" /> class.
@@ -70,8 +68,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(left, nameof(left));
             Check.NotNull(right, nameof(right));
 
-            OperatorType = VerifyOperator(operatorType);
+            if (!IsValidOperator(operatorType))
+            {
+                throw new InvalidOperationException(CoreStrings.UnsupportedBinaryOperator);
+            }
 
+            OperatorType = operatorType;
             Left = left;
             Right = right;
         }

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
@@ -31,10 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             ExpressionType.Negate
         };
 
-        private static ExpressionType VerifyOperator(ExpressionType operatorType)
-            => _allowedOperators.Contains(operatorType)
-                ? operatorType
-                : throw new InvalidOperationException(CoreStrings.UnsupportedUnary);
+        internal static bool IsValidOperator(ExpressionType operatorType)
+            => _allowedOperators.Contains(operatorType);
 
         /// <summary>
         ///     Creates a new instance of the <see cref="SqlUnaryExpression" /> class.
@@ -53,7 +51,12 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             Check.NotNull(operand, nameof(operand));
             Check.NotNull(type, nameof(type));
 
-            OperatorType = VerifyOperator(operatorType);
+            if (!IsValidOperator(operatorType))
+            {
+                throw new InvalidOperationException(CoreStrings.UnsupportedUnary);
+            }
+
+            OperatorType = operatorType;
             Operand = operand;
         }
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 15);
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory (Skip = "Issue#19247")]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Projection_when_arithmetic_mixed_subqueries(bool async)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -320,6 +323,14 @@ WHERE (((((((((((((([c].[CustomerID] = @__s1) OR ([c].[CustomerID] = @__s2)) OR 
 SELECT COUNT(*)
 FROM [Customers] AS [c]
 WHERE ((((((((((((([c].[CustomerID] = @__s1) OR ([c].[CustomerID] = @__s2)) OR ([c].[CustomerID] = @__s3)) OR ([c].[CustomerID] = @__s4)) OR ([c].[CustomerID] = @__s5)) OR ([c].[CustomerID] = @__s6)) OR ([c].[CustomerID] = @__s7)) OR ([c].[CustomerID] = @__s8)) OR ([c].[CustomerID] = @__s9)) OR ([c].[CustomerID] = @__s10)) OR ([c].[CustomerID] = @__s11)) OR ([c].[CustomerID] = @__s12)) OR ([c].[CustomerID] = @__s13)) OR ([c].[CustomerID] = @__s14)");
+        }
+
+        public override void MakeBinary_does_not_throw_for_unsupported_operator()
+        {
+            Assert.Equal(
+                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -10,6 +13,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         public NorthwindCompiledQuerySqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture)
             : base(fixture)
         {
+        }
+
+        public override void MakeBinary_does_not_throw_for_unsupported_operator()
+        {
+            Assert.Equal(
+                CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
+                Assert.Throws<InvalidOperationException>(
+                    () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
         }
     }
 }


### PR DESCRIPTION
Resolves #20622
