### PR TITLE
[SMALL] Fix to #20759 - Query: client eval followed by aggregate operation throws KeyNotFoundException: The given key 'EmptyProjectionMember' was not present in the dictionary.

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -223,8 +223,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var newSelector = selector == null
                 || selector.Body == selector.Parameters[0]
-                    ? selectExpression.GetMappedProjection(new ProjectionMember())
+                    ? selectExpression.Projection.Count == 0
+                        ? selectExpression.GetMappedProjection(new ProjectionMember())
+                        : null
                     : RemapLambdaBody(source, selector);
+
+            if (newSelector == null)
+            {
+                return null;
+            }
 
             var projection = _sqlTranslator.TranslateAverage(newSelector);
             return projection != null
@@ -683,8 +690,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var newSelector = selector == null
                 || selector.Body == selector.Parameters[0]
-                    ? selectExpression.GetMappedProjection(new ProjectionMember())
+                    ? selectExpression.Projection.Count == 0
+                        ? selectExpression.GetMappedProjection(new ProjectionMember())
+                        : null
                     : RemapLambdaBody(source, selector);
+
+            if (newSelector == null)
+            {
+                return null;
+            }
 
             var projection = _sqlTranslator.TranslateMax(newSelector);
 
@@ -701,8 +715,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var newSelector = selector == null
                 || selector.Body == selector.Parameters[0]
-                    ? selectExpression.GetMappedProjection(new ProjectionMember())
+                    ? selectExpression.Projection.Count == 0
+                        ? selectExpression.GetMappedProjection(new ProjectionMember())
+                        : null
                     : RemapLambdaBody(source, selector);
+
+            if (newSelector == null)
+            {
+                return null;
+            }
 
             var projection = _sqlTranslator.TranslateMin(newSelector);
 
@@ -1028,10 +1049,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var selectExpression = (SelectExpression)source.QueryExpression;
             selectExpression.PrepareForAggregate();
+
             var newSelector = selector == null
                 || selector.Body == selector.Parameters[0]
-                    ? selectExpression.GetMappedProjection(new ProjectionMember())
+                    ? selectExpression.Projection.Count == 0
+                        ? selectExpression.GetMappedProjection(new ProjectionMember())
+                        : null
                     : RemapLambdaBody(source, selector);
+
+            if (newSelector == null)
+            {
+                return null;
+            }
 
             var projection = _sqlTranslator.TranslateSum(newSelector);
             return projection != null

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -88,5 +88,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Enum_closure_typed_as_underlying_type_generates_correct_parameter_type(async);
         }
+
+        [ConditionalTheory(Skip = "issue #17386")]
+        public override Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
+        {
+            return base.Client_eval_followed_by_set_operation_throws_meaningful_exception(async);
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7481,6 +7481,31 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(w => w.SynergyWith != null && types.Contains(w.SynergyWith.AmmunitionType)));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
+        {
+            await AssertTranslationFailed(
+                () => AssertSum(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertAverage(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertMin(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertMax(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()


### PR DESCRIPTION
Problem is that when client eval happens in the projection before the aggregate operation SelectExpression projection mapping can/will be empty. However when we try to access them using GetMappedProjection we assume that we always find what we want.
Fix is to check that selectExpression.Projection is empty. Otherwise we know client eval happened and we can't translate aggregate.

Fixes #20936 
