### PR TITLE
Fix parameter name

### DIFF
--- a/src/EFCore/Metadata/ParameterBinding.cs
+++ b/src/EFCore/Metadata/ParameterBinding.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             [NotNull] params IPropertyBase[] consumedProperties)
         {
             Check.NotNull(parameterType, nameof(parameterType));
-            Check.NotNull(consumedProperties, nameof(parameterType));
+            Check.NotNull(consumedProperties, nameof(consumedProperties));
 
             ParameterType = parameterType;
             ConsumedProperties = consumedProperties;


### PR DESCRIPTION
Use the correct parameter name in the null guard exception.

Fixes #21233

