### PR TITLE
Allow DbContextFactory to use a pool

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -62,12 +62,13 @@ namespace Microsoft.EntityFrameworkCore
         private ChangeTracker _changeTracker;
 
         private IServiceScope _serviceScope;
-        private IDbContextPool _dbContextPool;
+        private IDbContextLease _lease;
+        private DbContextPoolConfigurationSnapshot _configurationSnapshot;
         private bool _initializing;
         private bool _disposed;
 
         private readonly Guid _contextId = Guid.NewGuid();
-        private int _lease;
+        private int _leaseCount;
 
         /// <summary>
         ///     <para>
@@ -150,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         public virtual DbContextId ContextId
-            => new DbContextId(_contextId, _lease);
+            => new DbContextId(_contextId, _leaseCount);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -623,11 +624,8 @@ namespace Microsoft.EntityFrameworkCore
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        void IDbContextPoolable.SetPool(IDbContextPool contextPool)
-        {
-            _dbContextPool = contextPool;
-            _lease = 1;
-        }
+        void IDbContextPoolable.ClearLease()
+            => _lease = null;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -636,39 +634,24 @@ namespace Microsoft.EntityFrameworkCore
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        DbContextPoolConfigurationSnapshot IDbContextPoolable.SnapshotConfiguration()
-            => new DbContextPoolConfigurationSnapshot(
-                _changeTracker?.AutoDetectChangesEnabled,
-                _changeTracker?.QueryTrackingBehavior,
-                _database?.AutoTransactionsEnabled,
-                _changeTracker?.LazyLoadingEnabled,
-                _changeTracker?.CascadeDeleteTiming,
-                _changeTracker?.DeleteOrphansTiming);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
-        void IDbContextPoolable.Resurrect(DbContextPoolConfigurationSnapshot configurationSnapshot)
+        void IDbContextPoolable.SetLease<TContext>(IDbContextLease<TContext> lease)
         {
+            _lease = lease;
             _disposed = false;
-            ++_lease;
+            ++_leaseCount;
 
-            if (configurationSnapshot.AutoDetectChangesEnabled != null)
+            if (_configurationSnapshot?.AutoDetectChangesEnabled != null)
             {
-                Check.DebugAssert(configurationSnapshot.QueryTrackingBehavior.HasValue, "!configurationSnapshot.QueryTrackingBehavior.HasValue");
-                Check.DebugAssert(configurationSnapshot.LazyLoadingEnabled.HasValue, "!configurationSnapshot.LazyLoadingEnabled.HasValue");
-                Check.DebugAssert(configurationSnapshot.CascadeDeleteTiming.HasValue, "!configurationSnapshot.CascadeDeleteTiming.HasValue");
-                Check.DebugAssert(configurationSnapshot.DeleteOrphansTiming.HasValue, "!configurationSnapshot.DeleteOrphansTiming.HasValue");
+                Check.DebugAssert(_configurationSnapshot.QueryTrackingBehavior.HasValue, "!configurationSnapshot.QueryTrackingBehavior.HasValue");
+                Check.DebugAssert(_configurationSnapshot.LazyLoadingEnabled.HasValue, "!configurationSnapshot.LazyLoadingEnabled.HasValue");
+                Check.DebugAssert(_configurationSnapshot.CascadeDeleteTiming.HasValue, "!configurationSnapshot.CascadeDeleteTiming.HasValue");
+                Check.DebugAssert(_configurationSnapshot.DeleteOrphansTiming.HasValue, "!configurationSnapshot.DeleteOrphansTiming.HasValue");
 
-                ChangeTracker.AutoDetectChangesEnabled = configurationSnapshot.AutoDetectChangesEnabled.Value;
-                ChangeTracker.QueryTrackingBehavior = configurationSnapshot.QueryTrackingBehavior.Value;
-                ChangeTracker.LazyLoadingEnabled = configurationSnapshot.LazyLoadingEnabled.Value;
-                ChangeTracker.CascadeDeleteTiming = configurationSnapshot.CascadeDeleteTiming.Value;
-                ChangeTracker.DeleteOrphansTiming = configurationSnapshot.DeleteOrphansTiming.Value;
+                ChangeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled.Value;
+                ChangeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
+                ChangeTracker.LazyLoadingEnabled = _configurationSnapshot.LazyLoadingEnabled.Value;
+                ChangeTracker.CascadeDeleteTiming = _configurationSnapshot.CascadeDeleteTiming.Value;
+                ChangeTracker.DeleteOrphansTiming = _configurationSnapshot.DeleteOrphansTiming.Value;
             }
             else
             {
@@ -678,10 +661,26 @@ namespace Microsoft.EntityFrameworkCore
             if (_database != null)
             {
                 _database.AutoTransactionsEnabled
-                    = configurationSnapshot.AutoTransactionsEnabled == null
-                    || configurationSnapshot.AutoTransactionsEnabled.Value;
+                    = _configurationSnapshot?.AutoTransactionsEnabled == null
+                    || _configurationSnapshot.AutoTransactionsEnabled.Value;
             }
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        void IDbContextPoolable.SnapshotConfiguration()
+            => _configurationSnapshot = new DbContextPoolConfigurationSnapshot(
+                _changeTracker?.AutoDetectChangesEnabled,
+                _changeTracker?.QueryTrackingBehavior,
+                _database?.AutoTransactionsEnabled,
+                _changeTracker?.LazyLoadingEnabled,
+                _changeTracker?.CascadeDeleteTiming,
+                _changeTracker?.DeleteOrphansTiming);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -757,8 +756,13 @@ namespace Microsoft.EntityFrameworkCore
 
         private bool DisposeSync()
         {
-            if (_dbContextPool == null
-                && !_disposed)
+            if (_lease != null)
+            {
+                _lease.ContextDisposed();
+                _disposed = true;
+                _lease = null;
+            }
+            else if (!_disposed)
             {
                 _dbContextDependencies?.InfrastructureLogger.ContextDisposed(this);
 

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -325,14 +325,28 @@ namespace Microsoft.Extensions.DependencyInjection
             Check.NotNull(serviceCollection, nameof(serviceCollection));
             Check.NotNull(optionsAction, nameof(optionsAction));
 
+            AddPoolingOptions<TContextImplementation>(serviceCollection, optionsAction, poolSize);
+
+            serviceCollection.TryAddSingleton<IDbContextPool<TContextImplementation>, DbContextPool<TContextImplementation>>();
+            serviceCollection.AddScoped<IDbContextLease<TContextImplementation>, ScopedDbContextLease<TContextImplementation>>();
+            serviceCollection.AddScoped<TContextService>(sp => sp.GetRequiredService<IDbContextLease<TContextImplementation>>().Context);
+
+            return serviceCollection;
+        }
+
+        private static void AddPoolingOptions<TContext>(
+            IServiceCollection serviceCollection,
+            Action<IServiceProvider, DbContextOptionsBuilder> optionsAction, int poolSize)
+            where TContext : DbContext
+        {
             if (poolSize <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(poolSize), CoreStrings.InvalidPoolSize);
             }
 
-            CheckContextConstructors<TContextImplementation>();
+            CheckContextConstructors<TContext>();
 
-            AddCoreServices<TContextImplementation>(
+            AddCoreServices<TContext>(
                 serviceCollection,
                 (sp, ob) =>
                 {
@@ -344,17 +358,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     ((IDbContextOptionsBuilderInfrastructure)ob).AddOrUpdateExtension(extension);
                 },
                 ServiceLifetime.Singleton);
-
-            serviceCollection.TryAddSingleton(
-                sp => new DbContextPool<TContextImplementation>(
-                    sp.GetService<DbContextOptions<TContextImplementation>>()));
-
-            serviceCollection.AddScoped<DbContextPool<TContextImplementation>.Lease>();
-
-            serviceCollection.AddScoped(
-                sp => (TContextService)sp.GetService<DbContextPool<TContextImplementation>.Lease>().Context);
-
-            return serviceCollection;
         }
 
         /// <summary>
@@ -557,10 +560,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         of given <see cref="DbContext"/> type.
         ///     </para>
         ///     <para>
-        ///         Using this method to register a factory is recommended for Blazor applications.
         ///         Registering a factory instead of registering the context type directly allows for easy creation of new
         ///         <see cref="DbContext" /> instances.
-        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with Blazor.
@@ -611,10 +614,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         of given <see cref="DbContext"/> type.
         ///     </para>
         ///     <para>
-        ///         Using this method to register a factory is recommended for Blazor applications.
         ///         Registering a factory instead of registering the context type directly allows for easy creation of new
         ///         <see cref="DbContext" /> instances.
-        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with Blazor.
@@ -676,10 +679,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         of given <see cref="DbContext"/> type.
         ///     </para>
         ///     <para>
-        ///         Using this method to register a factory is recommended for Blazor applications.
         ///         Registering a factory instead of registering the context type directly allows for easy creation of new
         ///         <see cref="DbContext" /> instances.
-        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with Blazor.
@@ -738,10 +741,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         of given <see cref="DbContext"/> type.
         ///     </para>
         ///     <para>
-        ///         Using this method to register a factory is recommended for Blazor applications.
         ///         Registering a factory instead of registering the context type directly allows for easy creation of new
         ///         <see cref="DbContext" /> instances.
-        ///         This is most useful where the dependency injection scope is not aligned with the context lifetime, such as in Blazor.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
         ///     </para>
         ///     <para>
         ///         Use this method when using dependency injection in your application, such as with Blazor.
@@ -799,6 +802,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TContext : DbContext
             where TFactory : IDbContextFactory<TContext>
         {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+
             AddCoreServices<TContext>(serviceCollection, optionsAction, lifetime);
 
             serviceCollection.AddSingleton<IDbContextFactorySource<TContext>, DbContextFactorySource<TContext>>();
@@ -808,6 +813,108 @@ namespace Microsoft.Extensions.DependencyInjection
                     typeof(IDbContextFactory<TContext>),
                     typeof(TFactory),
                     lifetime));
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type where instances are pooled for reuse.
+        ///     </para>
+        ///     <para>
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         A required action to configure the <see cref="DbContextOptions" /> for the context. When using
+        ///         context pooling, options configuration must be performed externally; <see cref="DbContext.OnConfiguring" />
+        ///         will not be called.
+        ///     </para>
+        /// </param>
+        /// <param name="poolSize">
+        ///     Sets the maximum number of instances retained by the pool.
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddPooledDbContextFactory<TContext>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [NotNull] Action<DbContextOptionsBuilder> optionsAction,
+            int poolSize = 128)
+            where TContext : DbContext
+        {
+            Check.NotNull(optionsAction, nameof(optionsAction));
+
+            return AddPooledDbContextFactory<TContext>(serviceCollection, (_, ob) => optionsAction(ob));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Registers an <see cref="IDbContextFactory{TContext}" /> in the <see cref="IServiceCollection" /> to create instances
+        ///         of given <see cref="DbContext"/> type where instances are pooled for reuse.
+        ///     </para>
+        ///     <para>
+        ///         Registering a factory instead of registering the context type directly allows for easy creation of new
+        ///         <see cref="DbContext" /> instances.
+        ///         Registering a factory is recommended for Blazor applications and other situations where the dependency
+        ///         injection scope is not aligned with the context lifetime.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with Blazor.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of <see cref="DbContext" /> to be created by the factory. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         A required action to configure the <see cref="DbContextOptions" /> for the context. When using
+        ///         context pooling, options configuration must be performed externally; <see cref="DbContext.OnConfiguring" />
+        ///         will not be called.
+        ///     </para>
+        /// </param>
+        /// <param name="poolSize">
+        ///     Sets the maximum number of instances retained by the pool.
+        /// </param>
+        /// <returns>
+        ///     The same service collection so that multiple calls can be chained.
+        /// </returns>
+        public static IServiceCollection AddPooledDbContextFactory<TContext>(
+            [NotNull] this IServiceCollection serviceCollection,
+            [NotNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
+            int poolSize = 128)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+            Check.NotNull(optionsAction, nameof(optionsAction));
+
+            AddPoolingOptions<TContext>(serviceCollection, optionsAction, poolSize);
+
+            serviceCollection.TryAddSingleton<IDbContextPool<TContext>, DbContextPool<TContext>>();
+            serviceCollection.TryAddSingleton<IDbContextFactory<TContext>, PooledDbContextFactory<TContext>>();
 
             return serviceCollection;
         }

--- a/src/EFCore/Internal/DbContextPool.cs
+++ b/src/EFCore/Internal/DbContextPool.cs
@@ -21,89 +21,25 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class DbContextPool<TContext> : IDbContextPool, IDisposable, IAsyncDisposable
+    public class DbContextPool<TContext> : IDbContextPool<TContext>, IDisposable, IAsyncDisposable
         where TContext : DbContext
     {
         private const int DefaultPoolSize = 32;
 
-        private readonly ConcurrentQueue<TContext> _pool = new ConcurrentQueue<TContext>();
+        private readonly ConcurrentQueue<IDbContextPoolable> _pool = new ConcurrentQueue<IDbContextPoolable>();
 
-        private readonly Func<TContext> _activator;
+        private readonly Func<DbContext> _activator;
 
         private int _maxSize;
         private int _count;
 
-        private DbContextPoolConfigurationSnapshot _configurationSnapshot;
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public sealed class Lease : IDisposable, IAsyncDisposable
-        {
-            private DbContextPool<TContext> _contextPool;
-
-            /// <summary>
-            ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-            ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-            ///     any release. You should only use it directly in your code with extreme caution and knowing that
-            ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-            /// </summary>
-            public Lease([NotNull] DbContextPool<TContext> contextPool)
-            {
-                _contextPool = contextPool;
-
-                Context = _contextPool.Rent();
-            }
-
-            /// <summary>
-            ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-            ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-            ///     any release. You should only use it directly in your code with extreme caution and knowing that
-            ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-            /// </summary>
-            public TContext Context { get; private set; }
-
-            void IDisposable.Dispose()
-            {
-                if (_contextPool != null)
-                {
-                    if (!_contextPool.Return(Context))
-                    {
-                        ((IDbContextPoolable)Context).SetPool(null);
-                        Context.Dispose();
-                    }
-
-                    _contextPool = null;
-                    Context = null;
-                }
-            }
-
-            async ValueTask IAsyncDisposable.DisposeAsync()
-            {
-                if (_contextPool != null)
-                {
-                    if (!_contextPool.Return(Context))
-                    {
-                        ((IDbContextPoolable)Context).SetPool(null);
-                        await Context.DisposeAsync().ConfigureAwait(false);
-                    }
-
-                    _contextPool = null;
-                    Context = null;
-                }
-            }
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public DbContextPool([NotNull] DbContextOptions options)
+        public DbContextPool([NotNull] DbContextOptions<TContext> options)
         {
             _maxSize = options.FindExtension<CoreOptionsExtension>()?.MaxPoolSize ?? DefaultPoolSize;
 
@@ -118,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
         }
 
-        private static Func<TContext> CreateActivator(DbContextOptions options)
+        private static Func<DbContext> CreateActivator(DbContextOptions<TContext> options)
         {
             var constructors
                 = typeof(TContext).GetTypeInfo().DeclaredConstructors
@@ -149,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual TContext Rent()
+        public virtual IDbContextPoolable Rent()
         {
             if (_pool.TryDequeue(out var context))
             {
@@ -157,20 +93,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
                 Check.DebugAssert(_count >= 0, $"_count is {_count}");
 
-                ((IDbContextPoolable)context).Resurrect(_configurationSnapshot);
-
                 return context;
             }
 
             context = _activator();
 
-            NonCapturingLazyInitializer
-                .EnsureInitialized(
-                    ref _configurationSnapshot,
-                    (IDbContextPoolable)context,
-                    c => c.SnapshotConfiguration());
-
-            ((IDbContextPoolable)context).SetPool(this);
+            context.SnapshotConfiguration();
 
             return context;
         }
@@ -181,22 +109,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool Return([NotNull] TContext context)
+        public virtual void Return([NotNull] IDbContextPoolable context)
         {
             if (Interlocked.Increment(ref _count) <= _maxSize)
             {
-                ((IDbContextPoolable)context).ResetState();
+                context.ResetState();
 
                 _pool.Enqueue(context);
-
-                return true;
             }
-
-            Interlocked.Decrement(ref _count);
-
-            Check.DebugAssert(_maxSize == 0 || _pool.Count <= _maxSize, $"_maxSize is {_maxSize}");
-
-            return false;
+            else
+            {
+                PooledReturn(context);
+            }
         }
 
         /// <summary>
@@ -205,15 +129,29 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        DbContext IDbContextPool.Rent() => Rent();
+        public virtual async ValueTask ReturnAsync([NotNull] IDbContextPoolable context, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _count) <= _maxSize)
+            {
+                await context.ResetStateAsync(cancellationToken).ConfigureAwait(false);
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        bool IDbContextPool.Return(DbContext context) => Return((TContext)context);
+                _pool.Enqueue(context);
+            }
+            else
+            {
+                PooledReturn(context);
+            }
+        }
+
+        private void PooledReturn(IDbContextPoolable context)
+        {
+            Interlocked.Decrement(ref _count);
+
+            Check.DebugAssert(_maxSize == 0 || _pool.Count <= _maxSize, $"_maxSize is {_maxSize}");
+
+            context.ClearLease();
+            context.Dispose();
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -227,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             while (_pool.TryDequeue(out var context))
             {
-                ((IDbContextPoolable)context).SetPool(null);
+                context.ClearLease();
                 context.Dispose();
             }
         }
@@ -244,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             while (_pool.TryDequeue(out var context))
             {
-                ((IDbContextPoolable)context).SetPool(null);
+                context.ClearLease();
                 await context.DisposeAsync().ConfigureAwait(false);
             }
         }

--- a/src/EFCore/Internal/IDbContextLease.cs
+++ b/src/EFCore/Internal/IDbContextLease.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -13,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPoolable : IResettableService, IDisposable, IAsyncDisposable
+    public interface IDbContextLease
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -21,23 +17,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void SetLease<TContext>([NotNull] IDbContextLease<TContext> lease)
-            where TContext : DbContext;
+        void ContextDisposed();
+    }
 
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public interface IDbContextLease<out TContext> : IDbContextLease
+        where TContext : DbContext
+    {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void ClearLease();
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        void SnapshotConfiguration();
+        TContext Context { get; }
     }
 }

