### PR TITLE
Further fix for 8332: Use -- for command line and -Args for Powershell

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -36,7 +36,7 @@ Register-TabExpansion Add-Migration @{
 .PARAMETER Namespace
     Specify to override the namespace for the migration.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -55,8 +55,7 @@ function Add-Migration
         [string] $Project,
         [string] $StartupProject,
         [string] $Namespace,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     WarnIfEF6 'Add-Migration'
 
@@ -77,13 +76,8 @@ function Add-Migration
 
     $params += GetParams $Context
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
-
     # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-    $result = (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json
+    $result = (EF $dteProject $dteStartupProject $params $Args) -join "`n" | ConvertFrom-Json
     Write-Host 'To undo this action, use Remove-Migration.'
 
     $dteProject.ProjectItems.AddFromFile($result.migrationFile) | Out-Null
@@ -121,7 +115,7 @@ Register-TabExpansion Drop-Database @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -135,8 +129,7 @@ function Drop-Database
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -148,12 +141,7 @@ function Drop-Database
         $params = 'database', 'drop', '--force'
         $params += GetParams $Context
 
-       if ($RemainingArguments -ne $null)
-       {
-           $params += $RemainingArguments
-       }
-
-        EF $dteProject $dteStartupProject $params -skipBuild
+        EF $dteProject $dteStartupProject $params $Args -skipBuild
     }
 }
 
@@ -193,7 +181,7 @@ Register-TabExpansion Get-DbContext @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -206,8 +194,7 @@ function Get-DbContext
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -217,19 +204,14 @@ function Get-DbContext
        $params = 'dbcontext', 'info', '--json'
        $params += GetParams $Context
 
-       if ($RemainingArguments -ne $null)
-       {
-           $params += $RemainingArguments
-       }
-
        # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-       return (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json
+       return (EF $dteProject $dteStartupProject $params $Args) -join "`n" | ConvertFrom-Json
     }
     else
     {
        $params = 'dbcontext', 'list', '--json'
        # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-       return (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json | Format-Table -Property safeName -HideTableHeaders
+       return (EF $dteProject $dteStartupProject $params $Args) -join "`n" | ConvertFrom-Json | Format-Table -Property safeName -HideTableHeaders
     }
 }
 
@@ -262,7 +244,7 @@ Register-TabExpansion Remove-Migration @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -277,8 +259,7 @@ function Remove-Migration
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -292,13 +273,8 @@ function Remove-Migration
 
     $params += GetParams $Context
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
-
     # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-    $result = (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json
+    $result = (EF $dteProject $dteStartupProject $params $Args) -join "`n" | ConvertFrom-Json
 
     $files = $result.migrationFile, $result.metadataFile, $result.snapshotFile
     $files | ?{ $_ -ne $null } | %{
@@ -374,7 +350,7 @@ Register-TabExpansion Scaffold-DbContext @{
 .PARAMETER ContextNamespace
     Specify to override the namespace for the DbContext class.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -401,8 +377,7 @@ function Scaffold-DbContext
         [string] $StartupProject,
         [string] $Namespace,
         [string] $ContextNamespace,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -457,13 +432,8 @@ function Scaffold-DbContext
         $params += '--no-onconfiguring'
     }
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
-
     # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-    $result = (EF $dteProject $dteStartupProject $params) -join "`n" | ConvertFrom-Json
+    $result = (EF $dteProject $dteStartupProject $params $Args) -join "`n" | ConvertFrom-Json
 
     $files = $result.entityTypeFiles + $result.contextFile
     $files | %{ $dteProject.ProjectItems.AddFromFile($_) | Out-Null }
@@ -500,7 +470,7 @@ Register-TabExpansion Script-DbContext @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -514,8 +484,7 @@ function Script-DbContext
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -538,16 +507,9 @@ function Script-DbContext
     }
 
     $params = 'dbcontext', 'script', '--output', $Output
-
     $params += GetParams $Context
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
-
-
-    EF $dteProject $dteStartupProject $params
+    EF $dteProject $dteStartupProject $params $Args
 
     $DTE.ItemOperations.OpenFile($Output) | Out-Null
     ShowConsole
@@ -593,7 +555,7 @@ Register-TabExpansion Script-Migration @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -614,8 +576,7 @@ function Script-Migration
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     $dteProject = GetProject $Project
     $dteStartupProject = GetStartupProject $StartupProject $dteProject
@@ -656,13 +617,8 @@ function Script-Migration
 
     $params += GetParams $Context
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
 
-
-    EF $dteProject $dteStartupProject $params
+    EF $dteProject $dteStartupProject $params $Args
 
     $DTE.ItemOperations.OpenFile($Output) | Out-Null
     ShowConsole
@@ -701,7 +657,7 @@ Register-TabExpansion Update-Database @{
 .PARAMETER StartupProject
     The startup project to use. Defaults to the solution's startup project.
 
-.PARAMETER RemainingArguments
+.PARAMETER Args
     Arguments passed to the application.
 
 .LINK
@@ -718,8 +674,7 @@ function Update-Database
         [string] $Context,
         [string] $Project,
         [string] $StartupProject,
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]] $RemainingArguments)
+        [string] $Args)
 
     WarnIfEF6 'Update-Database'
 
