### PR TITLE
Draft for SQL Server identity fluent API in model snapshot

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton<IMigrationsCodeGeneratorSelector, MigrationsCodeGeneratorSelector>()
                 .AddSingleton<IModelCodeGenerator, CSharpModelGenerator>()
                 .AddSingleton<IModelCodeGeneratorSelector, ModelCodeGeneratorSelector>()
+                .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<INamedConnectionStringResolver>(
                     new DesignTimeConnectionStringResolver(applicationServiceProviderAccessor))
                 .AddSingleton(reporter)

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
@@ -50,12 +50,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         [EntityFrameworkInternal]
         public CSharpSnapshotGeneratorDependencies(
             [NotNull] ICSharpHelper csharpHelper,
-            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource,
+            [NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
         {
             Check.NotNull(csharpHelper, nameof(csharpHelper));
 
             CSharpHelper = csharpHelper;
             RelationalTypeMappingSource = relationalTypeMappingSource;
+            AnnotationCodeGenerator = annotationCodeGenerator;
         }
 
         /// <summary>
@@ -69,12 +71,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
 
         /// <summary>
+        ///     The annotation code generator.
+        /// </summary>
+        public IAnnotationCodeGenerator AnnotationCodeGenerator { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="csharpHelper"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CSharpSnapshotGeneratorDependencies With([NotNull] ICSharpHelper csharpHelper)
-            => new CSharpSnapshotGeneratorDependencies(csharpHelper, RelationalTypeMappingSource);
+            => new CSharpSnapshotGeneratorDependencies(csharpHelper, RelationalTypeMappingSource, AnnotationCodeGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -82,6 +89,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="relationalTypeMappingSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CSharpSnapshotGeneratorDependencies With([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
-            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, relationalTypeMappingSource);
+            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, relationalTypeMappingSource, AnnotationCodeGenerator);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="annotationCodeGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public CSharpSnapshotGeneratorDependencies With([NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
+            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, RelationalTypeMappingSource, annotationCodeGenerator);
     }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -216,53 +216,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         private IEnumerable<string> GetAnnotationNamespaces(IEnumerable<IAnnotatable> items)
-        {
-            var ignoredAnnotations = new List<string>
-            {
-                CoreAnnotationNames.NavigationCandidates,
-                CoreAnnotationNames.AmbiguousNavigations,
-                CoreAnnotationNames.InverseNavigations,
-                ChangeDetector.SkipDetectChangesAnnotation,
-                CoreAnnotationNames.OwnedTypes,
-                CoreAnnotationNames.ChangeTrackingStrategy,
-                CoreAnnotationNames.BeforeSaveBehavior,
-                CoreAnnotationNames.AfterSaveBehavior,
-                CoreAnnotationNames.TypeMapping,
-                CoreAnnotationNames.ValueComparer,
-#pragma warning disable 618
-                CoreAnnotationNames.KeyValueComparer,
-                CoreAnnotationNames.StructuralValueComparer,
-#pragma warning restore 618
-                CoreAnnotationNames.ConstructorBinding,
-                CoreAnnotationNames.NavigationAccessMode,
-                CoreAnnotationNames.PropertyAccessMode,
-                CoreAnnotationNames.ProviderClrType,
-                CoreAnnotationNames.ValueConverter,
-                CoreAnnotationNames.ValueGeneratorFactory,
-                CoreAnnotationNames.DefiningQuery,
-                CoreAnnotationNames.QueryFilter,
-                RelationalAnnotationNames.RelationalModel,
-                RelationalAnnotationNames.CheckConstraints,
-                RelationalAnnotationNames.Sequences,
-                RelationalAnnotationNames.DbFunctions,
-                RelationalAnnotationNames.TableMappings,
-                RelationalAnnotationNames.TableColumnMappings,
-                RelationalAnnotationNames.ViewMappings,
-                RelationalAnnotationNames.ViewColumnMappings,
-                RelationalAnnotationNames.ForeignKeyMappings,
-                RelationalAnnotationNames.TableIndexMappings,
-                RelationalAnnotationNames.UniqueConstraintMappings,
-                RelationalAnnotationNames.RelationalOverrides
-            };
-
-            return items.SelectMany(
-                i => i.GetAnnotations().Select(
-                        a => new { Annotatable = i, Annotation = a })
-                    .Where(
-                        a => a.Annotation.Value != null
-                             && !ignoredAnnotations.Contains(a.Annotation.Name))
-                    .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces()));
-        }
+            => items.SelectMany(
+                    i =>
+                    {
+                        var annotations = i.GetAnnotations().ToDictionary(a => a.Name, a => a);
+                        Dependencies.AnnotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+                        return annotations.Values.Select(a => new { Annotatable = i, Annotation = a });
+                    })
+                .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces());
 
         private ValueConverter FindValueConverter(IProperty property)
             => (property.FindTypeMapping()
@@ -270,8 +231,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
         private Type GetProviderType(IAnnotatable annotatable, Type valueType)
             => annotatable is IProperty property
-               && valueType.UnwrapNullableType() == property.ClrType.UnwrapNullableType()
-                ? FindValueConverter(property)?.ProviderClrType ?? valueType
-                : valueType;
+                && valueType.UnwrapNullableType() == property.ClrType.UnwrapNullableType()
+                    ? FindValueConverter(property)?.ProviderClrType ?? valueType
+                    : valueType;
     }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGeneratorDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -46,9 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public MigrationsCodeGeneratorDependencies([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
+        public MigrationsCodeGeneratorDependencies(
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource,
+            [NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
         {
             RelationalTypeMappingSource = relationalTypeMappingSource;
+            AnnotationCodeGenerator = annotationCodeGenerator;
         }
 
         /// <summary>
@@ -57,11 +61,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
 
         /// <summary>
+        ///     The annotation code generator.
+        /// </summary>
+        public IAnnotationCodeGenerator AnnotationCodeGenerator { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="relationalTypeMappingSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public MigrationsCodeGeneratorDependencies With([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
-            => new MigrationsCodeGeneratorDependencies(relationalTypeMappingSource);
+            => new MigrationsCodeGeneratorDependencies(relationalTypeMappingSource, AnnotationCodeGenerator);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="annotationCodeGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsCodeGeneratorDependencies With([NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
+            => new MigrationsCodeGeneratorDependencies(RelationalTypeMappingSource, annotationCodeGenerator);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -264,41 +264,21 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.AppendLine("protected override void OnModelCreating(ModelBuilder modelBuilder)");
             _sb.Append("{");
 
-            var annotations = model.GetAnnotations().ToList();
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.ProductVersion);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.ChangeTrackingStrategy);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.OwnedTypes);
-            RemoveAnnotation(ref annotations, ChangeDetector.SkipDetectChangesAnnotation);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.MaxIdentifierLength);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.RelationalModel);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.CheckConstraints);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Sequences);
-            RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.DatabaseName);
-            RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.EntityTypeErrors);
+            var annotations = model.GetAnnotations().ToDictionary(a => a.Name, a => a);
 