--- a/src/EFCore/Internal/IDbContextPool.cs
+++ b/src/EFCore/Internal/IDbContextPool.cs
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -11,7 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPool
+    public interface IDbContextPool<TContext>
+        where TContext : DbContext
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        DbContext Rent();
+        IDbContextPoolable Rent();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -27,6 +29,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        bool Return([NotNull] DbContext context);
+        void Return(IDbContextPoolable context);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        ValueTask ReturnAsync(IDbContextPoolable context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore/Internal/PooledDbContextFactory.cs
+++ b/src/EFCore/Internal/PooledDbContextFactory.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -13,16 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPoolable : IResettableService, IDisposable, IAsyncDisposable
+    public class PooledDbContextFactory<TContext> : IDbContextFactory<TContext>
+        where TContext : DbContext
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        void SetLease<TContext>([NotNull] IDbContextLease<TContext> lease)
-            where TContext : DbContext;
+        private readonly IDbContextPool<TContext> _pool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void ClearLease();
+        public PooledDbContextFactory([NotNull] IDbContextPool<TContext> pool)
+            => _pool = pool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -38,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void SnapshotConfiguration();
+        public virtual TContext CreateDbContext()
+            => new StandaloneDbContextLease<TContext>(_pool).Context;
     }
 }

--- a/src/EFCore/Internal/ScopedDbContextLease.cs
+++ b/src/EFCore/Internal/ScopedDbContextLease.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -13,16 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPoolable : IResettableService, IDisposable, IAsyncDisposable
+    public sealed class ScopedDbContextLease<TContext> : IDbContextLease<TContext>, IDisposable, IAsyncDisposable
+        where TContext : DbContext
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        void SetLease<TContext>([NotNull] IDbContextLease<TContext> lease)
-            where TContext : DbContext;
+        private IDbContextPool<TContext> _contextPool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,7 +24,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void ClearLease();
+        public ScopedDbContextLease([NotNull] IDbContextPool<TContext> contextPool)
+        {
+            _contextPool = contextPool;
+
+            Context = (TContext)_contextPool.Rent();
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -38,6 +37,54 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void SnapshotConfiguration();
+        public TContext Context { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public void ContextDisposed()
+        {
+            // No-op for lease scoped by D.I.
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        void IDisposable.Dispose()
+        {
+            if (_contextPool != null)
+            {
+                _contextPool.Return(Context);
+                _contextPool = null;
+                Context = null;
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            if (_contextPool != null)
+            {
+                var pool = _contextPool;
+                var context = Context;
+                _contextPool = null;
+                Context = null;
+
+                return pool.ReturnAsync(context);
+            }
+
+            return new ValueTask();
+        }
     }
 }

--- a/src/EFCore/Internal/StandaloneDbContextLease.cs
+++ b/src/EFCore/Internal/StandaloneDbContextLease.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
@@ -13,16 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPoolable : IResettableService, IDisposable, IAsyncDisposable
+    public sealed class StandaloneDbContextLease<TContext> : IDbContextLease<TContext>
+        where TContext : DbContext
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        void SetLease<TContext>([NotNull] IDbContextLease<TContext> lease)
-            where TContext : DbContext;
+        private IDbContextPool<TContext> _contextPool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,7 +22,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void ClearLease();
+        public StandaloneDbContextLease([NotNull] IDbContextPool<TContext> contextPool)
+        {
+            _contextPool = contextPool;
+
+            var context = _contextPool.Rent();
+            Context = (TContext)context;
+            context.SetLease(this);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -38,6 +37,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void SnapshotConfiguration();
+        public TContext Context { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public void ContextDisposed()
+        {
+            if (_contextPool != null)
+            {
+                _contextPool.Return(Context);
+                _contextPool = null;
+                Context = null;
+            }
+        }
     }
 }

--- a/src/EFCore/Internal/StandaloneDbContextPool.cs
+++ b/src/EFCore/Internal/StandaloneDbContextPool.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// using JetBrains.Annotations;
+//
+// namespace Microsoft.EntityFrameworkCore.Internal
+// {
+//     /// <summary>
+//     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+//     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+//     ///     any release. You should only use it directly in your code with extreme caution and knowing that
+//     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+//     /// </summary>
+//     public class StandaloneDbContextPool<TContext> : DbContextPool<TContext>
+//         where TContext : DbContext
+//     {
+//         /// <summary>
+//         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+//         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+//         ///     any release. You should only use it directly in your code with extreme caution and knowing that
+//         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+//         /// </summary>
+//         public StandaloneDbContextPool([NotNull] DbContextOptions<TContext> options)
+//             : base(options)
+//         {
+//         }
+//
+//         /// <summary>
+//         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+//         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+//         ///     any release. You should only use it directly in your code with extreme caution and knowing that
+//         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+//         /// </summary>
+//         public override void ContextDisposed(DbContext context)
+//             => Return(context);
+//     }
+// }

--- a/test/EFCore.Specification.Tests/TestUtilities/PoolableDbContext.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/PoolableDbContext.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Internal;
-
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class PoolableDbContext : DbContext
     {
-        private IDbContextPool _contextPool;
-
         protected PoolableDbContext()
             : this(new DbContextOptions<PoolableDbContext>())
         {
@@ -17,26 +13,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public PoolableDbContext(DbContextOptions options)
             : base(options)
         {
-        }
-
-        public virtual void SetPool(IDbContextPool contextPool) => _contextPool = contextPool;
-
-        public override void Dispose()
-        {
-            if (_contextPool != null)
-            {
-                if (!_contextPool.Return(this))
-                {
-                    ((IDbContextPoolable)this).SetPool(null);
-                    base.Dispose();
-                }
-
-                _contextPool = null;
-            }
-            else
-            {
-                base.Dispose();
-            }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         private static readonly MethodInfo _addDbContextPool
             = typeof(EntityFrameworkServiceCollectionExtensions)
-                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkServiceCollectionExtensions.AddDbContextPool))
+                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory))
                 .Single(
                     mi => mi.GetParameters().Length == 3
                         && mi.GetParameters()[1].ParameterType == typeof(Action<IServiceProvider, DbContextOptionsBuilder>)

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -55,6 +55,21 @@ namespace Microsoft.EntityFrameworkCore
                     poolSize)
                 .BuildServiceProvider();
 
+        private static IServiceProvider BuildServiceProviderWithFactory<TContext>(int poolSize = 32)
+            where TContext : DbContext
+            => new ServiceCollection()
+                .AddPooledDbContextFactory<TContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
+                    poolSize)
+                .AddDbContextPool<SecondContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false),
+                    poolSize)
+                .BuildServiceProvider();
+
         private interface IPooledContext
         {
         }
