### PR TITLE
Query: Improve extensibility of null semantics processor

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -557,12 +557,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("ClientGroupByNotSupported");
 
         /// <summary>
-        ///     Unexpected join predicate shape: {predicate}.
+        ///     Unknown expression '{expression}' of type - '{expressionType}' encountered in '{visitor}'.
         /// </summary>
-        public static string UnexpectedJoinPredicateShape([CanBeNull] object predicate)
+        public static string UnknownExpressionType([CanBeNull] object expression, [CanBeNull] object expressionType, [CanBeNull] object visitor)
             => string.Format(
-                GetString("UnexpectedJoinPredicateShape", nameof(predicate)),
-                predicate);
+                GetString("UnknownExpressionType", nameof(expression), nameof(expressionType), nameof(visitor)),
+                expression, expressionType, visitor);
 
         /// <summary>
         ///     The subquery '{subquery}' references type '{type}' for which no type mapping could be found.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -488,8 +488,8 @@
   <data name="ClientGroupByNotSupported" xml:space="preserve">
     <value>Client side GroupBy is not supported.</value>
   </data>
-  <data name="UnexpectedJoinPredicateShape" xml:space="preserve">
-    <value>Unexpected join predicate shape: {predicate}.</value>
+  <data name="UnknownExpressionType" xml:space="preserve">
+    <value>Unknown expression '{expression}' of type - '{expressionType}' encountered in '{visitor}'.</value>
   </data>
   <data name="NoTypeMappingFoundForSubquery" xml:space="preserve">
     <value>The subquery '{subquery}' references type '{type}' for which no type mapping could be found.</value>

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -67,8 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 try
                 {
-                    var (selectExpression, canCache) =
-                        _relationalParameterBasedQueryTranslationPostprocessor.Optimize(_selectExpression, parameters);
+                    var selectExpression = _relationalParameterBasedQueryTranslationPostprocessor.Optimize(
+                        _selectExpression, parameters, out var canCache);
                     relationalCommand = _querySqlGeneratorFactory.Create().GetCommand(selectExpression);
 
                     if (canCache)

--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -14,93 +14,426 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-    // Whole API surface is going to change. See issue#20204
-    public class NullabilityBasedSqlProcessingExpressionVisitor : SqlExpressionVisitor
+    /// <summary>
+    ///     <para>
+    ///         A class that processes a SQL tree based on nullability of nodes to apply null semantics in use and
+    ///         optimize it based on parameter values.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class SqlNullabilityProcessor
     {
-        protected virtual bool UseRelationalNulls { get; }
-        protected virtual ISqlExpressionFactory SqlExpressionFactory { get; }
-        protected virtual IReadOnlyDictionary<string, object> ParameterValues { get; }
-        protected virtual List<ColumnExpression> NonNullableColumns { get; } = new List<ColumnExpression>();
+        private readonly List<ColumnExpression> _nonNullableColumns;
+        private bool _canCache;
 
-        protected virtual bool CanCache { get; set; }
-
-        private bool _nullable;
-        private bool _allowOptimizedExpansion;
-
-        public NullabilityBasedSqlProcessingExpressionVisitor(
+        /// <summary>
+        ///     Creates a new instance of the <see cref="SqlNullabilityProcessor" /> class.
+        /// </summary>
+        /// <param name="sqlExpressionFactory"> A SQL expression factory to use. </param>
+        /// <param name="parameterValues"> A dictionary of parameter values in use. </param>
+        /// <param name="useRelationalNulls"> A bool value indicating whether relational null semantics are in use. </param>
+        public SqlNullabilityProcessor(
             [NotNull] ISqlExpressionFactory sqlExpressionFactory,
             [NotNull] IReadOnlyDictionary<string, object> parameterValues,
             bool useRelationalNulls)
         {
+            Check.NotNull(sqlExpressionFactory, nameof(sqlExpressionFactory));
+            Check.NotNull(parameterValues, nameof(parameterValues));
+
             SqlExpressionFactory = sqlExpressionFactory;
             ParameterValues = parameterValues;
             UseRelationalNulls = useRelationalNulls;
-            CanCache = true;
-
-            _allowOptimizedExpansion = false;
-        }
-
-        private void RestoreNonNullableColumnsList(int counter)
-        {
-            if (counter < NonNullableColumns.Count)
-            {
-                NonNullableColumns.RemoveRange(counter, NonNullableColumns.Count - counter);
-            }
-        }
-
-        public virtual (SelectExpression selectExpression, bool canCache) Process([NotNull] SelectExpression selectExpression)
-        {
-            Check.NotNull(selectExpression, nameof(selectExpression));
-
-            return (selectExpression: VisitInternal<SelectExpression>(selectExpression).ResultExpression, canCache: CanCache);
+            _canCache = true;
+            _nonNullableColumns = new List<ColumnExpression>();
         }
 
         /// <summary>
-        ///     Method that handles visitation of SqlExpression nodes. All provider specific nodes should be handled by this method in the provider specific implementation of <see cref="NullabilityBasedSqlProcessingExpressionVisitor"/>.
-        ///     Depending on the settings, the method sets up state for the actual visitation, cleans up after the visitation is complete
-        ///     and returns resulting expression along with it's nullability.
+        ///     A bool value indicating whether relational null semantics are in use.
         /// </summary>
-        /// <typeparam name="TResult">Type of the resulting expression. </typeparam>
-        /// <param name="expression">Expression that is to be visited. </param>
-        /// <param name="allowOptimizedExpansion">True if null semantics inside the expression can be expanded in the optimized way (i.e. 'null' and 'false' are interchangable), false otherwise. </param>
-        /// <param name="restoreNonNullableColumnInformation">True if method should reset the number of non-nullable columns after the visitation is complete, false otherwise. </param>
-        /// <returns> Tuple representing visited expression and it's nullability. </returns>
-        protected virtual (TResult ResultExpression, bool Nullable) VisitInternal<TResult>(
-            [CanBeNull] Expression expression,
-            bool allowOptimizedExpansion = false,
-            bool restoreNonNullableColumnInformation = true)
-            where TResult : Expression
+        protected virtual bool UseRelationalNulls { get; }
+        /// <summary>
+        ///     The SQL expression factory to use for creating SQL expressions.
+        /// </summary>
+        protected virtual ISqlExpressionFactory SqlExpressionFactory { get; }
+        /// <summary>
+        ///     Dictionary of current parameter values in use.
+        /// </summary>
+        protected virtual IReadOnlyDictionary<string, object> ParameterValues { get; }
+
+        /// <summary>
+        ///     Processes a <see cref="SelectExpression"/> to apply null semantics and optimize it.
+        /// </summary>
+        /// <param name="selectExpression"> A select expression to process. </param>
+        /// <param name="canCache"> A bool value indicating whether the select expression can be cached. </param>
+        /// <returns> An optimized select expression. </returns>
+        public virtual SelectExpression Process([NotNull] SelectExpression selectExpression, out bool canCache)
         {
-            if (expression == null)
-            {
-                return (null, false);
-            }
+            Check.NotNull(selectExpression, nameof(selectExpression));
 
-            _nullable = false;
-            var currentNonNullableColumnsCount = NonNullableColumns.Count;
-            var previousAllowOptimizedExpansion = _allowOptimizedExpansion;
-            _allowOptimizedExpansion = allowOptimizedExpansion;
-            var resultExpression = (TResult)Visit(expression);
-            _allowOptimizedExpansion = previousAllowOptimizedExpansion;
-            if (restoreNonNullableColumnInformation)
-            {
-                RestoreNonNullableColumnsList(currentNonNullableColumnsCount);
-            }
+            var result = Visit(selectExpression);
+            canCache = _canCache;
 
-            return (resultExpression, _nullable);
+            return result;
         }
 
-        protected override Expression VisitCase(CaseExpression caseExpression)
+        /// <summary>
+        ///     Marks the select expression being processed as cannot be cached.
+        /// </summary>
+        protected virtual void DoNotCache() => _canCache = false;
+
+        /// <summary>
+        ///     Adds a column to non nullable columns list to further optimizations can take the column as non-nullable.
+        /// </summary>
+        /// <param name="columnExpression"> A column expression to add. </param>
+        protected virtual void AddNonNullableColumn([NotNull] ColumnExpression columnExpression)
+            => _nonNullableColumns.Add(Check.NotNull(columnExpression, nameof(columnExpression)));
+
+        /// <summary>
+        ///     Visits a <see cref="TableExpressionBase"/>.
+        /// </summary>
+        /// <param name="tableExpressionBase"> A table expression base to visit. </param>
+        /// <returns> An optimized table expression base. </returns>
+        protected virtual TableExpressionBase Visit([NotNull] TableExpressionBase tableExpressionBase)
+        {
+            Check.NotNull(tableExpressionBase, nameof(tableExpressionBase));
+
+            switch (tableExpressionBase)
+            {
+                case CrossApplyExpression crossApplyExpression:
+                    return crossApplyExpression.Update(Visit(crossApplyExpression.Table));
+
+                case CrossJoinExpression crossJoinExpression:
+                    return crossJoinExpression.Update(Visit(crossJoinExpression.Table));
+
+                case ExceptExpression exceptExpression:
+                {
+                    var source1 = Visit(exceptExpression.Source1);
+                    var source2 = Visit(exceptExpression.Source2);
+
+                    return exceptExpression.Update(source1, source2);
+                }
+
+                case FromSqlExpression fromSqlExpression:
+                    return fromSqlExpression;
+
+                case InnerJoinExpression innerJoinExpression:
+                {
+                    var newTable = Visit(innerJoinExpression.Table);
+                    var newJoinPredicate = ProcessJoinPredicate(innerJoinExpression.JoinPredicate);
+
+                    return TryGetBoolConstantValue(newJoinPredicate) == true
+                        ? (TableExpressionBase)new CrossJoinExpression(newTable)
+                        : innerJoinExpression.Update(newTable, newJoinPredicate);
+                }
+
+                case IntersectExpression intersectExpression:
+                {
+                    var source1 = Visit(intersectExpression.Source1);
+                    var source2 = Visit(intersectExpression.Source2);
+
+                    return intersectExpression.Update(source1, source2);
+                }
+
+                case LeftJoinExpression leftJoinExpression:
+                {
+                    var newTable = Visit(leftJoinExpression.Table);
+                    var newJoinPredicate = ProcessJoinPredicate(leftJoinExpression.JoinPredicate);
+
+                    return leftJoinExpression.Update(newTable, newJoinPredicate);
+                }
+
+                case OuterApplyExpression outerApplyExpression:
+                    return outerApplyExpression.Update(Visit(outerApplyExpression.Table));
+
+                case SelectExpression selectExpression:
+                    return Visit(selectExpression);
+
+                case TableValuedFunctionExpression tableValuedFunctionExpression:
+                    // See issue#20180
+                    return tableValuedFunctionExpression;
+
+                case TableExpression tableExpression:
+                    return tableExpression;
+
+                case UnionExpression unionExpression:
+                {
+                    var source1 = Visit(unionExpression.Source1);
+                    var source2 = Visit(unionExpression.Source2);
+
+                    return unionExpression.Update(source1, source2);
+                }
+
+                default:
+                    throw new InvalidOperationException(
+                        RelationalStrings.UnknownExpressionType(tableExpressionBase, tableExpressionBase.GetType(), nameof(SqlNullabilityProcessor)));
+            }
+        }
+
+        /// <summary>
+        ///     Visits a <see cref="SelectExpression"/>.
+        /// </summary>
+        /// <param name="selectExpression"> A select expression to visit. </param>
+        /// <returns> An optimized select expression. </returns>
+        protected virtual SelectExpression Visit([NotNull] SelectExpression selectExpression)
+        {
+            Check.NotNull(selectExpression, nameof(selectExpression));
+
+            var changed = false;
+            var projections = (List<ProjectionExpression>)selectExpression.Projection;
+            for (var i = 0; i < selectExpression.Projection.Count; i++)
+            {
+                var item = selectExpression.Projection[i];
+                var projection = item.Update(Visit(item.Expression, out _));
+                if (projection != item
+                    && projections == selectExpression.Projection)
+                {
+                    projections = new List<ProjectionExpression>();
+                    for (var j = 0; j < i; j++)
+                    {
+                        projections.Add(selectExpression.Projection[j]);
+                    }
+
+                    changed = true;
+                }
+
+                if (projections != selectExpression.Projection)
+                {
+                    projections.Add(projection);
+                }
+            }
+
+            var tables = (List<TableExpressionBase>)selectExpression.Tables;
+            for (var i = 0; i < selectExpression.Tables.Count; i++)
+            {
+                var item = selectExpression.Tables[i];
+                var table = Visit(item);
+                if (table != item
+                    && tables == selectExpression.Tables)
+                {
+                    tables = new List<TableExpressionBase>();
+                    for (var j = 0; j < i; j++)
+                    {
+                        tables.Add(selectExpression.Tables[j]);
+                    }
+
+                    changed = true;
+                }
+
+                if (tables != selectExpression.Tables)
+                {
+                    tables.Add(table);
+                }
+            }
+
+            var predicate = Visit(selectExpression.Predicate, allowOptimizedExpansion: true, out _);
+            changed |= predicate != selectExpression.Predicate;
+
+            if (TryGetBoolConstantValue(predicate) == true)
+            {
+                predicate = null;
+                changed = true;
+            }
+
+            var groupBy = (List<SqlExpression>)selectExpression.GroupBy;
+            for (var i = 0; i < selectExpression.GroupBy.Count; i++)
+            {
+                var item = selectExpression.GroupBy[i];
+                var groupingKey = Visit(item, out _);
+                if (groupingKey != item
+                    && groupBy == selectExpression.GroupBy)
+                {
+                    groupBy = new List<SqlExpression>();
+                    for (var j = 0; j < i; j++)
+                    {
+                        groupBy.Add(selectExpression.GroupBy[j]);
+                    }
+
+                    changed = true;
+                }
+
+                if (groupBy != selectExpression.GroupBy)
+                {
+                    groupBy.Add(groupingKey);
+                }
+            }
+
+            var having = Visit(selectExpression.Having, allowOptimizedExpansion: true, out _);
+            changed |= having != selectExpression.Having;
+
+            if (TryGetBoolConstantValue(having) == true)
+            {
+                having = null;
+                changed = true;
+            }
+
+            var orderings = (List<OrderingExpression>)selectExpression.Orderings;
+            for (var i = 0; i < selectExpression.Orderings.Count; i++)
+            {
+                var item = selectExpression.Orderings[i];
+                var ordering = item.Update(Visit(item.Expression, out _));
+                if (ordering != item
+                    && orderings == selectExpression.Orderings)
+                {
+                    orderings = new List<OrderingExpression>();
+                    for (var j = 0; j < i; j++)
+                    {
+                        orderings.Add(selectExpression.Orderings[j]);
+                    }
+
+                    changed = true;
+                }
+
+                if (orderings != selectExpression.Orderings)
+                {
+                    orderings.Add(ordering);
+                }
+            }
+
+            var offset = Visit(selectExpression.Offset, out _);
+            changed |= offset != selectExpression.Offset;
+
+            var limit = Visit(selectExpression.Limit, out _);
+            changed |= limit != selectExpression.Limit;
+
+            return changed
+                ? selectExpression.Update(
+                    projections, tables, predicate, groupBy, having, orderings, limit, offset)
+                : selectExpression;
+        }
+
+        /// <summary>
+        ///     Visits a <see cref="SqlExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlExpression"> A sql expression to visit. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression Visit([CanBeNull] SqlExpression sqlExpression, out bool nullable)
+            => Visit(sqlExpression, allowOptimizedExpansion: false, out nullable);
+
+        /// <summary>
+        ///     Visits a <see cref="SqlExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlExpression"> A sql expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression Visit([CanBeNull] SqlExpression sqlExpression, bool allowOptimizedExpansion, out bool nullable)
+            => Visit(sqlExpression, allowOptimizedExpansion, preserveNonNullableColumns: false, out nullable);
+
+        private SqlExpression Visit(
+            [CanBeNull] SqlExpression sqlExpression, bool allowOptimizedExpansion, bool preserveNonNullableColumns, out bool nullable)
+        {
+            if (sqlExpression == null)
+            {
+                nullable = false;
+                return sqlExpression;
+            }
+
+            var nonNullableColumnsCount = _nonNullableColumns.Count;
+            SqlExpression result;
+            switch (sqlExpression)
+            {
+                case CaseExpression caseExpression:
+                    result = VisitCase(caseExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case CollateExpression collateExpression:
+                    result = VisitCollate(collateExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case ColumnExpression columnExpression:
+                    result = VisitColumn(columnExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case ExistsExpression existsExpression:
+                    result = VisitExists(existsExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case InExpression inExpression:
+                    result = VisitIn(inExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case LikeExpression likeExpression:
+                    result = VisitLike(likeExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case RowNumberExpression rowNumberExpression:
+                    result = VisitRowNumber(rowNumberExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case ScalarSubqueryExpression scalarSubqueryExpression:
+                    result = VisitScalarSubquery(scalarSubqueryExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlBinaryExpression sqlBinaryExpression:
+                    result = VisitSqlBinary(sqlBinaryExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlConstantExpression sqlConstantExpression:
+                    result = VisitSqlConstant(sqlConstantExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlFragmentExpression sqlFragmentExpression:
+                    result = VisitSqlFragment(sqlFragmentExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlFunctionExpression sqlFunctionExpression:
+                    result = VisitSqlFunction(sqlFunctionExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlParameterExpression sqlParameterExpression:
+                    result = VisitSqlParameter(sqlParameterExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                case SqlUnaryExpression sqlUnaryExpression:
+                    result = VisitSqlUnary(sqlUnaryExpression, allowOptimizedExpansion, out nullable);
+                    break;
+
+                default:
+                    result = VisitCustomSqlExpression(sqlExpression, allowOptimizedExpansion, out nullable);
+                    break;
+            }
+
+            if (!preserveNonNullableColumns)
+            {
+                RestoreNonNullableColumnsList(nonNullableColumnsCount);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Visits a custom <see cref="SqlExpression"/> added by providers and computes its nullability.
+        /// </summary>
+        /// <param name="sqlExpression"> A sql expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitCustomSqlExpression(
+            [NotNull] SqlExpression sqlExpression, bool allowOptimizedExpansion, out bool nullable)
+            => throw new InvalidOperationException(
+                RelationalStrings.UnknownExpressionType(sqlExpression, sqlExpression.GetType(), nameof(SqlNullabilityProcessor)));
+
+        /// <summary>
+        ///     Visits a <see cref="CaseExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="caseExpression"> A case expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitCase([NotNull] CaseExpression caseExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(caseExpression, nameof(caseExpression));
 
             // if there is no 'else' there is a possibility of null, when none of the conditions are met
             // otherwise the result is nullable if any of the WhenClause results OR ElseResult is nullable
-            var nullable = caseExpression.ElseResult == null;
-            var currentNonNullableColumnsCount = NonNullableColumns.Count;
+            nullable = caseExpression.ElseResult == null;
+            var currentNonNullableColumnsCount = _nonNullableColumns.Count;
 
-            var operand = VisitInternal<SqlExpression>(caseExpression.Operand).ResultExpression;
+            var operand = Visit(caseExpression.Operand, out _);
             var whenClauses = new List<CaseWhenClause>();
             var testIsCondition = caseExpression.Operand == null;
 
@@ -108,10 +441,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             foreach (var whenClause in caseExpression.WhenClauses)
             {
                 // we can use non-nullable column information we got from visiting Test, in the Result
-                var test = VisitInternal<SqlExpression>(whenClause.Test, allowOptimizedExpansion: testIsCondition, restoreNonNullableColumnInformation: false).ResultExpression;
+                var test = Visit(whenClause.Test, allowOptimizedExpansion: testIsCondition, preserveNonNullableColumns: true, out _);
 
-                if (test is SqlConstantExpression testConstant
-                    && testConstant.Value is bool testConstantBool)
+                if (TryGetBoolConstantValue(test) is bool testConstantBool)
                 {
                     if (testConstantBool)
                     {
@@ -126,7 +458,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }
                 }
 
-                var (newResult, resultNullable) = VisitInternal<SqlExpression>(whenClause.Result);
+                var newResult = Visit(whenClause.Result, out var resultNullable);
 
                 nullable |= resultNullable;
                 whenClauses.Add(new CaseWhenClause(test, newResult));
@@ -142,9 +474,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             SqlExpression elseResult = null;
             if (!testEvaluatesToTrue)
             {
-                bool elseResultNullable;
-                (elseResult, elseResultNullable) = VisitInternal<SqlExpression>(caseExpression.ElseResult);
-                _nullable = nullable || elseResultNullable;
+                elseResult = Visit(caseExpression.ElseResult, out var elseResultNullable);
+                nullable |= elseResultNullable;
             }
 
             // if there are no whenClauses left (e.g. their tests evaluated to false):
@@ -158,91 +489,85 @@ namespace Microsoft.EntityFrameworkCore.Query
             // if there is only one When clause and it's test evaluates to 'true' AND there is no else block, simply return the result
             return elseResult == null
                 && whenClauses.Count == 1
-                && whenClauses[0].Test is SqlConstantExpression singleTestConstant
-                && singleTestConstant.Value is bool boolConstant
-                && boolConstant
+                && TryGetBoolConstantValue(whenClauses[0].Test) == true
                 ? whenClauses[0].Result
                 : caseExpression.Update(operand, whenClauses, elseResult);
         }
 
-        protected override Expression VisitCollate(CollateExpression collateExpresion)
+        /// <summary>
+        ///     Visits a <see cref="CollateExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="collateExpression"> A collate expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitCollate(
+            [NotNull] CollateExpression collateExpression, bool allowOptimizedExpansion, out bool nullable)
         {
-            Check.NotNull(collateExpresion, nameof(collateExpresion));
+            Check.NotNull(collateExpression, nameof(collateExpression));
 
-            return collateExpresion.Update(
-                VisitInternal<SqlExpression>(collateExpresion.Operand).ResultExpression);
+            return collateExpression.Update(Visit(collateExpression.Operand, out nullable));
         }
 
-        protected override Expression VisitColumn(ColumnExpression columnExpression)
+        /// <summary>
+        ///     Visits a <see cref="ColumnExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="columnExpression"> A column expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitColumn(
+            [NotNull] ColumnExpression columnExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(columnExpression, nameof(columnExpression));
 
-            _nullable = columnExpression.IsNullable && !NonNullableColumns.Contains(columnExpression);
+            nullable = columnExpression.IsNullable && !_nonNullableColumns.Contains(columnExpression);
 
             return columnExpression;
         }
 
-        protected override Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
-        {
-            Check.NotNull(crossApplyExpression, nameof(crossApplyExpression));
-
-            return crossApplyExpression.Update(
-                VisitInternal<TableExpressionBase>(crossApplyExpression.Table).ResultExpression);
-        }
-
-        protected override Expression VisitCrossJoin(CrossJoinExpression crossJoinExpression)
-        {
-            Check.NotNull(crossJoinExpression, nameof(crossJoinExpression));
-
-            return crossJoinExpression.Update(
-                VisitInternal<TableExpressionBase>(crossJoinExpression.Table).ResultExpression);
-        }
-
-        protected override Expression VisitExcept(ExceptExpression exceptExpression)
-        {
-            Check.NotNull(exceptExpression, nameof(exceptExpression));
-
-            var source1 = VisitInternal<SelectExpression>(exceptExpression.Source1).ResultExpression;
-            var source2 = VisitInternal<SelectExpression>(exceptExpression.Source2).ResultExpression;
-
-            return exceptExpression.Update(source1, source2);
-        }
-
-        protected override Expression VisitExists(ExistsExpression existsExpression)
+        /// <summary>
+        ///     Visits an <see cref="ExistsExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="existsExpression"> An exists expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitExists(
+            [NotNull] ExistsExpression existsExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(existsExpression, nameof(existsExpression));
 
-            var subquery = VisitInternal<SelectExpression>(existsExpression.Subquery).ResultExpression;
-            _nullable = false;
+            var subquery = Visit(existsExpression.Subquery);
+            nullable = false;
 
             // if subquery has predicate which evaluates to false, we can simply return false
-            return IsConstantFalse(subquery.Predicate)
+            return TryGetBoolConstantValue(subquery.Predicate) == false
                 ? subquery.Predicate
                 : existsExpression.Update(subquery);
         }
 
-        private static bool IsConstantFalse(SqlExpression expression)
-            => expression is SqlConstantExpression constantExpression
-            && constantExpression.Value is bool boolValue
-            && !boolValue;
-
-        protected override Expression VisitFromSql(FromSqlExpression fromSqlExpression)
-            => Check.NotNull(fromSqlExpression, nameof(fromSqlExpression));
-
-        protected override Expression VisitIn(InExpression inExpression)
+        /// <summary>
+        ///     Visits an <see cref="InExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="inExpression"> An in expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitIn([NotNull] InExpression inExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(inExpression, nameof(inExpression));
 
-            var (item, itemNullable) = VisitInternal<SqlExpression>(inExpression.Item);
+            var item = Visit(inExpression.Item, out var itemNullable);
 
             if (inExpression.Subquery != null)
             {
-                var subquery = VisitInternal<SelectExpression>(inExpression.Subquery).ResultExpression;
+                var subquery = Visit(inExpression.Subquery);
 
                 // a IN (SELECT * FROM table WHERE false) => false
-                if (IsConstantFalse(subquery.Predicate))
+                if (TryGetBoolConstantValue(subquery.Predicate) == false)
                 {
-                    _nullable = false;
+                    nullable = false;
 
                     return subquery.Predicate;
                 }
@@ -250,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 // if item is not nullable, and subquery contains a non-nullable column we know the result can never be null
                 // note: in this case we could broaden the optimization if we knew the nullability of the projection
                 // but we don't keep that information and we want to avoid double visitation
-                _nullable = !(!itemNullable
+                nullable = !(!itemNullable
                     && subquery.Projection.Count == 1
                     && subquery.Projection[0].Expression is ColumnExpression columnProjection
                     && !columnProjection.IsNullable);
@@ -263,8 +588,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (UseRelationalNulls
                 || !(inExpression.Values is SqlConstantExpression || inExpression.Values is SqlParameterExpression))
             {
-                var values = VisitInternal<SqlExpression>(inExpression.Values).ResultExpression;
-                _nullable = false;
+                var values = Visit(inExpression.Values, out _);
+                nullable = false;
 
                 return inExpression.Update(item, values, subquery: null);
             }
@@ -275,7 +600,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             // either values array is empty or only contains null
             if (inValuesList.Count == 0)
             {
-                _nullable = false;
+                nullable = false;
 
                 // a IN () -> false
                 // non_nullable IN (NULL) -> false
@@ -293,9 +618,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             if (!itemNullable
-                || (_allowOptimizedExpansion && !inExpression.IsNegated && !hasNullValue))
+                || (allowOptimizedExpansion && !inExpression.IsNegated && !hasNullValue))
             {
-                _nullable = false;
+                nullable = false;
 
                 // non_nullable IN (1, 2) -> non_nullable IN (1, 2)
                 // non_nullable IN (1, 2, NULL) -> non_nullable IN (1, 2)
@@ -305,7 +630,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return inExpression.Update(item, inValuesExpression, subquery: null);
             }
 
-            _nullable = false;
+            nullable = false;
 
             // nullable IN (1, 2) -> nullable IN (1, 2) AND nullable IS NOT NULL (full)
             // nullable IN (1, 2, NULL) -> nullable IN (1, 2) OR nullable IS NULL (full)
@@ -333,7 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
                 else if (valuesExpression is SqlParameterExpression sqlParameter)
                 {
-                    CanCache = false;
+                    DoNotCache();
                     typeMapping = sqlParameter.TypeMapping;
                     values = (IEnumerable)ParameterValues[sqlParameter.Name];
                 }
@@ -355,110 +680,35 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        protected override Expression VisitInnerJoin(InnerJoinExpression innerJoinExpression)
+        /// <summary>
+        ///     Visits a <see cref="LikeExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="likeExpression"> A like expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitLike([NotNull] LikeExpression likeExpression, bool allowOptimizedExpansion, out bool nullable)
         {
-            Check.NotNull(innerJoinExpression, nameof(innerJoinExpression));
+            Check.NotNull(likeExpression, nameof(likeExpression));
 
-            var newTable = VisitInternal<TableExpressionBase>(innerJoinExpression.Table).ResultExpression;
-            var newJoinPredicate = VisitJoinPredicate((SqlBinaryExpression)innerJoinExpression.JoinPredicate);
+            var match = Visit(likeExpression.Match, out var matchNullable);
+            var pattern = Visit(likeExpression.Pattern, out var patternNullable);
+            var escapeChar = Visit(likeExpression.EscapeChar, out var escapeCharNullable);
 
-            return newJoinPredicate is SqlConstantExpression constantJoinPredicate
-                && constantJoinPredicate.Value is bool boolPredicate
-                && boolPredicate
-                ? (Expression)new CrossJoinExpression(newTable)
-                : innerJoinExpression.Update(newTable, newJoinPredicate);
-        }
-
-        protected override Expression VisitIntersect(IntersectExpression intersectExpression)
-        {
-            Check.NotNull(intersectExpression, nameof(intersectExpression));
-
-            var source1 = VisitInternal<SelectExpression>(intersectExpression.Source1).ResultExpression;
-            var source2 = VisitInternal<SelectExpression>(intersectExpression.Source2).ResultExpression;
-
-            return intersectExpression.Update(source1, source2);
-        }
-
-        protected override Expression VisitLeftJoin(LeftJoinExpression leftJoinExpression)
-        {
-            Check.NotNull(leftJoinExpression, nameof(leftJoinExpression));
-
-            var newTable = VisitInternal<TableExpressionBase>(leftJoinExpression.Table).ResultExpression;
-            var newJoinPredicate = VisitJoinPredicate((SqlBinaryExpression)leftJoinExpression.JoinPredicate);
-
-            return leftJoinExpression.Update(newTable, newJoinPredicate);
-        }
-
-        private SqlExpression VisitJoinPredicate(SqlBinaryExpression predicate)
-        {
-            switch (predicate.OperatorType)
-            {
-                case ExpressionType.Equal:
-                {
-                    var (left, leftNullable) = VisitInternal<SqlExpression>(predicate.Left, allowOptimizedExpansion: true);
-                    var (right, rightNullable) = VisitInternal<SqlExpression>(predicate.Right, allowOptimizedExpansion: true);
-
-                    var result = OptimizeComparison(
-                        predicate.Update(left, right),
-                        left,
-                        right,
-                        leftNullable,
-                        rightNullable);
-
-                    return result;
-                }
-
-                case ExpressionType.AndAlso:
-                    return VisitInternal<SqlExpression>(predicate, allowOptimizedExpansion: true).ResultExpression;
-
-                default:
-                    throw new InvalidOperationException(RelationalStrings.UnexpectedJoinPredicateShape(predicate));
-            }
-        }
-
-        protected override Expression VisitLike(LikeExpression likeExpression)
-        {
-            var (match, matchNullable) = VisitInternal<SqlExpression>(likeExpression.Match);
-            var (pattern, patternNullable) = VisitInternal<SqlExpression>(likeExpression.Pattern);
-            var (escapeChar, escapeCharNullable) = VisitInternal<SqlExpression>(likeExpression.EscapeChar);
-            _nullable = matchNullable || patternNullable || escapeCharNullable;
+            nullable = matchNullable || patternNullable || escapeCharNullable;
 
             return likeExpression.Update(match, pattern, escapeChar);
         }
 
-        protected override Expression VisitOrdering(OrderingExpression orderingExpression)
-        {
-            Check.NotNull(orderingExpression, nameof(orderingExpression));
-
-            return orderingExpression.Update(
-                VisitInternal<SqlExpression>(orderingExpression.Expression).ResultExpression);
-        }
-
-        protected override Expression VisitOuterApply(OuterApplyExpression outerApplyExpression)
-        {
-            Check.NotNull(outerApplyExpression, nameof(outerApplyExpression));
-
-            return outerApplyExpression.Update(
-                VisitInternal<TableExpressionBase>(outerApplyExpression.Table).ResultExpression);
-        }
-
-        protected override Expression VisitProjection(ProjectionExpression projectionExpression)
-        {
-            Check.NotNull(projectionExpression, nameof(projectionExpression));
-
-            return projectionExpression.Update(
-                VisitInternal<SqlExpression>(projectionExpression.Expression).ResultExpression);
-        }
-
-        protected override Expression VisitTableValuedFunction(TableValuedFunctionExpression tableValuedFunctionExpression)
-        {
-            Check.NotNull(tableValuedFunctionExpression, nameof(tableValuedFunctionExpression));
-
-            // See issue#20180
-            return tableValuedFunctionExpression;
-        }
-
-        protected override Expression VisitRowNumber(RowNumberExpression rowNumberExpression)
+        /// <summary>
+        ///     Visits a <see cref="RowNumberExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="rowNumberExpression"> A row number expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitRowNumber(
+            [NotNull] RowNumberExpression rowNumberExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(rowNumberExpression, nameof(rowNumberExpression));
 
@@ -466,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var partitions = new List<SqlExpression>();
             foreach (var partition in rowNumberExpression.Partitions)
             {
-                var newPartition = VisitInternal<SqlExpression>(partition).ResultExpression;
+                var newPartition = Visit(partition, out _);
                 changed |= newPartition != partition;
                 partitions.Add(newPartition);
             }
@@ -474,131 +724,70 @@ namespace Microsoft.EntityFrameworkCore.Query
             var orderings = new List<OrderingExpression>();
             foreach (var ordering in rowNumberExpression.Orderings)
             {
-                var newOrdering = VisitInternal<OrderingExpression>(ordering).ResultExpression;
+                var newOrdering = ordering.Update(Visit(ordering.Expression, out _));
                 changed |= newOrdering != ordering;
                 orderings.Add(newOrdering);
             }
 
-            return rowNumberExpression.Update(partitions, orderings);
+            nullable = false;
+
+            return changed
+                ? rowNumberExpression.Update(partitions, orderings)
+                : rowNumberExpression;
         }
 
-        protected override Expression VisitScalarSubquery(ScalarSubqueryExpression scalarSubqueryExpression)
+        /// <summary>
+        ///     Visits a <see cref="ScalarSubqueryExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="scalarSubqueryExpression"> A scalar subquery expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+        protected virtual SqlExpression VisitScalarSubquery(
+            [NotNull] ScalarSubqueryExpression scalarSubqueryExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(scalarSubqueryExpression, nameof(scalarSubqueryExpression));
 
-            return scalarSubqueryExpression.Update(
-                VisitInternal<SelectExpression>(scalarSubqueryExpression.Subquery).ResultExpression);
+            nullable = true;
+
+            return scalarSubqueryExpression.Update(Visit(scalarSubqueryExpression.Subquery));
         }
+        /// <summary>
+        ///     Visits a <see cref="SqlBinaryExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlBinaryExpression"> A sql binary expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
 
-        protected override Expression VisitSelect(SelectExpression selectExpression)
-        {
-            Check.NotNull(selectExpression, nameof(selectExpression));
-
-            var changed = false;
-            var projections = new List<ProjectionExpression>();
-            foreach (var item in selectExpression.Projection)
-            {
-                var updatedProjection = VisitInternal<ProjectionExpression>(item).ResultExpression;
-                projections.Add(updatedProjection);
-                changed |= updatedProjection != item;
-            }
-
-            var tables = new List<TableExpressionBase>();
-            foreach (var table in selectExpression.Tables)
-            {
-                var newTable = VisitInternal<TableExpressionBase>(table).ResultExpression;
-                changed |= newTable != table;
-                tables.Add(newTable);
-            }
-
-            var predicate = VisitInternal<SqlExpression>(selectExpression.Predicate, allowOptimizedExpansion: true).ResultExpression;
-            changed |= predicate != selectExpression.Predicate;
-
-            if (predicate is SqlConstantExpression predicateConstantExpression
-                && predicateConstantExpression.Value is bool predicateBoolValue
-                && predicateBoolValue)
-            {
-                predicate = null;
-                changed = true;
-            }
-
-            var groupBy = new List<SqlExpression>();
-            foreach (var groupingKey in selectExpression.GroupBy)
-            {
-                var newGroupingKey = VisitInternal<SqlExpression>(groupingKey).ResultExpression;
-                changed |= newGroupingKey != groupingKey;
-                groupBy.Add(newGroupingKey);
-            }
-
-            var having = VisitInternal<SqlExpression>(selectExpression.Having, allowOptimizedExpansion: true).ResultExpression;
-            changed |= having != selectExpression.Having;
-
-            if (having is SqlConstantExpression havingConstantExpression
-                && havingConstantExpression.Value is bool havingBoolValue
-                && havingBoolValue)
-            {
-                having = null;
-                changed = true;
-            }
-
-            var orderings = new List<OrderingExpression>();
-            foreach (var ordering in selectExpression.Orderings)
-            {
-                var orderingExpression = VisitInternal<SqlExpression>(ordering.Expression).ResultExpression;
-                changed |= orderingExpression != ordering.Expression;
-                orderings.Add(ordering.Update(orderingExpression));
-            }
-
-            var offset = VisitInternal<SqlExpression>(selectExpression.Offset).ResultExpression;
-            changed |= offset != selectExpression.Offset;
-
-            var limit = VisitInternal<SqlExpression>(selectExpression.Limit).ResultExpression;
-            changed |= limit != selectExpression.Limit;
-
-            // SelectExpression can always yield null
-            // (e.g. projecting non-nullable column but with predicate that filters out all rows)
-            _nullable = true;
-
-            return changed
-                ? selectExpression.Update(
-                    projections, tables, predicate, groupBy, having, orderings, limit, offset)
-                : selectExpression;
-        }
-
-        protected override Expression VisitSqlBinary(SqlBinaryExpression sqlBinaryExpression)
+        protected virtual SqlExpression VisitSqlBinary(
+            [NotNull] SqlBinaryExpression sqlBinaryExpression, bool allowOptimizedExpansion, out bool nullable)
         {
             Check.NotNull(sqlBinaryExpression, nameof(sqlBinaryExpression));
 
-            _nullable = false;
-            var optimize = _allowOptimizedExpansion;
+            var optimize = allowOptimizedExpansion;
 
-            _allowOptimizedExpansion = _allowOptimizedExpansion
+            allowOptimizedExpansion = allowOptimizedExpansion
                 && (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
                     || sqlBinaryExpression.OperatorType == ExpressionType.OrElse);
 
-            var currentNonNullableColumnsCount = NonNullableColumns.Count;
+            var currentNonNullableColumnsCount = _nonNullableColumns.Count;
 
-            var (left, leftNullable) = VisitInternal<SqlExpression>(
-                sqlBinaryExpression.Left,
-                allowOptimizedExpansion: _allowOptimizedExpansion,
-                restoreNonNullableColumnInformation: false);
+            var left = Visit(sqlBinaryExpression.Left, allowOptimizedExpansion, preserveNonNullableColumns: true, out var leftNullable);
 
-            var leftNonNullableColumns = NonNullableColumns.Skip(currentNonNullableColumnsCount).ToList();
+            var leftNonNullableColumns = _nonNullableColumns.Skip(currentNonNullableColumnsCount).ToList();
             if (sqlBinaryExpression.OperatorType != ExpressionType.AndAlso)
             {
                 RestoreNonNullableColumnsList(currentNonNullableColumnsCount);
             }
 
-            var (right, rightNullable) = VisitInternal<SqlExpression>(
-                sqlBinaryExpression.Right,
-                allowOptimizedExpansion: _allowOptimizedExpansion,
-                restoreNonNullableColumnInformation: false);
+            var right = Visit(sqlBinaryExpression.Right, allowOptimizedExpansion, preserveNonNullableColumns: true, out var rightNullable);
 
             if (sqlBinaryExpression.OperatorType == ExpressionType.OrElse)
             {
-                var intersect = leftNonNullableColumns.Intersect(NonNullableColumns.Skip(currentNonNullableColumnsCount)).ToList();
+                var intersect = leftNonNullableColumns.Intersect(_nonNullableColumns.Skip(currentNonNullableColumnsCount)).ToList();
                 RestoreNonNullableColumnsList(currentNonNullableColumnsCount);
-                NonNullableColumns.AddRange(intersect);
+                _nonNullableColumns.AddRange(intersect);
             }
             else if (sqlBinaryExpression.OperatorType != ExpressionType.AndAlso)
             {
@@ -606,7 +795,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 RestoreNonNullableColumnsList(currentNonNullableColumnsCount);
             }
 
-            // nullableStringColumn + NULL -> COALESCE(nullableStringColumn, "") + ""
+            // nullableStringColumn + a -> COALESCE(nullableStringColumn, "") + a
             if (sqlBinaryExpression.OperatorType == ExpressionType.Add
                 && sqlBinaryExpression.Type == typeof(string))
             {
@@ -619,6 +808,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     right = AddNullConcatenationProtection(right, sqlBinaryExpression.TypeMapping);
                 }
+
+                nullable = false;
 
                 return sqlBinaryExpression.Update(left, right);
             }
@@ -633,13 +824,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                     left,
                     right,
                     leftNullable,
-                    rightNullable);
+                    rightNullable,
+                    out nullable);
 
                 if (optimized is SqlUnaryExpression optimizedUnary
                     && optimizedUnary.OperatorType == ExpressionType.NotEqual
                     && optimizedUnary.Operand is ColumnExpression optimizedUnaryColumnOperand)
                 {
-                    NonNullableColumns.Add(optimizedUnaryColumnOperand);
+                    _nonNullableColumns.Add(optimizedUnaryColumnOperand);
                 }
 
                 // we assume that NullSemantics rewrite is only needed (on the current level)
@@ -661,20 +853,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                         updated.Right,
                         leftNullable,
                         rightNullable,
-                        optimize);
-
-                    _allowOptimizedExpansion = optimize;
+                        optimize,
+                        out nullable);
 
                     return rewriteNullSemanticsResult;
                 }
 
-                _allowOptimizedExpansion = optimize;
-
                 return optimized;
             }
 
-            _nullable = leftNullable || rightNullable;
-            _allowOptimizedExpansion = optimize;
+            nullable = leftNullable || rightNullable;
 
             var result = sqlBinaryExpression.Update(left, right);
 
@@ -689,13 +877,188 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ? (SqlExpression)SqlExpressionFactory.Constant(string.Empty, typeMapping)
                 : SqlExpressionFactory.Coalesce(argument, SqlExpressionFactory.Constant(string.Empty, typeMapping));
         }
+        /// <summary>
+        ///     Visits a <see cref="SqlConstantExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlConstantExpression"> A sql constant expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+
+        protected virtual SqlExpression VisitSqlConstant(
+            [NotNull] SqlConstantExpression sqlConstantExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(sqlConstantExpression, nameof(sqlConstantExpression));
+
+            nullable = sqlConstantExpression.Value == null;
+
+            return sqlConstantExpression;
+        }
+        /// <summary>
+        ///     Visits a <see cref="SqlFragmentExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlFragmentExpression"> A sql fragment expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+
+        protected virtual SqlExpression VisitSqlFragment(
+            [NotNull] SqlFragmentExpression sqlFragmentExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(sqlFragmentExpression, nameof(sqlFragmentExpression));
+
+            nullable = false;
+
+            return sqlFragmentExpression;
+        }
+        /// <summary>
+        ///     Visits a <see cref="SqlFunctionExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlFunctionExpression"> A sql function expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+
+        protected virtual SqlExpression VisitSqlFunction(
+            [NotNull] SqlFunctionExpression sqlFunctionExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(sqlFunctionExpression, nameof(sqlFunctionExpression));
+
+            if (sqlFunctionExpression.IsBuiltIn
+                && string.Equals(sqlFunctionExpression.Name, "COALESCE", StringComparison.OrdinalIgnoreCase))
+            {
+                var left = Visit(sqlFunctionExpression.Arguments[0], out var leftNullable);
+                var right = Visit(sqlFunctionExpression.Arguments[1], out var rightNullable);
+
+                nullable = leftNullable && rightNullable;
+
+                return sqlFunctionExpression.Update(sqlFunctionExpression.Instance, new[] { left, right });
+            }
+
+            var instance = Visit(sqlFunctionExpression.Instance, out _);
+            nullable = sqlFunctionExpression.IsNullable;
+
+            if (sqlFunctionExpression.IsNiladic)
+            {
+                return sqlFunctionExpression.Update(instance, sqlFunctionExpression.Arguments);
+            }
+
+            var arguments = new SqlExpression[sqlFunctionExpression.Arguments.Count];
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                arguments[i] = Visit(sqlFunctionExpression.Arguments[i], out _);
+            }
+
+
+            return sqlFunctionExpression.Update(instance, arguments);
+        }
+        /// <summary>
+        ///     Visits a <see cref="SqlParameterExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlParameterExpression"> A sql parameter expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+
+        protected virtual SqlExpression VisitSqlParameter(
+            [NotNull] SqlParameterExpression sqlParameterExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(sqlParameterExpression, nameof(sqlParameterExpression));
+
+            nullable = ParameterValues[sqlParameterExpression.Name] == null;
+
+            return nullable
+                ? SqlExpressionFactory.Constant(null, sqlParameterExpression.TypeMapping)
+                : (SqlExpression)sqlParameterExpression;
+        }
+        /// <summary>
+        ///     Visits a <see cref="SqlUnaryExpression"/> and computes its nullability.
+        /// </summary>
+        /// <param name="sqlUnaryExpression"> A sql unary expression to visit. </param>
+        /// <param name="allowOptimizedExpansion"> A bool value indicating if optimized expansion which considers null value as false value is allowed. </param>
+        /// <param name="nullable"> A bool value indicating whether the sql expression is nullable. </param>
+        /// <returns> An optimized sql expression. </returns>
+
+        protected virtual SqlExpression VisitSqlUnary(
+            [NotNull] SqlUnaryExpression sqlUnaryExpression, bool allowOptimizedExpansion, out bool nullable)
+        {
+            Check.NotNull(sqlUnaryExpression, nameof(sqlUnaryExpression));
+
+            var operand = Visit(sqlUnaryExpression.Operand, out var operandNullable);
+            var updated = sqlUnaryExpression.Update(operand);
+
+            if (sqlUnaryExpression.OperatorType == ExpressionType.Equal
+                || sqlUnaryExpression.OperatorType == ExpressionType.NotEqual)
+            {
+                var result = ProcessNullNotNull(updated, operandNullable);
+
+                // result of IsNull/IsNotNull can never be null
+                nullable = false;
+
+                if (result is SqlUnaryExpression resultUnary
+                    && resultUnary.OperatorType == ExpressionType.NotEqual
+                    && resultUnary.Operand is ColumnExpression resultColumnOperand)
+                {
+                    _nonNullableColumns.Add(resultColumnOperand);
+                }
+
+                return result;
+            }
+
+            nullable = operandNullable;
+
+            return !operandNullable && sqlUnaryExpression.OperatorType == ExpressionType.Not
+                ? OptimizeNonNullableNotExpression(updated)
+                : updated;
+        }
+
+        private static bool? TryGetBoolConstantValue(SqlExpression expression)
+            => expression is SqlConstantExpression constantExpression
+            && constantExpression.Value is bool boolValue
+            ? boolValue
+            : (bool?)null;
+
+        private void RestoreNonNullableColumnsList(int counter)
+        {
+            if (counter < _nonNullableColumns.Count)
+            {
+                _nonNullableColumns.RemoveRange(counter, _nonNullableColumns.Count - counter);
+            }
+        }
+
+        private SqlExpression ProcessJoinPredicate(SqlExpression predicate)
+        {
+            if (predicate is SqlBinaryExpression sqlBinaryExpression)
+            {
+                if (sqlBinaryExpression.OperatorType == ExpressionType.Equal)
+                {
+                    var left = Visit(sqlBinaryExpression.Left, allowOptimizedExpansion: true, out var leftNullable);
+                    var right = Visit(sqlBinaryExpression.Right, allowOptimizedExpansion: true, out var rightNullable);
+
+                    var result = OptimizeComparison(
+                        sqlBinaryExpression.Update(left, right),
+                        left,
+                        right,
+                        leftNullable,
+                        rightNullable,
+                        out _);
+
+                    return result;
+                }
+
+                if (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso)
+                {
+                    return Visit(sqlBinaryExpression, allowOptimizedExpansion: true, out _);
+                }
+            }
+
+            throw new InvalidOperationException(
+                RelationalStrings.UnknownExpressionType(predicate, predicate.GetType(), nameof(SqlNullabilityProcessor)));
+        }
 
         private SqlExpression OptimizeComparison(
-            SqlBinaryExpression sqlBinaryExpression,
-            SqlExpression left,
-            SqlExpression right,
-            bool leftNullable,
-            bool rightNullable)
+            SqlBinaryExpression sqlBinaryExpression, SqlExpression left, SqlExpression right,
+            bool leftNullable, bool rightNullable, out bool nullable)
         {
             var leftNullValue = leftNullable && (left is SqlConstantExpression || left is SqlParameterExpression);
             var rightNullValue = rightNullable && (right is SqlConstantExpression || right is SqlParameterExpression);
@@ -708,7 +1071,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ? ProcessNullNotNull(SqlExpressionFactory.IsNull(left), leftNullable)
                     : ProcessNullNotNull(SqlExpressionFactory.IsNotNull(left), leftNullable);
 
-                _nullable = false;
+                nullable = false;
 
                 return result;
             }
@@ -721,37 +1084,37 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ? ProcessNullNotNull(SqlExpressionFactory.IsNull(right), rightNullable)
                     : ProcessNullNotNull(SqlExpressionFactory.IsNotNull(right), rightNullable);
 
-                _nullable = false;
+                nullable = false;
 
                 return result;
             }
 
-            if (IsTrueOrFalse(right) is bool rightTrueFalseValue
+            if (TryGetBoolConstantValue(right) is bool rightBoolValue
                 && !leftNullable)
             {
-                _nullable = leftNullable;
+                nullable = leftNullable;
 
                 // only correct in 2-value logic
                 // a == true -> a
                 // a == false -> !a
                 // a != true -> !a
                 // a != false -> a
-                return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ rightTrueFalseValue
+                return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ rightBoolValue
                     ? OptimizeNonNullableNotExpression(SqlExpressionFactory.Not(left))
                     : left;
             }
 
-            if (IsTrueOrFalse(left) is bool leftTrueFalseValue
+            if (TryGetBoolConstantValue(left) is bool leftBoolValue
                 && !rightNullable)
             {
-                _nullable = rightNullable;
+                nullable = rightNullable;
 
                 // only correct in 2-value logic
                 // true == a -> a
                 // false == a -> !a
                 // true != a -> !a
                 // false != a -> a
-                return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ leftTrueFalseValue
+                return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ leftBoolValue
                     ? SqlExpressionFactory.Not(right)
                     : right;
             }
@@ -762,7 +1125,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (!leftNullable
                 && left.Equals(right))
             {
-                _nullable = false;
+                nullable = false;
 
                 return SqlExpressionFactory.Constant(
                     sqlBinaryExpression.OperatorType == ExpressionType.Equal,
@@ -793,28 +1156,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 // !a == b <=> a == !b -> a != b
                 // a != b <=> !a != !b -> a != b
                 // !a != b <=> a != !b -> a == b
+
+                nullable = false;
+
                 return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ leftNegated == rightNegated
                     ? SqlExpressionFactory.NotEqual(left, right)
                     : SqlExpressionFactory.Equal(left, right);
             }
 
-            return sqlBinaryExpression.Update(left, right);
+            nullable = false;
 
-            static bool? IsTrueOrFalse(SqlExpression sqlExpression)
-            {
-                return sqlExpression is SqlConstantExpression sqlConstantExpression && sqlConstantExpression.Value is bool boolConstant
-                    ? boolConstant
-                    : (bool?)null;
-            }
+            return sqlBinaryExpression.Update(left, right);
         }
 
         private SqlExpression RewriteNullSemantics(
-            SqlBinaryExpression sqlBinaryExpression,
-            SqlExpression left,
-            SqlExpression right,
-            bool leftNullable,
-            bool rightNullable,
-            bool optimize)
+            SqlBinaryExpression sqlBinaryExpression, SqlExpression left, SqlExpression right,
+            bool leftNullable, bool rightNullable, bool optimize, out bool nullable)
         {
             var leftUnary = left as SqlUnaryExpression;
             var rightUnary = right as SqlUnaryExpression;
@@ -847,7 +1204,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 // when we use optimized form, the result can still be nullable
                 if (leftNullable && rightNullable)
                 {
-                    _nullable = true;
+                    nullable = true;
 
                     return SimplifyLogicalSqlBinaryExpression(
                         SqlExpressionFactory.OrElse(
@@ -859,14 +1216,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if ((leftNullable && !rightNullable)
                     || (!leftNullable && rightNullable))
                 {
-                    _nullable = true;
+                    nullable = true;
 
                     return SqlExpressionFactory.Equal(left, right);
                 }
             }
 
             // doing a full null semantics rewrite - removing all nulls from truth table
-            _nullable = false;
+            nullable = false;
 
             if (sqlBinaryExpression.OperatorType == ExpressionType.Equal)
             {
@@ -982,97 +1339,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             return sqlBinaryExpression;
         }
 
-        protected override Expression VisitSqlConstant(SqlConstantExpression sqlConstantExpression)
-        {
-            Check.NotNull(sqlConstantExpression, nameof(sqlConstantExpression));
-
-            _nullable = sqlConstantExpression.Value == null;
-
-            return sqlConstantExpression;
-        }
-
-        protected override Expression VisitSqlFragment(SqlFragmentExpression sqlFragmentExpression)
-        {
-            Check.NotNull(sqlFragmentExpression, nameof(sqlFragmentExpression));
-
-            return sqlFragmentExpression;
-        }
-
-        protected override Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
-        {
-            Check.NotNull(sqlFunctionExpression, nameof(sqlFunctionExpression));
-
-            if (sqlFunctionExpression.IsBuiltIn
-                && string.Equals(sqlFunctionExpression.Name, "COALESCE", StringComparison.OrdinalIgnoreCase))
-            {
-                var (left, leftNullable) = VisitInternal<SqlExpression>(sqlFunctionExpression.Arguments[0]);
-                var (right, rightNullable) = VisitInternal<SqlExpression>(sqlFunctionExpression.Arguments[1]);
-                _nullable = leftNullable && rightNullable;
-
-                return sqlFunctionExpression.Update(sqlFunctionExpression.Instance, new[] { left, right });
-            }
-
-            var (instance, _) = VisitInternal<SqlExpression>(sqlFunctionExpression.Instance);
-
-            if (sqlFunctionExpression.IsNiladic)
-            {
-                _nullable = sqlFunctionExpression.IsNullable;
-
-                return sqlFunctionExpression.Update(instance, sqlFunctionExpression.Arguments);
-            }
-
-            var arguments = new SqlExpression[sqlFunctionExpression.Arguments.Count];
-            for (var i = 0; i < arguments.Length; i++)
-            {
-                (arguments[i], _) = VisitInternal<SqlExpression>(sqlFunctionExpression.Arguments[i]);
-            }
-
-            _nullable = sqlFunctionExpression.IsNullable;
-
-            return sqlFunctionExpression.Update(instance, arguments);
-        }
-
-        protected override Expression VisitSqlParameter(SqlParameterExpression sqlParameterExpression)
-        {
-            Check.NotNull(sqlParameterExpression, nameof(sqlParameterExpression));
-
-            _nullable = ParameterValues[sqlParameterExpression.Name] == null;
-
-            return _nullable
-                ? SqlExpressionFactory.Constant(null, sqlParameterExpression.TypeMapping)
-                : (SqlExpression)sqlParameterExpression;
-        }
-
-        protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
-        {
-            Check.NotNull(sqlUnaryExpression, nameof(sqlUnaryExpression));
-
-            var (operand, operandNullable) = VisitInternal<SqlExpression>(sqlUnaryExpression.Operand);
-            var updated = sqlUnaryExpression.Update(operand);
-
-            if (sqlUnaryExpression.OperatorType == ExpressionType.Equal
-                || sqlUnaryExpression.OperatorType == ExpressionType.NotEqual)
-            {
-                var result = ProcessNullNotNull(updated, operandNullable);
-
-                // result of IsNull/IsNotNull can never be null
-                _nullable = false;
-
-                if (result is SqlUnaryExpression resultUnary
-                    && resultUnary.OperatorType == ExpressionType.NotEqual
-                    && resultUnary.Operand is ColumnExpression resultColumnOperand)
-                {
-                    NonNullableColumns.Add(resultColumnOperand);
-                }
-
-                return result;
-            }
-
-            return !_nullable && sqlUnaryExpression.OperatorType == ExpressionType.Not
-                ? OptimizeNonNullableNotExpression(updated)
-                : updated;
-        }
-
         private SqlExpression OptimizeNonNullableNotExpression(SqlUnaryExpression sqlUnaryExpression)
         {
             if (sqlUnaryExpression.OperatorType != ExpressionType.Not)
@@ -1173,13 +1439,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        protected virtual SqlExpression ProcessNullNotNull(
-            [NotNull] SqlUnaryExpression sqlUnaryExpression,
-            bool? operandNullable)
+        private SqlExpression ProcessNullNotNull(SqlUnaryExpression sqlUnaryExpression, bool operandNullable)
         {
-            Check.NotNull(sqlUnaryExpression, nameof(sqlUnaryExpression));
-
-            if (operandNullable == false)
+            if (!operandNullable)
             {
                 // when we know that operand is non-nullable:
                 // not_null_operand is null-> false
@@ -1210,7 +1472,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         sqlUnaryExpression.TypeMapping);
 
                 case ColumnExpression columnOperand
-                    when !columnOperand.IsNullable || NonNullableColumns.Contains(columnOperand):
+                    when !columnOperand.IsNullable || _nonNullableColumns.Contains(columnOperand):
                 {
                     // IsNull(non_nullable_column) -> false
                     // IsNotNull(non_nullable_column) -> true
@@ -1261,7 +1523,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             sqlBinaryOperand.Left,
                             typeof(bool),
                             sqlUnaryExpression.TypeMapping),
-                        operandNullable: null);
+                        operandNullable);
 
                     var right = ProcessNullNotNull(
                         SqlExpressionFactory.MakeUnary(
@@ -1269,7 +1531,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             sqlBinaryOperand.Right,
                             typeof(bool),
                             sqlUnaryExpression.TypeMapping),
-                        operandNullable: null);
+                        operandNullable);
 
                     return SimplifyLogicalSqlBinaryExpression(
                         SqlExpressionFactory.MakeBinary(
@@ -1294,7 +1556,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 sqlFunctionExpression.Arguments[0],
                                 typeof(bool),
                                 sqlUnaryExpression.TypeMapping),
-                            operandNullable: null);
+                            operandNullable);
 
                         var right = ProcessNullNotNull(
                             SqlExpressionFactory.MakeUnary(
@@ -1302,7 +1564,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 sqlFunctionExpression.Arguments[1],
                                 typeof(bool),
                                 sqlUnaryExpression.TypeMapping),
-                            operandNullable: null);
+                            operandNullable);
 
                         return SimplifyLogicalSqlBinaryExpression(
                             SqlExpressionFactory.MakeBinary(
@@ -1355,7 +1617,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     e,
                                     sqlUnaryExpression.Type,
                                     sqlUnaryExpression.TypeMapping),
-                                operandNullable: null))
+                                operandNullable))
                             .Aggregate((r, e) => SimplifyLogicalSqlBinaryExpression(
                                 sqlUnaryExpression.OperatorType == ExpressionType.Equal
                                     ? SqlExpressionFactory.OrElse(r, e)
@@ -1368,23 +1630,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             return sqlUnaryExpression;
-        }
-
-        protected override Expression VisitTable(TableExpression tableExpression)
-        {
-            Check.NotNull(tableExpression, nameof(tableExpression));
-
-            return tableExpression;
-        }
-
-        protected override Expression VisitUnion(UnionExpression unionExpression)
-        {
-            Check.NotNull(unionExpression, nameof(unionExpression));
-
-            var source1 = VisitInternal<SelectExpression>(unionExpression.Source1).ResultExpression;
-            var source2 = VisitInternal<SelectExpression>(unionExpression.Source2).ResultExpression;
-
-            return unionExpression.Update(source1, source2);
         }
 
         // ?a == ?b -> [(a == b) && (a != null && b != null)] || (a == null && b == null))
@@ -1623,5 +1868,4 @@ namespace Microsoft.EntityFrameworkCore.Query
                     SqlExpressionFactory.Equal(left, right),
                     leftIsNull));
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerParameterBasedQueryTranslationPostprocessor.cs
@@ -36,19 +36,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override (SelectExpression, bool) Optimize(
+        public override SelectExpression Optimize(
             SelectExpression selectExpression,
-            IReadOnlyDictionary<string, object> parametersValues)
+            IReadOnlyDictionary<string, object> parametersValues,
+            out bool canCache)
         {
             Check.NotNull(selectExpression, nameof(selectExpression));
             Check.NotNull(parametersValues, nameof(parametersValues));
 
-            var (optimizedSelectExpression, canCache) = base.Optimize(selectExpression, parametersValues);
+            var optimizedSelectExpression = base.Optimize(selectExpression, parametersValues, out canCache);
 
             var searchConditionOptimized = (SelectExpression)new SearchConditionConvertingExpressionVisitor(
                 Dependencies.SqlExpressionFactory).Visit(optimizedSelectExpression);
 
-            return (searchConditionOptimized, canCache);
+            return searchConditionOptimized;
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncFromSqlQuerySqlServerTest.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Internal
+namespace Microsoft.EntityFrameworkCore.Query
 {
     public class AsyncFromSqlQuerySqlServerTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {


### PR DESCRIPTION
Resolves #20204

For table sources, there is no concept of nullability
- `Process(TableExpressionBase)` which works as dispatcher.
- `Process(SelectExpression)` as a special case to avoid casting.
- No additional methods for individual table sources.

For SQL expressions,
- `Process(SqlExpression, out bool nullable)` which defaults allowOptimizedExpansion to false.
- `Process(SqlExpression, allowOptimizedExpansion, out bool nullable)` which works as dispatcher.
- Individual Process* methods to change bahavior of any particular SqlExpression.

Notes:
- Each individual SQLExpression processes it's children with appropriately set allowOptimizedExpansion flag. It collects nullable flag for all children and return nullable for itself through out parameter.
- NonNullableColumns are being used only in 2 places and both usages are different. Rather than crystal balling an API to expose it, we should just keep it private till a provider asks for it then we can discuss with provider writer what information is needed and how would they like it. Making it private does not cause any bug, may just miss an optimization in SQL.
- The processor does not derive from ExpressionVisitor anymore. It has ExpressionVisitor like dispatch system but non Visit API.
- Since it is not deriving from SqlExpressionVisitor there is no longer abstract method to force implementing for new SqlExpression type. Hence unknown expression type throws exception. Making it pass through could cause incorrect result as we don't visit custom expression's components.
- Added DoNotCache method rather than exposing _canCache.
- Changed API about returning tuple for caching to an out parameter.

TODO: Once API is approved, I will add XML docs.
