### PR TITLE
More on 4050. Named and unnamed versions of Core index errors.

### DIFF
--- a/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IndexAttributeConvention.cs
@@ -48,23 +48,45 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                         {
                             if (ignoredMembers.Contains(propertyName))
                             {
-                                throw new InvalidOperationException(
-                                    CoreStrings.IndexDefinedOnIgnoredProperty(
-                                        indexAttribute.Name,
-                                        entityType.DisplayName(),
-                                        indexAttribute.PropertyNames.Format(),
-                                        propertyName));
+                                if (indexAttribute.Name == null)
+                                {
+                                    throw new InvalidOperationException(
+                                        CoreStrings.UnnamedIndexDefinedOnIgnoredProperty(
+                                            entityType.DisplayName(),
+                                            indexAttribute.PropertyNames.Format(),
+                                            propertyName));
+                                }
+                                else
+                                {
+                                    throw new InvalidOperationException(
+                                        CoreStrings.NamedIndexDefinedOnIgnoredProperty(
+                                            indexAttribute.Name,
+                                            entityType.DisplayName(),
+                                            indexAttribute.PropertyNames.Format(),
+                                            propertyName));
+                                }
                             }
 
                             var property = entityType.FindProperty(propertyName);
                             if (property == null)
                             {
-                                throw new InvalidOperationException(
-                                    CoreStrings.IndexDefinedOnNonExistentProperty(
-                                        indexAttribute.Name,
-                                        entityType.DisplayName(),
-                                        indexAttribute.PropertyNames.Format(),
-                                        propertyName));
+                                if (indexAttribute.Name == null)
+                                {
+                                    throw new InvalidOperationException(
+                                        CoreStrings.UnnamedIndexDefinedOnNonExistentProperty(
+                                            entityType.DisplayName(),
+                                            indexAttribute.PropertyNames.Format(),
+                                            propertyName));
+                                }
+                                else
+                                {
+                                    throw new InvalidOperationException(
+                                        CoreStrings.NamedIndexDefinedOnNonExistentProperty(
+                                            indexAttribute.Name,
+                                            entityType.DisplayName(),
+                                            indexAttribute.PropertyNames.Format(),
+                                            propertyName));
+                                }
                             }
 
                             indexProperties.Add(property);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2661,18 +2661,34 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     The index named '{indexName}' on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.
         /// </summary>
-        public static string IndexDefinedOnIgnoredProperty([CanBeNull] object indexName, [CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
+        public static string NamedIndexDefinedOnIgnoredProperty([CanBeNull] object indexName, [CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
             => string.Format(
-                GetString("IndexDefinedOnIgnoredProperty", nameof(indexName), nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
+                GetString("NamedIndexDefinedOnIgnoredProperty", nameof(indexName), nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
                 indexName, entityType, indexPropertyList, propertyName);
+
+        /// <summary>
+        ///     The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.
+        /// </summary>
+        public static string UnnamedIndexDefinedOnIgnoredProperty([CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
+            => string.Format(
+                GetString("UnnamedIndexDefinedOnIgnoredProperty", nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
+                entityType, indexPropertyList, propertyName);
 
         /// <summary>
         ///     An index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.
         /// </summary>
-        public static string IndexDefinedOnNonExistentProperty([CanBeNull] object indexName, [CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
+        public static string NamedIndexDefinedOnNonExistentProperty([CanBeNull] object indexName, [CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
             => string.Format(
-                GetString("IndexDefinedOnNonExistentProperty", nameof(indexName), nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
+                GetString("NamedIndexDefinedOnNonExistentProperty", nameof(indexName), nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
                 indexName, entityType, indexPropertyList, propertyName);
+
+        /// <summary>
+        ///     An unnamed index on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.
+        /// </summary>
+        public static string UnnamedIndexDefinedOnNonExistentProperty([CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
+            => string.Format(
+                GetString("UnnamedIndexDefinedOnNonExistentProperty", nameof(entityType), nameof(indexPropertyList), nameof(propertyName)),
+                entityType, indexPropertyList, propertyName);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1403,10 +1403,16 @@
   <data name="QueryContextAlreadyInitializedStateManager" xml:space="preserve">
     <value>InitializeStateManager method has been called multiple times on current query context. This method is intended to be called only once before query enumeration starts.</value>
   </data>
-  <data name="IndexDefinedOnIgnoredProperty" xml:space="preserve">
+  <data name="NamedIndexDefinedOnIgnoredProperty" xml:space="preserve">
     <value>The index named '{indexName}' on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.</value>
   </data>
-  <data name="IndexDefinedOnNonExistentProperty" xml:space="preserve">
+  <data name="UnnamedIndexDefinedOnIgnoredProperty" xml:space="preserve">
+    <value>The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.</value>
+  </data>
+  <data name="NamedIndexDefinedOnNonExistentProperty" xml:space="preserve">
     <value>An index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.</value>
+  </data>
+  <data name="UnnamedIndexDefinedOnNonExistentProperty" xml:space="preserve">
+    <value>An unnamed index on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.</value>
   </data>
 </root>

--- a/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
@@ -156,15 +156,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [ConditionalFact]
-        public virtual void IndexAttribute_with_an_ignored_property_causes_error()
+        public virtual void IndexAttribute_without_name_and_an_ignored_property_causes_error()
         {
             var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
-            var entity = modelBuilder.Entity<EntityWithIgnoredProperty>();
+            modelBuilder.Entity<EntityUnnamedIndexWithIgnoredProperty>();
 
             Assert.Equal(
-                CoreStrings.IndexDefinedOnIgnoredProperty(
-                    "",
-                    nameof(EntityWithIgnoredProperty),
+                CoreStrings.UnnamedIndexDefinedOnIgnoredProperty(
+                    nameof(EntityUnnamedIndexWithIgnoredProperty),
                     "{'A', 'B'}",
                     "B"),
                 Assert.Throws<InvalidOperationException>(
@@ -172,15 +171,46 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [ConditionalFact]
-        public virtual void IndexAttribute_with_a_non_existent_property_causes_error()
+        public virtual void IndexAttribute_with_name_and_an_ignored_property_causes_error()
         {
             var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
-            var entity = modelBuilder.Entity<EntityWithNonExistentProperty>();
+            modelBuilder.Entity<EntityIndexWithIgnoredProperty>();
 
             Assert.Equal(
-                CoreStrings.IndexDefinedOnNonExistentProperty(
+                CoreStrings.NamedIndexDefinedOnIgnoredProperty(
+                    "IndexOnAAndIgnoredProperty",
+                    nameof(EntityIndexWithIgnoredProperty),
+                    "{'A', 'B'}",
+                    "B"),
+                Assert.Throws<InvalidOperationException>(
+                    () => modelBuilder.Model.FinalizeModel()).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void IndexAttribute_without_name_and_non_existent_property_causes_error()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+            modelBuilder.Entity<EntityUnnamedIndexWithNonExistentProperty>();
+
+            Assert.Equal(
+                CoreStrings.UnnamedIndexDefinedOnNonExistentProperty(
+                        nameof(EntityUnnamedIndexWithNonExistentProperty),
+                        "{'A', 'DoesNotExist'}",
+                        "DoesNotExist"),
+                Assert.Throws<InvalidOperationException>(
+                    () => modelBuilder.Model.FinalizeModel()).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void IndexAttribute_with_name_and_non_existent_property_causes_error()
+        {
+            var modelBuilder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+            var entity = modelBuilder.Entity<EntityIndexWithNonExistentProperty>();
+
+            Assert.Equal(
+                CoreStrings.NamedIndexDefinedOnNonExistentProperty(
                         "IndexOnAAndNonExistentProperty",
-                        nameof(EntityWithNonExistentProperty),
+                        nameof(EntityIndexWithNonExistentProperty),
                         "{'A', 'DoesNotExist'}",
                         "DoesNotExist"),
                 Assert.Throws<InvalidOperationException>(
@@ -266,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         [Index(nameof(A), nameof(B))]
-        private class EntityWithIgnoredProperty
+        private class EntityUnnamedIndexWithIgnoredProperty
         {
             public int Id { get; set; }
             public int A { get; set; }
@@ -274,8 +304,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public int B { get; set; }
         }
 
+        [Index(nameof(A), nameof(B), Name = "IndexOnAAndIgnoredProperty")]
+        private class EntityIndexWithIgnoredProperty
+        {
+            public int Id { get; set; }
+            public int A { get; set; }
+            [NotMapped]
+            public int B { get; set; }
+        }
+
+        [Index(nameof(A), "DoesNotExist")]
+        private class EntityUnnamedIndexWithNonExistentProperty
+        {
+            public int Id { get; set; }
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
         [Index(nameof(A), "DoesNotExist", Name = "IndexOnAAndNonExistentProperty")]
-        private class EntityWithNonExistentProperty
+        private class EntityIndexWithNonExistentProperty
         {
             public int Id { get; set; }
             public int A { get; set; }


### PR DESCRIPTION
See [this comment](https://github.com/dotnet/efcore/pull/21012#discussion_r432024488) and the ones above it. I put in the  messages for named and unnamed indexes for Relational, but I forgot there were 2 messages in Core that needed the same treatment. This fixes that. 