-            var annotationsToRemove = new List<IAnnotation>();
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(model, annotations);
+
+            annotations.Remove(CoreAnnotationNames.ProductVersion);
+            annotations.Remove(RelationalAnnotationNames.MaxIdentifierLength); // ?
+            annotations.Remove(ScaffoldingAnnotationNames.DatabaseName);
+            annotations.Remove(ScaffoldingAnnotationNames.EntityTypeErrors);
 
             var lines = new List<string>();
 
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(model, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(model, annotation);
-                    if (methodCall != null)
-                    {
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
+            lines.AddRange(
+                _annotationCodeGenerator.GenerateFluentApiCalls(model, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             if (lines.Count > 0)
             {
@@ -366,63 +346,45 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             GenerateKey(entityType.FindPrimaryKey(), entityType, useDataAnnotations);
 
-            var annotations = entityType.GetAnnotations().ToList();
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.ConstructorBinding);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.TableName);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Schema);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewName);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewSchema);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.TableMappings);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewMappings);
-            RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.DbSetName);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Comment);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewDefinitionSql);
+            var annotations = entityType.GetAnnotations().ToDictionary(a => a.Name, a => a);
+
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(entityType, annotations);
+
+            annotations.Remove(RelationalAnnotationNames.TableName);
+            annotations.Remove(RelationalAnnotationNames.Schema);
+            annotations.Remove(RelationalAnnotationNames.ViewName);
+            annotations.Remove(RelationalAnnotationNames.ViewSchema);
+            annotations.Remove(ScaffoldingAnnotationNames.DbSetName);
+            annotations.Remove(RelationalAnnotationNames.ViewDefinitionSql);
+
+            if (useDataAnnotations)
+            {
+                // Strip out any annotations handled as attributes - these are already handled when generating
+                // the entity's properties
+                _ = _annotationCodeGenerator.GenerateDataAnnotationAttributes(entityType, annotations);
+            }
 
             if (!useDataAnnotations || entityType.GetViewName() != null)
             {
                 GenerateTableName(entityType);
             }
 
-            var annotationsToRemove = new List<IAnnotation>();
-            var lines = new List<string>();
-
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(entityType, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(entityType, annotation);
-                    if (methodCall != null)
-                    {
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
-
-            if (entityType.GetComment() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalEntityTypeBuilderExtensions.HasComment)}" +
-                    $"({_code.Literal(entityType.GetComment())})");
-            }
+            var lines = new List<string>(
+                _annotationCodeGenerator.GenerateFluentApiCalls(entityType, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             AppendMultiLineFluentApi(entityType, lines);
 
             foreach (var index in entityType.GetIndexes())
             {
-                // If there are annotations that cannot be represented
-                // using an IndexAttribute then use fluent API even
+                // If there are annotations that cannot be represented using an IndexAttribute then use fluent API even
                 // if useDataAnnotations is true.
-                if (!useDataAnnotations
-                    || index.GetAnnotations().Any(
-                        a => !CSharpModelGenerator.IgnoredIndexAnnotations.Contains(a.Name)))
+                var indexAnnotations = index.GetAnnotations().ToDictionary(a => a.Name, a => a);
+                _annotationCodeGenerator.RemoveIgnoredAnnotations(indexAnnotations);
+                _annotationCodeGenerator.RemoveConventionalAnnotations(index, indexAnnotations);
+
+                if (!useDataAnnotations || indexAnnotations.Count > 0)
                 {
                     GenerateIndex(index);
                 }
@@ -481,11 +443,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 return;
             }
 
-            var annotations = key.GetAnnotations().ToList();
+            var annotations = key.GetAnnotations().ToDictionary(a => a.Name, a => a);
+
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(key, annotations);
 
             var explicitName = key.GetName() != key.GetDefaultName();
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Name);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.UniqueConstraintMappings);
+            annotations.Remove(RelationalAnnotationNames.Name);
 
             if (key.Properties.Count == 1
                 && annotations.Count == 0)
@@ -515,27 +479,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     $"({_code.Literal(key.GetName())})");
             }
 
-            var annotationsToRemove = new List<IAnnotation>();
-
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(key, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(key, annotation);
-                    if (methodCall != null)
-                    {
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
+            lines.AddRange(
+                _annotationCodeGenerator.GenerateFluentApiCalls(key, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             AppendMultiLineFluentApi(key.DeclaringEntityType, lines);
         }
@@ -589,53 +535,25 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
         private void GenerateIndex(IIndex index)
         {
-            var annotations = index.GetAnnotations().ToList();
+            var annotations = index.GetAnnotations().ToDictionary(a => a.Name, a => a);
+
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(index, annotations);
 
             var lines = new List<string> {
                 $".{nameof(EntityTypeBuilder.HasIndex)}" +
                 $"({_code.Lambda(index.Properties)}, " +
                 $"{_code.Literal(index.GetDatabaseName())})" };
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Name);
-
-            foreach (var annotation in CSharpModelGenerator.IgnoredIndexAnnotations)
-            {
-                RemoveAnnotation(ref annotations, annotation);
-            }
+            annotations.Remove(RelationalAnnotationNames.Name);
 
             if (index.IsUnique)
             {
                 lines.Add($".{nameof(IndexBuilder.IsUnique)}()");
             }
 
-            if (index.GetFilter() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalIndexBuilderExtensions.HasFilter)}" +
-                    $"({_code.Literal(index.GetFilter())})");
-                RemoveAnnotation(ref annotations, RelationalAnnotationNames.Filter);
-            }
-
-            var annotationsToRemove = new List<IAnnotation>();
-
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(index, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(index, annotation);
-                    if (methodCall != null)
-                    {
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
+            lines.AddRange(
+                _annotationCodeGenerator.GenerateFluentApiCalls(index, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             AppendMultiLineFluentApi(index.DeclaringEntityType, lines);
         }
@@ -644,55 +562,25 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             var lines = new List<string> { $".{nameof(EntityTypeBuilder.Property)}(e => e.{property.Name})" };
 
-            var annotations = property.GetAnnotations().ToList();
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
 
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.MaxLength);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.Precision);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.Scale);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.TypeMapping);
-            RemoveAnnotation(ref annotations, CoreAnnotationNames.Unicode);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ColumnName);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewColumnName);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ColumnType);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.DefaultValue);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.DefaultValueSql);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Comment);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.Collation);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ComputedColumnSql);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ComputedColumnIsStored);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.IsFixedLength);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.TableColumnMappings);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ViewColumnMappings);
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.RelationalOverrides);
-            RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.ColumnOrdinal);
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(property, annotations);
+            annotations.Remove(ScaffoldingAnnotationNames.ColumnOrdinal);
 
