### PR TITLE
Query: Process client eval in join when collection shaper

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -291,6 +291,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     : null;
             }
 
+            if (extensionExpression is CollectionShaperExpression)
+            {
+                return _clientEval
+                    ? extensionExpression
+                    : null;
+            }
+
             throw new InvalidOperationException(
                 CoreStrings.QueryFailed(extensionExpression.Print(), GetType().Name));
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindJoinQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindJoinQueryCosmosTest.cs
@@ -511,6 +511,18 @@ WHERE (c[""Discriminator""] = ""Order"")");
         }
 
         [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task SelectMany_with_client_eval_with_collection_shaper(bool async)
+        {
+            return base.SelectMany_with_client_eval_with_collection_shaper(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
+        {
+            return base.SelectMany_with_client_eval_with_collection_shaper_ignored(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
         public override Task SelectMany_with_client_eval_with_constructor(bool async)
         {
             return base.SelectMany_with_client_eval_with_constructor(async);

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindJoinQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindJoinQueryInMemoryTest.cs
@@ -27,6 +27,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalTheory(Skip = "Issue#21200")]
+        public override Task SelectMany_with_client_eval_with_collection_shaper(bool async)
+        {
+            return base.SelectMany_with_client_eval_with_collection_shaper(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#21200")]
+        public override Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
+        {
+            return base.SelectMany_with_client_eval_with_collection_shaper_ignored(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#21200")]
         public override Task SelectMany_with_client_eval_with_constructor(bool async)
         {
             return base.SelectMany_with_client_eval_with_constructor(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -524,7 +524,40 @@ CROSS APPLY (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[ContactName]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
-) AS [t]");
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'");
+        }
+
+        public override async Task SelectMany_with_client_eval_with_collection_shaper(bool async)
+        {
+            await base.SelectMany_with_client_eval_with_collection_shaper(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[ContactName], [c].[CustomerID], [t].[OrderID], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[ContactName]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+        }
+
+        public override async Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
+        {
+            await base.SelectMany_with_client_eval_with_collection_shaper_ignored(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate], [t].[ContactName]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[ContactName]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'");
         }
 
         public override async Task SelectMany_with_client_eval_with_constructor(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
@@ -18,5 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // CROSS APPLY is not supported
         public override Task SelectMany_with_client_eval(bool async) => Task.CompletedTask;
+        public override Task SelectMany_with_client_eval_with_collection_shaper(bool async) => Task.CompletedTask;
+        public override Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async) => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Extension of #19247 for collection shaper in client eval

This is not required for preview6. But the work depends on other split include work so creating PR against the feature branch, it will auto-cascade to master once those commits reach master.

