### PR TITLE
Helix: Start LocalDB early to make tests more reliable

### DIFF
--- a/eng/helix.proj
+++ b/eng/helix.proj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <HelixPreCommands Condition = "'$(HelixTargetQueue.StartsWith(`Windows`))'">$(HelixPreCommands); SqlLocalDB start</HelixPreCommands>
     <XUnitPublishTargetFramework>netcoreapp5.0</XUnitPublishTargetFramework>
     <XUnitRuntimeTargetFramework>netcoreapp2.0</XUnitRuntimeTargetFramework>
     <XUnitRunnerVersion>2.4.1</XUnitRunnerVersion>


### PR DESCRIPTION
Resolves #18682
