### PR TITLE
Implement ChangeTracker.Clear() to stop tracking all entities

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     </para>
         ///     <para>
         ///         Note that this method calls <see cref="DetectChanges" /> unless
-        ///         <see cref="AutoDetectChangesEnabled" /> has been set to <see langword="false"/>. 
+        ///         <see cref="AutoDetectChangesEnabled" /> has been set to <see langword="false"/>.
         ///     </para>
         /// </summary>
         /// <returns> <see langword="true"/> if there are changes to save, otherwise <see langword="false"/>. </returns>
@@ -395,6 +395,25 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             return default;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         Stops tracking all currently tracked entities.
+        ///     </para>
+        ///     <para>
+        ///         <see cref="DbContext"/> is designed to have a short lifetime where a new instance is created for each unit-of-work.
+        ///         This manner means all tracked entities are discarded when the context is disposed at the end of each unit-of-work.
+        ///         However, clearing all tracked entities using this method may be useful in situations where creating a new context
+        ///         instance is not practical.
+        ///     </para>
+        ///     <para>
+        ///         This method should always be preferred over detaching every tracked entity.
+        ///         Detaching entities is a slow process that may have side effects.
+        ///         This method is much more efficient at clearing all tracked entities from the context.
+        ///     </para>
+        /// </summary>
+        public virtual void Clear()
+            => StateManager.Clear();
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -449,5 +449,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        void Clear();
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -646,6 +646,20 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual void ResetState()
         {
+            Clear();
+
+            Tracked = null;
+            StateChanged = null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void Clear()
+        {
             Unsubscribe();
             ChangedCount = 0;
             _entityReferenceMap.Clear();
@@ -656,9 +670,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _identityMap1?.Clear();
 
             _needsUnsubscribe = false;
-
-            Tracked = null;
-            StateChanged = null;
 
             SavingChanges = false;
         }

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -25,6 +25,37 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     public class ChangeTrackerTest
     {
+        [ConditionalFact]
+        public void Change_tracker_can_be_cleared()
+        {
+            Seed();
+
+            using var context = new LikeAZooContext();
+
+            var cats = context.Cats.ToList();
+            var hats = context.Set<Hat>().ToList();
+
+            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(EntityState.Unchanged, context.Entry(cats[0]).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(hats[0]).State);
+
+            context.ChangeTracker.Clear();
+
+            Assert.Empty(context.ChangeTracker.Entries());
+            Assert.Equal(EntityState.Detached, context.Entry(cats[0]).State);
+            Assert.Equal(EntityState.Detached, context.Entry(hats[0]).State);
+
+            var catsAgain = context.Cats.ToList();
+            var hatsAgain = context.Set<Hat>().ToList();
+
+            Assert.Equal(3, context.ChangeTracker.Entries().Count());
+            Assert.Equal(EntityState.Unchanged, context.Entry(catsAgain[0]).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(hatsAgain[0]).State);
+
+            Assert.Equal(EntityState.Detached, context.Entry(cats[0]).State);
+            Assert.Equal(EntityState.Detached, context.Entry(hats[0]).State);
+        }
+
         [ConditionalTheory]
         [InlineData(false)]
         [InlineData(true)]

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -428,8 +428,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             Assert.Same(entries[2], testListener.CollectionChanged.Skip(2).Single().Item1);
         }
 
-        [ConditionalFact]
-        public void Entries_are_unsubscribed_when_context_is_disposed()
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Entries_are_unsubscribed_when_context_is_disposed_or_cleared(bool useClear)
         {
             var context = InMemoryTestHelpers.Instance.CreateContext(
                 new ServiceCollection().AddScoped<IChangeDetector, TestPropertyListener>(),
@@ -458,7 +460,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             Assert.Equal(2, testListener.Changing.Count);
             Assert.Equal(2, testListener.Changed.Count);
 
-            context.Dispose();
+            if (useClear)
+            {
+                context.ChangeTracker.Clear();
+            }
+            else
+            {
+                context.Dispose();
+            }
 
             entities[5].Name = "Carmack";
             Assert.Equal(2, testListener.Changing.Count);

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -68,6 +68,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
 
+        public void Clear() => throw new NotImplementedException();
+
         public bool SavingChanges => throw new NotImplementedException();
 
         public IEnumerable<TEntity> GetNonDeletedEntities<TEntity>()


### PR DESCRIPTION
Fixes #15577

This is an alternative to mass-detach for situations where creating a new context instance is difficult.

The context configuration is not reset, since it seems likely that setting like lazy-loading and registered events are more useful left as they would be--just as is the case when doing mass-detach.
