### PR TITLE
Rewrite cache synchronization to lock instead of spin

### DIFF
--- a/src/EFCore/Query/Internal/CompiledQueryCache.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryCache.cs
@@ -3,7 +3,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     /// </summary>
     public class CompiledQueryCache : ICompiledQueryCache
     {
-        private static readonly ConcurrentDictionary<object, object> _querySyncObjects
+        private static readonly ConcurrentDictionary<object, object> _locks
             = new ConcurrentDictionary<object, object>();
 
         private readonly IMemoryCache _memoryCache;
@@ -36,9 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public CompiledQueryCache([NotNull] IMemoryCache memoryCache)
-        {
-            _memoryCache = memoryCache;
-        }
+            => _memoryCache = memoryCache;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -48,42 +50,35 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual Func<QueryContext, TResult> GetOrAddQuery<TResult>(
             object cacheKey, Func<Func<QueryContext, TResult>> compiler)
-            => GetOrAddQueryCore(cacheKey, compiler);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual Func<QueryContext, TResult> GetOrAddAsyncQuery<TResult>(
-            object cacheKey, Func<Func<QueryContext, TResult>> compiler)
-            => GetOrAddQueryCore(cacheKey, compiler);
-
-        private Func<QueryContext, TFunc> GetOrAddQueryCore<TFunc>(
-            object cacheKey, Func<Func<QueryContext, TFunc>> compiler)
         {
-            retry:
-            if (!_memoryCache.TryGetValue(cacheKey, out Func<QueryContext, TFunc> compiledQuery))
+            // ReSharper disable once InconsistentlySynchronizedField
+            if (_memoryCache.TryGetValue(cacheKey, out Func<QueryContext, TResult> compiledQuery))
             {
-                if (!_querySyncObjects.TryAdd(cacheKey, value: null))
-                {
-                    goto retry;
-                }
-
-                try
-                {
-                    compiledQuery = compiler();
-
-                    _memoryCache.Set(cacheKey, compiledQuery, new MemoryCacheEntryOptions { Size = 10 });
-                }
-                finally
-                {
-                    _querySyncObjects.TryRemove(cacheKey, out _);
-                }
+                return compiledQuery;
             }
 
-            return compiledQuery;
+            // When multiple threads attempt to start processing the same query (program startup / thundering
+            // herd), have only one actually process and block the others.
+            // Note that the following synchronization isn't perfect - some race conditions may cause concurrent
+            // processing. This is benign (and rare).
+            var compilationLock = _locks.GetOrAdd(cacheKey, _ => new object());
+            try
+            {
+                lock (compilationLock)
+                {
+                    if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
+                    {
+                        compiledQuery = compiler();
+                        _memoryCache.Set(cacheKey, compiledQuery, new MemoryCacheEntryOptions { Size = 10 });
+                    }
+
+                    return compiledQuery;
+                }
+            }
+            finally
+            {
+                _locks.TryRemove(compilationLock, out _);
+            }
         }
     }
 }

--- a/src/EFCore/Query/Internal/ICompiledQueryCache.cs
+++ b/src/EFCore/Query/Internal/ICompiledQueryCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -29,16 +30,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         Func<QueryContext, TResult> GetOrAddQuery<TResult>(
-            [NotNull] object cacheKey,
-            [NotNull] Func<Func<QueryContext, TResult>> compiler);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        Func<QueryContext, TResult> GetOrAddAsyncQuery<TResult>(
             [NotNull] object cacheKey,
             [NotNull] Func<Func<QueryContext, TResult>> compiler);
     }


### PR DESCRIPTION
Closes #18516

tl;dr While results aren't very conclusive, this PR replaces spinning with an equivalent lock-based approach.

* The objective here is to remove the spinning loop that occurs when another thread is already compiling our query, and to generally simplify synchronization.
* I checked replacing the spinning loop with two things:
    * LOCKING: A proper lock; this keeps the behavior where multiple threads don't compile the same query, but rather the first one compiles and the others wait for it (just not via spinning).
    * NOSYNC: No synchronization, so multiple threads that happen to execute an un-compiled query compile in parallel.