-            if (!useDataAnnotations)
+            if (useDataAnnotations)
+            {
+                // Strip out any annotations handled as attributes - these are already handled when generating
+                // the entity's properties
+                _ = _annotationCodeGenerator.GenerateDataAnnotationAttributes(property, annotations);
+            }
+            else
             {
                 if (!property.IsNullable
                     && property.ClrType.IsNullableType()
                     && !property.IsPrimaryKey())
                 {
                     lines.Add($".{nameof(PropertyBuilder.IsRequired)}()");
-                }
-
-                var columnName = property.GetColumnName();
-
-                if (columnName != null
-                    && columnName != property.Name)
-                {
-                    lines.Add(
-                        $".{nameof(RelationalPropertyBuilderExtensions.HasColumnName)}" +
-                        $"({_code.Literal(columnName)})");
-                }
-
-                var viewColumnName = property.GetViewColumnName();
-
-                if (viewColumnName != null
-                    && viewColumnName != columnName)
-                {
-                    lines.Add(
-                        $".{nameof(RelationalPropertyBuilderExtensions.HasViewColumnName)}" +
-                        $"({_code.Literal(columnName)})");
                 }
 
                 var columnType = property.GetConfiguredColumnType();
@@ -703,81 +591,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                         $".{nameof(RelationalPropertyBuilderExtensions.HasColumnType)}" +
                         $"({_code.Literal(columnType)})");
                 }
-
-                var maxLength = property.GetMaxLength();
-
-                if (maxLength.HasValue)
-                {
-                    lines.Add(
-                        $".{nameof(PropertyBuilder.HasMaxLength)}" +
-                        $"({_code.Literal(maxLength.Value)})");
-                }
-            }
-
-            var precision = property.GetPrecision();
-            var scale = property.GetScale();
-            if (precision != null && scale != null && scale != 0)
-            {
-                lines.Add(
-                $".{nameof(PropertyBuilder.HasPrecision)}" +
-                $"({_code.Literal(precision.Value)}, {_code.Literal(scale.Value)})");
-            }
-            else if (precision != null)
-            {
-                lines.Add(
-                $".{nameof(PropertyBuilder.HasPrecision)}" +
-                $"({_code.Literal(precision.Value)})");
-            }
-
-            if (property.IsUnicode() != null)
-            {
-                lines.Add(
-                    $".{nameof(PropertyBuilder.IsUnicode)}" +
-                    $"({(property.IsUnicode() == false ? "false" : "")})");
-            }
-
-            if (property.IsFixedLength() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.IsFixedLength)}()");
-            }
-
-            if (property.GetDefaultValue() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}" +
-                    $"({_code.UnknownLiteral(property.GetDefaultValue())})");
-            }
-
-            if (property.GetDefaultValueSql() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql)}" +
-                    $"({_code.Literal(property.GetDefaultValueSql())})");
-            }
-
-            if (property.GetComputedColumnSql() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql)}" +
-                    $"({_code.Literal(property.GetComputedColumnSql())}" +
-                    (property.GetComputedColumnIsStored() is bool computedColumnIsStored
-                        ? $", stored: {_code.Literal(computedColumnIsStored)})"
-                        : ")"));
-            }
-
-            if (property.GetComment() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.HasComment)}" +
-                    $"({_code.Literal(property.GetComment())})");
-            }
-
-            if (property.GetCollation() != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.UseCollation)}" +
-                    $"({_code.Literal(property.GetCollation())})");
             }
 
             var valueGenerated = property.ValueGenerated;
@@ -805,27 +618,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 lines.Add($".{nameof(PropertyBuilder.IsConcurrencyToken)}()");
             }
 
