### PR TITLE
Fix SQL Server Contains whitespace issues

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -18,7 +18,7 @@ using Xunit;
 // ReSharper disable CompareOfFloatsByEqualityOperator
 // ReSharper disable ConditionIsAlwaysTrueOrFalse
 // ReSharper disable SpecifyACultureInStringConversionExplicitly
-#pragma warning disable RCS1215 // Expression is always equal to true/false. 
+#pragma warning disable RCS1215 // Expression is always equal to true/false.
 #pragma warning disable RCS1155 // Use StringComparison when comparing strings.
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -155,6 +155,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<Customer>().Where(c => c.ContactName.FirstOrDefault() == 'A'),
                 entryCount: 10);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task String_Contains_constant_with_whitespace(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("     ")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task String_Contains_parameter_with_whitespace(bool async)
+        {
+            var pattern = "     ";
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.ContactName.Contains(pattern)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 FROM (
     SELECT * FROM ""Customers""
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0";
+WHERE [c].[ContactName] LIKE N'%z%'";
 
             AssertSql(expected);
             Assert.Equal(expected, queryString);
@@ -73,7 +73,7 @@ FROM (
     SELECT
     * FROM ""Customers""
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%z%'");
         }
 
         public override void FromSqlRaw_queryable_composed_compiled()
@@ -85,7 +85,7 @@ WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
 FROM (
     SELECT * FROM ""Customers""
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%z%'");
         }
 
         public override void FromSqlRaw_queryable_composed_compiled_with_DbParameter()
@@ -99,7 +99,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @customer
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%z%'");
         }
 
         public override void FromSqlRaw_queryable_composed_compiled_with_nameless_DbParameter()
@@ -113,7 +113,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM (
     SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @p0
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%z%'");
         }
 
         public override void FromSqlRaw_queryable_composed_compiled_with_parameter()
@@ -125,7 +125,7 @@ WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
 FROM (
     SELECT * FROM ""Customers"" WHERE ""CustomerID"" = N'CONSH'
 ) AS [c]
-WHERE CHARINDEX(N'z', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%z%'");
         }
 
         public override void FromSqlRaw_composed_contains()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FunkyDataQuerySqlServerTest.cs
@@ -28,26 +28,26 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertSql(
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE CHARINDEX(N'%B', [f].[FirstName]) > 0",
+WHERE [f].[FirstName] LIKE N'%\%B%' ESCAPE N'\'",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE CHARINDEX(N'a_', [f].[FirstName]) > 0",
+WHERE [f].[FirstName] LIKE N'%a\_%' ESCAPE N'\'",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE CHARINDEX(NULL, [f].[FirstName]) > 0",
+WHERE [f].[FirstName] LIKE NULL",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE CHARINDEX(N'_Ba_', [f].[FirstName]) > 0",
+WHERE [f].[FirstName] LIKE N'%\_Ba\_%' ESCAPE N'\'",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (CHARINDEX(N'%B%a%r', [f].[FirstName]) > 0)",
+WHERE NOT ([f].[FirstName] LIKE N'%\%B\%a\%r%' ESCAPE N'\')",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
@@ -55,7 +55,7 @@ WHERE 0 = 1",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (CHARINDEX(NULL, [f].[FirstName]) > 0)");
+WHERE NOT ([f].[FirstName] LIKE NULL)");
         }
 
         public override async Task String_contains_on_argument_with_wildcard_parameter(bool async)
@@ -67,45 +67,45 @@ WHERE NOT (CHARINDEX(NULL, [f].[FirstName]) > 0)");
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm1_0 = N'') OR (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0)",
+WHERE (@__prm1_0 LIKE N'') OR (CHARINDEX(@__prm1_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm2_0='a_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm2_0 = N'') OR (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0)",
+WHERE (@__prm2_0 LIKE N'') OR (CHARINDEX(@__prm2_0, [f].[FirstName]) > 0)",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE CHARINDEX(NULL, [f].[FirstName]) > 0",
+WHERE (NULL LIKE N'') OR (CHARINDEX(NULL, [f].[FirstName]) > 0)",
                 //
                 @"@__prm4_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm4_0 = N'') OR (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0)",
+WHERE (@__prm4_0 LIKE N'') OR (CHARINDEX(@__prm4_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm5_0='_Ba_' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE (@__prm5_0 = N'') OR (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0)",
+WHERE (@__prm5_0 LIKE N'') OR (CHARINDEX(@__prm5_0, [f].[FirstName]) > 0)",
                 //
                 @"@__prm6_0='%B%a%r' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT ((@__prm6_0 = N'') OR (CHARINDEX(@__prm6_0, [f].[FirstName]) > 0))",
+WHERE NOT ((@__prm6_0 LIKE N'') OR (CHARINDEX(@__prm6_0, [f].[FirstName]) > 0))",
                 //
                 @"@__prm7_0='' (Size = 4000)
 
 SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT ((@__prm7_0 = N'') OR (CHARINDEX(@__prm7_0, [f].[FirstName]) > 0))",
+WHERE NOT ((@__prm7_0 LIKE N'') OR (CHARINDEX(@__prm7_0, [f].[FirstName]) > 0))",
                 //
                 @"SELECT [f].[FirstName]
 FROM [FunkyCustomers] AS [f]
-WHERE NOT (CHARINDEX(NULL, [f].[FirstName]) > 0)");
+WHERE NOT ((NULL LIKE N'') OR (CHARINDEX(NULL, [f].[FirstName]) > 0))");
         }
 
         public override async Task String_contains_on_argument_with_wildcard_column(bool async)
@@ -116,7 +116,7 @@ WHERE NOT (CHARINDEX(NULL, [f].[FirstName]) > 0)");
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE ([f0].[LastName] = N'') OR (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0)");
+WHERE ([f0].[LastName] LIKE N'') OR (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0)");
         }
 
         public override async Task String_contains_on_argument_with_wildcard_column_negated(bool async)
@@ -127,7 +127,7 @@ WHERE ([f0].[LastName] = N'') OR (CHARINDEX([f0].[LastName], [f].[FirstName]) > 
                 @"SELECT [f].[FirstName] AS [fn], [f0].[LastName] AS [ln]
 FROM [FunkyCustomers] AS [f]
 CROSS JOIN [FunkyCustomers] AS [f0]
-WHERE NOT ((([f0].[LastName] = N'') AND [f0].[LastName] IS NOT NULL) OR (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0))");
+WHERE NOT (([f0].[LastName] LIKE N'') OR (CHARINDEX([f0].[LastName], [f].[FirstName]) > 0))");
         }
 
         public override async Task String_starts_with_on_argument_with_wildcard_constant(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1319,7 +1319,7 @@ WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0)
+        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%')
     ) AS [t]) = CAST(1 AS bit))
 ORDER BY [g].[Nickname]");
         }