@@ -133,6 +148,12 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => BuildServiceProvider<PooledContext>(poolSize: -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => BuildServiceProviderWithFactory<PooledContext>(poolSize: 0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => BuildServiceProviderWithFactory<PooledContext>(poolSize: -1));
         }
 
         [ConditionalTheory]
@@ -161,6 +182,25 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalFact]
+        public void Options_modified_in_on_configuring_with_factory()
+        {
+            var serviceProvider = BuildServiceProviderWithFactory<PooledContext>();
+            var scopedProvider = serviceProvider.CreateScope().ServiceProvider;
+
+            PooledContext.ModifyOptions = true;
+
+            try
+            {
+                var factory = scopedProvider.GetService<IDbContextFactory<PooledContext>>();
+                Assert.Throws<InvalidOperationException>(() => factory.CreateDbContext());
+            }
+            finally
+            {
+                PooledContext.ModifyOptions = false;
+            }
+        }
+
         private class BadCtorContext : DbContext
         {
         }
@@ -181,18 +221,28 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Throws<ArgumentException>(
                     () => serviceCollection.AddDbContextPool<BadCtorContext>(
                         (_, __) => { })).Message);
+
+            Assert.Equal(
+                CoreStrings.DbContextMissingConstructor(nameof(BadCtorContext)),
+                Assert.Throws<ArgumentException>(
+                    () => serviceCollection.AddPooledDbContextFactory<BadCtorContext>(
+                        (_, __) => { })).Message);
         }
 