-            var annotationsToRemove = new List<IAnnotation>();
-
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(property, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(property, annotation);
-                    if (methodCall != null)
-                    {
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
+            lines.AddRange(
+                _annotationCodeGenerator.GenerateFluentApiCalls(property, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             switch (lines.Count)
             {
@@ -842,9 +637,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private void GenerateRelationship(IForeignKey foreignKey, bool useDataAnnotations)
         {
             var canUseDataAnnotations = true;
-            var annotations = foreignKey.GetAnnotations().ToList();
+            var annotations = foreignKey.GetAnnotations().ToDictionary(a => a.Name, a => a);
 
-            RemoveAnnotation(ref annotations, RelationalAnnotationNames.ForeignKeyMappings);
+            _annotationCodeGenerator.RemoveIgnoredAnnotations(annotations);
+            _annotationCodeGenerator.RemoveConventionalAnnotations(foreignKey, annotations);
 
             var lines = new List<string>
             {
@@ -883,34 +679,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             if (!string.IsNullOrEmpty((string)foreignKey[RelationalAnnotationNames.Name]))
             {
                 canUseDataAnnotations = false;
-                lines.Add(
-                    ".HasConstraintName" +
-                    $"({_code.Literal(foreignKey.GetConstraintName())})");
-                RemoveAnnotation(ref annotations, RelationalAnnotationNames.Name);
             }
 
-            var annotationsToRemove = new List<IAnnotation>();
-
-            foreach (var annotation in annotations)
-            {
-                if (annotation.Value == null
-                    || _annotationCodeGenerator.IsHandledByConvention(foreignKey, annotation))
-                {
-                    annotationsToRemove.Add(annotation);
-                }
-                else
-                {
-                    var methodCall = _annotationCodeGenerator.GenerateFluentApi(foreignKey, annotation);
-                    if (methodCall != null)
-                    {
-                        canUseDataAnnotations = false;
-                        lines.Add(_code.Fragment(methodCall));
-                        annotationsToRemove.Add(annotation);
-                    }
-                }
-            }
-
-            lines.AddRange(GenerateAnnotations(annotations.Except(annotationsToRemove)));
+            lines.AddRange(
+                _annotationCodeGenerator.GenerateFluentApiCalls(foreignKey, annotations).Select(m => _code.Fragment(m))
+                    .Concat(GenerateRawAnnotations(annotations.Values)));
 
             if (!useDataAnnotations
                 || !canUseDataAnnotations)
@@ -983,14 +756,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.AppendLine(";");
         }
 
-        private static void RemoveAnnotation(ref List<IAnnotation> annotations, string annotationName)
-            => annotations.Remove(annotations.SingleOrDefault(a => a.Name == annotationName));
-
-        private IList<string> GenerateAnnotations(IEnumerable<IAnnotation> annotations)
-            => annotations.Select(GenerateAnnotation).ToList();
-
-        private string GenerateAnnotation(IAnnotation annotation)
-            => $".HasAnnotation({_code.Literal(annotation.Name)}, " +
-               $"{_code.UnknownLiteral(annotation.Value)})";
+        private IList<string> GenerateRawAnnotations(IEnumerable<IAnnotation> annotations)
+            => annotations.Select(a =>
+                $".HasAnnotation({_code.Literal(a.Name)}, " + $"{_code.UnknownLiteral(a.Value)})").ToList();
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -129,11 +129,5 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             return resultingFiles;
         }
-
-        /// <summary>
-        /// The set of annotations ignored for the purposes of code generation for indexes.
-        /// </summary>
-        public static IReadOnlyList<string> IgnoredIndexAnnotations
-            => new List<string> { RelationalAnnotationNames.TableIndexMappings };
     }
 }

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -1,10 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+
+#pragma warning disable EF1001 // Accessing annotation names (internal)
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
@@ -36,13 +45,304 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// </summary>
         protected virtual AnnotationCodeGeneratorDependencies Dependencies { get; }
 
+        /// <inheritdoc />
+        public virtual void RemoveIgnoredAnnotations(IDictionary<string, IAnnotation> annotations)
+        {
+            annotations.Remove(CoreAnnotationNames.NavigationCandidates);
+            annotations.Remove(CoreAnnotationNames.AmbiguousNavigations);
+            annotations.Remove(CoreAnnotationNames.InverseNavigations);
+            annotations.Remove(ChangeDetector.SkipDetectChangesAnnotation);
+            annotations.Remove(CoreAnnotationNames.OwnedTypes);
+            annotations.Remove(CoreAnnotationNames.ChangeTrackingStrategy);
+            annotations.Remove(CoreAnnotationNames.BeforeSaveBehavior);
+            annotations.Remove(CoreAnnotationNames.AfterSaveBehavior);
+            annotations.Remove(CoreAnnotationNames.TypeMapping);
+            annotations.Remove(CoreAnnotationNames.ValueComparer);
+#pragma warning disable 618
+            annotations.Remove(CoreAnnotationNames.KeyValueComparer);
+            annotations.Remove(CoreAnnotationNames.StructuralValueComparer);
+#pragma warning restore 618
+            annotations.Remove(CoreAnnotationNames.ConstructorBinding);
+            annotations.Remove(CoreAnnotationNames.NavigationAccessMode);
+            annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+            annotations.Remove(CoreAnnotationNames.ProviderClrType);
+            annotations.Remove(CoreAnnotationNames.ValueConverter);
+            annotations.Remove(CoreAnnotationNames.ValueGeneratorFactory);
+            annotations.Remove(CoreAnnotationNames.DefiningQuery);
+            annotations.Remove(CoreAnnotationNames.QueryFilter);
+            annotations.Remove(RelationalAnnotationNames.RelationalModel);
+            annotations.Remove(RelationalAnnotationNames.CheckConstraints);
+            annotations.Remove(RelationalAnnotationNames.Sequences);
+            annotations.Remove(RelationalAnnotationNames.DbFunctions);
+            annotations.Remove(RelationalAnnotationNames.TableMappings);
+            annotations.Remove(RelationalAnnotationNames.TableColumnMappings);
+            annotations.Remove(RelationalAnnotationNames.ViewMappings);
+            annotations.Remove(RelationalAnnotationNames.ViewColumnMappings);
+            annotations.Remove(RelationalAnnotationNames.ForeignKeyMappings);
+            annotations.Remove(RelationalAnnotationNames.TableIndexMappings);
+            annotations.Remove(RelationalAnnotationNames.UniqueConstraintMappings);
+            annotations.Remove(RelationalAnnotationNames.RelationalOverrides);
+
+            foreach (var (name, annotation) in EnumerateForRemoval(annotations))
+            {
+                if (annotation.Value is null)
+                {
+                    annotations.Remove(name);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(IModel model, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(model, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(entityType, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var columnName = property.GetColumnName();
+
+            if (columnName == property.Name)
+            {
+                annotations.Remove(RelationalAnnotationNames.ColumnName);
+            }
+
+            if (annotations.TryGetValue(RelationalAnnotationNames.ViewColumnName, out var viewColumnNameAnnotation)
+                && viewColumnNameAnnotation.Value is string viewColumnName
+                && viewColumnName != columnName)
+            {
+                annotations.Remove(RelationalAnnotationNames.ViewColumnName);
+            }
+
+            RemoveConventionalAnnotationsHelper(property, annotations, IsHandledByConvention);
+        }
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(IKey key, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(key, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(
+            IForeignKey foreignKey, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(foreignKey, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveConventionalAnnotations(IIndex index, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(index, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IModel model, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema),
+                methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(model, annotations, GenerateFluentApi));
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Comment, nameof(RelationalEntityTypeBuilderExtensions.HasComment), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.ViewColumnName, nameof(RelationalPropertyBuilderExtensions.HasViewColumnName),
+                methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.DefaultValueSql, nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
+                methodCallCodeFragments);
+
+            if (TryGetAndRemove(annotations, RelationalAnnotationNames.DefaultValue, out object defaultValue))
+            {
+                var valueConverter = property.GetValueConverter()
+                    ?? (property.FindTypeMapping()
+                        ?? Dependencies.RelationalTypeMappingSource.FindMapping(property))?.Converter;
+
+                methodCallCodeFragments.Add(
+                    new MethodCallCodeFragment(
+                        nameof(RelationalPropertyBuilderExtensions.HasDefaultValue),
+                        valueConverter == null ? defaultValue : valueConverter.ConvertToProvider(defaultValue)));
+            }
+
+            if (TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnSql, out object computedColumnSql))
+            {
+                methodCallCodeFragments.Add(
+                    TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnIsStored, out bool isStored)
+                        ? new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
+                            computedColumnSql,
+                            isStored)
+                        : new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
+                            computedColumnSql));
+            }
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.IsFixedLength, nameof(RelationalPropertyBuilderExtensions.IsFixedLength),
+                methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Comment, nameof(RelationalPropertyBuilderExtensions.HasComment), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Collation, nameof(RelationalPropertyBuilderExtensions.UseCollation), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                CoreAnnotationNames.MaxLength, nameof(PropertyBuilder.HasMaxLength), methodCallCodeFragments);
+
+            var hasScale = TryGetAndRemove(annotations, CoreAnnotationNames.Scale, out int scale) && scale != 0;
+
+            if (TryGetAndRemove(annotations, CoreAnnotationNames.Precision, out int precision))
+            {
+                methodCallCodeFragments.Add(
+                    hasScale
+                        ? new MethodCallCodeFragment(nameof(PropertyBuilder.HasPrecision), precision, scale)
+                        : new MethodCallCodeFragment(nameof(PropertyBuilder.HasPrecision), precision));
+            }
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                CoreAnnotationNames.Unicode, nameof(PropertyBuilder.IsUnicode), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(property, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IKey key, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalKeyBuilderExtensions.HasName), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(key, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IForeignKey foreignKey, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalForeignKeyBuilderExtensions.HasConstraintName), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(foreignKey, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IIndex index, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalIndexBuilderExtensions.HasDatabaseName), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Filter, nameof(RelationalIndexBuilderExtensions.HasFilter), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(index, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+        {
+            var attributeCodeFragments = new List<AttributeCodeFragment>();
+
+            attributeCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateDataAnnotation));
+
+            return attributeCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var attributeCodeFragments = new List<AttributeCodeFragment>();
+
+            if (TryGetAndRemove(annotations, CoreAnnotationNames.MaxLength, out int maxLength))
+            {
+                attributeCodeFragments.Add(
+                    new AttributeCodeFragment(
+                        property.ClrType == typeof(string)
+                            ? typeof(StringLengthAttribute)
+                            : typeof(MaxLengthAttribute),
+                        maxLength));
+            }
+
+            attributeCodeFragments.AddRange(GenerateFluentApiCallsHelper(property, annotations, GenerateDataAnnotation));
+
+            return attributeCodeFragments;
+        }
+
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="model" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="model"> The <see cref="IModel" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IModel model, IAnnotation annotation)
+        /// <returns>
+        ///     <see langword="true"/> if the annotation is handled by convention;
+        ///     <see langword="false"/> if code must be generated.
+        /// </returns>
+        public virtual bool IsHandledByConvention([NotNull] IModel model, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
@@ -51,12 +351,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="entityType" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="entityType"> The <see cref="IEntityType" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IEntityType entityType, IAnnotation annotation)
+        public virtual bool IsHandledByConvention([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(annotation, nameof(annotation));
@@ -65,12 +371,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="key" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="key"> The <see cref="IKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IKey key, IAnnotation annotation)
+        public virtual bool IsHandledByConvention([NotNull] IKey key, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(key, nameof(key));
             Check.NotNull(annotation, nameof(annotation));
@@ -79,12 +391,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="property" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="property"> The <see cref="IProperty" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IProperty property, IAnnotation annotation)
+        public virtual bool IsHandledByConvention([NotNull] IProperty property, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
@@ -93,12 +411,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="foreignKey" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IForeignKey foreignKey, IAnnotation annotation)
+        public virtual bool IsHandledByConvention([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(annotation, nameof(annotation));
@@ -107,12 +431,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="index" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="index"> The <see cref="IIndex" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IIndex index, IAnnotation annotation)
+        public virtual bool IsHandledByConvention([NotNull] IIndex index, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(index, nameof(index));
             Check.NotNull(annotation, nameof(annotation));
@@ -121,12 +451,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="model"> The <see cref="IModel" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IModel model, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IModel model, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
@@ -135,12 +471,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="entityType"> The <see cref="IEntityType" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IEntityType entityType, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(annotation, nameof(annotation));
@@ -149,12 +491,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="key"> The <see cref="IKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IKey key, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IKey key, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(key, nameof(key));
             Check.NotNull(annotation, nameof(annotation));
@@ -163,12 +511,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="property"> The <see cref="IProperty" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IProperty property, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IProperty property, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
@@ -177,12 +531,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IForeignKey foreignKey, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(annotation, nameof(annotation));
@@ -191,17 +551,128 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="index"> The <see cref="IIndex" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
+        public virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IIndex index, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(index, nameof(index));
             Check.NotNull(annotation, nameof(annotation));
 
             return null;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         Returns a data annotation attribute code fragment for the given <paramref name="annotation" />,
+        ///         or <see langword="null" /> if no data annotation exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
+        /// </summary>
+        /// <param name="entityType"> The <see cref="IEntityType" />. </param>
+        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
+        /// <returns> <see langword="null" />. </returns>
+        public virtual AttributeCodeFragment GenerateDataAnnotation([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return null;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Returns a data annotation attribute code fragment for the given <paramref name="annotation" />,
+        ///         or <see langword="null" /> if no data annotation exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
+        /// </summary>
+        /// <param name="property"> The <see cref="IProperty" />. </param>
+        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
+        /// <returns> <see langword="null" />. </returns>
+        public virtual AttributeCodeFragment GenerateDataAnnotation([NotNull] IProperty property, [NotNull] IAnnotation annotation)
+        {
+            Check.NotNull(property, nameof(property));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return null;
+        }
+
+        private IEnumerable<TCodeFragment> GenerateFluentApiCallsHelper<TAnnotatable, TCodeFragment>(
+            TAnnotatable annotatable,
+            IDictionary<string, IAnnotation> annotations,
+            Func<TAnnotatable, IAnnotation, TCodeFragment> generateCodeFragment)
+        {
+            foreach (var (name, annotation) in EnumerateForRemoval(annotations))
+            {
+                var codeFragment = generateCodeFragment(annotatable, annotation);
+                if (codeFragment != null)
+                {
+                    yield return codeFragment;
+                    annotations.Remove(name);
+                }
+            }
+        }
+
+        private void RemoveConventionalAnnotationsHelper<TAnnotatable>(
+            TAnnotatable annotatable,
+            IDictionary<string, IAnnotation> annotations,
+            Func<TAnnotatable, IAnnotation, bool> isHandledByConvention)
+        {
+            foreach (var (name, annotation) in EnumerateForRemoval(annotations))
+            {
+                if (isHandledByConvention(annotatable, annotation))
+                {
+                    annotations.Remove(name);
+                }
+            }
+        }
+
+        private static bool TryGetAndRemove<T>(IDictionary<string, IAnnotation> annotations, string annotationName, out T annotationValue)
+        {
+            if (annotations.TryGetValue(annotationName, out var annotation)
+                && annotation.Value != null)
+            {
+                annotations.Remove(annotationName);
+                annotationValue = (T)annotation.Value;
+                return true;
+            }
+
+            annotationValue = default;
+            return false;
+        }
+
+        private static void GenerateSimpleFluentApiCall(
+            IDictionary<string, IAnnotation> annotations,
+            string annotationName,
+            string methodName,
+            List<MethodCallCodeFragment> methodCallCodeFragments)
+        {
+            if (annotations.TryGetValue(annotationName, out var annotation)
+                && annotation.Value is { } annotationValue)
+            {
+                annotations.Remove(annotationName);
+                methodCallCodeFragments.Add(
+                    new MethodCallCodeFragment(methodName, annotationValue));
+            }
+        }
+
+        // Dictionary is safe for removal during enumeration
+        private static IEnumerable<KeyValuePair<string, IAnnotation>> EnumerateForRemoval(IDictionary<string, IAnnotation> annotations)
+            => annotations is Dictionary<string, IAnnotation>
+                ? (IEnumerable<KeyValuePair<string, IAnnotation>>)annotations
+                : annotations.ToList();
     }
 }

--- a/src/EFCore.Relational/Design/AnnotationCodeGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGeneratorDependencies.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
@@ -44,8 +47,17 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public AnnotationCodeGeneratorDependencies()
+        public AnnotationCodeGeneratorDependencies(
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
         {
+            Check.NotNull(relationalTypeMappingSource, nameof(relationalTypeMappingSource));
+
+            RelationalTypeMappingSource = relationalTypeMappingSource;
         }
+
+        /// <summary>
+        ///     The type mapper.
+        /// </summary>
+        public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
     }
 }

--- a/src/EFCore.Relational/Design/AttributeCodeFragment.cs
+++ b/src/EFCore.Relational/Design/AttributeCodeFragment.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    /// <summary>
+    ///     Represents usage of an attribute.
+    /// </summary>
+    public class AttributeCodeFragment
+    {
+        private readonly List<object> _arguments;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AttributeCodeFragment" /> class.
+        /// </summary>
+        /// <param name="type"> The attribute's CLR type. </param>
+        /// <param name="arguments"> The attribute's arguments. </param>
+        public AttributeCodeFragment([NotNull] Type type, [NotNull] params object[] arguments)
+        {
+            Check.NotNull(type, nameof(type));
+            Check.NotNull(arguments, nameof(arguments));
+
+            Type = type;
+            _arguments = new List<object>(arguments);
+        }
+
+        /// <summary>
+        ///     Gets or sets the attribute's type.
+        /// </summary>
+        /// <value> The attribute's type. </value>
+        public virtual Type Type { get; }
+
+        /// <summary>
+        ///     Gets the method call's arguments.
+        /// </summary>
+        /// <value> The method call's arguments. </value>
+        public virtual IReadOnlyList<object> Arguments => _arguments;
+    }
+}

--- a/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -15,123 +17,137 @@ namespace Microsoft.EntityFrameworkCore.Design
     public interface IAnnotationCodeGenerator
     {
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IModel" />.
+        ///     Removes annotations from <paramref name="annotations" /> for which code should never be generated.
         /// </summary>
-        /// <param name="model"> The <see cref="IModel" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IModel model, [NotNull] IAnnotation annotation);
+        /// <param name="annotations"> The set of annotations from which to remove the ignored ones. </param>
+        void RemoveIgnoredAnnotations([NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IEntityType" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="entityType"> The <see cref="IEntityType" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation);
+        /// <param name="model"> The model to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IModel model, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IKey" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="key"> The <see cref="IKey" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IKey key, [NotNull] IAnnotation annotation);
+        /// <param name="entity"> The entity to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IEntityType entity, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IProperty" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="property"> The <see cref="IProperty" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IProperty property, [NotNull] IAnnotation annotation);
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IForeignKey" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation);
+        /// <param name="key"> The key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IKey key, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IIndex" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="index"> The <see cref="IIndex" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IIndex index, [NotNull] IAnnotation annotation);
+        /// <param name="foreignKey"> The foreign key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IForeignKey foreignKey, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="model"> The <see cref="IModel" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IModel model, [NotNull] IAnnotation annotation);
+        /// <param name="index"> The index to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveConventionalAnnotations([NotNull] IIndex index, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="entityType"> The <see cref="IEntityType" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation);
+        /// <param name="model"> The model to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IModel model, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="key"> The <see cref="IKey" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IKey key, [NotNull] IAnnotation annotation);
+        /// <param name="entityType"> The entity type to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IEntityType entityType, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="property"> The <see cref="IProperty" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IProperty property, [NotNull] IAnnotation annotation);
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="foreignKey"> The <see cref="IForeignKey" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation);
+        /// <param name="key"> The key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IKey key, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="index"> The <see cref="IIndex" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IIndex index, [NotNull] IAnnotation annotation);
+        /// <param name="foreignKey"> The foreign key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IForeignKey foreignKey, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="index"> The index to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IIndex index, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding data annotation attributes, returns those attribute code fragments
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="entityType"> The entity type to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            [NotNull] IEntityType entityType, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<AttributeCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding data annotation attributes, returns those attribute code fragments
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            [NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<AttributeCodeFragment>();
     }
 }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -13,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -70,6 +72,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var sqlServerTypeMappingSource = new SqlServerTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
             var code = new CSharpHelper(sqlServerTypeMappingSource);
             var reporter = new TestOperationReporter();
             var migrationAssembly
@@ -103,7 +107,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         new[]
                         {
                             new CSharpMigrationsGenerator(
-                                new MigrationsCodeGeneratorDependencies(sqlServerTypeMappingSource),
+                                new MigrationsCodeGeneratorDependencies(
+                                    sqlServerTypeMappingSource,
+                                    sqlServerAnnotationCodeGenerator),
                                 new CSharpMigrationsGeneratorDependencies(
                                     code,
                                     new CSharpMigrationOperationGenerator(
@@ -111,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                             code)),
                                     new CSharpSnapshotGenerator(
                                         new CSharpSnapshotGeneratorDependencies(
-                                            code, sqlServerTypeMappingSource))))
+                                            code, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))))
                         }),
                     historyRepository,
                     reporter,

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -16,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -278,15 +280,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 AddBoilerPlate(
                     @"
             modelBuilder
+                .UseIdentityColumns()
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
                 .HasAnnotation(""SqlServer:DatabaseMaxSize"", ""100 MB"")
                 .HasAnnotation(""SqlServer:PerformanceLevelSql"", ""'S0'"")
-                .HasAnnotation(""SqlServer:ServiceTierSql"", ""'basic'"")
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""SqlServer:ServiceTierSql"", ""'basic'"");"),
                 o =>
                 {
-                    Assert.Equal(7, o.GetAnnotations().Count());
+                    Assert.Equal(9, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                 });
         }
