### PR TITLE
Temporarily switch back TFMs from net5.0 to netcoreapp5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreTargetFramework>netcoreapp5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Outside tooling hasn't yet adapted to the new net5.0 TFM, e.g. Rider (https://youtrack.jetbrains.com/issue/RIDER-45160). Since netcoreapp5.0 works fine, we can temporarily switch back to it.