-        [ConditionalFact]
-        public void Can_pool_non_derived_context()
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_pool_non_derived_context(bool useFactory)
         {
-            var serviceProvider = BuildServiceProvider<DbContext>();
+            var serviceProvider = useFactory
+                ? BuildServiceProviderWithFactory<DbContext>()
+                : BuildServiceProvider<DbContext>();
 
             var serviceScope1 = serviceProvider.CreateScope();
-            var context1 = serviceScope1.ServiceProvider.GetService<DbContext>();
+            var context1 = GetContext(serviceScope1);
 
             var serviceScope2 = serviceProvider.CreateScope();
-            var context2 = serviceScope2.ServiceProvider.GetService<DbContext>();
+            var context2 = GetContext(serviceScope2);
 
             Assert.NotSame(context1, context2);
 
@@ -205,8 +255,18 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, id1.Lease);
             Assert.Equal(1, id2.Lease);
 
+            if (useFactory)
+            {
+                context1.Dispose();
+            }
+
             serviceScope1.Dispose();
             serviceScope2.Dispose();
+
+            if (useFactory)
+            {
+                context2.Dispose();
+            }
 
             var id1d = context1.ContextId;
             var id2d = context2.ContextId;
@@ -217,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, id2d.Lease);
 
             var serviceScope3 = serviceProvider.CreateScope();
