### PR TITLE
Add AddDbContextFactory to allow registering a factory for creating contexts

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -73,8 +73,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given <see cref="DbContext"/> as a service in the <see cref="IServiceCollection" />,
+        ///         Registers the given <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />,
         ///         and enables DbContext pooling for this registration.
         ///     </para>
         ///     <para>
@@ -132,8 +132,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -165,7 +165,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given <see cref="DbContext"/> as a service in the <see cref="IServiceCollection" />,
+        ///         Registers the given <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />,
         ///         and enables DbContext pooling for this registration.
         ///     </para>
         ///     <para>
@@ -177,8 +177,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -216,7 +216,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given <see cref="DbContext"/> as a service in the <see cref="IServiceCollection" />,
+        ///         Registers the given <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />,
         ///         and enables DbContext pooling for this registration.
         ///     </para>
         ///     <para>
@@ -228,8 +228,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -237,11 +237,11 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
         ///     <para>
-        ///         This overload has an <paramref name="optionsAction" /> that provides the applications
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
         ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
         ///         its internal services from the primary application service provider.
         ///         By default, we recommend using
-        ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/> which allows
+        ///         <see cref="AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)" /> which allows
         ///         Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal Entity Framework services.
         ///     </para>
         /// </summary>
@@ -269,7 +269,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given <see cref="DbContext"/> as a service in the <see cref="IServiceCollection" />,
+        ///         Registers the given <see cref="DbContext" /> as a service in the <see cref="IServiceCollection" />,
         ///         and enables DbContext pooling for this registration.
         ///     </para>
         ///     <para>
@@ -281,8 +281,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -290,11 +290,11 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
         ///     <para>
-        ///         This overload has an <paramref name="optionsAction" /> that provides the applications
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
         ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
         ///         its internal services from the primary application service provider.
         ///         By default, we recommend using
-        ///         <see cref="AddDbContextPool{TContext,TContextImplementation}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>
+        ///         <see cref="AddDbContextPool{TContext,TContextImplementation}(IServiceCollection,Action{DbContextOptionsBuilder},int)" />
         ///         which allows Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal
         ///         Entity Framework services.
         ///     </para>
@@ -363,8 +363,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -392,8 +392,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -427,8 +427,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -436,11 +436,11 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
         ///     <para>
-        ///         This overload has an <paramref name="optionsAction" /> that provides the applications
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
         ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
         ///         its internal services from the primary application service provider.
         ///         By default, we recommend using
-        ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)"/>
+        ///         <see cref="AddDbContext{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />
         ///         which allows Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal
         ///         Entity Framework services.
         ///     </para>
@@ -482,8 +482,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext"/>
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring"/> can then be
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
@@ -491,11 +491,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
         ///     <para>
-        ///         This overload has an <paramref name="optionsAction" /> that provides the applications
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
         ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
         ///         its internal services from the primary application service provider.
         ///         By default, we recommend using
-        ///         <see cref="AddDbContext{TContext,TContextImplementation}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)"/>
+        ///         <see
+        ///             cref="AddDbContext{TContext,TContextImplementation}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime,ServiceLifetime)" />
         ///         which allows Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal
         ///         Entity Framework services.
         ///     </para>
