### PR TITLE
Tests : A better infrastructure for asserting includes in the query

### DIFF
--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -162,16 +162,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(
             bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional1"),
@@ -187,11 +187,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToMany_Optional1.OneToMany_Optional2.OneToMany_Required_Inverse3")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(e => e.OneToMany_Optional1).ThenInclude(e => e.OneToMany_Optional2)
                     .ThenInclude(e => e.OneToMany_Required_Inverse3.OneToMany_Optional2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalFact]
@@ -653,7 +653,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_includes(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
@@ -661,21 +661,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1)
                     .ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToMany_Optional1)
                     .ThenInclude(e => e.OneToOne_Optional_FK2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_includes_self_ref(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_Self1),
                 new ExpectedInclude<Level1>(l2 => l2.OneToMany_Optional_Self1, "OneToOne_Optional_Self1"),
@@ -683,21 +683,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_Self1, "OneToMany_Optional_Self1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_Self1)
                     .ThenInclude(e => e.OneToMany_Optional_Self1)
                     .Include(e => e.OneToMany_Optional_Self1)
                     .ThenInclude(e => e.OneToOne_Optional_Self1),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_complex_include_select(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
@@ -705,7 +705,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(e => e)
@@ -714,7 +714,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Select(e => e)
                     .Include(e => e.OneToMany_Optional1)
                     .ThenInclude(e => e.OneToOne_Optional_FK2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -1249,33 +1249,33 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_optional_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
                       where l1.OneToOne_Optional_FK1.Name != "L2 05"
                       select l1,
-                new List<IExpectedInclude> { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_nested_with_optional_navigation(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l1 => l1.OneToMany_Required2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level3>(l1 => l1.OneToOne_Required_FK3, "OneToOne_Optional_FK1.OneToMany_Required2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from l1 in ss.Set<Level1>()
                           .Include(e => e.OneToOne_Optional_FK1.OneToMany_Required2)
                           .ThenInclude(e => e.OneToOne_Required_FK3)
                       where l1.OneToOne_Optional_FK1.Name != "L2 09"
                       select l1,
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -1431,28 +1431,28 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_multi_include_with_order_by_and_paging(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Required_FK1),
                 new ExpectedInclude<Level2>(l1 => l1.OneToMany_Optional2, "OneToOne_Required_FK1"),
                 new ExpectedInclude<Level2>(l1 => l1.OneToMany_Required2, "OneToOne_Required_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Required2)
                     .OrderBy(t => t.Name)
                     .Skip(0).Take(10),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
@@ -1460,41 +1460,41 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Required2, "OneToOne_Required_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToMany_Optional2)
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Required2)
                     .OrderBy(t => t.Name)
                     .Skip(0).Take(10),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToOne_Optional_FK1.OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2).ThenInclude(e => e.OneToMany_Optional3)
                     .OrderBy(t => t.Name)
                     .Skip(0).Take(10),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_include_with_multiple_optional_navigations(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Required_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Required_FK1"),
@@ -1503,7 +1503,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Optional2)
@@ -1511,7 +1511,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
                     .Where(e => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name != "Foo")
                     .OrderBy(e => e.Id),
-                expectedIncludes,
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes),
                 assertOrder: true);
         }
 
@@ -1724,310 +1724,268 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Orderby_SelectMany_with_Include1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().OrderBy(l1 => l1.Id)
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include2(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToOne_Required_FK2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include_ThenInclude(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2),
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToOne_Required_FK2)
                     .ThenInclude(l3 => l3.OneToMany_Optional3),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_SelectMany_with_Include(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Required_FK3),
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .SelectMany(l2 => l2.OneToMany_Optional2)
                     .Include(l3 => l3.OneToOne_Required_FK3)
                     .Include(l3 => l3.OneToMany_Optional3),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_string_based_Include1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include("OneToOne_Required_FK2"),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_string_based_Include2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2),
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Required_FK3, "OneToOne_Required_FK2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include("OneToOne_Required_FK2.OneToOne_Required_FK3"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_SelectMany_with_string_based_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .SelectMany(l1 => l1.OneToMany_Optional2)
                     .Include("OneToOne_Required_FK3"),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level3>(l3 => l3.OneToOne_Required_FK3)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToOne_Required_FK3)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_with_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level3>()
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToMany_Required_Inverse2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Required_Inverse2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Required_Inverse2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Required_navigation_with_Include_ThenInclude(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Required_Inverse3),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional_Inverse2, "OneToMany_Required_Inverse3")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Include(l3 => l3.OneToMany_Required_Inverse3)
                     .ThenInclude(l2 => l2.OneToMany_Optional_Inverse2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigations_with_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                });
+               elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_using_multiple_selects_with_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_with_string_based_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                     .Include("OneToOne_Optional_FK2"),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_required_navigation_using_multiple_selects_with_string_based_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level4>()
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                     .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                     .Include("OneToOne_Optional_FK2"),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_Include_ThenInclude(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2),
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToMany_Optional2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .ThenInclude(l3 => l3.OneToOne_Optional_FK3),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_optional_navigation_with_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l3 => l3.OneToMany_Optional3),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_optional_navigation_with_string_based_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l2 => l2.OneToOne_Optional_PK2)
                     .Include("OneToMany_Optional3"),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_order_by_and_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -2035,16 +1993,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Optional_navigation_with_Include_and_order(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -2052,16 +2007,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_order_by_and_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .OrderBy(l2 => l2.Name)
                     .Include(l2 => l2.OneToMany_Optional2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -2069,16 +2021,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_Include_and_order_by(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .SelectMany(l1 => l1.OneToMany_Optional1)
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -2099,16 +2048,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_navigation_and_Distinct(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from l1 in ss.Set<Level1>().Include(l => l.OneToMany_Optional1)
                       from l2 in l1.OneToMany_Optional1.Distinct()
                       where l2 != null
                       select l1,
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1)));
         }
 
         [ConditionalTheory]