-            var context3 = serviceScope3.ServiceProvider.GetService<DbContext>();
+            var context3 = GetContext(serviceScope3);
 
             var id1r = context3.ContextId;
 
@@ -228,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, id1r.Lease);
 
             var serviceScope4 = serviceProvider.CreateScope();
-            var context4 = serviceScope4.ServiceProvider.GetService<DbContext>();
+            var context4 = GetContext(serviceScope4);
 
             var id2r = context4.ContextId;
 
@@ -237,6 +297,11 @@ namespace Microsoft.EntityFrameworkCore
             Assert.NotEqual(default, id2r.InstanceId);
             Assert.NotEqual(id2, id2r);
             Assert.Equal(2, id2r.Lease);
+
+            DbContext GetContext(IServiceScope serviceScope)
+                => useFactory
+                    ? serviceScope.ServiceProvider.GetService<IDbContextFactory<DbContext>>().CreateDbContext()
+                    : serviceScope.ServiceProvider.GetService<DbContext>();
         }
 
         [ConditionalFact]
@@ -367,6 +432,38 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(secondContext2, secondContext4);
         }
 
+        [ConditionalFact]
+        public void Contexts_are_pooled_with_factory()
+        {
+            var factory = BuildServiceProviderWithFactory<PooledContext>().GetService<IDbContextFactory<PooledContext>>();
+
+            var context1 = factory.CreateDbContext();
+            var secondContext1 = factory.CreateDbContext();
+
+            var context2 = factory.CreateDbContext();
+            var secondContext2 = factory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.NotSame(secondContext1, secondContext2);
+
+            context1.Dispose();
+            secondContext1.Dispose();
+            context2.Dispose();
+            secondContext2.Dispose();
+
+            var context3 = factory.CreateDbContext();
+            var secondContext3 = factory.CreateDbContext();
+
+            Assert.Same(context1, context3);
+            Assert.Same(secondContext1, secondContext3);
+
+            var context4 = factory.CreateDbContext();
+            var secondContext4 = factory.CreateDbContext();
+
+            Assert.Same(context2, context4);
+            Assert.Same(secondContext2, secondContext4);
+        }
+
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
@@ -398,6 +495,34 @@ namespace Microsoft.EntityFrameworkCore
             var context2 = useInterface
                 ? (DbContext)scopedProvider.GetService<IPooledContext>()
                 : scopedProvider.GetService<PooledContext>();
