### PR TITLE
Avoid using ActivatorServices for common DbContext constructor

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -801,6 +801,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             AddCoreServices<TContext>(serviceCollection, optionsAction, lifetime);
 
+            serviceCollection.AddSingleton<IDbContextFactorySource<TContext>, DbContextFactorySource<TContext>>();
+
             serviceCollection.TryAdd(
                 new ServiceDescriptor(
                     typeof(IDbContextFactory<TContext>),

--- a/src/EFCore/Internal/DbContextFactorySource.cs
+++ b/src/EFCore/Internal/DbContextFactorySource.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class DbContextFactorySource<TContext> : IDbContextFactorySource<TContext>
+        where TContext : DbContext
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public DbContextFactorySource()
+            => Factory = CreateActivator();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Func<IServiceProvider, DbContextOptions<TContext>, TContext> Factory { get; }
+
+        private static Func<IServiceProvider, DbContextOptions<TContext>, TContext> CreateActivator()
+        {
+            var constructors
+                = typeof(TContext).GetTypeInfo().DeclaredConstructors
+                    .Where(c => !c.IsStatic && c.IsPublic)
+                    .ToArray();
+
+            if (constructors.Length == 1)
+            {
+                var parameters = constructors[0].GetParameters();
+
+                if (parameters.Length == 1)
+                {
+                    var isGeneric = parameters[0].ParameterType == typeof(DbContextOptions<TContext>);
+                    if (isGeneric
+                        || parameters[0].ParameterType == typeof(DbContextOptions))
+                    {
+                        var optionsParam = Expression.Parameter(typeof(DbContextOptions<TContext>), "options");
+                        var providerParam = Expression.Parameter(typeof(IServiceProvider), "provider");
+
+                        return Expression.Lambda<Func<IServiceProvider, DbContextOptions<TContext>, TContext>>(
+                                Expression.New(
+                                    constructors[0],
+                                    isGeneric
+                                        ? optionsParam
+                                        : (Expression)Expression.Convert(optionsParam, typeof(DbContextOptions))),
+                                providerParam, optionsParam)
+                            .Compile();
+                    }
+                }
+            }
+
+            return (p, _) => ActivatorUtilities.CreateInstance<TContext>(p);
+        }
+    }
+}

--- a/src/EFCore/Internal/IDbContextFactorySource.cs
+++ b/src/EFCore/Internal/IDbContextFactorySource.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public interface IDbContextFactorySource<TContext>
+        where TContext : DbContext
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        Func<IServiceProvider, DbContextOptions<TContext>, TContext> Factory { get; }
+    }
+}

--- a/test/EFCore.Tests/DbContextFactoryTest.cs
+++ b/test/EFCore.Tests/DbContextFactoryTest.cs
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public void Can_register_factories_for_multiple_contexts()
+        public void Can_register_factories_for_multiple_contexts_even_with_non_generic_options()
         {
             var serviceProvider = (IServiceProvider)new ServiceCollection()
                 .AddDbContextFactory<CroydeContext>(
@@ -333,15 +333,11 @@ namespace Microsoft.EntityFrameworkCore
                     b => b.UseInMemoryDatabase(nameof(ClovellyContext)))
                 .BuildServiceProvider(validateScopes: true);
 
-            Assert.Equal(
-                CoreStrings.NonGenericOptions(nameof(CroydeContext)),
-                Assert.Throws<InvalidOperationException>(
-                    ()
-                        =>
-                    {
-                        using var context1 = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
-                        using var context2 = serviceProvider.GetService<IDbContextFactory<ClovellyContext>>().CreateDbContext();
-                    }).Message);
+            using var context1 = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
+            using var context2 = serviceProvider.GetService<IDbContextFactory<ClovellyContext>>().CreateDbContext();
+
+            Assert.Equal(nameof(CroydeContext), GetStoreName(context1));
+            Assert.Equal(nameof(ClovellyContext), GetStoreName(context2));
         }
 
         private class ClovellyContext : DbContext
@@ -353,7 +349,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public void Throws_for_multiple_non_generic_builders()
+        public void Can_register_factories_for_multiple_contexts()
         {
             var serviceProvider = (IServiceProvider)new ServiceCollection()
                 .AddDbContextFactory<WidemouthBayContext>(


### PR DESCRIPTION
Improvement to #18575

This change checks if the DbContext has the usual constructor taking just options:

```C#
MyContext(DbContextOptions<MyContext> options)
```

If it does, then we create a delegate (once in a singleton service) and use that to create context instances. This avoids using ActivatorServices and falling out of constructor injection (other than the delegate) for the common case.
