### PR TITLE
Update references to ReferenceHandler based on recent renaming

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -1600,7 +1600,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 #if NETCOREAPP5_0
             var options = new JsonSerializerOptions
             {
-                ReferenceHandling = ReferenceHandling.Preserve,
+                ReferenceHandler = ReferenceHandler.Preserve,
                 WriteIndented = writeIndented,
                 MaxDepth = maxDepth
             };


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/37296#issuecomment-638992710.

The property and the type ReferenceHandling were recently renamed to Referencehandler on https://github.com/dotnet/runtime/pull/36829.

Above PR was also ported to dotnet/runtime preview6 branch under https://github.com/dotnet/runtime/pull/37296 therefore once this is into master, it should be ported to release/5.0-preview6 branch as well.

I don't see the CI build failing because of the name missmatch; is EFCore using the latest bits from dotnet/runtime? cc @dougbu 

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


