### PR TITLE
[TINY] Add regression test for #20992 - Select with coalesce operator on field non unicode string should not append N

### DIFF
--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7564,6 +7564,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<City>().Where(c => c.Location.CompareTo("Unknown") == 0));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Coalesce_used_with_non_unicode_string_column_and_constant(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<City>().Select(c => c.Location ?? "Unknown"));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6971,6 +6971,15 @@ FROM [Cities] AS [c]
 WHERE [c].[Location] = 'Unknown'");
         }
 
+        public override async Task Coalesce_used_with_non_unicode_string_column_and_constant(bool async)
+        {
+            await base.Coalesce_used_with_non_unicode_string_column_and_constant(async);
+
+            AssertSql(
+                @"SELECT COALESCE([c].[Location], 'Unknown')
+FROM [Cities] AS [c]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Resolves #20992