@@ -1334,7 +1334,7 @@ FROM [Gears] AS [g]
 WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
     SELECT DISTINCT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0)) = CAST(1 AS bit))
+    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%')) = CAST(1 AS bit))
 ORDER BY [g].[Nickname]");
         }
 
@@ -1350,7 +1350,7 @@ WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0)
+        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%')
     ) AS [t]) = CAST(1 AS bit))
 ORDER BY [g].[Nickname]");
         }
@@ -1715,7 +1715,7 @@ WHERE ([g].[Nickname] = N'Marcus') AND ([c].[Location] = 'Jacinto''s location')"
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE CHARINDEX('Jacinto', [c].[Location]) > 0");
+WHERE [c].[Location] LIKE '%Jacinto%'");
         }
 
         public override async Task Non_unicode_string_literals_is_used_for_non_unicode_column_with_concat(bool async)
@@ -1725,7 +1725,7 @@ WHERE CHARINDEX('Jacinto', [c].[Location]) > 0");
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
-WHERE CHARINDEX('Add', COALESCE([c].[Location], '') + 'Added') > 0");
+WHERE COALESCE([c].[Location], '') + 'Added' LIKE '%Add%'");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
@@ -2007,7 +2007,7 @@ END = CAST(1 AS bit)");
                 @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
-WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) OR (CHARINDEX(N'Cole', [t].[Note]) > 0)");
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) OR ([t].[Note] LIKE N'%Cole%')");
         }
 
         public override async Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool async)
@@ -2016,7 +2016,7 @@ WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) OR (CHARINDEX(N'Cole', [t].[Note]) >
 
             AssertSql(
                 @"SELECT CASE
-    WHEN ([g].[HasSoulPatch] = CAST(1 AS bit)) AND (CHARINDEX(N'Cole', [t].[Note]) > 0) THEN CAST(1 AS bit)
+    WHEN ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ([t].[Note] LIKE N'%Cole%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END
 FROM [Tags] AS [t]
@@ -5080,7 +5080,7 @@ FROM [Gears] AS [g]");
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0)
+        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%')
     ) AS [t])
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
@@ -5094,7 +5094,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
                 @"SELECT (
     SELECT DISTINCT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
-    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0))
+    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%'))
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
         }
@@ -5109,7 +5109,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
     FROM (
         SELECT DISTINCT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
         FROM [Weapons] AS [w]
-        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND (CHARINDEX(N'Lancer', [w].[Name]) > 0)
+        WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Lancer%')
     ) AS [t])
 FROM [Gears] AS [g]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
