### PR TITLE
[TINY] Regression test for #13906 - String.CompareTo emits unicode literal against varchar column

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7555,6 +7555,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 + Environment.NewLine + CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task CompareTo_used_with_non_unicode_string_column_and_constant(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<City>().Where(c => c.Location.CompareTo("Unknown") == 0));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6961,6 +6961,16 @@ WHERE [w0].[Id] IS NOT NULL AND ([w0].[AmmunitionType] IN (1) OR [w0].[Ammunitio
 FROM [Missions] AS [m]");
         }
 
+        public override async Task CompareTo_used_with_non_unicode_string_column_and_constant(bool async)
+        {
+            await base.CompareTo_used_with_non_unicode_string_column_and_constant(async);
+
+            AssertSql(
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
+FROM [Cities] AS [c]
+WHERE [c].[Location] = 'Unknown'");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Issue has been fixed in earlier commit.

Resolves #13906