### PR TITLE
Fix for 21133. IndexAttribute properties did not have the right TypeMappings

### DIFF
--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -230,7 +230,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
         /// <summary>
         ///     Configures an index on the specified property names.
-        ///     If there is an existing index on the given list of properyt names,
+        ///     If there is an existing index on the given list of property names,
         ///     then the existing index will be returned for configuration.
         /// </summary>
         /// <param name="propertyNames"> The names of the properties that make up the index. </param>

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -229,6 +229,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         bool CanRemoveKey(bool fromDataAnnotation = false);
 
         /// <summary>
+        ///     Configures an index on the specified property names.
+        ///     If there is an existing index on the given list of properyt names,
+        ///     then the existing index will be returned for configuration.
+        /// </summary>
+        /// <param name="propertyNames"> The names of the properties that make up the index. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the index if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionIndexBuilder HasIndex(
+            [NotNull] IReadOnlyList<string> propertyNames, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures an index on the specified property names.
+        ///     If there is an existing index on the given list of properyt names,
+        ///     then the existing index will be returned for configuration.
+        /// </summary>
+        /// <param name="propertyNames"> The names of the properties that make up the index. </param>
+        /// <param name="name"> The name of the index. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the index if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionIndexBuilder HasIndex(
+            [NotNull] IReadOnlyList<string> propertyNames,
+            [NotNull] string name,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
         ///     Configures an index on the specified properties.
         ///     If there is an existing index on the given list of properties,
         ///     then the existing index will be returned for configuration.

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -61,6 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var inversePropertyAttributeConvention = new InversePropertyAttributeConvention(Dependencies);
             var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention(Dependencies);
             var servicePropertyDiscoveryConvention = new ServicePropertyDiscoveryConvention(Dependencies);