@@ -5782,7 +5782,7 @@ LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ORDER BY (
     SELECT TOP(1) [w0].[Name]
     FROM [Weapons] AS [w0]
-    WHERE ([g].[FullName] = [w0].[OwnerFullName]) AND (CHARINDEX(N'Gnasher', [w0].[Name]) > 0)), [g].[Nickname], [g].[SquadId], [w].[Id]");
+    WHERE ([g].[FullName] = [w0].[OwnerFullName]) AND ([w0].[Name] LIKE N'%Gnasher%')), [g].[Nickname], [g].[SquadId], [w].[Id]");
         }
 
         public override async Task Anonymous_projection_take_followed_by_projecting_single_element_from_collection_navigation(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
             ClearLog();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         protected override bool CanExecuteQueryString => true;
@@ -115,7 +115,7 @@ WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'%m')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(N'M', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%M%'");
         }
 
         public override async Task String_Contains_Identity(bool async)
@@ -125,7 +125,7 @@ WHERE CHARINDEX(N'M', [c].[ContactName]) > 0");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0)");
+WHERE ([c].[ContactName] LIKE N'') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0)");
         }
 
         public override async Task String_Contains_Column(bool async)
@@ -135,7 +135,29 @@ WHERE ([c].[ContactName] = N'') OR (CHARINDEX([c].[ContactName], [c].[ContactNam
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE ([c].[ContactName] = N'') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0)");
+WHERE ([c].[ContactName] LIKE N'') OR (CHARINDEX([c].[ContactName], [c].[ContactName]) > 0)");
+        }
+
+        public override async Task String_Contains_constant_with_whitespace(bool async)
+        {
+            await base.String_Contains_constant_with_whitespace(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE N'%     %'");
+        }
+
+        public override async Task String_Contains_parameter_with_whitespace(bool async)
+        {
+            await base.String_Contains_parameter_with_whitespace(async);
+
+            AssertSql(
+                @"@__pattern_0='     ' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (@__pattern_0 LIKE N'') OR (CHARINDEX(@__pattern_0, [c].[ContactName]) > 0)");
         }
 
         public override async Task String_FirstOrDefault_MethodCall(bool async)
@@ -169,7 +191,7 @@ WHERE SUBSTRING([c].[ContactName], LEN([c].[ContactName]), 1) = N's'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE CHARINDEX(N'M', [c].[ContactName]) > 0");
+WHERE [c].[ContactName] LIKE N'%M%'");
         }
 
         public override async Task String_Compare_simple_zero(bool async)
@@ -1181,7 +1203,7 @@ WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(nvarchar
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = N'ALFKI') AND ((CHARINDEX(N'1997', CONVERT(nvarchar(max), [o].[OrderDate])) > 0) OR (CHARINDEX(N'1998', CONVERT(nvarchar(max), [o].[OrderDate])) > 0))");
+WHERE ([o].[CustomerID] = N'ALFKI') AND ((CONVERT(nvarchar(max), [o].[OrderDate]) LIKE N'%1997%') OR (CONVERT(nvarchar(max), [o].[OrderDate]) LIKE N'%1998%'))");
         }
 
         public override async Task Indexof_with_emptystring(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -2772,7 +2772,7 @@ WHERE [o].[OrderDate] > @__p_0");
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (@__NewLine_0 = N'') OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
+WHERE (@__NewLine_0 LIKE N'') OR (CHARINDEX(@__NewLine_0, [c].[CustomerID]) > 0)");
         }
 
         public override async Task Concat_string_int(bool async)
@@ -3150,7 +3150,7 @@ ORDER BY (
             AssertSql(
                 @"SELECT [o].[CustomerID]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] IS NOT NULL AND (CHARINDEX(N'10', CONVERT(VARCHAR(10), [o].[EmployeeID])) > 0)");
+WHERE [o].[OrderDate] IS NOT NULL AND (CONVERT(VARCHAR(10), [o].[EmployeeID]) LIKE N'%10%')");
         }
 
         public override async Task Select_expression_long_to_string(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -37,7 +37,7 @@ WHERE [c].[City] = N'Seattle'");
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-WHERE CHARINDEX(N'Sea', [c].[City]) > 0");
+WHERE [c].[City] LIKE N'%Sea%'");
         }
 
         public override async Task Select_Where_Navigation_Deep(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -59,7 +59,7 @@ WHERE [c].[City] = N'London'
 INTERSECT
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM [Customers] AS [c0]
-WHERE CHARINDEX(N'Thomas', [c0].[ContactName]) > 0");
+WHERE [c0].[ContactName] LIKE N'%Thomas%'");
         }
 
         public override async Task Except(bool async)