@@ -3213,7 +3159,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Level4_Include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Select(l1 => l1.OneToOne_Required_PK1)
                     .Where(t => t != null)
@@ -3223,10 +3169,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(t => t != null)
                     .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                     .Include(l2 => l2.OneToOne_Optional_FK2),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)),
                 elementSorter: e => e.Id);
         }
 
@@ -3449,7 +3392,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_inside_subquery(bool async)
         {
-            // can't use AssertIncludeQuery here, see #18191
+            // can't use AssertQuery here, see #18191
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
@@ -3475,13 +3418,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_member(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => l2.Name)
                     .ThenBy(l2 => l2.Level1_Required_Id),
-                new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -3489,13 +3432,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_property(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => EF.Property<int>(l2, "Level1_Required_Id"))
                     .ThenBy(l2 => l2.Name),
-                new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -3503,13 +3446,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_methodcall(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => Math.Abs(l2.Level1_Required_Id))
                     .ThenBy(l2 => l2.Name),
-                new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -3517,13 +3460,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_complex(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => Math.Abs(l2.Level1_Required_Id) + 7)
                     .ThenBy(l2 => l2.Name),
-                new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -3531,13 +3474,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_multiple_orderbys_complex_repeated(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToMany_Optional2)
                     .OrderBy(l2 => -l2.Level1_Required_Id)
                     .ThenBy(l2 => -l2.Level1_Required_Id).ThenBy(l2 => l2.Name),
-                new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                 assertOrder: true);
         }
 
@@ -3547,13 +3490,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             checked
             {
-                return AssertIncludeQuery(
+                return AssertQuery(
                     async,
                     ss => ss.Set<Level2>()
                         .Include(l2 => l2.OneToMany_Optional2)
                         .OrderBy(l2 => -l2.Level1_Required_Id)
                         .ThenBy(l2 => -l2.Level1_Required_Id).ThenBy(l2 => l2.Name),
-                    new List<IExpectedInclude> { new ExpectedInclude<Level2>(e => e.OneToMany_Optional2) },
+                    elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(e => e.OneToMany_Optional2)),
                     assertOrder: true);
             }
         }
@@ -3578,117 +3521,105 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_with_groupby_in_subquery(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1)));
         }
 
         [ConditionalTheory(Skip = "Issue#12088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)));
         }
 
         [ConditionalTheory(Skip = "Issue#12088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multi_include_with_groupby_in_subquery(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#12088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_before_groupby(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .Where(l1 => l1.Id > 3)
                     .GroupBy(g => g.Name)
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)));
         }
 
         [ConditionalTheory(Skip = "Issue#12088")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_groupby_in_subquery_and_filter_after_groupby(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .GroupBy(g => g.Name)
                     .Where(g => g.Key != "Foo")
                     .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-                expectedIncludes: new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)
-                });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToMany_Optional1)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigation_with_same_name_and_same_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceSameType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("ReferenceSameType"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigation_with_same_name_and_different_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceDifferentType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceDifferentType)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -3697,49 +3628,49 @@ namespace Microsoft.EntityFrameworkCore.Query
             String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
                 bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.ReferenceDifferentType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceDifferentType),
                 new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "ReferenceDifferentType")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType.BaseCollection"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_same_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.CollectionSameType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.CollectionSameType)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("CollectionSameType"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("CollectionDifferentType"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -3748,24 +3679,24 @@ namespace Microsoft.EntityFrameworkCore.Query
             String_include_multiple_derived_collection_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains(
                 bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType),
                 new ExpectedInclude<InheritanceDerived2>(e => e.CollectionDifferentType),
                 new ExpectedInclude<InheritanceLeaf2>(e => e.BaseCollection, "CollectionDifferentType")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase1>().Include("CollectionDifferentType.BaseCollection"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_include_multiple_derived_navigations_complex(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<InheritanceBase2>(e => e.Reference),
                 new ExpectedInclude<InheritanceDerived1>(e => e.CollectionDifferentType, "Reference"),
@@ -3775,26 +3706,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<InheritanceDerived2>(e => e.ReferenceSameType, "Collection")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<InheritanceBase2>().Include("Reference.CollectionDifferentType").Include("Collection.ReferenceSameType"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_collection_order_by_reference_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
                     .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1.Id),
-                expectedIncludes: new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
-                    new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToOne_Optional_FK1")
-                },
+                    new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToOne_Optional_FK1")),
                 assertOrder: true);
         }
 
@@ -3823,40 +3752,40 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_reference_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Include(l3 => l3.OneToMany_Optional3),
-                new List<IExpectedInclude> { new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_multiple_SelectMany_and_reference_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).SelectMany(l2 => l2.OneToMany_Optional2)
                     .Select(l3 => l3.OneToOne_Required_FK3).Include(l4 => l4.OneToMany_Required_Self4),
