### PR TITLE
Query: Cosmos: Generate enum literal/parameter correctly

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
@@ -31,30 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type()
-        {
-            base.Can_query_using_any_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-            base.Can_query_using_any_data_type_nullable_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_shadow()
-        {
-            base.Can_query_using_any_data_type_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_nullable_data_type()
-        {
-            base.Can_query_using_any_nullable_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
         public override void Can_query_using_any_nullable_data_type_as_literal()
         {
             base.Can_query_using_any_nullable_data_type_as_literal();
@@ -66,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Can_query_with_null_parameters_using_any_nullable_data_type();
         }
 
-        [ConditionalFact(Skip = "Issue #16919")]
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_string_key()
         {
             base.Can_insert_and_read_back_with_string_key();

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -37,30 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type()
-        {
-            base.Can_query_using_any_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-            base.Can_query_using_any_data_type_nullable_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_shadow()
-        {
-            base.Can_query_using_any_data_type_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_nullable_data_type()
-        {
-            base.Can_query_using_any_nullable_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
         public override void Can_query_using_any_nullable_data_type_as_literal()
         {
             base.Can_query_using_any_nullable_data_type_as_literal();
@@ -72,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Can_query_with_null_parameters_using_any_nullable_data_type();
         }
 
-        [ConditionalFact(Skip = "Issue #16919")]
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_string_key()
         {
             base.Can_insert_and_read_back_with_string_key();

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -1995,6 +1995,31 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Can_compare_enum_to_constant()
+        {
+            using var context = CreateContext();
+            var query = context.Set<AnimalIdentification>()
+                .Where(a => a.Method == IdentificationMethod.EarTag)
+                .ToList();
+
+            var result = Assert.Single(query);
+            Assert.Equal(IdentificationMethod.EarTag, result.Method);
+        }
+
+        [ConditionalFact]
+        public virtual void Can_compare_enum_to_parameter()
+        {
+            var method = IdentificationMethod.EarTag;
+            using var context = CreateContext();
+            var query = context.Set<AnimalIdentification>()
+                .Where(a => a.Method == method)
+                .ToList();
+
+            var result = Assert.Single(query);
+            Assert.Equal(IdentificationMethod.EarTag, result.Method);
+        }
+
+        [ConditionalFact]
         public virtual void Object_to_string_conversion()
         {
             using var context = CreateContext();


### PR DESCRIPTION
Resolves #20916
