### PR TITLE
Add support for seed data for entity types using table sharing where the principal is using TPT

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -601,6 +601,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.ColumnType,
                 RelationalAnnotationNames.TableColumnMappings,
                 RelationalAnnotationNames.ViewColumnMappings,
+                RelationalAnnotationNames.RelationalOverrides,
                 CoreAnnotationNames.ValueGeneratorFactory,
                 CoreAnnotationNames.PropertyAccessMode,
                 CoreAnnotationNames.ChangeTrackingStrategy,
@@ -849,7 +850,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var discriminatorMappingCompleteAnnotation = annotations.FirstOrDefault(a => a.Name == CoreAnnotationNames.DiscriminatorMappingComplete);
             var discriminatorValueAnnotation = annotations.FirstOrDefault(a => a.Name == CoreAnnotationNames.DiscriminatorValue);
 
-            if ((discriminatorPropertyAnnotation ?? discriminatorMappingCompleteAnnotation ?? discriminatorValueAnnotation) != null)
+            if ((discriminatorPropertyAnnotation?.Value
+                ?? discriminatorMappingCompleteAnnotation?.Value
+                ?? discriminatorValueAnnotation?.Value) != null)
             {
                 stringBuilder
                     .AppendLine()

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -251,7 +251,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.ViewColumnMappings,
                 RelationalAnnotationNames.ForeignKeyMappings,
                 RelationalAnnotationNames.TableIndexMappings,
-                RelationalAnnotationNames.UniqueConstraintMappings
+                RelationalAnnotationNames.UniqueConstraintMappings,
+                RelationalAnnotationNames.RelationalOverrides
             };
 
             return items.SelectMany(

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -663,6 +663,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.IsFixedLength);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.TableColumnMappings);
             RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewColumnMappings);
+            RemoveAnnotation(ref annotations, RelationalAnnotationNames.RelationalOverrides);
             RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.ColumnOrdinal);
 
             if (!useDataAnnotations)