-                new List<IExpectedInclude> { new ExpectedInclude<Level4>(l4 => l4.OneToMany_Required_Self4) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level4>(l4 => l4.OneToMany_Required_Self4)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_multiple_reference_navigations(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                     .Select(l3 => l3.OneToOne_Required_FK3).Include(l4 => l4.OneToMany_Optional_Self4),
-                new List<IExpectedInclude> { new ExpectedInclude<Level4>(l4 => l4.OneToMany_Optional_Self4) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level4>(l4 => l4.OneToMany_Optional_Self4)));
         }
 
         [ConditionalTheory(Skip = "Issue#16752")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_after_SelectMany_and_reference_navigation_with_another_SelectMany_with_Distinct(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from lOuter in ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
                           .Include(l3 => l3.OneToMany_Optional3)
@@ -3868,7 +3797,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       from lInner in lOuter.OneToMany_Optional3.Distinct()
                       where lInner != null
                       select lOuter,
-                new List<IExpectedInclude> { new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
         }
 
         [ConditionalTheory]
@@ -3971,7 +3900,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation(bool async)
         {
-            // can't use AssertIncludeQuery here, see #18191
+            // can't use AssertQuery here, see #18191
             return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
@@ -3991,140 +3920,139 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1),
-                new List<IExpectedInclude> { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_FK1),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include3(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_PK1),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include4(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l1 => l1.OneToOne_Optional_PK2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include5(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include6(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_FK1),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include7(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
-                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_PK1),
-                new List<IExpectedInclude>());
+                ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_PK1));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include8(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar")
                     .Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include9(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level2>()
                     .Include(l2 => l2.OneToOne_Optional_FK_Inverse2)
                     .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include10(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1"),
@@ -4133,19 +4061,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_PK3, "OneToOne_Optional_FK1.OneToOne_Optional_FK2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include11(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1"),
@@ -4159,7 +4087,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
@@ -4167,42 +4095,45 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_FK3)
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3)
                     .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_PK2),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include12(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                     .Select(l1 => l1.OneToOne_Optional_FK1),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include13(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1)
                     .Select(l1 => new { one = l1, two = l1 }),
-                expectedIncludes,
-                clientProjections: new List<Func<dynamic, object>> { x => x.one, x => x.two },
+                elementAsserter: (e, a) =>
+                {
+                    AssertInclude(e.one, a.one, expectedIncludes);
+                    AssertInclude(e.two, a.two, expectedIncludes);
+                },
                 elementSorter: e => e.one.Id);
         }
 
@@ -4210,13 +4141,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include14(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2.OneToOne_Optional_FK2)
@@ -4227,12 +4158,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                             two = l1.OneToOne_Optional_FK1,
                             three = l1.OneToOne_Optional_PK1
                         }),
-                expectedIncludes,
-                clientProjections: new List<Func<dynamic, object>>
+                elementAsserter: (e, a) =>
                 {
-                    x => x.one
-                    // issue #15368
-                    //x => x.two,
+                    AssertInclude(e.one, a.one, expectedIncludes);
+                    AssertInclude(e.two, a.two, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2));
+                    AssertEqual(e.three, a.three);
                 },
                 elementSorter: e => e.one.Id);
         }
@@ -4271,45 +4201,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include18_1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(x => x.OneToOne_Optional_FK1).Distinct(),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include18_1_1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1).Take(10),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include18_2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Where(x => x.OneToOne_Required_FK1.Name != "Foo").Include(x => x.OneToOne_Optional_FK1).Distinct(),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalFact]
@@ -4355,18 +4285,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include18_3_3(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level2>(l1 => l1.OneToOne_Optional_FK2)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                     .Select(l1 => l1.OneToOne_Optional_FK1)
                     .Distinct(),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalFact]
@@ -4511,21 +4441,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task IncludeCollection8(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Level1>(e => e.OneToMany_Optional1),
                 new ExpectedInclude<Level2>(e => e.OneToOne_Optional_PK2, "OneToMany_Optional1"),
                 new ExpectedInclude<Level3>(e => e.OneToOne_Optional_FK3, "OneToMany_Optional1.OneToOne_Optional_PK2")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
                     .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
                     .Where(l1 => l1.OneToMany_Optional1.Where(l2 => l2.OneToOne_Optional_PK2.Name != "Foo").Count() > 0),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -4645,14 +4575,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_collections_on_same_level(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1).Include(l1 => l1.OneToMany_Required1),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
-                    new ExpectedInclude<Level1>(l1 => l1.OneToMany_Required1)
-                },
+                    new ExpectedInclude<Level1>(l1 => l1.OneToMany_Required1)),
                 assertOrder: true);
         }
 
@@ -4985,113 +4913,99 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_basic_Where(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1.Where(l2 => l2.Id > 5)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.Where(l2 => l2.Id > 5))
-                });
+                        includeFilter: x => x.Where(l2 => l2.Id > 5))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_OrderBy(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1.OrderBy(x => x.Name)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.OrderBy(x => x.Name))
-                });
+                        includeFilter: x => x.OrderBy(x => x.Name))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_ThenInclude_OrderBy(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToMany_Optional2.OrderBy(x => x.Name)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToMany_Optional1),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToMany_Optional1",
-                        includeFilter: x => x.OrderBy(x => x.Name))
-                });
+                        includeFilter: x => x.OrderBy(x => x.Name))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_ThenInclude_OrderBy(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.OrderBy(x => x.Name))
                     .ThenInclude(l2 => l2.OneToMany_Optional2.OrderByDescending(x => x.Name)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.OrderBy(x => x.Name)),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToMany_Optional1",
-                        includeFilter: x => x.OrderByDescending(x => x.Name))
-                });
+                        includeFilter: x => x.OrderByDescending(x => x.Name))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_basic_OrderBy_Take(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1.OrderBy(x => x.Name).Take(3)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.OrderBy(x => x.Name).Take(3))
-                });
+                        includeFilter: x => x.OrderBy(x => x.Name).Take(3))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_basic_OrderBy_Skip(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1.OrderBy(x => x.Name).Skip(1)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.OrderBy(x => x.Name).Skip(1))
-                });
+                        includeFilter: x => x.OrderBy(x => x.Name).Skip(1))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_basic_OrderBy_Skip_Take(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1.OrderBy(x => x.Name).Skip(1).Take(3)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.OrderBy(x => x.Name).Skip(1).Take(3))
-                });
+                        includeFilter: x => x.OrderBy(x => x.Name).Skip(1).Take(3))));
         }
 
         [ConditionalFact]