@@ -304,12 +306,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     @"
             modelBuilder
                 .HasDefaultSchema(""DefaultSchema"")
+                .UseIdentityColumns()
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
                 o =>
                 {
-                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(7, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                     Assert.Equal("DefaultSchema", o[RelationalAnnotationNames.DefaultSchema]);
                 });
@@ -332,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -344,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -383,7 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .HasColumnType(""nvarchar(max)"");
@@ -404,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
 
                     Assert.Equal("DerivedEntity",
                         o.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity").GetTableName());
@@ -444,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .IsCyclic();"),
                 o =>
                 {
-                    Assert.Equal(4, o.GetAnnotations().Count());
+                    Assert.Equal(6, o.GetAnnotations().Count());
                 });
         }
 
@@ -466,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -479,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
                 });
         }
 
@@ -501,7 +503,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -527,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
                 });
         }
 
@@ -552,13 +554,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
                     b.ToTable(""EntityWithOneProperty"");
 
-                    b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
                 });"),
                 o =>
                 {
@@ -584,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -652,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -712,7 +715,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -810,7 +813,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -848,7 +851,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -884,7 +887,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -925,7 +928,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -937,7 +940,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1060,7 +1063,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -1097,7 +1100,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -1129,7 +1132,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -1199,7 +1202,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
@@ -1230,7 +1233,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""AlternateId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<string>(""EntityWithStringKeyId"")
                                 .HasColumnType(""nvarchar(450)"");
@@ -1273,7 +1276,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<int?>(""EntityWithOnePropertyId"")
                                 .HasColumnType(""int"");
@@ -1376,7 +1379,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1390,7 +1393,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1404,7 +1407,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderDetailsOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1423,7 +1426,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1437,7 +1440,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderDetailsOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1456,7 +1459,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1470,7 +1473,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderInfoOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1539,15 +1542,15 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1564,7 +1567,7 @@ namespace RootNamespace
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<int>(""TestEnum"")
                                 .HasColumnType(""int"");
@@ -1641,8 +1644,8 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn()
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.HasKey(""Id"");
 
@@ -1669,7 +1672,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1692,7 +1695,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -1722,7 +1725,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -1749,7 +1752,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(100)"")
@@ -1775,7 +1778,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""varchar(max)"")
@@ -1801,7 +1804,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nchar(100)"")
@@ -1835,7 +1838,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""varchar(100)"")
@@ -1873,7 +1876,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .IsConcurrencyToken()
@@ -1903,11 +1906,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
-                        .HasColumnName(""CName"")
-                        .HasColumnType(""int"");
+                        .HasColumnType(""int"")
+                        .HasColumnName(""CName"");
 
                     b.HasKey(""Id"");
 