* I used two benchmarking scenarios (the MemoryCache is compacted/reset at the beginning of each invocation):
    * Simply spin up 16 threads which execute the same heavy-ish query
    * Spin up 1 thread, wait a bit, then execute 15 more.
* The results are a bit inconclusive - benchmarking scenarios like this is very messy as the threads interfere with each other etc. But I was able to generate a scenario where locking improved perf a bit. I'm not convinced this is important, but as @smitpatel argued for this and the implementation simple, I went for that.
* Unrelated: this PR also removes ICompiledQueryCache.GetOrAddAsync which isn't used anywhere (and is a bit more complicated to implement with locking). I don't think there is a justification for a compiled query cache which performs I/O as part of its job...

<details>
<summary>Benchmark code</summary>

```c#
[Benchmark]
public virtual async Task MultipleThreadsNoDelay()
{
    _memoryCache.Compact(100); // Clear the cache between invocations

    for (var i = 0; i < 16; i++)
        _tasks[i] = Task.Run(ExecuteQuery);

    await Task.WhenAll(_tasks);
}

[Benchmark]
public virtual async Task MultipleThreadsDelay()
{
    _memoryCache.Compact(100); // Clear the cache between invocations

    _tasks[0] = Task.Run(ExecuteQuery);
    await Task.Delay(60);

    for (var i = 1; i < 16; i++)
        _tasks[i] = Task.Run(ExecuteQuery);

    await Task.WhenAll(_tasks);
}

async Task<List<Customer>> ExecuteQuery()
{
    using var context = _fixture.CreateContext(_serviceProvider);
    return await context.Customers
        .AsNoTracking()
        .Include(c => c.Orders)
        .ThenInclude(o => o.OrderLines)
        .ThenInclude(ol => ol.Product)
        .ToListAsync();
}
```
</details>

<details>
<summary>Benchmark results</summary>