@@ -5114,78 +5028,70 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_on_ThenInclude(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1)
                     .ThenInclude(l2 => l2.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToOne_Optional_FK1",
-                        x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3))
-                });
+                        x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_after_reference_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToOne_Optional_FK1",
-                        x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3))
-                });
+                        x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_after_different_filtered_include_same_level(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Take(3))
                     .Include(l1 => l1.OneToMany_Required1.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Take(3)),
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Required1,
-                        includeFilter: x => x.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1))
-                });
+                        includeFilter: x => x.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_after_different_filtered_include_different_level(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Take(3))
                     .ThenInclude(l2 => l2.OneToMany_Required2.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Take(3)),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Required2,
                         "OneToMany_Optional1",
-                        includeFilter: x => x.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1))
-                });
+                        includeFilter: x => x.Where(x => x.Name != "Bar").OrderByDescending(x => x.Name).Skip(1))));
         }
 
         [ConditionalTheory]
@@ -5216,102 +5122,91 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_same_filter_set_on_same_navigation_twice(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderByDescending(x => x.Id).Take(2))
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderByDescending(x => x.Id).Take(2)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderByDescending(x => x.Id).Take(2)),
-                });
+                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderByDescending(x => x.Id).Take(2))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_same_filter_set_on_same_navigation_twice_followed_by_ThenIncludes(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(2)).ThenInclude(l2 => l2.OneToMany_Optional2)
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(2)).ThenInclude(l2 => l2.OneToOne_Required_FK2),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(2)),
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2),
-                    new ExpectedInclude<Level2>(e => e.OneToOne_Required_FK2),
-                });
+                    new ExpectedInclude<Level2>(e => e.OneToOne_Required_FK2)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_multiple_multi_level_includes_with_first_level_using_filter_include_on_one_of_the_chains_only(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(2)).ThenInclude(l2 => l2.OneToMany_Optional2)
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Required_FK2),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(2)),
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToMany_Optional1"),
-                    new ExpectedInclude<Level2>(e => e.OneToOne_Required_FK2, "OneToMany_Optional1"),
-                });
+                    new ExpectedInclude<Level2>(e => e.OneToOne_Required_FK2, "OneToMany_Optional1")));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_and_non_filtered_include_on_same_navigation1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1)
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3))
-                });
+                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_and_non_filtered_include_on_same_navigation2(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3))
                     .Include(l1 => l1.OneToMany_Optional1),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
-                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3))
-                });
+                        includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(3))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1))
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_PK2.OneToMany_Optional3.Where(x => x.Id > 1)),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedFilteredInclude<Level1, Level2>(
                         e => e.OneToMany_Optional1,
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)),
@@ -5319,50 +5214,45 @@ namespace Microsoft.EntityFrameworkCore.Query
                     new ExpectedFilteredInclude<Level3, Level4>(
                         e => e.OneToMany_Optional3,
                         "OneToMany_Optional1.OneToOne_Optional_PK2",
-                        includeFilter: x => x.Where(x => x.Id > 1)),
-                });
+                        includeFilter: x => x.Where(x => x.Id > 1))));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_complex_three_level_with_middle_having_filter1(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)).ThenInclude(l3 => l3.OneToMany_Optional3)
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)).ThenInclude(l3 => l3.OneToMany_Required3),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToMany_Optional1),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToMany_Optional1",
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)),
                     new ExpectedInclude<Level3>(e => e.OneToMany_Optional3, "OneToMany_Optional1.OneToMany_Optional2"),
-                    new ExpectedInclude<Level3>(e => e.OneToMany_Required3, "OneToMany_Optional1.OneToMany_Optional2"),
-                });
+                    new ExpectedInclude<Level3>(e => e.OneToMany_Required3, "OneToMany_Optional1.OneToMany_Optional2")));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Filtered_include_complex_three_level_with_middle_having_filter2(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Level1>()
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)).ThenInclude(l3 => l3.OneToMany_Optional3)
                     .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToMany_Optional2).ThenInclude(l3 => l3.OneToMany_Required3),