--- a/src/EFCore.Relational/Metadata/Internal/ColumnListComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnListComparer.cs
@@ -36,7 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public int Compare(IReadOnlyList<IColumn> x, IReadOnlyList<IColumn> y)
         {
             var result = x.Count - y.Count;
-
             if (result != 0)
             {
                 return result;

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
@@ -34,9 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public int Compare(IColumnMappingBase x, IColumnMappingBase y)
         {
-            var result = x.Column.IsNullable == y.Column.IsNullable
-                ? 0
-                : x.Column.IsNullable ? 1 : -1;
+            var result = y.Column.IsNullable.CompareTo(x.Column.IsNullable);
             if (result != 0)
             {
                 return result;

--- a/src/EFCore.Relational/Metadata/Internal/TableMappingBaseComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMappingBaseComparer.cs
@@ -48,8 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public int Compare(ITableMappingBase x, ITableMappingBase y)
         {
             var result = _isForEntityType
-                ? x.IsMainTableMapping.CompareTo(y.IsMainTableMapping)
-                : x.IsMainEntityTypeMapping.CompareTo(y.IsMainEntityTypeMapping);
+                ? y.IsMainTableMapping.CompareTo(x.IsMainTableMapping)
+                : y.IsMainEntityTypeMapping.CompareTo(x.IsMainEntityTypeMapping);
             if (result != 0)
             {
                 return result;

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -757,7 +757,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var derivedType = entityType.GetDerivedTypes().SingleOrDefault(et => et.ClrType == resultType);
                 if (derivedType != null)
                 {
-                    if (!derivedType.GetIsDiscriminatorMappingComplete()
+                    if (!derivedType.GetRootType().GetIsDiscriminatorMappingComplete()
                         || !derivedType.GetAllBaseTypesInclusiveAscending()
                             .All(e => (e == derivedType || e.IsAbstract()) && !HasSiblings(e)))
                     {

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -881,7 +881,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private bool AddDiscriminatorCondition(SelectExpression selectExpression, IEntityType entityType)
         {
-            if (entityType.GetIsDiscriminatorMappingComplete()
+            if (entityType.GetRootType().GetIsDiscriminatorMappingComplete()
                 && entityType.GetAllBaseTypesInclusiveAscending()
                     .All(e => (e == entityType || e.IsAbstract()) && !HasSiblings(e)))
             {

--- a/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
+++ b/src/EFCore.Relational/Update/Internal/SharedTableEntryMap.cs
@@ -19,11 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
     {
         private readonly ITable _table;
         private readonly IUpdateAdapter _updateAdapter;
-        private readonly SharedTableEntryValueFactory<TValue> _createElement;
         private readonly IComparer<IUpdateEntry> _comparer;
-
-        private readonly Dictionary<IUpdateEntry, TValue> _entryValueMap
-            = new Dictionary<IUpdateEntry, TValue>();
+        private readonly Dictionary<IUpdateEntry, TValue> _entryValueMap = new Dictionary<IUpdateEntry, TValue>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -33,56 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         /// </summary>
         public SharedTableEntryMap(
             [NotNull] ITable table,
-            [NotNull] IUpdateAdapter updateAdapter,
-            [NotNull] SharedTableEntryValueFactory<TValue> createElement)
+            [NotNull] IUpdateAdapter updateAdapter)
         {
             _table = table;
             _updateAdapter = updateAdapter;
-            _createElement = createElement;
             _comparer = new EntryComparer(table);
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public static Dictionary<(string Name, string Schema), SharedTableEntryMapFactory<TValue>>
-            CreateSharedTableEntryMapFactories(
-                [NotNull] IModel model,
-                [NotNull] IUpdateAdapter updateAdapter)
-        {
-            var sharedTablesMap = new Dictionary<(string, string), SharedTableEntryMapFactory<TValue>>();
-            foreach (var table in model.GetRelationalModel().Tables)
-            {
-                if (!table.IsShared)
-                {
-                    continue;
-                }
-
-                var factory = CreateSharedTableEntryMapFactory(table, updateAdapter);
-
-                sharedTablesMap.Add((table.Name, table.Schema), factory);
-            }
-
-            return sharedTablesMap;
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public static SharedTableEntryMapFactory<TValue> CreateSharedTableEntryMapFactory(
-            [NotNull] ITable table,
-            [NotNull] IUpdateAdapter updateAdapter)
-            => createElement
-                => new SharedTableEntryMap<TValue>(
-                    table,
-                    updateAdapter,
-                    createElement);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -98,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual TValue GetOrAddValue([NotNull] IUpdateEntry entry)
+        public virtual TValue GetOrAddValue([NotNull] IUpdateEntry entry, [NotNull] SharedTableEntryValueFactory<TValue> createElement)
         {
             var mainEntry = GetMainEntry(entry);
             if (_entryValueMap.TryGetValue(mainEntry, out var sharedCommand))
@@ -106,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 return sharedCommand;
             }
 
-            sharedCommand = _createElement(_table.Name, _table.Schema, _comparer);
+            sharedCommand = createElement(_table.Name, _table.Schema, _comparer);
             _entryValueMap.Add(mainEntry, sharedCommand);
 
             return sharedCommand;

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -742,15 +742,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         public static bool GetIsDiscriminatorMappingComplete([NotNull] this IEntityType entityType)
-        {
-            if (entityType.BaseType != null)
-            {
-                return entityType.GetRootType().GetIsDiscriminatorMappingComplete();
-            }
-
-            return (bool?)entityType[CoreAnnotationNames.DiscriminatorMappingComplete]
+            => (bool?)entityType[CoreAnnotationNames.DiscriminatorMappingComplete]
                 ?? GetDefaultIsDiscriminatorMappingComplete(entityType);
-        }
 
         private static bool GetDefaultIsDiscriminatorMappingComplete(IEntityType entityType) => true;
 

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -587,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            entityType.GetRootType().SetOrRemoveAnnotation(CoreAnnotationNames.DiscriminatorMappingComplete, complete);
+            entityType.SetOrRemoveAnnotation(CoreAnnotationNames.DiscriminatorMappingComplete, complete);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -4051,6 +4051,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Metadata.SetDiscriminatorProperty(null, configurationSource);
 
+            if (configurationSource == ConfigurationSource.Explicit)
+            {
+                Metadata.SetDiscriminatorMappingComplete(null);
+            }
+            else if (CanSetAnnotation(CoreAnnotationNames.DiscriminatorMappingComplete, null, configurationSource))
+            {
+                Metadata.SetDiscriminatorMappingComplete(null, configurationSource == ConfigurationSource.DataAnnotation);
+            }
+
             return this;
         }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -64,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.ColumnType,
                 RelationalAnnotationNames.TableColumnMappings,
                 RelationalAnnotationNames.ViewColumnMappings,
+                RelationalAnnotationNames.RelationalOverrides,
                 RelationalAnnotationNames.DefaultValueSql,
                 RelationalAnnotationNames.ComputedColumnSql,
                 RelationalAnnotationNames.DefaultValue,

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -239,6 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     && a != RelationalAnnotationNames.ForeignKeyMappings
                     && a != RelationalAnnotationNames.TableIndexMappings
                     && a != RelationalAnnotationNames.UniqueConstraintMappings
+                    && a != RelationalAnnotationNames.RelationalOverrides
 #pragma warning disable CS0618 // Type or member is obsolete
                     && a != RelationalAnnotationNames.SequencePrefix))
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalFixture.cs
@@ -22,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Country>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<Eagle>().HasMany(e => e.Prey).WithOne().HasForeignKey(e => e.EagleId).IsRequired(false);
 
+            modelBuilder.Entity<Animal>().HasDiscriminator().IsComplete(IsDiscriminatorMappingComplete);
             modelBuilder.Entity<Animal>().Property(e => e.Species).HasMaxLength(100);
 
             modelBuilder.Entity<Coke>().Property(e => e.Carbonation).HasColumnName("CokeCO2");

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var ordersView = orderMapping.View;
             Assert.Same(ordersView, model.FindView(ordersView.Name, ordersView.Schema));
             Assert.Equal(
-                new[] { "OrderDetails.BillingAddress#Address", "OrderDetails.ShippingAddress#Address", nameof(Order), nameof(OrderDetails) },
+                new[] { nameof(Order), "OrderDetails.BillingAddress#Address", "OrderDetails.ShippingAddress#Address", nameof(OrderDetails) },
                 ordersView.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
             Assert.Equal(new[] {
                     nameof(Order.AlternateId),
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var ordersTable = orderMapping.Table;
             Assert.Same(ordersTable, model.FindTable(ordersTable.Name, ordersTable.Schema));
             Assert.Equal(
-                new[] { "OrderDetails.BillingAddress#Address", "OrderDetails.ShippingAddress#Address", nameof(Order), nameof(OrderDetails) },
+                new[] { nameof(Order), "OrderDetails.BillingAddress#Address", "OrderDetails.ShippingAddress#Address", nameof(OrderDetails) },
                 ordersTable.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
             Assert.Equal(new[] {
                     nameof(Order.AlternateId),

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -859,9 +859,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 baseTypeBuilder.HasDiscriminator<string>("Discriminator").IsComplete(false);
                 Assert.False(baseTypeBuilder.Metadata.GetIsDiscriminatorMappingComplete());
+                Assert.True(derivedTypeBuilder.Metadata.GetIsDiscriminatorMappingComplete());
 
                 derivedTypeBuilder.HasDiscriminator<string>("Discriminator").IsComplete(true);
-                Assert.True(baseTypeBuilder.Metadata.GetIsDiscriminatorMappingComplete());
+                Assert.False(baseTypeBuilder.Metadata.GetIsDiscriminatorMappingComplete());
+                Assert.True(derivedTypeBuilder.Metadata.GetIsDiscriminatorMappingComplete());
             }
 
             protected class L


### PR DESCRIPTION
Sort table mappings consistently
Remove discriminator-related facets completely when using TPT
Simplify SharedTableEntryMap

Part of #2266