+            var indexAttributeConvention = new IndexAttributeConvention(Dependencies);
 
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(Dependencies));
@@ -70,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(keyDiscoveryConvention);
+            conventionSet.EntityTypeAddedConventions.Add(indexAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention(Dependencies));
@@ -87,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(propertyDiscoveryConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(keyDiscoveryConvention);
+            conventionSet.EntityTypeBaseTypeChangedConventions.Add(indexAttributeConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(foreignKeyIndexConvention);
@@ -123,6 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyAddedConventions.Add(backingFieldAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyDiscoveryConvention);
+            conventionSet.PropertyAddedConventions.Add(indexAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.EntityTypePrimaryKeyChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
@@ -170,6 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
 
             conventionSet.ModelFinalizingConventions.Add(new ModelCleanupConvention(Dependencies));
             conventionSet.ModelFinalizingConventions.Add(keyAttributeConvention);
+            conventionSet.ModelFinalizingConventions.Add(indexAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(foreignKeyAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(new ChangeTrackingStrategyConvention(Dependencies));
             conventionSet.ModelFinalizingConventions.Add(new ConstructorBindingConvention(Dependencies));
@@ -182,7 +187,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizingConventions.Add(new QueryFilterDefiningQueryRewritingConvention(Dependencies));
             conventionSet.ModelFinalizingConventions.Add(inversePropertyAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(backingFieldConvention);
-            conventionSet.ModelFinalizingConventions.Add(new IndexAttributeConvention(Dependencies));
 
             conventionSet.ModelFinalizedConventions.Add(new ValidatingConvention(Dependencies));
 

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -126,7 +126,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.PropertyAddedConventions.Add(backingFieldAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(keyDiscoveryConvention);
-            conventionSet.PropertyAddedConventions.Add(indexAttributeConvention);
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.EntityTypePrimaryKeyChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -4463,6 +4463,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         [DebuggerStepThrough]
         IConventionIndexBuilder IConventionEntityTypeBuilder.HasIndex(
+            IReadOnlyList<string> propertyNames, bool fromDataAnnotation)
+            => HasIndex(
+                propertyNames,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [DebuggerStepThrough]
+        IConventionIndexBuilder IConventionEntityTypeBuilder.HasIndex(
+            IReadOnlyList<string> propertyNames, string name, bool fromDataAnnotation)
+            => HasIndex(
+                propertyNames,
+                name,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [DebuggerStepThrough]
+        IConventionIndexBuilder IConventionEntityTypeBuilder.HasIndex(
             IReadOnlyList<IConventionProperty> properties, bool fromDataAnnotation)
             => HasIndex(
                 properties as IReadOnlyList<Property> ?? properties.Cast<Property>().ToList(),

--- a/test/EFCore.Relational.Tests/Metadata/RelationalIndexTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalIndexTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    public class RelationalIndexExtensionsTest
+    {
+        [ConditionalFact]
+        public void IndexAttribute_database_name_can_be_overriden_using_fluent_api()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+            var entityBuilder = modelBuilder.Entity<EntityWithIndexes>();
+
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                foreach (var index in entityType.GetDeclaredIndexes())
+                {
+                    index.SetDatabaseName("My" + index.Name);
+                }
+            }
+
+            modelBuilder.Model.FinalizeModel();
+
+            var index0 = (Internal.Index)entityBuilder.Metadata.GetIndexes().First();
+            Assert.Equal(ConfigurationSource.DataAnnotation, index0.GetConfigurationSource());
+            Assert.Equal("IndexOnAAndB", index0.Name);
+            Assert.Equal("MyIndexOnAAndB", index0.GetDatabaseName());
+            Assert.Equal(ConfigurationSource.Explicit, index0.GetDatabaseNameConfigurationSource());
+            Assert.True(index0.IsUnique);
+            Assert.Equal(ConfigurationSource.DataAnnotation, index0.GetIsUniqueConfigurationSource());
+            Assert.Collection(index0.Properties,
+                prop0 => Assert.Equal("A", prop0.Name),
+                prop1 => Assert.Equal("B", prop1.Name));
+
+            var index1 = (Internal.Index)entityBuilder.Metadata.GetIndexes().Skip(1).First();
+            Assert.Equal(ConfigurationSource.DataAnnotation, index1.GetConfigurationSource());
+            Assert.Equal("IndexOnBAndC", index1.Name);
+            Assert.Equal("MyIndexOnBAndC", index1.GetDatabaseName());
+            Assert.Equal(ConfigurationSource.Explicit, index1.GetDatabaseNameConfigurationSource());
+            Assert.False(index1.IsUnique);
+            Assert.Null(index1.GetIsUniqueConfigurationSource());
+            Assert.Collection(index1.Properties,
+                prop0 => Assert.Equal("B", prop0.Name),
+                prop1 => Assert.Equal("C", prop1.Name));
+        }
+
+        protected virtual ModelBuilder CreateConventionModelBuilder() => RelationalTestHelpers.Instance.CreateConventionBuilder();
+
+        [Index(nameof(A), nameof(B), Name = "IndexOnAAndB", IsUnique = true)]
+        [Index(nameof(B), nameof(C), Name = "IndexOnBAndC")]
+        private class EntityWithIndexes
+        {
+            public int Id { get; set; }
+            public int A { get; set; }
+            public int B { get; set; }
+            public int C { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTestBase.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             builder.Entity<MyRelatedType4>().Property(e => e.Relationship2Id).IsUnicode();
             builder.Entity<MyPrecisionType>().Property(e => e.PrecisionOnly).HasPrecision(16);
             builder.Entity<MyPrecisionType>().Property(e => e.PrecisionAndScale).HasPrecision(18, 7);
+            builder.Entity<MyTypeWithIndexAttribute>();
 
             return builder.Model;
         }
@@ -84,6 +85,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             public string Relationship2Id { get; set; }
             public MyRelatedType3 Relationship2 { get; set; }
+        }
+
+        [Index(nameof(Name))]
+        protected class MyTypeWithIndexAttribute
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -385,6 +385,30 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalTheory]
+        [InlineData(true, false)]
+        [InlineData(null, false)]
+        [InlineData(true, null)]
+        [InlineData(null, null)]
+        public void Does_IndexAttribute_column_SQL_Server_string_mapping(bool? unicode, bool? fixedLength)
+        {
+            var model = CreateModel();
+            var entityType = model.FindEntityType(typeof(MyTypeWithIndexAttribute));
+            var property = entityType.FindProperty("Name");
+            property.SetIsUnicode(unicode);
+            property.SetIsFixedLength(fixedLength);
+            model.FinalizeModel();
+
+            var typeMapping = CreateTypeMapper().GetMapping(property);
+
+            Assert.Null(typeMapping.DbType);
+            Assert.Equal("nvarchar(450)", typeMapping.StoreType);
+            Assert.Equal(450, typeMapping.Size);
+            Assert.True(typeMapping.IsUnicode);
+            Assert.False(typeMapping.IsFixedLength);
+            Assert.Equal(450, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [ConditionalTheory]
         [InlineData(false)]
         [InlineData(null)]
         public void Does_non_key_SQL_Server_string_mapping_ansi(bool? fixedLength)
@@ -600,6 +624,28 @@ namespace Microsoft.EntityFrameworkCore
             property.SetIsUnicode(false);
             property.SetIsFixedLength(fixedLength);
             entityType.AddIndex(property);
+
+            var typeMapping = CreateTypeMapper().GetMapping(property);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.DbType);
+            Assert.Equal("varchar(900)", typeMapping.StoreType);
+            Assert.Equal(900, typeMapping.Size);
+            Assert.False(typeMapping.IsUnicode);
+            Assert.False(typeMapping.IsFixedLength);
+            Assert.Equal(900, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void Does_IndexAttribute_column_SQL_Server_string_mapping_ansi(bool? fixedLength)
+        {
+            var model = CreateModel();
+            var entityType = model.FindEntityType(typeof(MyTypeWithIndexAttribute));
+            var property = entityType.FindProperty("Name");
+            property.SetIsUnicode(false);
+            property.SetIsFixedLength(fixedLength);
+            model.FinalizeModel();
 
             var typeMapping = CreateTypeMapper().GetMapping(property);
 


### PR DESCRIPTION
Fixes #21133 .
IndexAttribute properties did not have the right TypeMappings. Also create indexes before ModelFinalizing to allow fluent api overrides.