+
+            Assert.Same(context1, context2);
+
+            Assert.False(context2.ChangeTracker.AutoDetectChangesEnabled);
+            Assert.False(context2.ChangeTracker.LazyLoadingEnabled);
+            Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
+            Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.CascadeDeleteTiming);
+            Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.DeleteOrphansTiming);
+            Assert.False(context2.Database.AutoTransactionsEnabled);
+        }
+
+        [ConditionalFact]
+        public void Context_configuration_is_reset_with_factory()
+        {
+            var factory = BuildServiceProviderWithFactory<PooledContext>().GetService<IDbContextFactory<PooledContext>>();
+
+            var context1 = factory.CreateDbContext();
+
+            context1.ChangeTracker.AutoDetectChangesEnabled = true;
+            context1.ChangeTracker.LazyLoadingEnabled = true;
+            context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
+            context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
+            context1.Database.AutoTransactionsEnabled = true;
+
+            context1.Dispose();
+
+            var context2 = factory.CreateDbContext();
 
             Assert.Same(context1, context2);
 
@@ -486,6 +611,35 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(context2.Database.AutoTransactionsEnabled);
         }
 
+        [ConditionalFact]
+        public void Default_Context_configuration_is_reset_with_factory()
+        {
+            var factory = BuildServiceProviderWithFactory<DefaultOptionsPooledContext>()
+                .GetService<IDbContextFactory<DefaultOptionsPooledContext>>();
+
+            var context1 = factory.CreateDbContext();
+
+            context1.ChangeTracker.AutoDetectChangesEnabled = false;
+            context1.ChangeTracker.LazyLoadingEnabled = false;
+            context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            context1.Database.AutoTransactionsEnabled = false;
+            context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
+            context1.ChangeTracker.DeleteOrphansTiming = CascadeTiming.Immediate;
+
+            context1.Dispose();
+
+            var context2 = factory.CreateDbContext();
+
+            Assert.Same(context1, context2);
+
+            Assert.True(context2.ChangeTracker.AutoDetectChangesEnabled);
+            Assert.True(context2.ChangeTracker.LazyLoadingEnabled);
+            Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
+            Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.CascadeDeleteTiming);
+            Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.DeleteOrphansTiming);
+            Assert.True(context2.Database.AutoTransactionsEnabled);
+        }
+
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
@@ -530,6 +684,36 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static T Scoper<T>(Func<T> getter) => getter();
+
+        [ConditionalFact]
+        public void State_manager_is_reset_with_factory()
+        {
+            var weakRef = Scoper(
+                () =>
+                {
+                    var factory = BuildServiceProviderWithFactory<PooledContext>()
+                        .GetService<IDbContextFactory<PooledContext>>();
+
+                    var context1 = factory.CreateDbContext();
+
+                    var entity = context1.Customers.First(c => c.CustomerId == "ALFKI");
+
+                    Assert.Single(context1.ChangeTracker.Entries());
+
+                    context1.Dispose();
+
+                    var context2 = factory.CreateDbContext();
+
+                    Assert.Same(context1, context2);
+                    Assert.Empty(context2.ChangeTracker.Entries());
+
+                    return new WeakReference(entity);
+                });
+
+            GC.Collect();
+
+            Assert.False(weakRef.IsAlive);
+        }
 
         [ConditionalTheory]
         [InlineData(true)]