@@ -1933,7 +1936,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""CType"");
@@ -1962,7 +1965,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -1993,7 +1996,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -2024,7 +2027,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -2051,7 +2054,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .ValueGeneratedOnAdd()
@@ -2085,7 +2088,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -2126,7 +2129,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long?>(""Day"")
                         .HasColumnType(""bigint"");
@@ -2152,7 +2155,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -2177,7 +2180,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .HasColumnType(""nvarchar(max)"");
@@ -2207,11 +2210,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
-                        .HasColumnName(""CName"")
                         .HasColumnType(""int"")
+                        .HasColumnName(""CName"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.HasKey(""Id"");
@@ -2254,14 +2257,14 @@ namespace RootNamespace
                 AddBoilerPlate(
                     @"
             modelBuilder
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns();
 
             modelBuilder.Entity(""Building"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -2296,7 +2299,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2329,7 +2332,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2363,7 +2366,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2407,7 +2410,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2439,7 +2442,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2473,7 +2476,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2511,7 +2514,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2546,7 +2549,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2588,7 +2591,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
@@ -2618,7 +2621,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2661,7 +2664,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2709,7 +2712,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2769,7 +2772,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -2781,7 +2784,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2838,7 +2841,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -2892,7 +2895,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2943,7 +2946,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2994,7 +2997,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3048,7 +3051,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -3116,7 +3119,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3128,7 +3131,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3175,7 +3178,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3187,7 +3190,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3237,7 +3240,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -3260,7 +3263,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3313,7 +3316,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3371,7 +3374,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3563,15 +3566,15 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithManyProperties"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<bool>(""Boolean"")
                         .HasColumnType(""bit"");
@@ -3908,8 +3911,8 @@ namespace RootNamespace
 
         protected virtual string GetHeading(bool empty = false) => @"
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"
             + (empty
                 ? null
                 : @"
@@ -3974,11 +3977,17 @@ namespace RootNamespace
                     {
                         new SqlServerNetTopologySuiteTypeMappingSourcePlugin(NtsGeometryServices.Instance)
                     }));
+
             var codeHelper = new CSharpHelper(
                 sqlServerTypeMappingSource);
 
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
+
             var generator = new CSharpMigrationsGenerator(
-                new MigrationsCodeGeneratorDependencies(sqlServerTypeMappingSource),
+                new MigrationsCodeGeneratorDependencies(
+                    sqlServerTypeMappingSource,
+                    sqlServerAnnotationCodeGenerator),
                 new CSharpMigrationsGeneratorDependencies(
                     codeHelper,
                     new CSharpMigrationOperationGenerator(
@@ -3986,7 +3995,7 @@ namespace RootNamespace
                             codeHelper)),
                     new CSharpSnapshotGenerator(
                         new CSharpSnapshotGeneratorDependencies(
-                            codeHelper, sqlServerTypeMappingSource))));
+                            codeHelper, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))));
 
             var code = generator.GenerateSnapshot("RootNamespace", typeof(DbContext), "Snapshot", model);
             Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -247,20 +247,20 @@ namespace TestNamespace
         }
 
         [ConditionalFact]