```
### LOCKING, NODELAY

-------------------- Histogram --------------------                                                                                          
[ 41.421 ms ;  59.439 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                                                                                  
[ 59.439 ms ;  77.456 ms) |                              
[ 77.456 ms ;  92.401 ms) | @                                         
[ 92.401 ms ; 110.419 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[110.419 ms ; 121.052 ms) | @@                            
[121.052 ms ; 140.837 ms) |                              
[140.837 ms ; 158.855 ms) | @@@@@@@@@@@                                                                                                      
[158.855 ms ; 179.837 ms) | @                                                                                                                
[179.837 ms ; 191.093 ms) |                                                                                                                  
[191.093 ms ; 209.110 ms) | @@@@                          
[209.110 ms ; 223.323 ms) | @                            
---------------------------------------------------         
                                                                                                                                             
// * Summary *                                                                                                                               
                                                                                                                                             
BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04                             
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores                                                                        
.NET Core SDK=5.0.100-preview.6.20266.3                   
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
                                                                      
                                                                      
|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
| MultipleThreadsNoDelay | 94.62 ms | 16.87 ms | 44.73 ms |

### LOCKING, DELAY

-------------------- Histogram --------------------
[ 46.843 ms ;  86.274 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@
[ 86.274 ms ; 117.981 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[117.981 ms ; 163.849 ms) | @@@@@@@@@@@@
[163.849 ms ; 200.926 ms) | @@@@@
[200.926 ms ; 222.260 ms) | @
[222.260 ms ; 253.967 ms) | @@@@@
[253.967 ms ; 277.726 ms) | 
[277.726 ms ; 309.433 ms) | @@@@@@@@@@@@@
[309.433 ms ; 343.544 ms) | @@@
[343.544 ms ; 375.251 ms) | @
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|               Method |     Mean |    Error |   StdDev |   Median |
|--------------------- |---------:|---------:|---------:|---------:|
| MultipleThreadsDelay | 146.5 ms | 28.69 ms | 83.25 ms | 114.1 ms |



### LOCKING_OLD, NODELAY

-------------------- Histogram --------------------
[ 43.083 ms ;  58.162 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@
[ 58.162 ms ;  73.240 ms) | 
[ 73.240 ms ;  81.958 ms) | 
[ 81.958 ms ;  91.323 ms) | @@@@@@
[ 91.323 ms ; 106.402 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[106.402 ms ; 121.480 ms) | 
[121.480 ms ; 136.559 ms) | 
[136.559 ms ; 158.610 ms) | @@@@@@@@@@@@
[158.610 ms ; 173.689 ms) | 
[173.689 ms ; 188.767 ms) | 
[188.767 ms ; 200.078 ms) | 
[200.078 ms ; 216.918 ms) | @@
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
| MultipleThreadsNoDelay | 93.30 ms | 14.08 ms | 37.59 ms |


### LOCKING_OLD, DELAY

-------------------- Histogram --------------------
[ 29.367 ms ;  47.891 ms) | @@@@@@@
[ 47.891 ms ;  72.333 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[ 72.333 ms ;  96.776 ms) | 
[ 96.776 ms ; 121.218 ms) | 
[121.218 ms ; 145.661 ms) | 
[145.661 ms ; 170.103 ms) | 
[170.103 ms ; 205.960 ms) | @@@@@@@@@@@@@@@@@@
[205.960 ms ; 229.476 ms) | @@@@@@@
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|               Method |     Mean |    Error |   StdDev |   Median |
|--------------------- |---------:|---------:|---------:|---------:|
| MultipleThreadsDelay | 93.21 ms | 22.17 ms | 63.95 ms | 56.50 ms |


### NOSYNC, NODELAY

-------------------- Histogram --------------------
[ 57.361 ms ;  78.356 ms) | @@@@@@@@@@@
[ 78.356 ms ;  99.352 ms) | 
[ 99.352 ms ; 113.401 ms) | 
[113.401 ms ; 127.650 ms) | @@
[127.650 ms ; 148.646 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[148.646 ms ; 168.370 ms) | @@@@@@@@@@@
[168.370 ms ; 189.366 ms) | 
[189.366 ms ; 214.092 ms) | @@@@@@@
[214.092 ms ; 235.088 ms) | @@@@@@@@@@@@@@@@@@@@@@
[235.088 ms ; 250.854 ms) | @@@@@@
[250.854 ms ; 271.849 ms) | 
[271.849 ms ; 299.214 ms) | 
[299.214 ms ; 320.210 ms) | @
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|                 Method |     Mean |    Error |   StdDev |
|----------------------- |---------:|---------:|---------:|
| MultipleThreadsNoDelay | 165.7 ms | 19.16 ms | 54.36 ms |


### NOSYNC, DELAY

-------------------- Histogram --------------------
[ 40.168 ms ;  67.306 ms) | @@@@@@@@@
[ 67.306 ms ;  94.106 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[ 94.106 ms ; 112.470 ms) | @@@@@
[112.470 ms ; 139.269 ms) | 
[139.269 ms ; 166.069 ms) | 
[166.069 ms ; 185.753 ms) | 
[185.753 ms ; 206.214 ms) | @@@@@@
[206.214 ms ; 233.014 ms) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[233.014 ms ; 257.876 ms) | @@@@@
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.12.0, OS=ubuntu 20.04
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.6.20266.3
  [Host]     : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT
  DefaultJob : .NET Core 3.1.1 (CoreCLR 4.700.19.60701, CoreFX 4.700.19.60801), X64 RyuJIT


|               Method |     Mean |    Error |   StdDev |   Median |
|--------------------- |---------:|---------:|---------:|---------:|
| MultipleThreadsDelay | 142.3 ms | 24.25 ms | 70.36 ms | 96.36 ms |
```
</details>