### PR TITLE
Use scoped query logger from QueryContext

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
             private readonly Type _contextType;
             private readonly string _partitionKey;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _performIdentityResolution;
 
             public QueryingEnumerable(
@@ -43,7 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 Func<CosmosQueryContext, JObject, T> shaper,
                 Type contextType,
                 string partitionKeyFromExtension,
-                IDiagnosticsLogger<DbLoggerCategory.Query> logger,
                 bool performIdentityResolution)
             {
                 _cosmosQueryContext = cosmosQueryContext;
@@ -52,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 _selectExpression = selectExpression;
                 _shaper = shaper;
                 _contextType = contextType;
-                _logger = logger;
+                _queryLogger = cosmosQueryContext.QueryLogger;
                 _performIdentityResolution = performIdentityResolution;
 
                 var partitionKey = selectExpression.GetPartitionKey(cosmosQueryContext.ParameterValues);
@@ -108,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 private readonly Func<CosmosQueryContext, JObject, T> _shaper;
                 private readonly Type _contextType;
                 private readonly string _partitionKey;
-                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
                 private readonly bool _performIdentityResolution;
 
                 private IEnumerator<JObject> _enumerator;
@@ -121,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     _selectExpression = queryingEnumerable._selectExpression;
                     _contextType = queryingEnumerable._contextType;
                     _partitionKey = queryingEnumerable._partitionKey;
-                    _logger = queryingEnumerable._logger;
+                    _queryLogger = queryingEnumerable._queryLogger;
                     _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                 }
 
@@ -160,7 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }
@@ -183,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 private readonly Func<CosmosQueryContext, JObject, T> _shaper;
                 private readonly Type _contextType;
                 private readonly string _partitionKey;
-                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
                 private readonly bool _performIdentityResolution;
                 private readonly CancellationToken _cancellationToken;
 
@@ -197,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     _selectExpression = queryingEnumerable._selectExpression;
                     _contextType = queryingEnumerable._contextType;
                     _partitionKey = queryingEnumerable._partitionKey;
-                    _logger = queryingEnumerable._logger;
+                    _queryLogger = queryingEnumerable._queryLogger;
                     _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                     _cancellationToken = cancellationToken;
                 }
@@ -235,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             private readonly ReadItemExpression _readItemExpression;
             private readonly Func<CosmosQueryContext, JObject, T> _shaper;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _performIdentityResolution;
 
             public ReadItemQueryingEnumerable(
@@ -42,14 +42,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 ReadItemExpression readItemExpression,
                 Func<CosmosQueryContext, JObject, T> shaper,
                 Type contextType,
-                IDiagnosticsLogger<DbLoggerCategory.Query> logger,
                 bool performIdentityResolution)
             {
                 _cosmosQueryContext = cosmosQueryContext;
                 _readItemExpression = readItemExpression;
                 _shaper = shaper;
                 _contextType = contextType;
-                _logger = logger;
+                _queryLogger = _cosmosQueryContext.QueryLogger;
                 _performIdentityResolution = performIdentityResolution;
             }
 
@@ -71,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 private readonly ReadItemExpression _readItemExpression;
                 private readonly Func<CosmosQueryContext, JObject, T> _shaper;
                 private readonly Type _contextType;
-                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
                 private readonly bool _performIdentityResolution;
                 private readonly CancellationToken _cancellationToken;
 
@@ -84,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     _readItemExpression = readItemEnumerable._readItemExpression;
                     _shaper = readItemEnumerable._shaper;
                     _contextType = readItemEnumerable._contextType;
-                    _logger = readItemEnumerable._logger;
+                    _queryLogger = readItemEnumerable._queryLogger;
                     _performIdentityResolution = readItemEnumerable._performIdentityResolution;
                     _cancellationToken = cancellationToken;
                 }
@@ -124,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }
@@ -163,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -22,7 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
         private readonly IQuerySqlGeneratorFactory _querySqlGeneratorFactory;
         private readonly Type _contextType;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private readonly string _partitionKeyFromExtension;
 
         /// <summary>
@@ -41,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             _sqlExpressionFactory = sqlExpressionFactory;
             _querySqlGeneratorFactory = querySqlGeneratorFactory;
             _contextType = cosmosQueryCompilationContext.ContextType;
-            _logger = cosmosQueryCompilationContext.Logger;
             _partitionKeyFromExtension = cosmosQueryCompilationContext.PartitionKeyFromExtension;
         }
 
@@ -87,7 +85,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(shaperLambda.Compile()),
                         Expression.Constant(_contextType),
                         Expression.Constant(_partitionKeyFromExtension, typeof(string)),
-                        Expression.Constant(_logger),
                         Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
 
                 case ReadItemExpression readItemExpression:
@@ -109,7 +106,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(readItemExpression),
                         Expression.Constant(shaperReadItemLambda.Compile()),
                         Expression.Constant(_contextType),