-        public void ModelInDiferentNamespaceDbContext_works()
+        public void ModelInDifferentNamespaceDbContext_works()
         {
             var modelGenerationOptions = new ModelCodeGenerationOptions
             {
                 ContextNamespace = "TestNamespace", ModelNamespace = "AnotherNamespaceOfModel"
             };
 
-            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+            const string entityInAnotherNamespaceTypeName = "EntityInAnotherNamespace";
 
             Test(
-                modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                modelBuilder => modelBuilder.Entity(entityInAnotherNamespaceTypeName)
                 , modelGenerationOptions
                 , code => Assert.Contains(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
-                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnotherNamespaceTypeName)))
             );
         }
 
@@ -269,13 +269,13 @@ namespace TestNamespace
         {
             var modelGenerationOptions = new ModelCodeGenerationOptions { ContextNamespace = "TestNamespace" };
 
-            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+            const string entityInAnotherNamespaceTypeName = "EntityInAnotherNamespace";
 
             Test(
-                modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                modelBuilder => modelBuilder.Entity(entityInAnotherNamespaceTypeName)
                 , modelGenerationOptions
                 , code => Assert.DoesNotContain(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
-                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnotherNamespaceTypeName)))
             );
         }
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -422,7 +422,7 @@ namespace TestNamespace
                     .HasFilter(""Filter SQL"")
                     .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                entity.Property(e => e.Id).HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                entity.Property(e => e.Id).UseIdentityColumn();
             });
 
             OnModelCreatingPartial(modelBuilder);
