### PR TITLE
Fix preview 5 break in DbContextActivator

### DIFF
--- a/src/EFCore.Design/Design/DbContextActivator.cs
+++ b/src/EFCore.Design/Design/DbContextActivator.cs
@@ -22,13 +22,28 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="contextType"> The <see cref="DbContext" /> type to instantiate. </param>
         /// <param name="startupAssembly"> The application's startup assembly. </param>
         /// <param name="reportHandler"> The design-time report handler. </param>
-        /// <param name="arguments"> Arguments passed to the application. </param>
         /// <returns> The newly created object. </returns>
         public static DbContext CreateInstance(
             [NotNull] Type contextType,
             [CanBeNull] Assembly startupAssembly = null,
-            [CanBeNull] IOperationReportHandler reportHandler = null,
-            [CanBeNull] string[] arguments = null)
+            [CanBeNull] IOperationReportHandler reportHandler = null)
+            => CreateInstance(contextType, startupAssembly, reportHandler, null);
+
+        /// <summary>
+        ///     Creates an instance of the specified <see cref="DbContext" /> type using the standard design-time
+        ///     mechanisms. When available, this will use any <see cref="IDesignTimeDbContextFactory{TContext}" />
+        ///     implementations or the application's service provider.
+        /// </summary>
+        /// <param name="contextType"> The <see cref="DbContext" /> type to instantiate. </param>
+        /// <param name="startupAssembly"> The application's startup assembly. </param>
+        /// <param name="reportHandler"> The design-time report handler. </param>
+        /// <param name="arguments"> Arguments passed to the application. </param>
+        /// <returns> The newly created object. </returns>
+        public static DbContext CreateInstance(
+            [NotNull] Type contextType,
+            [CanBeNull] Assembly startupAssembly,
+            [CanBeNull] IOperationReportHandler reportHandler,
+            [CanBeNull] string[] arguments)
         {
             Check.NotNull(contextType, nameof(contextType));
 

--- a/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
+++ b/test/EFCore.Design.Tests/Design/DbContextActivatorTest.cs
@@ -15,6 +15,18 @@ namespace Microsoft.EntityFrameworkCore.Design
             Assert.IsType<TestContext>(result);
         }
 
+        [ConditionalFact]
+        public void CreateInstance_with_arguments_works()
+        {
+            var result = DbContextActivator.CreateInstance(
+                typeof(TestContext),
+                null,
+                null,
+                new[] { "A", "B" });
+
+            Assert.IsType<TestContext>(result);
+        }
+
         private class TestContext : DbContext
         {
             protected override void OnConfiguring(DbContextOptionsBuilder options)


### PR DESCRIPTION
CTI testing resulted in this exception from tooling:

```
Method not found: 'Microsoft.EntityFrameworkCore.DbContext Microsoft.EntityFrameworkCore.Design.DbContextActivator.CreateInstance(System.Type, System.Reflection.Assembly, Microsoft.EntityFrameworkCore.Design.IOperationReportHandler)'.
```
