### PR TITLE
[SMALL] Fix to #19801 - Query: add validation to warn about required navigations pointing to entity with query filter

### DIFF
--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -104,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             RequiredAttributeOnCollection,
             CollectionWithoutComparer,
             ConflictingKeylessAndKeyAttributesWarning,
+            PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning,
 
             // ChangeTracking events
             DetectChangesStarting = CoreBaseId + 800,
@@ -645,6 +646,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId ConflictingKeylessAndKeyAttributesWarning = MakeModelId(Id.ConflictingKeylessAndKeyAttributesWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         Required navigation with principal entity having global query filter defined
+        ///         and the declaring entity not having a matching filter
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model.Validation" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="ForeignKeyEventData" /> payload when used with a
+        ///         <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning
+            = MakeModelValidationId(Id.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning);
 
         private static readonly string _changeTrackingPrefix = DbLoggerCategory.ChangeTracking.Name + ".";
         private static EventId MakeChangeTrackingId(Id id) => new EventId((int)id, _changeTrackingPrefix + id);

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -2996,5 +2996,44 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 p.Property.Name,
                 p.Property.DeclaringEntityType.DisplayName());
         }
+
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="foreignKey"> Foreign key which is used in the incorrectly setup navigation. </param>
+        public static void PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model.Validation> diagnostics,
+            [NotNull] IForeignKey foreignKey)
+        {
+            var definition = CoreResources.LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(
+                    diagnostics,
+                    foreignKey.PrincipalEntityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName());
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new ForeignKeyEventData(
+                    definition,
+                    PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning,
+                    foreignKey);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
+
+        private static string PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (ForeignKeyEventData)payload;
+            return d.GenerateMessage(
+                p.ForeignKey.PrincipalEntityType.DisplayName(),
+                p.ForeignKey.DeclaringEntityType.DisplayName());
+        }
     }
 }

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -654,5 +654,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         [EntityFrameworkInternal]
         public EventDefinitionBase LogConflictingKeylessAndKeyAttributes;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public EventDefinitionBase LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction;
     }
 }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -947,6 +947,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     throw new InvalidOperationException(
                         CoreStrings.BadFilterDerivedType(entityType.GetQueryFilter(), entityType.DisplayName()));
                 }
+
+                var requiredNavigationWithQueryFilter = entityType.GetNavigations()
+                    .Where(n => !n.IsCollection
+                        && n.ForeignKey.IsRequired
+                        && n.IsOnDependent
+                        && n.ForeignKey.PrincipalEntityType.GetQueryFilter() != null
+                        && n.ForeignKey.DeclaringEntityType.GetQueryFilter() == null).FirstOrDefault();
+
+                if (requiredNavigationWithQueryFilter != null)
+                {
+                    logger.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning(requiredNavigationWithQueryFilter.ForeignKey);
+                }
             }
         }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -4243,5 +4243,29 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
 
             return (EventDefinition<string, string>)definition;
         }
+
+        /// <summary>
+        ///     Entity '{principalEntityType}' has global query filter defined and is a required end of a relationship with the entity '{declaringEntityType}'. This may lead to unexpected results when the required entity is filtered out. Either use optional navigation or define matching query filters for both entities in the navigation. See https://go.microsoft.com/fwlink/?linkid=2131316 for more information.
+        /// </summary>
+        public static EventDefinition<string, string> LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction,
+                    () => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning,
+                            _resourceManager.GetString("LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction"))));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1375,6 +1375,10 @@
     <value>Conflicting attributes have been applied: the 'Key' attribute on property '{property}' and the 'Keyless' attribute on its entity '{entity}'. Note that the entity will have no key unless you use fluent API to override this.</value>
     <comment>Warning CoreEventId.ConflictingKeylessAndKeyAttributesWarning string string</comment>
   </data>
+  <data name="LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction" xml:space="preserve">
+    <value>Entity '{principalEntityType}' has global query filter defined and is a required end of a relationship with the entity '{declaringEntityType}'. This may lead to unexpected results when the required entity is filtered out. Either use optional navigation or define matching query filters for both entities in the navigation. See https://go.microsoft.com/fwlink/?linkid=2131316 for more information.</value>
+    <comment>Warning CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning string string</comment>
+  </data>
   <data name="InvalidSwitch" xml:space="preserve">
     <value>Invalid {name}: {value}</value>
   </data>

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -1300,6 +1300,46 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             VerifyError(CoreStrings.DuplicateDiscriminatorValue(typeof(C).Name, 1, typeof(A).Name), model);
         }
 
+        [ConditionalFact]
+        public virtual void Required_navigation_with_query_filter_on_one_side_issues_a_warning()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>().HasMany(x => x.Orders).WithOne(x => x.Customer).IsRequired();
+            modelBuilder.Entity<Customer>().HasQueryFilter(x => x.Id > 5);
+
+            var message = CoreResources.LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction(
+                CreateValidationLogger()).GenerateMessage(nameof(Customer), nameof(Order));
+
+            VerifyWarning(message, modelBuilder.Model);
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_navigation_with_query_filter_on_one_side_doesnt_issue_a_warning()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>().HasMany(x => x.Orders).WithOne(x => x.Customer).IsRequired(false);
+            modelBuilder.Entity<Customer>().HasQueryFilter(x => x.Id > 5);
+
+            var message = CoreResources.LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction(
+                CreateValidationLogger()).GenerateMessage(nameof(Customer), nameof(Order));
+
+            VerifyLogDoesNotContain(message, modelBuilder.Model);
+        }
+
+        [ConditionalFact]
+        public virtual void Required_navigation_with_query_filter_on_both_sides_doesnt_issue_a_warning()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>().HasMany(x => x.Orders).WithOne(x => x.Customer).IsRequired();
+            modelBuilder.Entity<Customer>().HasQueryFilter(x => x.Id > 5);
+            modelBuilder.Entity<Order>().HasQueryFilter(x => x.Customer.Id > 5);
+
+            var message = CoreResources.LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction(
+                CreateValidationLogger()).GenerateMessage(nameof(Customer), nameof(Order));
+
+            VerifyLogDoesNotContain(message, modelBuilder.Model);
+        }
+
         // INotify interfaces not really implemented; just marking the classes to test metadata construction
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
         {


### PR DESCRIPTION
Warning is issued for required navigations for which required side has query filter and the optional side doesn't.
When both sides define query filters we assume they are correct, i.e. we don't peek inside the filters to make sure they are consistent.

Fixes #19801