### PR TITLE
Add an overload to UseCosmos that takes a connection string

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosDbContextOptionsExtensions.cs
@@ -74,5 +74,58 @@ namespace Microsoft.EntityFrameworkCore
 
             return optionsBuilder;
         }
+
+        /// <summary>
+        ///     Configures the context to connect to an Azure Cosmos database.
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
+        /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
+        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="databaseName"> The database name. </param>
+        /// <param name="cosmosOptionsAction"> An optional action to allow additional Cosmos-specific configuration. </param>
+        /// <returns> The options builder so that further configuration can be chained. </returns>
+        public static DbContextOptionsBuilder<TContext> UseCosmos<TContext>(
+            [NotNull] this DbContextOptionsBuilder<TContext> optionsBuilder,
+            [NotNull] string connectionString,
+            [NotNull] string databaseName,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+            where TContext : DbContext
+            => (DbContextOptionsBuilder<TContext>)UseCosmos(
+                (DbContextOptionsBuilder)optionsBuilder,
+                connectionString,
+                databaseName,
+                cosmosOptionsAction);
+
+        /// <summary>
+        ///     Configures the context to connect to a Azure Cosmos database.
+        /// </summary>
+        /// <param name="optionsBuilder"> The builder being used to configure the context. </param>
+        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="databaseName"> The database name. </param>
+        /// <param name="cosmosOptionsAction"> An optional action to allow additional Cosmos-specific configuration. </param>
+        /// <returns> The options builder so that further configuration can be chained. </returns>
+        public static DbContextOptionsBuilder UseCosmos(
+            [NotNull] this DbContextOptionsBuilder optionsBuilder,
+            [NotNull] string connectionString,
+            [NotNull] string databaseName,
+            [CanBeNull] Action<CosmosDbContextOptionsBuilder> cosmosOptionsAction = null)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+            Check.NotNull(connectionString, nameof(connectionString));
+            Check.NotNull(databaseName, nameof(databaseName));
+
+            var extension = optionsBuilder.Options.FindExtension<CosmosOptionsExtension>()
+                            ?? new CosmosOptionsExtension();
+
+            extension = extension
+                .WithConnectionString(connectionString)
+                .WithDatabaseName(databaseName);
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            cosmosOptionsAction?.Invoke(new CosmosDbContextOptionsBuilder(optionsBuilder));
+
+            return optionsBuilder;
+        }
     }
 }

--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///     </para>
     ///     <para>
     ///         Instances of this class are returned from a call to
-    ///         <see cref="CosmosDbContextOptionsExtensions.UseCosmos{TContext}" />
+    ///         <see cref="M:CosmosDbContextOptionsExtensions.UseCosmos{TContext}" />
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
@@ -62,6 +62,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual string ConnectionString { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual void Initialize(IDbContextOptions options)
         {
             var cosmosOptions = options.FindExtension<CosmosOptionsExtension>();
@@ -71,6 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                 AccountKey = cosmosOptions.AccountKey;
                 Region = cosmosOptions.Region;
                 ConnectionMode = cosmosOptions.ConnectionMode;
+                ConnectionString = cosmosOptions.ConnectionString;
             }
         }
 
@@ -85,7 +94,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
             var cosmosOptions = options.FindExtension<CosmosOptionsExtension>();
 
             if (cosmosOptions != null
-                && (AccountEndpoint != cosmosOptions.AccountEndpoint
+                && (ConnectionString != cosmosOptions.ConnectionString
+                    || AccountEndpoint != cosmosOptions.AccountEndpoint
                     || AccountKey != cosmosOptions.AccountKey
                     || Region != cosmosOptions.Region
                     || ConnectionMode != cosmosOptions.ConnectionMode))

--- a/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
@@ -54,5 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         ConnectionMode? ConnectionMode { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        string ConnectionString { get; }
     }
 }

--- a/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         private readonly CosmosClientOptions _options;
         private readonly string _endpoint;
         private readonly string _key;
+        private readonly string _connectionString;
         private CosmosClient _client;
 
         /// <summary>
@@ -42,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             _endpoint = options.AccountEndpoint;
             _key = options.AccountKey;
+            _connectionString = options.ConnectionString;
             var configuration = new CosmosClientOptions
             {
                 ApplicationName = _userAgent, ConnectionMode = options.ConnectionMode ?? ConnectionMode.Direct
@@ -61,7 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual CosmosClient Client => _client ??= new CosmosClient(_endpoint, _key, _options);
+        public virtual CosmosClient Client => _client ??= string.IsNullOrEmpty(_connectionString)
+                    ? new CosmosClient(_endpoint, _key, _options)
+                    : new CosmosClient(_connectionString, _options);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.Cosmos.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/ConnectionSpecificationTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos
+{
+    public class ConnectionSpecificationTest
+    {
+        [ConditionalFact]
+        public async Task Can_specify_connection_string_in_OnConfiguring()
+        {
+            await using var testDatabase = CosmosTestStore.Create("NonExisting");
+            try
+            {
+                using var context = new BloggingContext(testDatabase);
+                var creator = context.GetService<IDatabaseCreator>();
+
+                Assert.True(creator.EnsureCreated());
+            }
+            finally
+            {
+                testDatabase.Initialize(testDatabase.ServiceProvider, () => new BloggingContext(testDatabase));
+            }
+        }
+
+        public class BloggingContext : DbContext
+        {
+            private readonly string _connectionString;
+            private readonly string _name;
+
+            public BloggingContext(CosmosTestStore testStore)
+            {
+                _connectionString = testStore.ConnectionString;
+                _name = testStore.Name;
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseCosmos(_connectionString, _name, b => b.ApplyConfiguration());
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+            }
+
+            public DbSet<Blog> Blogs { get; set; }
+        }
+
+        public class Blog
+        {
+            public int Id { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -44,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             ConnectionUri = TestEnvironment.DefaultConnection;
             AuthToken = TestEnvironment.AuthToken;
+            ConnectionString = TestEnvironment.ConnectionString;
             _configureCosmos = extensionConfiguration == null
                 ? (Action<CosmosDbContextOptionsBuilder>)(b => b.ApplyConfiguration())
                 : (b =>
@@ -68,6 +69,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public string ConnectionUri { get; }
         public string AuthToken { get; }
+        public string ConnectionString { get; }
 
         protected override DbContext CreateDefaultContext() => new TestStoreContext(this);
 

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -25,6 +25,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             ? "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
             : Config["AuthToken"];
 
+        public static string ConnectionString { get; } = string.IsNullOrEmpty(Config["ConnectionString"])
+            ? "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+            : Config["ConnectionString"];
+
         public static bool IsEmulator { get; } = DefaultConnection.StartsWith("https://localhost:8081", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Add an overload to UseCosmos that takes a connection string.

Fixes #20712

For now, I have some problems with testing it. Could you please suggest if I'm on the right way? I'll continue to work on tests.


