### PR TITLE
API review: Rename ISqlExpressionFactory.Function to NiladicFunction

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -338,7 +338,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        [Obsolete("Use overload that explicitly specifies value for 'nullable' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         SqlFunctionExpression Function(
             [NotNull] string name,
             [NotNull] Type returnType,
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        [Obsolete("Use overload that explicitly specifies value for 'nullable' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         SqlFunctionExpression Function(
             [NotNull] string schema,
             [NotNull] string name,
@@ -367,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        [Obsolete("Use overload that explicitly specifies value for 'instancePropagatesNullability' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         SqlFunctionExpression Function(
             [NotNull] SqlExpression instance,
             [NotNull] string name,
@@ -435,21 +435,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             [CanBeNull] RelationalTypeMapping typeMapping = null);
 
         /// <summary>
-        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a function call in a SQL tree.
+        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a niladic function call in a SQL tree.
         /// </summary>
         /// <param name="name"> The name of the function. </param>
         /// <param name="nullable"> A bool value indicating whether this function can return null. </param>
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        SqlFunctionExpression Function(
+        SqlFunctionExpression NiladicFunction(
             [NotNull] string name,
             bool nullable,
             [NotNull] Type returnType,
             [CanBeNull] RelationalTypeMapping typeMapping = null);
 
         /// <summary>
-        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a function call in a SQL tree.
+        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a niladic function call in a SQL tree.
         /// </summary>
         /// <param name="schema"> The schema in which the function is defined. </param>
         /// <param name="name"> The name of the function. </param>
@@ -457,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        SqlFunctionExpression Function(
+        SqlFunctionExpression NiladicFunction(
             [NotNull] string schema,
             [NotNull] string name,
             bool nullable,
@@ -465,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             [CanBeNull] RelationalTypeMapping typeMapping = null);
 
         /// <summary>
-        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a function call in a SQL tree.
+        ///     Creates a new <see cref="SqlFunctionExpression" /> which represents a niladic function call in a SQL tree.
         /// </summary>
         /// <param name="instance"> An expression on which the function is applied. </param>
         /// <param name="name"> The name of the function. </param>
@@ -474,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="returnType"> The <see cref="Type"/> of the expression. </param>
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping"/> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
-        SqlFunctionExpression Function(
+        SqlFunctionExpression NiladicFunction(
             [NotNull] SqlExpression instance,
             [NotNull] string name,
             bool nullable,

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -555,19 +555,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 typeMapping);
 
         /// <inheritdoc />
-        [Obsolete("Use overload that explicitly specifies value for 'nullable' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         public virtual SqlFunctionExpression Function(string name, Type returnType, RelationalTypeMapping typeMapping = null)
-            => Function(name, nullable: true, returnType, typeMapping);
+            => NiladicFunction(name, nullable: true, returnType, typeMapping);
 
         /// <inheritdoc />
-        [Obsolete("Use overload that explicitly specifies value for 'nullable' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         public virtual SqlFunctionExpression Function(string schema, string name, Type returnType, RelationalTypeMapping typeMapping = null)
-            => Function(schema, name, nullable: true, returnType, typeMapping);
+            => NiladicFunction(schema, name, nullable: true, returnType, typeMapping);
 
         /// <inheritdoc />
-        [Obsolete("Use overload that explicitly specifies value for 'instancePropagatesNullability' argument.")]
+        [Obsolete("Use NiladicFunction method.")]
         public virtual SqlFunctionExpression Function(SqlExpression instance, string name, Type returnType, RelationalTypeMapping typeMapping = null)
-            => Function(instance, name, nullable: true, instancePropagatesNullability: false, returnType, typeMapping);
+            => NiladicFunction(instance, name, nullable: true, instancePropagatesNullability: false, returnType, typeMapping);
 
         /// <inheritdoc />
         public virtual SqlFunctionExpression Function(
@@ -645,7 +645,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual SqlFunctionExpression Function(string name, bool nullable, Type returnType, RelationalTypeMapping typeMapping = null)
+        public virtual SqlFunctionExpression NiladicFunction(string name, bool nullable, Type returnType, RelationalTypeMapping typeMapping = null)
         {
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(returnType, nameof(returnType));
@@ -654,7 +654,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual SqlFunctionExpression Function(string schema, string name, bool nullable, Type returnType, RelationalTypeMapping typeMapping = null)
+        public virtual SqlFunctionExpression NiladicFunction(string schema, string name, bool nullable, Type returnType, RelationalTypeMapping typeMapping = null)
         {
             Check.NotEmpty(schema, nameof(schema));
             Check.NotEmpty(name, nameof(name));
@@ -664,7 +664,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public virtual SqlFunctionExpression Function(
+        public virtual SqlFunctionExpression NiladicFunction(
             SqlExpression instance,
             string name,
             bool nullable,

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerGeometryMemberTranslator.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
 
                 if (Equals(member, _srid))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NiladicFunction(
                         instance,
                         "STSrid",
                         nullable: true,

--- a/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/Internal/SqlServerPointMemberTranslator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                         ? _geographyMemberToPropertyName.TryGetValue(member, out propertyName)
                         : _geometryMemberToPropertyName.TryGetValue(member, out propertyName)))
                 {
-                    return _sqlExpressionFactory.Function(
+                    return _sqlExpressionFactory.NiladicFunction(
                         instance,
                         propertyName,
                         nullable: true,


### PR DESCRIPTION
Resolves #20409

- Updated obsolete message for old methods
- Renamed newly added methods