@@ -546,6 +547,265 @@ namespace Microsoft.Extensions.DependencyInjection
             AddCoreServices<TContextImplementation>(serviceCollection, optionsAction, optionsLifetime);
 
             serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContextService), typeof(TContextImplementation), contextLifetime));
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type.
+        ///     </para>
+        ///     <para>
+        ///         Using this method to register a factory is recommended for Blazor applications.
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         An optional action to configure the <see cref="DbContextOptions" /> for the context. This provides an
+        ///         alternative to performing configuration of the context by overriding the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context.
+        ///     </para>
+        ///     <para>
+        ///         If an action is supplied here, the <see cref="DbContext.OnConfiguring" /> method will still be run if it has
+        ///         been overridden on the derived context. <see cref="DbContext.OnConfiguring" /> configuration will be applied
+        ///         in addition to configuration performed here.
+        ///     </para>
+        ///     <para>
+        ///         In order for the options to be passed into your context, you need to expose a constructor on your context that takes
+        ///         <see cref="DbContextOptions{TContext}" /> and passes it to the base constructor of <see cref="DbContext" />.
+        ///     </para>
+        /// </param>
+        /// <param name="lifetime">
+        ///     The lifetime with which to register the factory and options.
+        ///     The default is <see cref="ServiceLifetime.Singleton" />
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddDbContextFactory<TContext>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TContext : DbContext
+            => AddDbContextFactory<TContext, DbContextFactory<TContext>>(serviceCollection, optionsAction, lifetime);
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type.
+        ///     </para>
+        ///     <para>
+        ///         Using this method to register a factory is recommended for Blazor applications.
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         This overload allows a specific implementation of <see cref="IDbContextFactory{TContext}"/> to be registered
+        ///         instead of using the default factory shipped with EF Core.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <typeparam name="TFactory"> The type of <see cref="IDbContextFactory{TContext}"/> to register. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         An optional action to configure the <see cref="DbContextOptions" /> for the context. This provides an
+        ///         alternative to performing configuration of the context by overriding the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context.
+        ///     </para>
+        ///     <para>
+        ///         If an action is supplied here, the <see cref="DbContext.OnConfiguring" /> method will still be run if it has
+        ///         been overridden on the derived context. <see cref="DbContext.OnConfiguring" /> configuration will be applied
+        ///         in addition to configuration performed here.
+        ///     </para>
+        ///     <para>
+        ///         In order for the options to be passed into your context, you need to expose a constructor on your context that takes
+        ///         <see cref="DbContextOptions{TContext}" /> and passes it to the base constructor of <see cref="DbContext" />.
+        ///     </para>
+        /// </param>
+        /// <param name="lifetime">
+        ///     The lifetime with which to register the factory and options.
+        ///     The default is <see cref="ServiceLifetime.Singleton" />
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddDbContextFactory<TContext, TFactory>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [CanBeNull] Action<DbContextOptionsBuilder> optionsAction = null,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TContext : DbContext
+            where TFactory : IDbContextFactory<TContext>
+            => AddDbContextFactory<TContext, TFactory>(
+                serviceCollection,
+                optionsAction == null
+                    ? (Action<IServiceProvider, DbContextOptionsBuilder>)null
+                    : (p, b) => optionsAction.Invoke(b),
+                lifetime);
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type.
+        ///     </para>
+        ///     <para>
+        ///         Using this method to register a factory is recommended for Blazor applications.
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
+        ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
+        ///         its internal services from the primary application service provider.
+        ///         By default, we recommend using
+        ///         <see cref="AddDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime)" /> which allows
+        ///         Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal Entity Framework services.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         An optional action to configure the <see cref="DbContextOptions" /> for the context. This provides an
+        ///         alternative to performing configuration of the context by overriding the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context.
+        ///     </para>
+        ///     <para>
+        ///         If an action is supplied here, the <see cref="DbContext.OnConfiguring" /> method will still be run if it has
+        ///         been overridden on the derived context. <see cref="DbContext.OnConfiguring" /> configuration will be applied
+        ///         in addition to configuration performed here.
+        ///     </para>
+        ///     <para>
+        ///         In order for the options to be passed into your context, you need to expose a constructor on your context that takes
+        ///         <see cref="DbContextOptions{TContext}" /> and passes it to the base constructor of <see cref="DbContext" />.
+        ///     </para>
+        /// </param>
+        /// <param name="lifetime">
+        ///     The lifetime with which to register the factory and options.
+        ///     The default is <see cref="ServiceLifetime.Singleton" />
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddDbContextFactory<TContext>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TContext : DbContext
+            => AddDbContextFactory<TContext, DbContextFactory<TContext>>(serviceCollection, optionsAction, lifetime);
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type.
+        ///     </para>
+        ///     <para>
+        ///         Using this method to register a factory is recommended for Blazor applications.
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         This overload allows a specific implementation of <see cref="IDbContextFactory{TContext}"/> to be registered
+        ///         instead of using the default factory shipped with EF Core.
+        ///     </para>
+        ///     <para>
+        ///         This overload has an <paramref name="optionsAction" /> that provides the application's
+        ///         <see cref="IServiceProvider" />. This is useful if you want to setup Entity Framework Core to resolve
+        ///         its internal services from the primary application service provider.
+        ///         By default, we recommend using
+        ///         <see cref="AddDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime)" /> which allows
+        ///         Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal Entity Framework services.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <typeparam name="TFactory"> The type of <see cref="IDbContextFactory{TContext}"/> to register. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         An optional action to configure the <see cref="DbContextOptions" /> for the context. This provides an
+        ///         alternative to performing configuration of the context by overriding the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context.
+        ///     </para>
+        ///     <para>
+        ///         If an action is supplied here, the <see cref="DbContext.OnConfiguring" /> method will still be run if it has
+        ///         been overridden on the derived context. <see cref="DbContext.OnConfiguring" /> configuration will be applied
+        ///         in addition to configuration performed here.
+        ///     </para>
+        ///     <para>
+        ///         In order for the options to be passed into your context, you need to expose a constructor on your context that takes
+        ///         <see cref="DbContextOptions{TContext}" /> and passes it to the base constructor of <see cref="DbContext" />.
+        ///     </para>
+        /// </param>
+        /// <param name="lifetime">
+        ///     The lifetime with which to register the factory and options.
+        ///     The default is <see cref="ServiceLifetime.Singleton" />
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddDbContextFactory<TContext, TFactory>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TContext : DbContext
+            where TFactory : IDbContextFactory<TContext>
+        {
+            AddCoreServices<TContext>(serviceCollection, optionsAction, lifetime);
+
+            serviceCollection.TryAdd(
+                new ServiceDescriptor(
+                    typeof(IDbContextFactory<TContext>),
+                    typeof(TFactory),
+                    lifetime));
 
             return serviceCollection;
         }

