### PR TITLE
[release/3.1] Tools: Fix up App.config path on .NET Framework

### DIFF
--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -7,6 +7,10 @@ using System.Reflection;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.EntityFrameworkCore.Tools.Properties;
 
+#if NET461
+using System.Configuration;
+#endif
+
 namespace Microsoft.EntityFrameworkCore.Tools.Commands
 {
     internal abstract class ProjectCommandBase : EFCommandBase
@@ -60,6 +64,27 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 }
                 catch (MissingMethodException) // NB: Thrown with EF Core 3.1
                 {
+                    var configurationFile = (_startupAssembly.Value() ?? _assembly.Value()) + ".config";
+                    if (File.Exists(configurationFile))
+                    {
+                        AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", configurationFile);
+                        try
+                        {
+                            typeof(ConfigurationManager)
+                                .GetField("s_initState", BindingFlags.Static | BindingFlags.NonPublic)
+                                .SetValue(null, 0);
+                            typeof(ConfigurationManager)
+                                .GetField("s_configSystem", BindingFlags.Static | BindingFlags.NonPublic)
+                                .SetValue(null, null);
+                            typeof(ConfigurationManager).Assembly
+                                .GetType("System.Configuration.ClientConfigPaths")
+                                .GetField("s_current", BindingFlags.Static | BindingFlags.NonPublic)
+                                .SetValue(null, null);
+                        }
+                        catch
+                        {
+                        }
+                    }
                 }
 #elif !NETCOREAPP2_0
 #error target frameworks need to be updated.

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #19760

@ajcvickers Should we `Servicing-consider` this?

### Description

For EF Core 2.x projects, we use `AppDomainSetup.ConfigurationFile` to specify which *.config file to use at design time.

In EF Core 3.0, we removed support for .NET Framework and simplified some design-time hooks since we no longer needed to support our AppDomain strategy for invoking user code.

In EF Core 3.1, we re-added support for .NET Framework but not our AppDomain strategy. Instead, we use a Reflection strategy to invoke user code. There is no API for specifying the *.config file without creating a new AppDomain. (see https://github.com/dotnet/runtime/issues/931)

### Customer Impact

APIs used to read the connection string from the *.config file (like `ConfigurationManager`) stopped working at design-time after upgrading to EF Core 3.1. For example, the Migrations command `Update-Database` started throwing NullReferenceException.

### How found

We discussed this limitation as a team prior to releasing EF Core 3.1 and decided it was acceptable given that most EF Core users on .NET Framework were creating ASP.NET Core applications and, thus, using `Microsoft.Extensions.Configuration` and not `System.Configuration`.

Since releasing, several users have hit this limitation and filed issues requesting that we fix it.

### Test coverage

Manually verified. Automated testing in this area has been very flakey in the past proving to not be very useful.

### Regression?

Yes, from EF Core 2.2 to 3.1. EF Core 3.0 did not support .NET Framework.

### Risk

Very low. If the added code fails (e.g. on Mono) execution continues with the same behavior that exists today.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