-                new List<IExpectedInclude>
-                {
+                elementAsserter: (e, a) => AssertInclude(e, a,
                     new ExpectedInclude<Level1>(e => e.OneToMany_Optional1),
                     new ExpectedFilteredInclude<Level2, Level3>(
                         e => e.OneToMany_Optional2,
                         "OneToMany_Optional1",
                         includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1)),
                     new ExpectedInclude<Level3>(e => e.OneToMany_Optional3, "OneToMany_Optional1.OneToMany_Optional2"),
-                    new ExpectedInclude<Level3>(e => e.OneToMany_Required3, "OneToMany_Optional1.OneToMany_Optional2"),
-                });
+                    new ExpectedInclude<Level3>(e => e.OneToMany_Required3, "OneToMany_Optional1.OneToMany_Optional2")));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -48,17 +48,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_one_to_one_and_one_to_many(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<CogTag>(t => t.Gear),
                 new ExpectedInclude<Gear>(g => g.Weapons, "Gear"),
                 new ExpectedInclude<Officer>(o => o.Weapons, "Gear")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Include(t => t.Gear.Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -89,17 +89,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_one_to_one_optional_and_one_to_one_required(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<CogTag>(t => t.Gear),
                 new ExpectedInclude<Gear>(g => g.Squad, "Gear"),
                 new ExpectedInclude<Officer>(o => o.Squad, "Gear")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Include(t => t.Gear.Squad),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -114,49 +114,49 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_circular(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.CityOfBirth),
                 new ExpectedInclude<Officer>(o => o.CityOfBirth),
                 new ExpectedInclude<City>(c => c.StationedGears, "CityOfBirth")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => g.CityOfBirth.StationedGears),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_multiple_circular_with_filter(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.CityOfBirth),
                 new ExpectedInclude<Officer>(o => o.CityOfBirth),
                 new ExpectedInclude<City>(c => c.StationedGears, "CityOfBirth")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => g.CityOfBirth.StationedGears).Where(g => g.Nickname == "Marcus"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_using_alternate_key(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(o => o.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => g.Weapons).Where(g => g.Nickname == "Marcus"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -178,116 +178,116 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_navigation_on_derived_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.Reports) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>().Include(o => o.Reports),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task String_based_Include_navigation_on_derived_type(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.Reports) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>().Include("Reports"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_Where_Navigation_Included(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<CogTag>(t => t.Gear) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<CogTag>(t => t.Gear) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from t in ss.Set<CogTag>().Include(o => o.Gear)
                       where t.Gear.Nickname == "Marcus"
                       select t,
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_reference1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.CityOfBirth),
                 new ExpectedInclude<Officer>(o => o.CityOfBirth)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Join(
                     ss.Set<CogTag>(),
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     (g, t) => g).Include(g => g.CityOfBirth),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_reference2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.CityOfBirth),
                 new ExpectedInclude<Officer>(o => o.CityOfBirth)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Join(
                     ss.Set<Gear>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     (t, g) => g).Include(g => g.CityOfBirth),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_collection1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(o => o.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Join(
                     ss.Set<CogTag>(),
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     (g, t) => g).Include(g => g.Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_collection2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(o => o.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Join(
                     ss.Set<Gear>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     (t, g) => g).Include(g => g.Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -359,46 +359,46 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_multi_level(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.CityOfBirth),
                 new ExpectedInclude<Officer>(o => o.CityOfBirth),
                 new ExpectedInclude<City>(c => c.StationedGears, "CityOfBirth")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Join(
                     ss.Set<CogTag>(),
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     (g, t) => g).Include(g => g.CityOfBirth.StationedGears),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_and_inheritance1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.CityOfBirth) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.CityOfBirth) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Join(
                     ss.Set<Gear>().OfType<Officer>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     o => new { SquadId = (int?)o.SquadId, o.Nickname },
                     (t, o) => o).Include(o => o.CityOfBirth),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_and_inheritance_with_orderby_before_and_after_include(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.Reports) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Join(
                         ss.Set<Gear>().OfType<Officer>().OrderBy(ee => ee.SquadId),
@@ -406,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         o => new { SquadId = (int?)o.SquadId, o.Nickname },
                         (t, o) => o).OrderBy(ee => ee.FullName).Include(o => o.Reports).OrderBy(oo => oo.HasSoulPatch)
                     .ThenByDescending(oo => oo.Nickname),
-                expectedIncludes,
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes),
                 assertOrder: true);
         }
 
@@ -414,47 +414,47 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_and_inheritance2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Weapons) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.Weapons) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>().Join(
                     ss.Set<CogTag>(),
                     o => new { SquadId = (int?)o.SquadId, o.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     (o, t) => o).Include(g => g.Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_join_and_inheritance3(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Officer>(o => o.Reports) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Join(
                     ss.Set<Gear>().OfType<Officer>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
                     g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     (t, o) => o).Include(o => o.Reports),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_nested_navigation_in_order_by(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Weapon>(w => w.Owner) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Weapon>(w => w.Owner) };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Weapon>()
                     .Include(w => w.Owner)
                     .Where(w => w.Owner.Nickname != "Paduk")
                     .OrderBy(e => e.Owner.CityOfBirth.Name).ThenBy(e => e.Id),
-                expectedIncludes,
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes),
                 assertOrder: true);
         }
 
@@ -1711,26 +1711,26 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_with_inheritance_and_join_include_joined(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => (from t in ss.Set<CogTag>()
                        join g in ss.Set<Gear>().OfType<Officer>() on new { id1 = t.GearSquadId, id2 = t.GearNickName }
                            equals new { id1 = (int?)g.SquadId, id2 = g.Nickname }
                        select g).Include(g => g.Tag),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Tag) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Tag)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Collection_with_inheritance_and_join_include_source(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => (from g in ss.Set<Gear>().OfType<Officer>()
                        join t in ss.Set<CogTag>() on new { id1 = (int?)g.SquadId, id2 = g.Nickname }
                            equals new { id1 = t.GearSquadId, id2 = t.GearNickName }
                        select g).Include(g => g.Tag),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Tag) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Tag)));
         }
 
         [ConditionalTheory]
@@ -1866,31 +1866,31 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(g => g.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
                       join g2 in ss.Set<Gear>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
                       select g2 ?? g1,
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#16899")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(g => g.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
                       join g2 in ss.Set<Gear>().Include(g => g.Weapons)
@@ -1902,45 +1902,44 @@ namespace Microsoft.EntityFrameworkCore.Query
                           g2,
                           coalesce = g2 ?? g1
                       },
