### PR TITLE
Add test coverage for altering check constraints

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -1114,6 +1114,22 @@ namespace Microsoft.EntityFrameworkCore
                     // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
                 });
 
+            [ConditionalFact]
+            public virtual Task Alter_check_constraint()
+                => Test(
+                    builder => builder.Entity(
+                        "People", e =>
+                        {
+                            e.Property<int>("Id");
+                            e.Property<int>("DriverLicense");
+                        }),
+                    builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                    builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 1"),
+                    model =>
+                    {
+                        // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+                    });
+
         [ConditionalFact]
         public virtual Task Drop_check_constraint()
             => Test(

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -1565,6 +1565,16 @@ ALTER TABLE [People] ALTER COLUMN [SomeField] nvarchar(450) NOT NULL;",
                 @"ALTER TABLE [People] ADD CONSTRAINT [CK_Foo] CHECK ([DriverLicense] > 0);");
         }
 
+        public override async Task Alter_check_constraint()
+        {
+            await base.Alter_check_constraint();
+
+            AssertSql(
+                @"ALTER TABLE [People] DROP CONSTRAINT [CK_Foo];",
+                //
+                @"ALTER TABLE [People] ADD CONSTRAINT [CK_Foo] CHECK ([DriverLicense] > 1);");
+        }
+
         public override async Task Drop_check_constraint()
         {
             await base.Drop_check_constraint();

--- a/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -387,6 +387,10 @@ CREATE INDEX ""foo"" ON ""People"" (""FirstName"");");
             => AssertNotSupportedAsync(
                 base.Add_check_constraint_with_name, SqliteStrings.InvalidMigrationOperation("CreateCheckConstraintOperation"));
 
+        public override Task Alter_check_constraint()
+            => AssertNotSupportedAsync(
+                base.Alter_check_constraint, SqliteStrings.InvalidMigrationOperation("DropCheckConstraintOperation"));
+
         public override Task Drop_check_constraint()
             => AssertNotSupportedAsync(base.Drop_check_constraint, SqliteStrings.InvalidMigrationOperation("DropCheckConstraintOperation"));
 


### PR DESCRIPTION
Pretty trivial since it's just DROP/CREATE, but coverage seems important especially since we now generate check constraints automatically for enums (#15411).