### PR TITLE
[SMALL] Fix to #21164 - Error translating Contains expression when UseRelationalNulls(true)

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -606,6 +606,42 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Select(e => e.Id).ToList();
         }
 
+        [ConditionalFact]
+        public virtual void Where_contains_on_parameter_array_with_relational_null_semantics()
+        {
+            using var context = CreateContext(useRelationalNulls: true);
+            var names = new[] { "Foo", "Bar" };
+            var result = context.Entities1
+                .Where(e => names.Contains(e.NullableStringA))
+                .Select(e => e.NullableStringA).ToList();
+
+            Assert.True(result.All(r => r == "Foo" || r == "Bar"));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_contains_on_parameter_empty_array_with_relational_null_semantics()
+        {
+            using var context = CreateContext(useRelationalNulls: true);
+            var names = new string[0];
+            var result = context.Entities1
+                .Where(e => names.Contains(e.NullableStringA))
+                .Select(e => e.NullableStringA).ToList();
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_contains_on_parameter_array_with_just_null_with_relational_null_semantics()
+        {
+            using var context = CreateContext(useRelationalNulls: true);
+            var names = new string[] { null };
+            var result = context.Entities1
+                .Where(e => names.Contains(e.NullableStringA))
+                .Select(e => e.NullableStringA).ToList();
+
+            Assert.Equal(0, result.Count);
+        }
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_nullable_bool(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1005,6 +1005,36 @@ FROM [Entities1] AS [e]
 WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
         }
 
+        public override void Where_contains_on_parameter_array_with_relational_null_semantics()
+        {
+            base.Where_contains_on_parameter_array_with_relational_null_semantics();
+
+            AssertSql(
+                @"SELECT [e].[NullableStringA]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] IN (N'Foo', N'Bar')");
+        }
+
+        public override void Where_contains_on_parameter_empty_array_with_relational_null_semantics()
+        {
+            base.Where_contains_on_parameter_empty_array_with_relational_null_semantics();
+
+            AssertSql(
+                @"SELECT [e].[NullableStringA]
+FROM [Entities1] AS [e]
+WHERE 0 = 1");
+        }
+
+        public override void Where_contains_on_parameter_array_with_just_null_with_relational_null_semantics()
+        {
+            base.Where_contains_on_parameter_array_with_just_null_with_relational_null_semantics();
+
+            AssertSql(
+                @"SELECT [e].[NullableStringA]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] IN (NULL)");
+        }
+
         public override async Task Where_nullable_bool(bool async)
         {
             await base.Where_nullable_bool(async);


### PR DESCRIPTION
Correctly processing values expression for the relational nulls code path

Fixes #21164