### PR TITLE
Modified ALTER DATABASE statement to support complex names. (#19291)

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -911,7 +911,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder
                     .AppendLine("BEGIN")
                     .AppendLine("DECLARE @db_name NVARCHAR(MAX) = DB_NAME();")
-                    .AppendLine("EXEC(N'ALTER DATABASE ' + @db_name + ' MODIFY ( ")
+                    .AppendLine("EXEC(N'ALTER DATABASE [' + @db_name + '] MODIFY ( ")
                     .Append(editionOptions.Replace("'", "''"))
                     .AppendLine(" );');")
                     .AppendLine("END")


### PR DESCRIPTION
Ports fix for #19290 to 3.1.

### Description

Creating a SQL Server database from EF Core fails when the database name contains special characters.

### Customer Impact

The only workarounds are to not use EF to create the database, or to remove the special characters from the name.

### How found

Reported by two customers.

### Test coverage

This fix is already in 5.0 and has been manually tested. Automated testing is not possible because it would involve dropping a database in a test run, which destabilizes SQL Server.

### Regression?

No.

### Risk

Very low.
