### PR TITLE
Return true for IsModified on navigations pointing to Added or Deleted entities

### DIFF
--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -240,7 +240,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var relatedEntry = InternalEntry.StateManager.TryGetEntry(relatedEntity, Metadata.TargetEntityType);
 
             return relatedEntry != null
-                && Metadata.ForeignKey.Properties.Any(relatedEntry.IsModified);
+                && (relatedEntry.EntityState == EntityState.Added
+                || relatedEntry.EntityState == EntityState.Deleted
+                || Metadata.ForeignKey.Properties.Any(relatedEntry.IsModified));
         }
 
         private void SetFkPropertiesModified(object relatedEntity, bool modified)

--- a/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -397,16 +397,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             var reference = context.Entry(chunky).Reference(e => e.Baked);
 
-            Assert.False(reference.IsModified);
+            Assert.True(reference.IsModified);
 
             reference.IsModified = true;
 
-            Assert.False(reference.IsModified);
+            Assert.True(reference.IsModified);
             Assert.False(context.Entry(half).Property(e => e.MonkeyId).IsModified);
 
             reference.IsModified = false;
 
-            Assert.False(reference.IsModified);
+            Assert.True(reference.IsModified);
             Assert.False(context.Entry(half).Property(e => e.MonkeyId).IsModified);
             Assert.Equal(dependentState, context.Entry(half).State);
         }


### PR DESCRIPTION
Fixes #16513

I investigated this some more and I now understand why this was labeled a bug. Collection navigations already have this behavior--that is, Deleted or Added related entities indicate that the navigation property is modified. So this change brings reference navigations inline, which I think is a bug. Nevertheless, I think it makes sense to document this as a breaking change.