-                expectedIncludes,
-                elementSorter: e => e.g1.Nickname,
-                clientProjections: new List<Func<dynamic, object>>
+                elementAsserter: (e, a) =>
                 {
-                    r => r.g1,
-                    r => r.g2,
-                    r => r.coalesce
-                });
+                    AssertInclude(e.g1, a.g1, expectedIncludes);
+                    AssertInclude(e.g2, a.g2, expectedIncludes);
+                    AssertInclude(e.coalesce, a.coalesce, expectedIncludes);
+                },
+                elementSorter: e => e.g1.Nickname);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_inheritance_and_coalesce_result(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(g => g.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
                       join g2 in ss.Set<Gear>().OfType<Officer>().Include(g => g.Weapons)
                           on g1.LeaderNickname equals g2.Nickname into grouping
                       from g2 in grouping.DefaultIfEmpty()
                       select g2 ?? g1,
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#15783")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(g => g.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
                       join g2 in ss.Set<Gear>().Include(g => g.Weapons)
@@ -1949,19 +1948,19 @@ namespace Microsoft.EntityFrameworkCore.Query
 #pragma warning disable IDE0029 // Use coalesce expression
                       select g2 != null ? g2 : g1,
 #pragma warning restore IDE0029 // Use coalesce expression
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "issue #16899")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_complex_projection_result(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Weapons), new ExpectedInclude<Officer>(g => g.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from g1 in ss.Set<Gear>().Include(g => g.Weapons)
                       join g2 in ss.Set<Gear>().Include(g => g.Weapons)
@@ -1976,15 +1975,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                           conditional = g2 != null ? g2 : g1
                       },
 #pragma warning restore IDE0029 // Use coalesce expression
-                expectedIncludes,
-                elementSorter: e => e.g1.Nickname + " " + e.g2?.Nickname,
-                clientProjections: new List<Func<dynamic, object>>
+                elementAsserter: (e, a) =>
                 {
-                    e => e.g1,
-                    e => e.g2,
-                    e => e.coalesce,
-                    e => e.conditional
-                });
+                    AssertInclude(e.g1, a.g1, expectedIncludes);
+                    AssertInclude(e.g2, a.g2, expectedIncludes);
+                    AssertInclude(e.coalesce, a.coalesce, expectedIncludes);
+                    AssertInclude(e.conditional, a.conditional, expectedIncludes);
+                },
+                elementSorter: e => e.g1.Nickname + " " + e.g2?.Nickname);
         }
 
         [ConditionalTheory]
@@ -2736,7 +2734,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_is_properly_lifted_from_subquery_created_by_include(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>()
                     .Where(g => g.FullName != "Augustus Cole")
@@ -2744,7 +2742,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .OrderBy(g => g.FullName)
                     .Where(g => !g.HasSoulPatch)
                     .Select(g => g),
-                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.Tag) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Gear>(e => e.Tag)),
                 assertOrder: true);
         }
 
@@ -2833,13 +2831,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Subquery_created_by_include_gets_lifted_nested(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from gear in ss.Set<Gear>().OrderBy(g => g.Rank).Where(g => g.Weapons.Any()).Include(g => g.CityOfBirth)
                       where !gear.HasSoulPatch
                       orderby gear.Nickname
                       select gear,
-                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.CityOfBirth) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Gear>(e => e.CityOfBirth)),
                 assertOrder: true);
         }
 
@@ -3161,18 +3159,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_derived_entity_using_OfType(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustHorde>(e => e.Commander),
                 new ExpectedInclude<LocustHorde>(e => e.Leaders)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => from lh in ss.Set<Faction>().OfType<LocustHorde>().Include(h => h.Commander).Include(h => h.Leaders)
                       orderby lh.Name
                       select lh,
-                expectedIncludes,
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes),
                 assertOrder: true);
         }
 
@@ -3180,15 +3178,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_derived_entity_with_cast(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude> { new ExpectedInclude<Faction>(e => e.Capital) };
+            var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Faction>(e => e.Capital) };
 
             // TODO: should we disable this scenario? see #14671
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => (from f in ss.Set<Faction>()
                        where f is LocustHorde
                        select f).Include(f => f.Capital),
-                expectedIncludes,
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes),
                 assertOrder: true);
         }
 
@@ -3360,73 +3358,73 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_string(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include("DefeatedBy"),
-                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_string_nested1(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy),
                 new ExpectedInclude<Gear>(g => g.Squad, "DefeatedBy")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include("DefeatedBy.Squad"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_string_nested2(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy),
                 new ExpectedInclude<Officer>(o => o.Reports, "DefeatedBy"),
                 new ExpectedInclude<Gear>(g => g.CityOfBirth, "DefeatedBy.Reports")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include("DefeatedBy.Reports.CityOfBirth"),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy),
-                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda_with_soft_cast(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include(ll => (ll as LocustCommander).DefeatedBy),
-                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_reference_on_derived_type_using_lambda_with_tracking(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().AsTracking().Include(ll => ((LocustCommander)ll).DefeatedBy),
-                new List<IExpectedInclude> { new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)),
                 entryCount: 7);
         }
 
