### PR TITLE
Cosmos: Make the 'id' property more flexible 

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -54,8 +54,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (DiscriminatorConvention)discriminatorConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.PropertyAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            conventionSet.EntityTypePrimaryKeyChangedConventions.Add(storeKeyConvention);
 
+            conventionSet.KeyAddedConventions.Add(storeKeyConvention);
+
+            conventionSet.KeyRemovedConventions.Add(storeKeyConvention);
             ReplaceConvention(conventionSet.KeyRemovedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
@@ -74,6 +77,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
 
             conventionSet.EntityTypeAnnotationChangedConventions.Add(storeKeyConvention);
             conventionSet.EntityTypeAnnotationChangedConventions.Add(keyDiscoveryConvention);
+
+            ReplaceConvention(conventionSet.PropertyAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+
+            conventionSet.PropertyAnnotationChangedConventions.Add(storeKeyConvention);
 
             return conventionSet;
         }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -206,6 +206,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 GetString("NoPartitionKeyKey", nameof(entityType), nameof(partitionKey), nameof(idProperty)),
                 entityType, partitionKey, idProperty);
 
+        /// <summary>
+        ///     Both properties '{property1}' and '{property2}' on entity type '{entityType}' are mapped to '{storeName}'. Map one of the properties to a different JSON property.
+        /// </summary>
+        public static string JsonPropertyCollision([CanBeNull] object property1, [CanBeNull] object property2, [CanBeNull] object entityType, [CanBeNull] object storeName)
+            => string.Format(
+                GetString("JsonPropertyCollision", nameof(property1), nameof(property2), nameof(entityType), nameof(storeName)),
+                property1, property2, entityType, storeName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -192,4 +192,7 @@
   <data name="NoPartitionKeyKey" xml:space="preserve">
     <value>The entity type '{entityType}' does not have a key declared on '{partitionKey}' and '{idProperty}' properties. Add a key to '{entityType}' that contains '{partitionKey}' and '{idProperty}'.</value>
   </data>
+  <data name="JsonPropertyCollision" xml:space="preserve">
+    <value>Both properties '{property1}' and '{property2}' on entity type '{entityType}' are mapped to '{storeName}'. Map one of the properties to a different JSON property.</value>
+  </data>
 </root>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                             {
                                 var entityTypePrimaryKeyProperties = entityType.FindPrimaryKey().Properties;
                                 var idProperty = entityType.GetProperties()
-                                    .First(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyName);
+                                    .First(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName);
 
                                 if (TryGetPartitionKeyProperty(entityType, out var partitionKeyProperty)
                                     && entityTypePrimaryKeyProperties.SequenceEqual(queryProperties)

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 private bool TryGetResourceId(out string resourceId)
                 {
                     var idProperty = _readItemExpression.EntityType.GetProperties()
-                        .FirstOrDefault(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyName);
+                        .FirstOrDefault(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName);
 
                     if (TryGetParameterValue(idProperty, out var value))
                     {

--- a/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
+++ b/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
         {
             _collectionId = entityType.GetContainer();
             _database = database;
-            _idProperty = entityType.GetProperties().FirstOrDefault(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyName);
+            _idProperty = entityType.GetProperties().FirstOrDefault(p => p.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName);
             _jObjectProperty = entityType.FindProperty(StoreKeyConvention.JObjectPropertyName);
         }
 

--- a/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
+++ b/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
@@ -37,17 +36,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
             var builder = new StringBuilder();
             var entityType = entry.Metadata;
 
-            var pk = entityType.FindPrimaryKey();
+            var primaryKey = entityType.FindPrimaryKey();
             var discriminator = entityType.GetDiscriminatorValue();
             if (discriminator != null
-                && !pk.Properties.Contains(entityType.GetDiscriminatorProperty()))
+                && !primaryKey.Properties.Contains(entityType.GetDiscriminatorProperty()))
             {
                 AppendString(builder, discriminator);
                 builder.Append("|");
             }
 
-            var partitionKey = entityType.GetPartitionKeyPropertyName() ?? CosmosClientWrapper.DefaultPartitionKey;
-            foreach (var property in pk.Properties)
+            var partitionKey = entityType.GetPartitionKeyPropertyName();
+            foreach (var property in primaryKey.Properties)
             {
                 if (property.Name == partitionKey)
                 {
@@ -77,18 +76,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
             switch (propertyValue)
             {
                 case string stringValue:
-                    builder.Append(stringValue.Replace("|", "/|"));
+                    builder.Append(stringValue.Replace("|", "^|"));
                     return;
                 case IEnumerable enumerable:
                     foreach (var item in enumerable)
                     {
-                        builder.Append(item.ToString().Replace("|", "/|"));
+                        builder.Append(item.ToString().Replace("|", "^|"));
                         builder.Append("|");
                     }
 
                     return;
                 default:
-                    builder.Append(propertyValue == null ? "null" : propertyValue.ToString().Replace("|", "/|"));
+                    builder.Append(propertyValue == null ? "null" : propertyValue.ToString().Replace("|", "^|"));
                     return;
             }
         }

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -136,10 +137,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
                 context.Add(customer);
 
-                storeId = entry.Property<string>("id").CurrentValue;
+                storeId = entry.Property<string>(StoreKeyConvention.DefaultIdPropertyName).CurrentValue;
             }
 
-            Assert.NotNull(storeId);
+            Assert.Equal("Customer|42", storeId);
 
             using (var context = new CustomerContext(options))
             {
@@ -154,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                 customer.Name = "Theon Greyjoy";
 
                 var entry = context.Entry(customer);
-                entry.Property<string>("id").CurrentValue = storeId;
+                entry.Property<string>(StoreKeyConvention.DefaultIdPropertyName).CurrentValue = storeId;
 
                 entry.State = EntityState.Modified;
 
@@ -172,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             using (var context = new CustomerContext(options))
             {
                 var entry = context.Entry(customer);
-                entry.Property<string>("id").CurrentValue = storeId;
+                entry.Property<string>(StoreKeyConvention.DefaultIdPropertyName).CurrentValue = storeId;
                 entry.State = EntityState.Deleted;
 
                 await context.SaveChangesAsync();
@@ -648,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
                 context.Database.EnsureCreated();
 
                 var customerEntry = context.Entry(customer);
-                customerEntry.Property("id").CurrentValue = "42";
+                customerEntry.Property(StoreKeyConvention.DefaultIdPropertyName).CurrentValue = "42";
                 customerEntry.State = EntityState.Added;
 
                 context.SaveChanges();
@@ -797,7 +798,7 @@ OFFSET 0 LIMIT 1");
                     {
                         var valueGeneratorFactory = new CustomPartitionKeyIdValueGeneratorFactory();
 
-                        cb.Property("id")
+                        cb.Property(StoreKeyConvention.DefaultIdPropertyName)
                             .HasValueGenerator((p, e) => valueGeneratorFactory.Create(p));
 
                         cb.Property(c => c.Id);
@@ -823,7 +824,7 @@ OFFSET 0 LIMIT 1");
                     {
                         var valueGeneratorFactory = new CustomPartitionKeyIdValueGeneratorFactory();
 
-                        cb.Property("id").HasValueGenerator((Type)null);
+                        cb.Property(StoreKeyConvention.DefaultIdPropertyName).HasValueGenerator((Type)null);
 
                         cb.Property(c => c.Id);
                         cb.Property(c => c.PartitionKey).HasConversion<string>();

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CustomPartitionKeyIdGenerator.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CustomPartitionKeyIdGenerator.cs
@@ -22,19 +22,20 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             var builder = new StringBuilder();
             var entityType = entry.Metadata;
 
-            var pk = entityType.FindPrimaryKey();
+            var primaryKey = entityType.FindPrimaryKey();
             var discriminator = entityType.GetDiscriminatorValue();
             if (discriminator != null
-                && !pk.Properties.Contains(entityType.GetDiscriminatorProperty()))
+                && !primaryKey.Properties.Contains(entityType.GetDiscriminatorProperty()))
             {
                 AppendString(builder, discriminator);
                 builder.Append("-");
             }
 
-            var partitionKey = entityType.GetPartitionKeyPropertyName() ?? CosmosClientWrapper.DefaultPartitionKey;
-            foreach (var property in pk.Properties.Where(p => p.Name != StoreKeyConvention.IdPropertyName))
+            var partitionKey = entityType.GetPartitionKeyPropertyName();
+            foreach (var property in primaryKey.Properties)
             {
-                if (property.Name == partitionKey)
+                if (property.Name == partitionKey
+                    || property.GetJsonPropertyName() == StoreKeyConvention.IdPropertyJsonName)
                 {
                     continue;
                 }

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -181,6 +181,38 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
+        public virtual void Detects_properties_mapped_to_same_property()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Order>(ob =>
+            {
+                ob.Property(o => o.Id).ToJsonProperty("Details");
+                ob.Property(o => o.PartitionId).ToJsonProperty("Details");
+            });
+
+            var model = modelBuilder.Model;
+            VerifyError(
+                CosmosStrings.JsonPropertyCollision(
+                    nameof(Order.PartitionId), nameof(Order.Id), typeof(Order).Name, "Details"), model);
+        }
+
+        [ConditionalFact]
+        public virtual void Detects_property_and_embedded_type_mapped_to_same_property()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Order>(ob =>
+            {
+                ob.Property(o => o.PartitionId).ToJsonProperty("Details");
+                ob.OwnsOne(o => o.OrderDetails).ToJsonProperty("Details");
+            });
+
+            var model = modelBuilder.Model;
+            VerifyError(
+                CosmosStrings.JsonPropertyCollision(
+                    nameof(Order.OrderDetails), nameof(Order.PartitionId), typeof(Order).Name, "Details"), model);
+        }
+
+        [ConditionalFact]
         public virtual void Detects_missing_discriminator()
         {
             var modelBuilder = CreateConventionalModelBuilder();

--- a/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
+++ b/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
@@ -27,5 +27,21 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             return builder;
         }
+
+        public static ModelBuilderTest.TestPropertyBuilder<TProperty> ToJsonProperty<TProperty>(
+            this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string name)
+        {
+            switch (builder)
+            {
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.ToJsonProperty(name);
+                    break;
+                case IInfrastructure<PropertyBuilder> nonGenericBuilder:
+                    nonGenericBuilder.Instance.ToJsonProperty(name);
+                    break;
+            }
+
+            return builder;
+        }
     }
 }

--- a/test/EFCore.Cosmos.Tests/ValueGenerator/Internal/IdValueGeneratorTest.cs
+++ b/test/EFCore.Cosmos.Tests/ValueGenerator/Internal/IdValueGeneratorTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -46,8 +47,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGenerator.Internal
 
             string Create<TEntity>(TEntity entity)
                 where TEntity : class, new()
-                => (string)CosmosTestHelpers.Instance.CreateInternalEntry(
-                    model, EntityState.Added, entity)[model.FindEntityType(typeof(TEntity)).FindProperty("id")];
+                => (string)CosmosTestHelpers.Instance.CreateInternalEntry(model, EntityState.Added, entity)
+                    [model.FindEntityType(typeof(TEntity)).FindProperty(StoreKeyConvention.DefaultIdPropertyName)];
         }
 
         private class Blog


### PR DESCRIPTION
- Rename the 'id' property created by convention to '__id' to avoid it clashing with an entity property.
- Make sure that the property created by the convention is removed if any other property is mapped to 'id' (the new property should get a value generator).
- Remove the value generator from the property mapped to 'id' if it's part of the PK
- Validate all properties have distinct database names

Fixes #17751