@@ -631,6 +815,25 @@ namespace Microsoft.EntityFrameworkCore
             Assert.NotSame(context1, context2);
         }
 
+        [ConditionalFact]
+        public void Can_double_dispose_with_factory()
+        {
+            var factory = BuildServiceProviderWithFactory<PooledContext>()
+                .GetService<IDbContextFactory<PooledContext>>();
+
+            var context = factory.CreateDbContext();
+
+            context.Customers.Load();
+
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => context.Customers.ToList());
+
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => context.Customers.ToList());
+        }
+
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
@@ -675,6 +878,37 @@ namespace Microsoft.EntityFrameworkCore
             var context3 = useInterface
                 ? (PooledContext)scopedProvider.GetService<IPooledContext>()
                 : scopedProvider.GetService<PooledContext>();
+
+            Assert.Same(context2, context3);
+            Assert.Null(context3.Database.CurrentTransaction);
+        }
+
+        [ConditionalFact]
+        public void Provider_services_are_reset_with_factory()
+        {
+            var factory = BuildServiceProviderWithFactory<PooledContext>()
+                .GetService<IDbContextFactory<PooledContext>>();
+
+            var context1 = factory.CreateDbContext();
+
+            context1.Database.BeginTransaction();
+
+            Assert.NotNull(context1.Database.CurrentTransaction);
+
+            context1.Dispose();
+
+            var context2 = factory.CreateDbContext();
+
+            Assert.Same(context1, context2);
+            Assert.Null(context2.Database.CurrentTransaction);
+
+            context2.Database.BeginTransaction();
+
+            Assert.NotNull(context2.Database.CurrentTransaction);
+
+            context2.Dispose();
+
+            var context3 = factory.CreateDbContext();
 
             Assert.Same(context2, context3);
             Assert.Null(context3.Database.CurrentTransaction);


### PR DESCRIPTION
Fixes #21247

Uses the existing pooling code, although some divergence here could result in better perf, which could be relevant for high-throughput cases like SingleQuery.

Has the same restrictions as regular pooling since the context instances are reused.