@@ -3434,143 +3432,143 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_string(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include("Reports"),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_lambda(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_derived_type_using_lambda_with_soft_cast(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => (g as Officer).Reports),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_base_navigation_on_derived_entity(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Officer>(e => e.Tag), new ExpectedInclude<Officer>(e => e.Weapons)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => ((Officer)g).Tag).Include(g => ((Officer)g).Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task ThenInclude_collection_on_derived_after_base_reference(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<CogTag>(e => e.Gear), new ExpectedInclude<Officer>(e => e.Weapons, "Gear")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Include(t => t.Gear).ThenInclude(g => (g as Officer).Weapons),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task ThenInclude_collection_on_derived_after_derived_reference(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustHorde>(e => e.Commander),
                 new ExpectedInclude<LocustCommander>(e => e.DefeatedBy, "Commander"),
                 new ExpectedInclude<Officer>(e => e.Reports, "Commander.DefeatedBy")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Faction>().Include(f => (f as LocustHorde).Commander).ThenInclude(c => (c.DefeatedBy as Officer).Reports),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task ThenInclude_collection_on_derived_after_derived_collection(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Officer>(e => e.Reports),
                 new ExpectedInclude<Officer>(e => e.Reports, "Reports")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports).ThenInclude(g => ((Officer)g).Reports),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task ThenInclude_reference_on_derived_after_derived_collection(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustHorde>(e => e.Leaders),
                 new ExpectedInclude<LocustCommander>(e => e.DefeatedBy, "Leaders")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Faction>().Include(f => ((LocustHorde)f).Leaders).ThenInclude(l => ((LocustCommander)l).DefeatedBy),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_derived_included_on_one_method(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustHorde>(e => e.Commander),
                 new ExpectedInclude<LocustCommander>(e => e.DefeatedBy, "Commander"),
                 new ExpectedInclude<Officer>(e => e.Reports, "Commander.DefeatedBy")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Faction>().Include(f => (((LocustHorde)f).Commander.DefeatedBy as Officer).Reports),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_derived_multi_level(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Officer>(e => e.Reports),
                 new ExpectedInclude<Gear>(e => e.Squad, "Reports"),
                 new ExpectedInclude<Squad>(e => e.Missions, "Reports.Squad")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => ((Officer)g).Reports).ThenInclude(g => g.Squad.Missions),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory(Skip = "Issue#15312")]
@@ -4733,18 +4731,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_on_derived_type_with_order_by_and_paging(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<LocustCommander>(e => e.DefeatedBy),
                 new ExpectedInclude<Gear>(e => e.Weapons, "DefeatedBy")
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy).ThenInclude(g => g.Weapons)
                     .OrderBy(ll => ((LocustCommander)ll).DefeatedBy.Tag.Note).Take(10),
                 ss => ss.Set<LocustLeader>().Take(10),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
@@ -4839,16 +4837,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_with_concat(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(g => g.Squad), new ExpectedInclude<Officer>(o => o.Squad)
             };
 
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertIncludeQuery(
+                () => AssertQuery(
                     async,
                     ss => ss.Set<Gear>().Include(g => g.Squad).Concat(ss.Set<Gear>()),
-                    expectedIncludes))).Message;
+                    elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes)))).Message;
 
             Assert.Equal(
                 "When performing a set operation, both operands must have the same Include operations.",
@@ -5169,11 +5167,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_order_by_constant(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Squad>().Include(s => s.Members).OrderBy(s => 42).Select(s => s),
                 expectedQuery: ss => ss.Set<Squad>(),
-                new List<IExpectedInclude> { new ExpectedInclude<Squad>(s => s.Members) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Squad>(s => s.Members)));
         }
 
         [ConditionalTheory]
@@ -5225,31 +5223,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
-        [ConditionalTheory(Skip = "issue #11567")]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual Task Include_with_order_by_constant_null_of_non_mapped_type(bool async)
-        {
-            return AssertIncludeQuery(
-                async,
-                ss => ss.Set<Squad>().Include(s => s.Members).OrderBy(s => (MyDTO)null),
-                expectedQuery: ss => ss.Set<Squad>(),
-                new List<IExpectedInclude> { new ExpectedInclude<Squad>(s => s.Members) });
-        }
-
-        [ConditionalFact(Skip = "issue #11567")]
-        public virtual void Include_groupby_constant_null_of_non_mapped_type()
-        {
-            using var ctx = CreateContext();
-            var query = ctx.Squads.Include(s => s.Members).GroupBy(s => (MyDTO)null);
-            var result = query.ToList();
-
-            Assert.Single(result);
-            var bucket = result[0].ToList();
-            Assert.Equal(2, bucket.Count);
-            Assert.NotNull(bucket[0].Members);
-            Assert.NotNull(bucket[1].Members);
-        }
-
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
@@ -5271,12 +5244,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_OrderBy_aggregate(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.Count).ThenBy(o => o.Nickname),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)),
                 assertOrder: true);
         }
 
@@ -5284,12 +5257,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_complex_OrderBy2(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic).ThenBy(o => o.Nickname),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)),
                 assertOrder: true);
         }
 
@@ -5297,12 +5270,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_complex_OrderBy3(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>()
                     .Include(o => o.Reports)
                     .OrderBy(o => o.Weapons.OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()).ThenBy(o => o.Nickname),
-                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)),
                 assertOrder: true);
         }
 
@@ -5790,7 +5763,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector(bool async)
         {
-            // TODO: convert to AssertIncludeQuery
             return AssertQuery(
                 async,
                 ss => ss.Set<Gear>()
@@ -5811,7 +5783,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector_using_EF_Property(bool async)
         {
-            // TODO: convert to AssertIncludeQuery
             return AssertQuery(
                 async,
                 ss => ss.Set<Gear>()
@@ -5861,26 +5832,26 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_group_by_and_FirstOrDefault_gets_properly_applied(bool async)
         {
-            var expectedIncludes = new List<IExpectedInclude>
+            var expectedIncludes = new IExpectedInclude[]
             {
                 new ExpectedInclude<Gear>(e => e.CityOfBirth),
                 new ExpectedInclude<Officer>(e => e.CityOfBirth)
             };
 
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().Include(g => g.CityOfBirth).GroupBy(g => g.Rank).Select(g => g.FirstOrDefault(gg => gg.HasSoulPatch)),
-                expectedIncludes);
+                elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_with_Cast_to_base(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>().OfType<Officer>().Include(o => o.Weapons).Cast<Gear>(),
-                new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.Weapons) });
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Gear>(e => e.Weapons)));
         }
 
         [ConditionalTheory]
@@ -6200,13 +6171,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_with_complex_order_by(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<Gear>()
                     .Include(g => g.Weapons)
                     .OrderBy(g => g.Weapons.FirstOrDefault(w => w.Name.Contains("Gnasher")).Name)
                     .ThenBy(g => g.Nickname),
-                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.Weapons) },
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Gear>(e => e.Weapons)),
                 assertOrder: true);
         }
 
