### PR TITLE
Workaround for #21016

### DIFF
--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -23,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///         The implementation does not need to be thread-safe.
     ///     </para>
     /// </summary>
-    public class DiagnosticsLogger<TLoggerCategory> : IDiagnosticsLogger<TLoggerCategory>
+    public class DiagnosticsLogger<TLoggerCategory> : IDiagnosticsLogger<TLoggerCategory>, IDisposable
         where TLoggerCategory : LoggerCategory<TLoggerCategory>, new()
     {
         /// <summary>
@@ -68,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IInterceptors Interceptors { get; }
+        public virtual IInterceptors Interceptors { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -85,6 +86,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual LoggingDefinitions Definitions { get; }
+
+        public void Dispose()
+        {
+            Interceptors = null;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/DiagnosticsLogger.cs
+++ b/src/EFCore/Internal/DiagnosticsLogger.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public virtual LoggingDefinitions Definitions { get; }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             Interceptors = null;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/efcore/issues/21016
Another "light" way to workaround the memory leak : we clear Interceptors when the parent ServiceProviderEngineScope is Disposing the scope.