### PR TITLE
[SMALL] Fix to #18565 - Throw when a query filter is configured on an owned type

### DIFF
--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -969,11 +969,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                if (entityType.GetQueryFilter() != null
-                    && entityType.BaseType != null)
+                if (entityType.GetQueryFilter() != null)
                 {
-                    throw new InvalidOperationException(
-                        CoreStrings.BadFilterDerivedType(entityType.GetQueryFilter(), entityType.DisplayName()));
+                    if (entityType.BaseType != null)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.BadFilterDerivedType(entityType.GetQueryFilter(), entityType.DisplayName()));
+                    }
+
+                    if (entityType.IsOwned())
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.BadFilterOwnedType(entityType.GetQueryFilter(), entityType.DisplayName()));
+                    }
                 }
 
                 var requiredNavigationWithQueryFilter = entityType.GetNavigations()

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1687,6 +1687,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 filter, entityType);
 
         /// <summary>
+        ///     The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the entity that is not owned.
+        /// </summary>
+        public static string BadFilterOwnedType([CanBeNull] object filter, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("BadFilterOwnedType", nameof(filter), nameof(entityType)),
+                filter, entityType);
+
+        /// <summary>
         ///     The entity type '{entityType}' cannot use 'ToQuery' to create a defining query because it also defines a primary key. Defining queries can only be used to back entity types without keys.
         /// </summary>
         public static string DefiningQueryWithKey([CanBeNull] object entityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -890,6 +890,9 @@
   <data name="BadFilterDerivedType" xml:space="preserve">
     <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.</value>
   </data>
+  <data name="BadFilterOwnedType" xml:space="preserve">
+    <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the entity that is not owned.</value>
+  </data>
   <data name="DefiningQueryWithKey" xml:space="preserve">
     <value>The entity type '{entityType}' cannot use 'ToQuery' to create a defining query because it also defines a primary key. Defining queries can only be used to back entity types without keys.</value>
   </data>

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -173,6 +173,21 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
+        public virtual void Detects_filter_on_owned_type()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            var queryFilter = (Expression<Func<ReferencedEntity, bool>>)(_ => true);
+            modelBuilder.Entity<SampleEntity>()
+                .OwnsOne(
+                    s => s.ReferencedEntity, eb =>
+                    {
+                        eb.OwnedEntityType.SetQueryFilter(queryFilter);
+                    });
+
+            VerifyError(CoreStrings.BadFilterOwnedType(queryFilter, nameof(ReferencedEntity)), modelBuilder.Model);
+        }
+
+        [ConditionalFact]
         public virtual void Detects_defining_query_on_keyed_entity_type()
         {
             var modelBuilder = CreateConventionalModelBuilder();


### PR DESCRIPTION
Added model validation rule.

Fixes #18565