--- a/src/EFCore/IDbContextFactory.cs
+++ b/src/EFCore/IDbContextFactory.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Defines a factory for creating <see cref="DbContext" /> instances.
+    ///     A service of this type is registered in the dependency injection container by the
+    ///     <see cref="M:EntityFrameworkServiceCollectionExtensions.AddDbContextPool" /> methods.
+    /// </summary>
+    /// <typeparam name="TContext"> The <see cref="DbContext" /> type to create. </typeparam>
+    public interface IDbContextFactory<out TContext>
+        where TContext : DbContext
+    {
+        /// <summary>
+        ///     <para>
+        ///         Creates a new <see cref="DbContext" /> instance.
+        ///     </para>
+        ///     <para>
+        ///         The caller is responsible for disposing the context; it will not be disposed by the dependency injection container.
+        ///     </para>
+        /// </summary>
+        /// <returns> A new context instance. </returns>
+        TContext CreateDbContext();
+    }
+}

--- a/src/EFCore/Internal/DbContextFactory.cs
+++ b/src/EFCore/Internal/DbContextFactory.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class DbContextFactory<TContext> : IDbContextFactory<TContext>
+        where TContext : DbContext
+    {
+        private readonly IServiceProvider _provider;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public DbContextFactory([NotNull] IServiceProvider provider)
+        {
+            Check.NotNull(provider, nameof(provider));
+
+            _provider = provider;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual TContext CreateDbContext()
+            => ActivatorUtilities.CreateInstance<TContext>(_provider);
+    }
+}