@@ -740,13 +695,8 @@ function Update-Database
 
     $params += GetParams $Context
 
-    if ($RemainingArguments -ne $null)
-    {
-        $params += $RemainingArguments
-    }
 
-
-    EF $dteProject $dteStartupProject $params
+    EF $dteProject $dteStartupProject $params $Args
 }
 
 #
@@ -776,7 +726,7 @@ function GetContextTypes($projectName, $startupProjectName)
     $params = 'dbcontext', 'list', '--json'
 
     # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-    $result = (EF $project $startupProject $params -skipBuild) -join "`n" | ConvertFrom-Json
+    $result = (EF $project $startupProject $params $null -skipBuild) -join "`n" | ConvertFrom-Json
 
     return $result | %{ $_.safeName }
 }
@@ -790,7 +740,7 @@ function GetMigrations($context, $projectName, $startupProjectName)
     $params += GetParams $context
 
     # NB: -join is here to support ConvertFrom-Json on PowerShell 3.0
-    $result = (EF $project $startupProject $params -skipBuild) -join "`n" | ConvertFrom-Json
+    $result = (EF $project $startupProject $params $null -skipBuild) -join "`n" | ConvertFrom-Json
 
     return $result | %{ $_.safeName }
 }
@@ -937,7 +887,7 @@ function WriteErrorLine($message)
     }
 }
 
-function EF($project, $startupProject, $params, [switch] $skipBuild)
+function EF($project, $startupProject, $params, $applicationArgs, [switch] $skipBuild)
 {
     if (IsDocker $startupProject)
     {
@@ -1073,6 +1023,12 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
     }
 
     $arguments = ToArguments $params
+    if ($applicationArgs -ne $null)
+    {
+        $arguments += ' -- '
+        $arguments += $applicationArgs
+    }
+
     $startInfo = New-Object 'System.Diagnostics.ProcessStartInfo' -Property @{
         FileName = $exePath;
         Arguments = $arguments;

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -27,10 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Tools
         private CommandOption _noBuild;
         private CommandOption _help;
         private IList<string> _args;
+        private IList<string> _applicationArgs;
 
         public override void Configure(CommandLineApplication command)
         {
             command.FullName = Resources.DotnetEfFullName;
+            command.AllowArgumentSeparator = true;
 
             var options = new ProjectOptions();
             options.Configure(command);
@@ -47,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             _help = command.Option("-h|--help", description: null);
 
             _args = command.RemainingArguments;
+            _applicationArgs = command.ApplicationArguments;
 
             base.Configure(command);
 
@@ -195,6 +198,12 @@ namespace Microsoft.EntityFrameworkCore.Tools
             {
                 args.Add("--root-namespace");
                 args.Add(project.RootNamespace);
+            }
+
+            if (_applicationArgs.Any())
+            {
+                args.Add("--");
+                args.AddRange(_applicationArgs);
             }
 
             return Exe.Run(executable, args, startupProject.ProjectDir);

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -22,6 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
 
         public override void Configure(CommandLineApplication command)
         {
+            command.AllowArgumentSeparator = true;
+
             _assembly = command.Option("-a|--assembly <PATH>", Resources.AssemblyDescription);
             _startupAssembly = command.Option("-s|--startup-assembly <PATH>", Resources.StartupAssemblyDescription);
             _dataDir = command.Option("--data-dir <PATH>", Resources.DataDirDescription);

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
 
 namespace Microsoft.EntityFrameworkCore.Tools
@@ -51,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             Reporter.WriteVerbose(Resources.UsingWorkingDirectory(Directory.GetCurrentDirectory()));
             Reporter.WriteVerbose(Resources.UsingRootNamespace(RootNamespace));
             Reporter.WriteVerbose(Resources.UsingProjectDir(ProjectDirectory));
-            Reporter.WriteVerbose(Resources.RemainingArguments(string.Join(",", RemainingArguments)));
+            Reporter.WriteVerbose(Resources.RemainingArguments(string.Join(",", RemainingArguments.Select(s => "'" + s + "'"))));
         }
 
         public virtual void Dispose()

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -515,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("MigrationsNamespaceDescription");
 
         /// <summary>
-        ///     Remaining arguments: '{remainingArguments}'.
+        ///     Remaining arguments: {remainingArguments}.
         /// </summary>
         public static string RemainingArguments([CanBeNull] object remainingArguments)
             => string.Format(

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -343,7 +343,7 @@
     <value>Specify to override the namespace for the migration.</value>
   </data>
   <data name="RemainingArguments" xml:space="preserve">
-    <value>Remaining arguments: '{remainingArguments}'.</value>
+    <value>Remaining arguments: {remainingArguments}.</value>
   </data>
   <data name="SuppressOnConfiguringDescription" xml:space="preserve">
     <value>Suppress generation of the DbContext.OnConfiguring() method.</value>


### PR DESCRIPTION
Fixes #8332 
Re-enable errors if unexpected arguments are detected. Use `--` for command line to indicate arguments to be passed to the application. And `-Args` in Powershell for the same thing. 