@@ -73,7 +73,7 @@ WHERE [c].[City] = N'London'
 EXCEPT
 SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM [Customers] AS [c0]
-WHERE CHARINDEX(N'Thomas', [c0].[ContactName]) > 0");
+WHERE [c0].[ContactName] LIKE N'%Thomas%'");
         }
 
         public override async Task Union_OrderBy_Skip_Take(bool async)
@@ -112,7 +112,7 @@ FROM (
     FROM [Customers] AS [c0]
     WHERE [c0].[City] = N'London'
 ) AS [t]
-WHERE CHARINDEX(N'Thomas', [t].[ContactName]) > 0");
+WHERE [t].[ContactName] LIKE N'%Thomas%'");
         }
 
         public override async Task Union_Skip_Take_OrderBy_ThenBy_Where(bool async)
@@ -137,7 +137,7 @@ FROM (
     ORDER BY [t].[Region], [t].[City]
     OFFSET @__p_0 ROWS
 ) AS [t0]
-WHERE CHARINDEX(N'Thomas', [t0].[ContactName]) > 0
+WHERE [t0].[ContactName] LIKE N'%Thomas%'
 ORDER BY [t0].[Region], [t0].[City]");
         }
 
@@ -176,7 +176,7 @@ WHERE [c1].[City] = N'Mannheim'");
 INTERSECT
 SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
 FROM [Customers] AS [c1]
-WHERE CHARINDEX(N'Thomas', [c1].[ContactName]) > 0");
+WHERE [c1].[ContactName] LIKE N'%Thomas%'");
         }
 
         [ConditionalTheory]
@@ -243,7 +243,7 @@ FROM (
     FROM [Customers] AS [c0]
     WHERE [c0].[City] = N'London'
 ) AS [t]
-WHERE CHARINDEX(N'Hanover', [t].[Address]) > 0");
+WHERE [t].[Address] LIKE N'%Hanover%'");
         }
 
         public override async Task Union_Select_scalar(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -925,7 +925,7 @@ END) OR [e].[NullableStringC] IS NULL");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE (([e].[NullableStringB] = N'') OR (CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0)) AND ([e].[BoolA] = CAST(1 AS bit))");
+WHERE (([e].[NullableStringB] LIKE N'') OR (CHARINDEX([e].[NullableStringB], [e].[NullableStringA]) > 0)) AND ([e].[BoolA] = CAST(1 AS bit))");
         }
 
         public override async Task Null_comparison_in_selector_with_relational_nulls(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5683,7 +5683,7 @@ WHERE [f].[String] = N'1337'");
                 AssertSql(
                     @"SELECT [t].[Id], [t].[Nombre]
 FROM [TipoServicio9582] AS [t]
-WHERE CHARINDEX('lla', [t].[Nombre]) > 0");
+WHERE [t].[Nombre] LIKE '%lla%'");
             }
         }
 


### PR DESCRIPTION
* Translate to LIKE instead of CHARINDEX for constant patterns
* Change empty string compensation from equality to LIKE

### StartsWith/EndsWith

*EDIT:* This can't currently be fixed, and not just because of the compensation - the main translation - `LEFT(LEN))` - also doesn't work for whitespace-only patterns (see https://github.com/dotnet/efcore~/pull/21097#issuecomment-637031454). Nothing to do about this for now.

~StartsWith/EndsWith still isn't fixed with regards to empty string compensation, so a whitespace-only pattern returns all rows. I can't change it to use LIKE, since the compensation happens in preprocessing. Our options:~

~1. Keep things the same, so we have false positives when the pattern is whitespace-only (all rows returned)~
~2. Remove the compensation, so we'll have a false negative for empty string - seems less problematic than the false positives, but is also a breaking change.~
~3. Find some way to move the empty-string compensation from preprocessing to translation, in which case we can switch to LIKE just like Contains.~

~Since we haven't had complaints, I say we leave it like this for now (option 1).~

### StartsWith/EndsWith/ContainsWith with null pattern

Need to decide on what happens with StartsWith/EndsWith/Contains and null patterns. StartsWith/EndsWith translated this to the LIKE with null, and this PR changes Contains to do the same. LIKE is different from equality in that it doesn't get null-compensated (as we recently decided). Options:

* Leave as-is
* Simply return a false constant for null patterns - works for constants/patterns but not for columns (unusual case).
* Specifically compensate for null pattern in translation, which doesn't seem right (should be in SqlNullabilityProcessor, what about respecting relation null semantics...)
String_contains_on_argument_with_wildcard_column_negated

Fixes #19402