-                        Expression.Constant(_logger),
                         Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
 
                 default:

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             private readonly IEnumerable<ValueBuffer> _innerEnumerable;
             private readonly Func<QueryContext, ValueBuffer, T> _shaper;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _performIdentityResolution;
 
             public QueryingEnumerable(
@@ -36,14 +36,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 IEnumerable<ValueBuffer> innerEnumerable,
                 Func<QueryContext, ValueBuffer, T> shaper,
                 Type contextType,
-                IDiagnosticsLogger<DbLoggerCategory.Query> logger,
                 bool performIdentityResolution)
             {
                 _queryContext = queryContext;
                 _innerEnumerable = innerEnumerable;
                 _shaper = shaper;
                 _contextType = contextType;
-                _logger = logger;
+                _queryLogger = queryContext.QueryLogger;
                 _performIdentityResolution = performIdentityResolution;
             }
 
@@ -63,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 private readonly IEnumerable<ValueBuffer> _innerEnumerable;
                 private readonly Func<QueryContext, ValueBuffer, T> _shaper;
                 private readonly Type _contextType;
-                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+                private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
                 private readonly bool _performIdentityResolution;
                 private readonly CancellationToken _cancellationToken;
 
@@ -73,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     _innerEnumerable = queryingEnumerable._innerEnumerable;
                     _shaper = queryingEnumerable._shaper;
                     _contextType = queryingEnumerable._contextType;
-                    _logger = queryingEnumerable._logger;
+                    _queryLogger = queryingEnumerable._queryLogger;
                     _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                     _cancellationToken = cancellationToken;
                 }
@@ -93,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }
@@ -112,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     }
                     catch (Exception exception)
                     {
-                        _logger.QueryIterationFailed(_contextType, exception);
+                        _queryLogger.QueryIterationFailed(_contextType, exception);
 
                         throw;
                     }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.cs
@@ -17,7 +17,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
     public partial class InMemoryShapedQueryCompilingExpressionVisitor : ShapedQueryCompilingExpressionVisitor
     {
         private readonly Type _contextType;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,7 +30,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             : base(dependencies, queryCompilationContext)
         {
             _contextType = queryCompilationContext.ContextType;
-            _logger = queryCompilationContext.Logger;
         }
 
         /// <summary>
@@ -92,7 +90,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 innerEnumerable,
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
-                Expression.Constant(_logger),
                 Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
         }
 

--- a/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly IReadOnlyList<ReaderColumn> _readerColumns;
         private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
         private readonly Type _contextType;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
         private readonly bool _performIdentityResolution;
 
         /// <summary>
@@ -44,7 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IReadOnlyList<ReaderColumn> readerColumns,
             [NotNull] Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> shaper,
             [NotNull] Type contextType,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             bool performIdentityResolution)
         {
             _relationalQueryContext = relationalQueryContext;
@@ -53,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _readerColumns = readerColumns;
             _shaper = shaper;
             _contextType = contextType;
-            _logger = logger;
+            _queryLogger = relationalQueryContext.QueryLogger;
             _performIdentityResolution = performIdentityResolution;
         }
 
@@ -150,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly IReadOnlyList<ReaderColumn> _readerColumns;
             private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _performIdentityResolution;
 
             private RelationalDataReader _dataReader;
@@ -166,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _readerColumns = queryingEnumerable._readerColumns;
                 _shaper = queryingEnumerable._shaper;
                 _contextType = queryingEnumerable._contextType;
-                _logger = queryingEnumerable._logger;
+                _queryLogger = queryingEnumerable._queryLogger;
                 _performIdentityResolution = queryingEnumerable._performIdentityResolution;
             }
 
@@ -228,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
                 catch (Exception exception)
                 {
-                    _logger.QueryIterationFailed(_contextType, exception);
+                    _queryLogger.QueryIterationFailed(_contextType, exception);
 
                     throw;
                 }
@@ -273,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly IReadOnlyList<ReaderColumn> _readerColumns;
             private readonly Func<QueryContext, DbDataReader, ResultContext, int[], ResultCoordinator, T> _shaper;
             private readonly Type _contextType;
-            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
+            private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _queryLogger;
             private readonly bool _performIdentityResolution;
             private readonly CancellationToken _cancellationToken;
 
@@ -292,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _readerColumns = queryingEnumerable._readerColumns;
                 _shaper = queryingEnumerable._shaper;
                 _contextType = queryingEnumerable._contextType;
-                _logger = queryingEnumerable._logger;
+                _queryLogger = queryingEnumerable._queryLogger;
                 _performIdentityResolution = queryingEnumerable._performIdentityResolution;
                 _cancellationToken = cancellationToken;
             }
@@ -353,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 }
                 catch (Exception exception)
                 {
-                    _logger.QueryIterationFailed(_contextType, exception);
+                    _queryLogger.QueryIterationFailed(_contextType, exception);
 
                     throw;
                 }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -20,7 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Query
     public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQueryCompilingExpressionVisitor
     {
         private readonly Type _contextType;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Query> _logger;
         private readonly ISet<string> _tags;
         private readonly bool _detailedErrorsEnabled;
         private readonly bool _useRelationalNulls;
@@ -42,7 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             RelationalDependencies = relationalDependencies;
 
             _contextType = queryCompilationContext.ContextType;
-            _logger = queryCompilationContext.Logger;
             _tags = queryCompilationContext.Tags;
             _detailedErrorsEnabled = relationalDependencies.CoreSingletonOptions.AreDetailedErrorsEnabled;
             _useRelationalNulls = RelationalOptionsExtension.Extract(queryCompilationContext.ContextOptions).UseRelationalNulls;
@@ -109,7 +107,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Expression.Constant(projectionColumns, typeof(IReadOnlyList<ReaderColumn>)),
                 Expression.Constant(shaperLambda.Compile()),
                 Expression.Constant(_contextType),
-                Expression.Constant(_logger),
                 Expression.Constant(QueryCompilationContext.PerformIdentityResolution));
         }
     }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
