### PR TITLE
Temporarily switch back TFMs from net5.0 to netcoreapp5.0, take 2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreTargetFramework>netcoreapp5.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <XUnitPublishTargetFramework>net5.0</XUnitPublishTargetFramework>
+    <XUnitPublishTargetFramework>netcoreapp5.0</XUnitPublishTargetFramework>
     <XUnitRuntimeTargetFramework>netcoreapp2.0</XUnitRuntimeTargetFramework>
     <XUnitRunnerVersion>2.4.1</XUnitRunnerVersion>
     <XUnitArguments></XUnitArguments>


### PR DESCRIPTION
Outside tooling hasn't yet adapted to the new net5.0 TFM, e.g. Rider (https://youtrack.jetbrains.com/issue/RIDER-45160). Since netcoreapp5.0 works fine, we can temporarily switch back to it.

Will not accidentally merge before it's green this time around...
