### PR TITLE
Replace decimal with double in benchmarks

### DIFF
--- a/benchmark/EF.Benchmarks.Shared/Models/Orders/OrderLine.cs
+++ b/benchmark/EF.Benchmarks.Shared/Models/Orders/OrderLine.cs
@@ -7,7 +7,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders
     {
         public int OrderLineId { get; set; }
         public int Quantity { get; set; }
-        public decimal Price { get; set; }
+        public double Price { get; set; }
         public bool IsSubjectToTax { get; set; }
         public string SpecialRequests { get; set; }
         public bool IsShipped { get; set; }

--- a/benchmark/EF.Benchmarks.Shared/Models/Orders/Product.cs
+++ b/benchmark/EF.Benchmarks.Shared/Models/Orders/Product.cs
@@ -12,8 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders
         public string Name { get; set; }
         public string Description { get; set; }
         public string SKU { get; set; }
-        public decimal Retail { get; set; }
-        public decimal CurrentPrice { get; set; }
+        public double Retail { get; set; }
+        public double CurrentPrice { get; set; }
         public int TargetStockLevel { get; set; }
         public int ActualStockLevel { get; set; }
         public int? ReorderStockLevel { get; set; }

--- a/benchmark/EF6.SqlServer.Benchmarks/Query/QueryCompilationTests.cs
+++ b/benchmark/EF6.SqlServer.Benchmarks/Query/QueryCompilationTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             public string Description { get; set; }
             public int ActualStockLevel { get; set; }
             public string SKU { get; set; }
-            public decimal Savings { get; set; }
+            public double Savings { get; set; }
             public int Surplus { get; set; }
         }
     }

--- a/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
             public string Description { get; set; }
             public int ActualStockLevel { get; set; }
             public string SKU { get; set; }
-            public decimal Savings { get; set; }
+            public double Savings { get; set; }
             public int Surplus { get; set; }
         }
 


### PR DESCRIPTION
Because Sqlite doesn't support operations on decimals (e.g. ordering)

Fixes #20822