### PR TITLE
Rename MigrationSqlGeneratorTest -> MigrationsSqlGeneratorTest

### DIFF
--- a/test/EFCore.Relational.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
 {
-    public abstract class MigrationSqlGeneratorTestBase
+    public abstract class MigrationsSqlGeneratorTestBase
     {
         protected static string EOL => Environment.NewLine;
 
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         public void All_tests_must_be_overriden()
         {
             var baseTests = GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public)
-                .Where(method => method.IsVirtual && !method.IsFinal && method.DeclaringType == typeof(MigrationSqlGeneratorTestBase))
+                .Where(method => method.IsVirtual && !method.IsFinal && method.DeclaringType == typeof(MigrationsSqlGeneratorTestBase))
                 .ToList();
 
             Assert.True(baseTests.Count == 0, $"{GetType().ShortDisplayName()} should override the following methods to assert the generated SQL:" + EOL
@@ -718,7 +718,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         protected DbContextOptions ContextOptions { get; }
         protected IServiceCollection CustomServices { get; }
 
-        protected MigrationSqlGeneratorTestBase(
+        protected MigrationsSqlGeneratorTestBase(
             TestHelpers testHelpers, IServiceCollection customServices = null, DbContextOptions options = null)
         {
             TestHelpers = testHelpers;

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
 {
-    public class SqlServerMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
+    public class SqlServerMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
     {
         [ConditionalFact]
         public virtual void AddColumnOperation_identity_legacy()
@@ -928,7 +928,7 @@ SELECT @@ROWCOUNT;
             AssertSql(expectedSql);
         }
 
-        public SqlServerMigrationSqlGeneratorTest()
+        public SqlServerMigrationsSqlGeneratorTest()
             : base(SqlServerTestHelpers.Instance,
                   new ServiceCollection().AddEntityFrameworkSqlServerNetTopologySuite(),
                   SqlServerTestHelpers.Instance.AddProviderOptions(

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
 {
-    public class SqliteMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
+    public class SqliteMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
     {
         [ConditionalFact]
         public virtual void It_lifts_foreign_key_additions()
@@ -631,7 +631,7 @@ SELECT changes();
 ");
         }
 
-        public SqliteMigrationSqlGeneratorTest()
+        public SqliteMigrationsSqlGeneratorTest()
             : base(SqliteTestHelpers.Instance,
                   new ServiceCollection().AddEntityFrameworkSqliteNetTopologySuite(),
                   SqliteTestHelpers.Instance.AddProviderOptions(


### PR DESCRIPTION
For consistency with MigrationsSqlGenerator
