### PR TITLE
Fix for 21041. Make all concurrency properties capable of storing "store-generated values"

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
@@ -107,6 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                                 !exampleProperty.IsNullable).Builder;
                         concurrencyShadowPropertyBuilder
                             .HasColumnName(concurrencyColumnName)
+                            .HasColumnType(exampleProperty.GetColumnType())
                             ?.IsConcurrencyToken(true)
                             ?.ValueGenerated(exampleProperty.ValueGenerated);
 #pragma warning restore EF1001 // Internal EF Core API usage.
@@ -141,8 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
                 foreach (var property in entityType.GetDeclaredProperties())
                 {
-                    if (property.IsConcurrencyToken
-                        && (property.ValueGenerated & ValueGenerated.OnUpdate) != 0)
+                    if (property.IsConcurrencyToken)
                     {
                         if (!concurrencyColumnsToProperties.TryGetValue(table, out var columnToProperties))
                         {

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -457,8 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                         || (entry.EntityState == EntityState.Modified && !entry.IsModified(property))
                         || (entry.EntityState == EntityState.Added && Equals(_originalValue, entry.GetCurrentValue(property)))))
                 {
-                    // Should be `entry.SetStoreGeneratedValue(property, _currentValue);` but see issue #21041
-                    ((InternalEntityEntry)entry)[property] = _currentValue;
+                    entry.SetStoreGeneratedValue(property, _currentValue);
 
                     return false;
                 }

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -112,7 +112,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static bool MayBeStoreGenerated([NotNull] this IProperty property)
         {
-            if (property.ValueGenerated != ValueGenerated.Never)
+            if (property.ValueGenerated != ValueGenerated.Never
+                || property.IsConcurrencyToken)
             {
                 return true;
             }

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -448,7 +448,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             VerifyError(
                 RelationalStrings.DuplicateColumnNameConcurrencyTokenMismatch(
-                    nameof(Cat), nameof(Cat.Breed), nameof(Dog), nameof(Dog.Breed), nameof(Cat.Breed), nameof(Animal)), modelBuilder.Model);
+                    nameof(Animal), "_TableSharingConcurrencyTokenConvention_Breed",
+                    nameof(Dog), nameof(Dog.Breed),
+                    nameof(Cat.Breed), nameof(Animal)),
+                modelBuilder.Model);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Fixes #21041.

All concurrency properties should be able to store "store-generated values". Note: in this context "store-generated values" just means "can be injected from the update pipeline".

Also updated `TableSharingConcurrencyTokenConvention` to create shadow concurrency property for all concurrency properties in the hierarchy, even non-store-generated ones.
