### PR TITLE
Use cloned IDiagnosticsLogger in compiled query cache

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 _innerEnumerable = innerEnumerable;
                 _shaper = shaper;
                 _contextType = contextType;
-                _logger = logger;
+                _logger = logger.CloneWithoutInterceptor();
             }
 
             public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
+++ b/src/EFCore/Diagnostics/IDiagnosticsLogger`.cs
@@ -32,5 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     Holds registered interceptors, if any.
         /// </summary>
         IInterceptors Interceptors { get; }
+
+        IDiagnosticsLogger<TLoggerCategory> CloneWithoutInterceptor();
     }
 }

--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -52,6 +52,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        private DiagnosticsLogger(
+            [NotNull] ILogger logger,
+            [NotNull] ILoggingOptions loggingOptions,
+            [NotNull] DiagnosticSource diagnosticSource,
+            [NotNull] LoggingDefinitions loggingDefinitions)
+        {
+            Logger = logger;
+            Options = loggingOptions;
+            DiagnosticSource = diagnosticSource;
+            Definitions = loggingDefinitions;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual ILoggingOptions Options { get; }
 
         /// <summary>
@@ -85,6 +103,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual LoggingDefinitions Definitions { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IDiagnosticsLogger<TLoggerCategory> CloneWithoutInterceptor()
+            => new DiagnosticsLogger<TLoggerCategory>(Logger, Options, DiagnosticSource, Definitions);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Model = dependencies.Model;
             ContextOptions = dependencies.ContextOptions;
             ContextType = context.GetType();
-            Logger = dependencies.Logger;
+            Logger = dependencies.Logger.CloneWithoutInterceptor();
 
             _queryTranslationPreprocessorFactory = dependencies.QueryTranslationPreprocessorFactory;
             _queryableMethodTranslatingExpressionVisitorFactory = dependencies.QueryableMethodTranslatingExpressionVisitorFactory;

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeDiagnosticsLogger.cs
@@ -35,6 +35,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public IDisposable BeginScope<TState>(TState state) => null;
 
+        public IDiagnosticsLogger<T> CloneWithoutInterceptor()
+            => new FakeDiagnosticsLogger<T>();
+
         public virtual LoggingDefinitions Definitions { get; } = new TestRelationalLoggingDefinitions();
 
         public IInterceptors Interceptors { get; }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLogger`.cs
@@ -10,5 +10,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         where TDefinitions : LoggingDefinitions, new()
     {
         public IInterceptors Interceptors { get; }
+
+        public IDiagnosticsLogger<TCategory> CloneWithoutInterceptor()
+            => new TestLogger<TCategory, TDefinitions>();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/21016 
This PR fixs the memory leak in compiled query cache
It introduce a IDiagnosticsLogger clone used in the QueryingEnumerable code paths, so the Closure held by compiled `Func<QueryContext,T>` never reference Scoped instances via Interceptors.

I have tried to use a IDiagnosticsLogger singleton, but since ILoggerFactory can be either scoped or singleton, going Singleton for DiagnosticsLogger requires breaking changes.
This "clone way" have minimum impact on the existing code base.