--- a/test/EFCore.Tests/DbContextFactoryTest.cs
+++ b/test/EFCore.Tests/DbContextFactoryTest.cs
@@ -1,0 +1,432 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContextFactoryTest
+    {
+        [ConditionalTheory]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Transient)]
+        public void Factory_creates_new_context_instance(ServiceLifetime lifetime)
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                    lifetime)
+                .BuildServiceProvider(validateScopes: true);
+
+            if (lifetime == ServiceLifetime.Scoped)
+            {
+                serviceProvider = serviceProvider.CreateScope().ServiceProvider;
+            }
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        [ConditionalTheory]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Transient)]
+        public void Factory_and_options_have_the_same_lifetime(ServiceLifetime lifetime)
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)),
+                    lifetime);
+
+            Assert.Equal(lifetime, serviceCollection.Single(e => e.ServiceType == typeof(IDbContextFactory<WoolacombeContext>)).Lifetime);
+            Assert.Equal(lifetime, serviceCollection.Single(e => e.ServiceType == typeof(DbContextOptions<WoolacombeContext>)).Lifetime);
+        }
+
+
+        [ConditionalFact]
+        public void Default_lifetime_is_singleton()
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)));
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                serviceCollection.Single(e => e.ServiceType == typeof(IDbContextFactory<WoolacombeContext>)).Lifetime);
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                serviceCollection.Single(e => e.ServiceType == typeof(DbContextOptions<WoolacombeContext>)).Lifetime);
+        }
+
+        private class WoolacombeContext : DbContext
+        {
+            public WoolacombeContext(DbContextOptions<WoolacombeContext> options)
+                : base(options)
+            {
+            }
+        }
+
+        [ConditionalFact]
+        public void Factory_can_use_constructor_with_non_generic_builder()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<CroydeContext>(
+                    b => b.UseInMemoryDatabase(nameof(CroydeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            using var context = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
+
+            Assert.Equal(nameof(CroydeContext), GetStoreName(context));
+        }
+
+        private class CroydeContext : DbContext
+        {
+            public CroydeContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        [ConditionalFact]
+        public void Factory_can_use_parameterless_constructor()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<MortehoeContext>()
+                .BuildServiceProvider(validateScopes: true);
+
+            using var context = serviceProvider.GetService<IDbContextFactory<MortehoeContext>>().CreateDbContext();
+
+            Assert.Equal(nameof(MortehoeContext), GetStoreName(context));
+        }
+
+        private class MortehoeContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(nameof(MortehoeContext));
+        }
+
+        [ConditionalTheory]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Transient)]
+        public void Can_always_inject_singleton_and_transient_services(ServiceLifetime lifetime)
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddSingleton<SingletonService>()
+                .AddTransient<TransientService>()
+                .AddDbContextFactory<IlfracombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(IlfracombeContext)),
+                    lifetime)
+                .BuildServiceProvider(validateScopes: true);
+
+            if (lifetime == ServiceLifetime.Scoped)
+            {
+                serviceProvider = serviceProvider.CreateScope().ServiceProvider;
+            }
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<IlfracombeContext>>();
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+
+            Assert.NotNull(context1.SingletonService);
+            Assert.Same(context1.SingletonService, context2.SingletonService);
+
+            Assert.NotNull(context1.TransientService);
+            Assert.NotNull(context2.TransientService);
+            Assert.NotSame(context1.TransientService, context2.TransientService);
+        }
+
+        private class TransientService : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+            public void Dispose() => IsDisposed = true;
+        }
+
+        private class SingletonService
+        {
+        }
+
+        private class IlfracombeContext : DbContext
+        {
+            public IlfracombeContext(
+                DbContextOptions<IlfracombeContext> options,
+                SingletonService singletonService,
+                TransientService transientService)
+                : base(options)
+            {
+                SingletonService = singletonService;
+                TransientService = transientService;
+            }
+
+            public SingletonService SingletonService { get; }
+            public TransientService TransientService { get; }
+        }
+
+        [ConditionalFact]
+        public void Can_inject_singleton_transient_and_scoped_services_into_scoped_factory()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddSingleton<SingletonService>()
+                .AddScoped<ScopedService>()
+                .AddTransient<TransientService>()
+                .AddDbContextFactory<CombeMartinContext>(
+                    b => b.UseInMemoryDatabase(nameof(CombeMartinContext)),
+                    ServiceLifetime.Scoped)
+                .BuildServiceProvider(validateScopes: true);
+
+            var scope = serviceProvider.CreateScope();
+            var scopedServiceProvider = scope.ServiceProvider;
+
+            var contextFactory = scopedServiceProvider.GetService<IDbContextFactory<CombeMartinContext>>();
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+
+            var singletonService = context1.SingletonService;
+            Assert.NotNull(singletonService);
+            Assert.Same(singletonService, context2.SingletonService);
+
+            var scopedService = context1.ScopedService;
+            Assert.NotNull(scopedService);
+            Assert.Same(scopedService, context2.ScopedService);
+
+            var transientService = context1.TransientService;
+            Assert.NotNull(transientService);
+            Assert.NotNull(context2.TransientService);
+            Assert.NotSame(transientService, context2.TransientService);
+
+            scope.Dispose();
+
+            Assert.True(transientService.IsDisposed);
+            Assert.True(scopedService.IsDisposed);
+
+            scope = serviceProvider.CreateScope();
+            scopedServiceProvider = scope.ServiceProvider;
+            contextFactory = scopedServiceProvider.GetService<IDbContextFactory<CombeMartinContext>>();
+
+            using var context = contextFactory.CreateDbContext();
+
+            Assert.Same(singletonService, context.SingletonService);
+            Assert.NotNull(context.ScopedService);
+            Assert.NotSame(scopedService, context.ScopedService);
+            Assert.NotNull(context.TransientService);
+            Assert.NotSame(transientService, context.TransientService);
+
+            scope.Dispose();
+        }
+
+        private class ScopedService : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+            public void Dispose() => IsDisposed = true;
+        }
+
+        private class CombeMartinContext : DbContext
+        {
+            public CombeMartinContext(
+                DbContextOptions<CombeMartinContext> options,
+                SingletonService singletonService,
+                ScopedService scopedService,
+                TransientService transientService)
+                : base(options)
+            {
+                SingletonService = singletonService;
+                ScopedService = scopedService;
+                TransientService = transientService;
+            }
+
+            public SingletonService SingletonService { get; }
+            public ScopedService ScopedService { get; }
+            public TransientService TransientService { get; }
+        }
+
+        [ConditionalTheory]
+        [InlineData(ServiceLifetime.Singleton)]
+        [InlineData(ServiceLifetime.Scoped)]
+        [InlineData(ServiceLifetime.Transient)]
+        public void Can_resolve_from_the_service_provider_in_options_action(ServiceLifetime lifetime)
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddSingleton<SingletonService>()
+                .AddScoped<ScopedService>()
+                .AddTransient<TransientService>()
+                .AddDbContextFactory<WoolacombeContext>(
+                    optionsAction: (p, b) =>
+                    {
+                        Assert.NotNull(p.GetService<SingletonService>());
+                        Assert.NotNull(p.GetService<TransientService>());
+
+                        if (lifetime == ServiceLifetime.Scoped)
+                        {
+                            Assert.NotNull(p.GetService<ScopedService>());
+                        }
+
+                        b.UseInMemoryDatabase(nameof(WoolacombeContext));
+                    },
+                    lifetime)
+                .BuildServiceProvider(validateScopes: true);
+
+            if (lifetime == ServiceLifetime.Scoped)
+            {
+                serviceProvider = serviceProvider.CreateScope().ServiceProvider;
+            }
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        [ConditionalFact]
+        public void Throws_if_dependencies_are_not_in_DI()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<WestwardHoContext>(
+                    b => b.UseInMemoryDatabase(nameof(WestwardHoContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            var factory = serviceProvider.GetService<IDbContextFactory<WestwardHoContext>>();
+
+            Assert.Contains(
+                typeof(Random).FullName,
+                Assert.Throws<InvalidOperationException>(() => factory.CreateDbContext()).Message);
+        }
+
+        private class WestwardHoContext : DbContext
+        {
+            public WestwardHoContext(DbContextOptions options, Random random)
+                : base(options)
+            {
+            }
+        }
+
+        [ConditionalFact]
+        public void Can_register_factories_for_multiple_contexts()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<CroydeContext>(
+                    b => b.UseInMemoryDatabase(nameof(CroydeContext)))
+                .AddDbContextFactory<ClovellyContext>(
+                    b => b.UseInMemoryDatabase(nameof(ClovellyContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            Assert.Equal(
+                CoreStrings.NonGenericOptions(nameof(CroydeContext)),
+                Assert.Throws<InvalidOperationException>(
+                    ()
+                        =>
+                    {
+                        using var context1 = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
+                        using var context2 = serviceProvider.GetService<IDbContextFactory<ClovellyContext>>().CreateDbContext();
+                    }).Message);
+        }
+
+        private class ClovellyContext : DbContext
+        {
+            public ClovellyContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        [ConditionalFact]
+        public void Throws_for_multiple_non_generic_builders()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<WidemouthBayContext>(
+                    b => b.UseInMemoryDatabase(nameof(WidemouthBayContext)))
+                .AddDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            using var context1 = serviceProvider.GetService<IDbContextFactory<WidemouthBayContext>>().CreateDbContext();
+            using var context2 = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+
+            Assert.Equal(nameof(WidemouthBayContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        private class WidemouthBayContext : DbContext
+        {
+            public WidemouthBayContext(DbContextOptions<WidemouthBayContext> options)
+                : base(options)
+            {
+            }
+        }
+
+        [ConditionalFact]
+        public void Application_can_register_explicit_factory_implementation()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddSingleton<IDbContextFactory<WoolacombeContext>, WoolacombeContextFactory>()
+                .AddDbContextFactory<WoolacombeContext>(b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            Assert.IsType<WoolacombeContextFactory>(contextFactory);
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        [ConditionalFact]
+        public void Application_can_register_factory_implementation_in_AddDbContextFactory()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<WoolacombeContext, WoolacombeContextFactory>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            Assert.IsType<WoolacombeContextFactory>(contextFactory);
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        private class WoolacombeContextFactory : IDbContextFactory<WoolacombeContext>
+        {
+            private readonly DbContextOptions<WoolacombeContext> _options;
+
+            public WoolacombeContextFactory(DbContextOptions<WoolacombeContext> options) => _options = options;
+
+            public WoolacombeContext CreateDbContext() => new WoolacombeContext(_options);
+        }
+
+        private static string GetStoreName(DbContext context1)
+            => context1.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>().StoreName;
+    }
+}


### PR DESCRIPTION
Fixes #18575

Mostly this is copied from @JeremyLikness's sample, with tests added. It evolved a bit as I was testing. Most significantly, we now register an IDbContextFactory interface, for which we provide a default implementation. This allows the factory to be replaced by one specific for the application, which can be more performant because it doesn't use ActivatorUtilities. Overloads have been added for this.

I believe we can also add overloads to allow the factory to resolve from a context pool, but I will file a new issue for this.