@@ -6503,13 +6474,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Reference_include_chain_loads_correctly_when_middle_is_null(bool async)
         {
-            return AssertIncludeQuery(
+            return AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().AsTracking().OrderBy(t => t.Note).Include(t => t.Gear).ThenInclude(g => g.Squad),
-                new List<IExpectedInclude>
-                {
-                    new ExpectedInclude<CogTag>(t => t.Gear), new ExpectedInclude<Gear>(t => t.Squad, "Gear")
-                },
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                new ExpectedInclude<CogTag>(t => t.Gear), new ExpectedInclude<Gear>(t => t.Squad, "Gear")),
                 entryCount: 13);
         }
 

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -80,47 +80,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TResult : struct
             => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, async, testMethodName);
 
-        public Task<List<TResult>> AssertIncludeQuery<TResult>(
-            bool async,
-            Func<ISetSource, IQueryable<TResult>> query,
-            List<IExpectedInclude> expectedIncludes,
-            Func<TResult, object> elementSorter = null,
-            List<Func<TResult, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            => AssertIncludeQuery(
-                async,
-                query,
-                query,
-                expectedIncludes,
-                elementSorter,
-                clientProjections,
-                assertOrder,
-                entryCount,
-                testMethodName);
-
-        public Task<List<TResult>> AssertIncludeQuery<TResult>(
-            bool async,
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            List<IExpectedInclude> expectedIncludes,
-            Func<TResult, object> elementSorter = null,
-            List<Func<TResult, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            [CallerMemberName] string testMethodName = null)
-            => Fixture.QueryAsserter.AssertIncludeQuery(
-                actualQuery,
-                expectedQuery,
-                expectedIncludes,
-                elementSorter,
-                clientProjections,
-                assertOrder,
-                entryCount,
-                async,
-                testMethodName);
-
         protected Task AssertSingleResult<TResult>(
             bool async,
             Expression<Func<ISetSource, TResult>> syncQuery,
@@ -1116,6 +1075,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<TElement, object> elementSorter = null,
             Action<TElement, TElement> elementAsserter = null)
             => Fixture.QueryAsserter.AssertCollection(expected, actual, ordered, elementSorter, elementAsserter);
+
+        protected void AssertInclude<TEntity>(
+            TEntity expected,
+            TEntity actual,
+            params IExpectedInclude[] expectedIncludes)
+            => Fixture.QueryAsserter.AssertInclude(expected, actual, expectedIncludes);
 
         protected void AssertGrouping<TKey, TElement>(
             IGrouping<TKey, TElement> expected,

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -51,17 +51,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             string testMethodName)
             where TResult : struct;
 
-        public abstract Task<List<TResult>> AssertIncludeQuery<TResult>(
-            Func<ISetSource, IQueryable<TResult>> actualQuery,
-            Func<ISetSource, IQueryable<TResult>> expectedQuery,
-            List<IExpectedInclude> expectedIncludes,
-            Func<TResult, object> elementSorter,
-            List<Func<TResult, object>> clientProjections,
-            bool assertOrder,
-            int entryCount,
-            bool async,
-            string testMethodName);
-
         #region Assert termination operation methods
 
         public abstract Task AssertAny<TResult>(
@@ -536,6 +525,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             bool ordered = false,
             Func<TElement, object> elementSorter = null,
             Action<TElement, TElement> elementAsserter = null);
+
+        public abstract void AssertInclude<TEntity>(
+            TEntity expected,
+            TEntity actual,
+            IExpectedInclude[] expectedIncludes);
 
         #endregion
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -208,22 +208,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Assert.Equal(expected.Count, actual.Count);
 
             if (elementSorter == null
-                && !verifyOrdered)
+                && !verifyOrdered
+                && expected.Count > 1 // If there is only 1 element then sorting is not necessary
+                && expected.FirstOrDefault(e => e != null) is T nonNullElement
+                    && nonNullElement.GetType().GetInterface(nameof(IComparable)) == null)
             {
-                if (expected.Count > 1)
+                if (elementAsserter != null)
                 {
-                    if (expected.FirstOrDefault(e => e != null) is T nonNullElement
-                        && nonNullElement.GetType().GetInterface(nameof(IComparable)) == null)
-                    {
-                        if (elementAsserter != null)
-                        {
-                            throw new InvalidOperationException(
-                                "Element asserter will not be used because results are not properly ordered - either remove asserter from the AssertQuery, add element sorter or set assertOrder to 'true'.");
-                        }
-
-                        return AssertResults(expected, actual);
-                    }
+                    throw new InvalidOperationException(
+                        "Element asserter will not be used because results are not properly ordered - either remove asserter from the AssertQuery, add element sorter or set assertOrder to 'true'.");
                 }
+
+                return AssertResults(expected, actual);
             }
 
             elementSorter ??= (e => e);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -4839,22 +4839,6 @@ LEFT JOIN (
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]");
         }
 
-        public override async Task Include_with_order_by_constant_null_of_non_mapped_type(bool async)
-        {
-            await base.Include_with_order_by_constant_null_of_non_mapped_type(async);
-
-            AssertSql(
-                "");
-        }
-
-        public override void Include_groupby_constant_null_of_non_mapped_type()
-        {
-            base.Include_groupby_constant_null_of_non_mapped_type();
-
-            AssertSql(
-                "");
-        }
-
         public override async Task Include_collection_OrderBy_aggregate(bool async)
         {
             await base.Include_collection_OrderBy_aggregate(async);


### PR DESCRIPTION
Remove AssertIncludeQuery which is based on queryable
Introduce AssertInclude method over element which can be used anywhere element asserter can be passed just like collection asserter

Resolves #15368