@@ -503,7 +503,7 @@ namespace TestNamespace
                     .HasFilter(""Filter SQL"")
                     .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                entity.Property(e => e.Id).HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                entity.Property(e => e.Id).UseIdentityColumn();
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Design.Internal
@@ -14,7 +18,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IKey_works_when_clustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
+
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -36,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IKey_works_when_nonclustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -59,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_when_clustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -82,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_when_nonclustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -106,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_with_fillfactor()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -118,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 });
 
             var index = modelBuilder.Model.FindEntityType("Post").GetIndexes().Single();
-            var annotation = index.FindAnnotation(SqlServerAnnotationNames.FillFactor); 
+            var annotation = index.FindAnnotation(SqlServerAnnotationNames.FillFactor);
             var result = generator.GenerateFluentApi(index, annotation);
 
             Assert.Equal("HasFillFactor", result.Method);
@@ -129,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_with_includes()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -151,5 +156,86 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var properties = Assert.IsType<string[]>(result.Arguments[0]);
             Assert.Equal(new[] { "FirstName" }, properties.AsEnumerable());
         }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IModel_works_with_identity()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.UseIdentityColumns(seed: 5, increment: 10);
+
+            var annotations = modelBuilder.Model.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(modelBuilder.Model, annotations).Single();
+
+            Assert.Equal("UseIdentityColumns", result.Method);
+
+            Assert.Collection(result.Arguments,
+                seed => Assert.Equal(5, seed),
+                increment => Assert.Equal(10, increment));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IProperty_works_with_identity()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.Entity("Post", x => x.Property<int>("Id").UseIdentityColumn(5, 10));
+            var property = modelBuilder.Model.FindEntityType("Post").FindProperty("Id");
+
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(property, annotations).Single();
+
+            Assert.Equal("UseIdentityColumn", result.Method);
+
+            Assert.Collection(result.Arguments,
+                seed => Assert.Equal(5, seed),
+                increment => Assert.Equal(10, increment));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IModel_works_with_HiLo()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.UseHiLo("HiLoIndexName", "HiLoIndexSchema");
+
+            var annotations = modelBuilder.Model.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(modelBuilder.Model, annotations).Single();
+
+            Assert.Equal("UseHiLo", result.Method);
+
+            Assert.Collection(result.Arguments,
+                name => Assert.Equal("HiLoIndexName", name),
+                schema => Assert.Equal("HiLoIndexSchema", schema));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IProperty_works_with_HiLo()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.Entity("Post", x => x.Property<int>("Id").UseHiLo("HiLoIndexName", "HiLoIndexSchema"));
+            var property = modelBuilder.Model.FindEntityType("Post").FindProperty("Id");
+
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(property, annotations).Single();
+
+            Assert.Equal("UseHiLo", result.Method);
+
+            Assert.Collection(result.Arguments,
+                name => Assert.Equal("HiLoIndexName", name),
+                schema => Assert.Equal("HiLoIndexSchema", schema));
+        }
+
+        private SqlServerAnnotationCodeGenerator CreateGenerator()
+            => new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(
+                    new SqlServerTypeMappingSource(
+                        new TypeMappingSourceDependencies(
+                            new ValueConverterSelector(
+                                new ValueConverterSelectorDependencies()),
+                            Array.Empty<ITypeMappingSourcePlugin>()),
+                        new RelationalTypeMappingSourceDependencies(
+                            Array.Empty<IRelationalTypeMappingSourcePlugin>()))));
     }
 }


### PR DESCRIPTION
@bricelam this is some quick draft work on #16922:

* Add new API to IAnnotationCodeGenerator to receive all annotations, allowing generating a single fluent API call for several annotations. Fully backwards-compatible.
* Implement handling for seed/increment via the new API
* Plumb IAnnotationCodeGenerator into CSharpSnapshotGenerator and use it to generate fluent API calls.
* Note: this currently removes annotations that are identified as by-convention by IAnnotationCodeGenerator from the context snapshopt - I'm guessing that's probably not good (since conventions may change across EF Core versions). If that's the case we should simply split IAnnotationCodeGenerator API - one for removing by-convention annotations, and another for generating fluent API calls.
* If we go down this route, we can just remove all the older IsHandledByConvention/GenerateFluentApi methods from the interface (but not from the base class), since we no longer call them directly.

If this looks like a good direction, let me know and I'll continue.