### PR TITLE
Query: Make IPrintableExpression.Print explicit interface implementation

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/InExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/InExpression.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/KeyAccessExpression.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ObjectAccessExpression.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/ObjectArrayProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ObjectArrayProjectionExpression.cs
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/OrderingExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/OrderingExpression.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/ProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ProjectionExpression.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlBinaryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlBinaryExpression.cs
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlConditionalExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlConditionalExpression.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlConstantExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlConstantExpression.cs
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpression.cs
@@ -69,7 +69,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public abstract void Print(ExpressionPrinter expressionPrinter);
+        protected abstract void Print([NotNull] ExpressionPrinter expressionPrinter);
+
+        /// <inheritdoc />
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter) => Print(expressionPrinter);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/SqlFunctionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlFunctionExpression.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlParameterExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlParameterExpression.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Cosmos/Query/Internal/SqlUnaryExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlUnaryExpression.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.InMemory/Query/Internal/EntityProjectionExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/EntityProjectionExpression.cs
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.InMemory/Query/Internal/InMemoryTableExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryTableExpression.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.InMemory/Query/Internal/SingleResultShaperExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/SingleResultShaperExpression.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/Internal/CollectionInitializingExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionInitializingExpression.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/Internal/CollectionPopulatingExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionPopulatingExpression.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
@@ -95,8 +95,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+
             base.Print(expressionPrinter);
             expressionPrinter.Append($".FromSql({Sql}, ");
             expressionPrinter.Visit(Argument);

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             expressionPrinter.AppendLine("RelationalCommandCache.SelectExpression(");
             using (expressionPrinter.Indent())

--- a/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
@@ -81,8 +81,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+
             expressionPrinter.Append(Function.MethodInfo.DisplayName());
             expressionPrinter.Append("(");
             expressionPrinter.VisitCollection(Arguments);

--- a/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 : this;
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/CollateExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CollateExpression.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ColumnExpression.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             => new ColumnExpression(Name, Table, Type.MakeNullable(), TypeMapping, true);
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossApplyExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CrossJoinExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExceptExpression.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ExistsExpression.cs
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InExpression.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/InnerJoinExpression.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/IntersectExpression.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LeftJoinExpression.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/LikeExpression.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OrderingExpression.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/OuterApplyExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ProjectionExpression.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/RowNumberExpression.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/ScalarSubqueryExpression.cs
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2139,7 +2139,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlBinaryExpression.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlConstantExpression.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlExpression.cs
@@ -46,8 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// <inheritdoc />
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
 
+        /// <summary>
+        ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter"/>.
+        /// </summary>
+        /// <param name="expressionPrinter"> The expression printer to use. </param>
+        protected abstract void Print([NotNull] ExpressionPrinter expressionPrinter);
+
         /// <inheritdoc />
-        public abstract void Print(ExpressionPrinter expressionPrinter);
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter) => Print(expressionPrinter);
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -320,7 +320,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlParameterExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlUnaryExpression.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpressionBase.cs
@@ -47,8 +47,15 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         public override Type Type => typeof(object);
         /// <inheritdoc />
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter"/>.
+        /// </summary>
+        /// <param name="expressionPrinter"> The expression printer to use. </param>
+        protected abstract void Print([NotNull] ExpressionPrinter expressionPrinter);
+
         /// <inheritdoc />
-        public abstract void Print(ExpressionPrinter expressionPrinter);
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter) => Print(expressionPrinter);
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableValuedFunctionExpression.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             if (!string.IsNullOrEmpty(Schema))
             {

--- a/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/UnionExpression.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <inheritdoc />
-        public override void Print(ExpressionPrinter expressionPrinter)
+        protected override void Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/CollectionShaperExpression.cs
+++ b/src/EFCore/Query/CollectionShaperExpression.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -215,7 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public sealed override ExpressionType NodeType => ExpressionType.Extension;
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/GroupByShaperExpression.cs
+++ b/src/EFCore/Query/GroupByShaperExpression.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public void MarkAsOptional() => IsOptional = true;
 
-            public void Print(ExpressionPrinter expressionPrinter)
+            void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
             {
                 Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return this;
             }
 
-            public void Print(ExpressionPrinter expressionPrinter)
+            void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
             {
                 Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 
@@ -287,7 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public override Type Type => Value.Type;
 
-            public void Print(ExpressionPrinter expressionPrinter)
+            void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
             {
                 Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
+++ b/src/EFCore/Query/MaterializeCollectionNavigationExpression.cs
@@ -72,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/ProjectionBindingExpression.cs
+++ b/src/EFCore/Query/ProjectionBindingExpression.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 

--- a/src/EFCore/Query/QueryRootExpression.cs
+++ b/src/EFCore/Query/QueryRootExpression.cs
@@ -76,8 +76,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
 
-        /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        /// <summary>
+        ///     Creates a printable string representation of the given expression using <see cref="ExpressionPrinter"/>.
+        /// </summary>
+        /// <param name="expressionPrinter"> The expression printer to use. </param>
+        protected virtual void Print([NotNull] ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 
@@ -90,6 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expressionPrinter.Append($"DbSet<{EntityType.ClrType.ShortDisplayName()}>()");
             }
         }
+
+        /// <inheritdoc />
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter) => Print(expressionPrinter);
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/EFCore/Query/ShapedQueryExpression.cs
+++ b/src/EFCore/Query/ShapedQueryExpression.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             => new ShapedQueryExpression(QueryExpression, ShaperExpression, resultCardinality);
 
         /// <inheritdoc />
-        public virtual void Print(ExpressionPrinter expressionPrinter)
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
         {
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 


### PR DESCRIPTION
Issue:
- We have Print extension method on Expression without any additional arguments.
- We also have IPrintableExpression.Print method which takes ExpressionPrinter as argument.

So when calling Print on a arbitrary expression, extension method works fine. But when calling print on a custom expression when type is known (especially in debugger), it asks to pass the ExpressionPrinter argument as it does not pick up extension method.
This is a breaking change but unlikely to cause any issues since Print method on custom expression directly should not be called.
