### PR TITLE
Correcting order of param definitions

### DIFF
--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -86,8 +86,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     Configures the relationships to the entity types participating in the many-to-many relationship.
         /// </summary>
         /// <param name="joinEntity"> The type of the join entity. </param>
-        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <returns> The builder for the association type. </returns>
         public virtual EntityTypeBuilder UsingEntity(
             [NotNull] Type joinEntity,
@@ -109,8 +109,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     Configures the relationships to the entity types participating in the many-to-many relationship.
         /// </summary>
         /// <param name="joinEntity"> The type of the join entity. </param>
-        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureAssociation"> The configuration of the association type. </param>
         /// <returns> The builder for the originating entity type so that multiple configuration calls can be chained. </returns>
         public virtual EntityTypeBuilder UsingEntity(

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -41,8 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures the relationships to the entity types participating in the many-to-many relationship.
         /// </summary>
-        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <typeparam name="TAssociationEntity"> The type of the association entity. </typeparam>
         /// <returns> The builder for the association type. </returns>
         public virtual EntityTypeBuilder<TAssociationEntity> UsingEntity<TAssociationEntity>(
@@ -64,8 +64,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures the relationships to the entity types participating in the many-to-many relationship.
         /// </summary>
-        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureRight"> The configuration for the relationship to the right entity type. </param>
+        /// <param name="configureLeft"> The configuration for the relationship to the left entity type. </param>
         /// <param name="configureAssociation"> The configuration of the association type. </param>
         /// <typeparam name="TAssociationEntity"> The type of the association entity. </typeparam>
         /// <returns> The builder for the originating entity type so that multiple configuration calls can be chained. </returns>


### PR DESCRIPTION
Very small part of #10508 

Elsewhere in the code we keep the order of the parameter definitions in the XML comments the same as the order of the parameters. This is some very small updates to fix that for the `CollectionCollectionBuilder` classes.