-        ///     Gets the current DbContext.
+        ///     The current DbContext in using while executing the query.
         /// </summary>
         public virtual DbContext Context => Dependencies.CurrentContext.Context;
 
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual QueryContextDependencies Dependencies { get; }
 
         /// <summary>
-        ///     Sets the navigation as loaded.
+        ///     Sets the navigation for given entity as loaded.
         /// </summary>
         /// <param name="entity"> The entity instance. </param>
         /// <param name="navigation"> The navigation property. </param>
@@ -74,64 +74,47 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     The query provider.
         /// </summary>
-        /// <value>
-        ///     The query provider.
-        /// </value>
+        [Obsolete("The service requiring IQueryProvider should inject it directly.")]
         public virtual IQueryProvider QueryProvider
             => Dependencies.QueryProvider;
 
         /// <summary>
-        ///     The execution strategy factory.
+        ///     The execution strategy factory to use while executing the query.
         /// </summary>
-        /// <value>
-        ///     The execution strategy factory.
-        /// </value>
         public virtual IExecutionStrategyFactory ExecutionStrategyFactory
             => Dependencies.ExecutionStrategyFactory;
 
         /// <summary>
-        ///     Gets the concurrency detector.
+        ///     The concurrency detector to use while executing the query.
         /// </summary>
-        /// <value>
-        ///     The concurrency detector.
-        /// </value>
         public virtual IConcurrencyDetector ConcurrencyDetector
             => Dependencies.ConcurrencyDetector;
 
         /// <summary>
-        ///     Gets or sets the cancellation token.
+        ///     The cancellation token to use while executing the query.
         /// </summary>
-        /// <value>
-        ///     The cancellation token.
-        /// </value>
         public virtual CancellationToken CancellationToken { get; set; }
 
         /// <summary>
-        ///     Gets or sets the cancellation token.
+        ///     The command logger to use while executing the query.
         /// </summary>
-        /// <value>
-        ///     The cancellation token.
-        /// </value>
         public virtual IDiagnosticsLogger<DbLoggerCategory.Database.Command> CommandLogger
             => Dependencies.CommandLogger;
 
         /// <summary>
-        ///     Gets or sets the cancellation token.
+        ///     The query logger to use while executing the query.
         /// </summary>
-        /// <value>
-        ///     The cancellation token.
-        /// </value>
         public virtual IDiagnosticsLogger<DbLoggerCategory.Query> QueryLogger
             => Dependencies.QueryLogger;
 
         /// <summary>
-        ///     The parameter values.
+        ///     The parameter values to use while executing the query.
         /// </summary>
         public virtual IReadOnlyDictionary<string, object> ParameterValues
             => (IReadOnlyDictionary<string, object>)_parameterValues;
 
         /// <summary>
-        ///     Adds a parameter.
+        ///     Adds a parameter to <see cref="ParameterValues"/> for this query.
         /// </summary>
         /// <param name="name"> The name. </param>
         /// <param name="value"> The value. </param>

--- a/src/EFCore/Query/QueryContextDependencies.cs
+++ b/src/EFCore/Query/QueryContextDependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -95,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     Gets the query provider.
         /// </summary>
+        [Obsolete("Use the service by getting it from " + nameof(CurrentContext) + ".")]
         public IQueryProvider QueryProvider => CurrentContext.GetDependencies().QueryProvider;
 
         /// <summary>

--- a/test/EFCore.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Tests/ApiConsistencyTestBase.cs
@@ -916,7 +916,9 @@ namespace Microsoft.EntityFrameworkCore
                     typeof(QueryCompilationContextDependencies).GetProperty(nameof(QueryCompilationContextDependencies.ContextType)),
                     typeof(QueryCompilationContextDependencies).GetProperty(nameof(QueryCompilationContextDependencies.IsTracking)),
                     typeof(QueryContextDependencies).GetProperty(nameof(QueryContextDependencies.StateManager)),
+#pragma warning disable CS0618 // Type or member is obsolete
                     typeof(QueryContextDependencies).GetProperty(nameof(QueryContextDependencies.QueryProvider))
+#pragma warning restore CS0618 // Type or member is obsolete
                 };
 
 


### PR DESCRIPTION
Resolves #21016

All scoped services used while executing the query comes from QueryContext.
All scoped services on QueryCompilationContext should only be used while compiling the query and should not be made part of QueryExecutorLambda.
Singleton services comes from QueryCompilationContext and added to the QueryExecutorLambda directly during compilation.