### PR TITLE
Refactor annotation code generation

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddSingleton<IMigrationsCodeGeneratorSelector, MigrationsCodeGeneratorSelector>()
                 .AddSingleton<IModelCodeGenerator, CSharpModelGenerator>()
                 .AddSingleton<IModelCodeGeneratorSelector, ModelCodeGeneratorSelector>()
+                .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<INamedConnectionStringResolver>(
                     new DesignTimeConnectionStringResolver(applicationServiceProviderAccessor))
                 .AddSingleton(reporter)

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
@@ -50,12 +50,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         [EntityFrameworkInternal]
         public CSharpSnapshotGeneratorDependencies(
             [NotNull] ICSharpHelper csharpHelper,
-            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource,
+            [NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
         {
             Check.NotNull(csharpHelper, nameof(csharpHelper));
 
             CSharpHelper = csharpHelper;
             RelationalTypeMappingSource = relationalTypeMappingSource;
+            AnnotationCodeGenerator = annotationCodeGenerator;
         }
 
         /// <summary>
@@ -69,12 +71,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
 
         /// <summary>
+        ///     The annotation code generator.
+        /// </summary>
+        public IAnnotationCodeGenerator AnnotationCodeGenerator { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="csharpHelper"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CSharpSnapshotGeneratorDependencies With([NotNull] ICSharpHelper csharpHelper)
-            => new CSharpSnapshotGeneratorDependencies(csharpHelper, RelationalTypeMappingSource);
+            => new CSharpSnapshotGeneratorDependencies(csharpHelper, RelationalTypeMappingSource, AnnotationCodeGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -82,6 +89,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="relationalTypeMappingSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CSharpSnapshotGeneratorDependencies With([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
-            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, relationalTypeMappingSource);
+            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, relationalTypeMappingSource, AnnotationCodeGenerator);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="annotationCodeGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public CSharpSnapshotGeneratorDependencies With([NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
+            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, RelationalTypeMappingSource, annotationCodeGenerator);
     }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -216,53 +216,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         private IEnumerable<string> GetAnnotationNamespaces(IEnumerable<IAnnotatable> items)
-        {
-            var ignoredAnnotations = new List<string>
-            {
-                CoreAnnotationNames.NavigationCandidates,
-                CoreAnnotationNames.AmbiguousNavigations,
-                CoreAnnotationNames.InverseNavigations,
-                ChangeDetector.SkipDetectChangesAnnotation,
-                CoreAnnotationNames.OwnedTypes,
-                CoreAnnotationNames.ChangeTrackingStrategy,
-                CoreAnnotationNames.BeforeSaveBehavior,
-                CoreAnnotationNames.AfterSaveBehavior,
-                CoreAnnotationNames.TypeMapping,
-                CoreAnnotationNames.ValueComparer,
-#pragma warning disable 618
-                CoreAnnotationNames.KeyValueComparer,
-                CoreAnnotationNames.StructuralValueComparer,
-#pragma warning restore 618
-                CoreAnnotationNames.ConstructorBinding,
-                CoreAnnotationNames.NavigationAccessMode,
-                CoreAnnotationNames.PropertyAccessMode,
-                CoreAnnotationNames.ProviderClrType,
-                CoreAnnotationNames.ValueConverter,
-                CoreAnnotationNames.ValueGeneratorFactory,
-                CoreAnnotationNames.DefiningQuery,
-                CoreAnnotationNames.QueryFilter,
-                RelationalAnnotationNames.RelationalModel,
-                RelationalAnnotationNames.CheckConstraints,
-                RelationalAnnotationNames.Sequences,
-                RelationalAnnotationNames.DbFunctions,
-                RelationalAnnotationNames.TableMappings,
-                RelationalAnnotationNames.TableColumnMappings,
-                RelationalAnnotationNames.ViewMappings,
-                RelationalAnnotationNames.ViewColumnMappings,
-                RelationalAnnotationNames.ForeignKeyMappings,
-                RelationalAnnotationNames.TableIndexMappings,
-                RelationalAnnotationNames.UniqueConstraintMappings,
-                RelationalAnnotationNames.RelationalOverrides
-            };
-
-            return items.SelectMany(
-                i => i.GetAnnotations().Select(
-                        a => new { Annotatable = i, Annotation = a })
-                    .Where(
-                        a => a.Annotation.Value != null
-                             && !ignoredAnnotations.Contains(a.Annotation.Name))
-                    .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces()));
-        }
+            => items.SelectMany(
+                    i => Dependencies.AnnotationCodeGenerator.FilterIgnoredAnnotations(i.GetAnnotations())
+                        .Select(a => new { Annotatable = i, Annotation = a })
+                .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces()));
 
         private ValueConverter FindValueConverter(IProperty property)
             => (property.FindTypeMapping()
@@ -270,8 +227,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
         private Type GetProviderType(IAnnotatable annotatable, Type valueType)
             => annotatable is IProperty property
-               && valueType.UnwrapNullableType() == property.ClrType.UnwrapNullableType()
-                ? FindValueConverter(property)?.ProviderClrType ?? valueType
-                : valueType;
+                && valueType.UnwrapNullableType() == property.ClrType.UnwrapNullableType()
+                    ? FindValueConverter(property)?.ProviderClrType ?? valueType
+                    : valueType;
     }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGeneratorDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -46,9 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public MigrationsCodeGeneratorDependencies([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
+        public MigrationsCodeGeneratorDependencies(
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource,
+            [NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
         {
             RelationalTypeMappingSource = relationalTypeMappingSource;
+            AnnotationCodeGenerator = annotationCodeGenerator;
         }
 
         /// <summary>
@@ -57,11 +61,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
 
         /// <summary>
+        ///     The annotation code generator.
+        /// </summary>
+        public IAnnotationCodeGenerator AnnotationCodeGenerator { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="relationalTypeMappingSource"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public MigrationsCodeGeneratorDependencies With([NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
-            => new MigrationsCodeGeneratorDependencies(relationalTypeMappingSource);
+            => new MigrationsCodeGeneratorDependencies(relationalTypeMappingSource, AnnotationCodeGenerator);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="annotationCodeGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public MigrationsCodeGeneratorDependencies With([NotNull] IAnnotationCodeGenerator annotationCodeGenerator)
+            => new MigrationsCodeGeneratorDependencies(RelationalTypeMappingSource, annotationCodeGenerator);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -27,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     /// </summary>
     public class CSharpEntityTypeGenerator : ICSharpEntityTypeGenerator
     {
+        private readonly IAnnotationCodeGenerator _annotationCodeGenerator;
         private readonly ICSharpHelper _code;
 
         private IndentedStringBuilder _sb = null!;
@@ -39,10 +40,12 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public CSharpEntityTypeGenerator(
+            [NotNull] IAnnotationCodeGenerator annotationCodeGenerator,
             [NotNull] ICSharpHelper cSharpHelper)
         {
             Check.NotNull(cSharpHelper, nameof(cSharpHelper));
 
+            _annotationCodeGenerator = annotationCodeGenerator;
             _code = cSharpHelper;
         }
 
@@ -102,8 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GenerateClass(
-            [NotNull] IEntityType entityType)
+        protected virtual void GenerateClass([NotNull] IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -132,14 +134,27 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GenerateEntityTypeDataAnnotations(
-            [NotNull] IEntityType entityType)
+        protected virtual void GenerateEntityTypeDataAnnotations([NotNull] IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
             GenerateKeylessAttribute(entityType);
             GenerateTableAttribute(entityType);
             GenerateIndexAttributes(entityType);
+
+            var annotations = _annotationCodeGenerator
+                .FilterIgnoredAnnotations(entityType.GetAnnotations())
+                .ToDictionary(a => a.Name, a => a);
+            _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(entityType, annotations);
+
+            foreach (var attribute in _annotationCodeGenerator.GenerateDataAnnotationAttributes(entityType, annotations))
+            {
+                var attributeWriter = new AttributeWriter(attribute.Type.Name);
+                foreach (var argument in attribute.Arguments)
+                {
+                    attributeWriter.AddParameter(_code.UnknownLiteral(argument));
+                }
+            }
         }
 
         private void GenerateKeylessAttribute(IEntityType entityType)
@@ -181,10 +196,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             foreach (var index in entityType.GetIndexes().Where(i =>
                 ConfigurationSource.Convention != ((IConventionIndex)i).GetConfigurationSource()))
             {
-                // If there are annotations that cannot be represented
-                // using an IndexAttribute then use fluent API instead.
-                if (!index.GetAnnotations().Any(
-                        a => !CSharpModelGenerator.IgnoredIndexAnnotations.Contains(a.Name)))
+                // If there are annotations that cannot be represented using an IndexAttribute then use fluent API instead.
+                var annotations = _annotationCodeGenerator
+                    .FilterIgnoredAnnotations(index.GetAnnotations())
+                    .ToDictionary(a => a.Name, a => a);
+                _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(index, annotations);
+
+                if (annotations.Count == 0)
                 {
                     var indexAttribute = new AttributeWriter(nameof(IndexAttribute));
                     foreach (var property in index.Properties)
@@ -213,8 +231,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GenerateConstructor(
-            [NotNull] IEntityType entityType)
+        protected virtual void GenerateConstructor([NotNull] IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -244,8 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GenerateProperties(
-            [NotNull] IEntityType entityType)
+        protected virtual void GenerateProperties([NotNull] IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -266,15 +282,27 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GeneratePropertyDataAnnotations(
-            [NotNull] IProperty property)
+        protected virtual void GeneratePropertyDataAnnotations([NotNull] IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
             GenerateKeyAttribute(property);
             GenerateRequiredAttribute(property);
             GenerateColumnAttribute(property);
-            GenerateMaxLengthAttribute(property);
+
+            var annotations = _annotationCodeGenerator
+                .FilterIgnoredAnnotations(property.GetAnnotations())
+                .ToDictionary(a => a.Name, a => a);
+            _annotationCodeGenerator.RemoveAnnotationsHandledByConventions(property, annotations);
+
+            foreach (var attribute in _annotationCodeGenerator.GenerateDataAnnotationAttributes(property, annotations))
+            {
+                var attributeWriter = new AttributeWriter(attribute.Type.Name);
+                foreach (var argument in attribute.Arguments)
+                {
+                    attributeWriter.AddParameter(_code.UnknownLiteral(argument));
+                }
+            }
         }
 
         private void GenerateKeyAttribute(IProperty property)
@@ -312,23 +340,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GenerateMaxLengthAttribute(IProperty property)
-        {
-            var maxLength = property.GetMaxLength();
-
-            if (maxLength.HasValue)
-            {
-                var lengthAttribute = new AttributeWriter(
-                    property.ClrType == typeof(string)
-                        ? nameof(StringLengthAttribute)
-                        : nameof(MaxLengthAttribute));
-
-                lengthAttribute.AddParameter(_code.Literal(maxLength.Value));
-
-                _sb.AppendLine(lengthAttribute.ToString());
-            }
-        }
-
         private void GenerateRequiredAttribute(IProperty property)
         {
             if (!property.IsNullable
@@ -345,8 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual void GenerateNavigationProperties(
-            [NotNull] IEntityType entityType)
+        protected virtual void GenerateNavigationProperties([NotNull] IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -129,11 +129,5 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             return resultingFiles;
         }
-
-        /// <summary>
-        /// The set of annotations ignored for the purposes of code generation for indexes.
-        /// </summary>
-        public static IReadOnlyList<string> IgnoredIndexAnnotations
-            => new List<string> { RelationalAnnotationNames.TableIndexMappings };
     }
 }

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -1,10 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
+
+#pragma warning disable EF1001 // Accessing annotation names (internal)
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
@@ -20,6 +27,22 @@ namespace Microsoft.EntityFrameworkCore.Design
     /// </summary>
     public class AnnotationCodeGenerator : IAnnotationCodeGenerator
     {
+        private static readonly ISet<string> _ignoredRelationalAnnotations = new HashSet<string>
+        {
+            RelationalAnnotationNames.RelationalModel,
+            RelationalAnnotationNames.CheckConstraints,
+            RelationalAnnotationNames.Sequences,
+            RelationalAnnotationNames.DbFunctions,
+            RelationalAnnotationNames.TableMappings,
+            RelationalAnnotationNames.TableColumnMappings,
+            RelationalAnnotationNames.ViewMappings,
+            RelationalAnnotationNames.ViewColumnMappings,
+            RelationalAnnotationNames.ForeignKeyMappings,
+            RelationalAnnotationNames.TableIndexMappings,
+            RelationalAnnotationNames.UniqueConstraintMappings,
+            RelationalAnnotationNames.RelationalOverrides
+        };
+
         /// <summary>
         ///     Initializes a new instance of this class.
         /// </summary>
@@ -36,13 +59,235 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// </summary>
         protected virtual AnnotationCodeGeneratorDependencies Dependencies { get; }
 
+        /// <inheritdoc />
+        public virtual IEnumerable<IAnnotation> FilterIgnoredAnnotations(IEnumerable<IAnnotation> annotations)
+            => annotations.Where(
+                a => !(
+                    a.Value is null
+                    || CoreAnnotationNames.AllNames.Contains(a.Name)
+                    || _ignoredRelationalAnnotations.Contains(a.Name)));
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(IModel model, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(model, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(entityType, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var columnName = property.GetColumnName();
+
+            if (columnName == property.Name)
+            {
+                annotations.Remove(RelationalAnnotationNames.ColumnName);
+            }
+
+            if (annotations.TryGetValue(RelationalAnnotationNames.ViewColumnName, out var viewColumnNameAnnotation)
+                && viewColumnNameAnnotation.Value is string viewColumnName
+                && viewColumnName != columnName)
+            {
+                annotations.Remove(RelationalAnnotationNames.ViewColumnName);
+            }
+
+            RemoveConventionalAnnotationsHelper(property, annotations, IsHandledByConvention);
+        }
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(IKey key, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(key, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(
+            IForeignKey foreignKey, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(foreignKey, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual void RemoveAnnotationsHandledByConventions(IIndex index, IDictionary<string, IAnnotation> annotations)
+            => RemoveConventionalAnnotationsHelper(index, annotations, IsHandledByConvention);
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IModel model, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema),
+                methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(model, annotations, GenerateFluentApi));
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Comment, nameof(RelationalEntityTypeBuilderExtensions.HasComment), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.ViewColumnName, nameof(RelationalPropertyBuilderExtensions.HasViewColumnName),
+                methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.DefaultValueSql, nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
+                methodCallCodeFragments);
+
+            if (TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnSql, out object computedColumnSql))
+            {
+                methodCallCodeFragments.Add(
+                    TryGetAndRemove(annotations, RelationalAnnotationNames.IsStored, out bool isStored)
+                        ? new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
+                            computedColumnSql,
+                            isStored)
+                        : new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
+                            computedColumnSql));
+            }
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.IsFixedLength, nameof(RelationalPropertyBuilderExtensions.IsFixedLength),
+                methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Comment, nameof(RelationalPropertyBuilderExtensions.HasComment), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Collation, nameof(RelationalPropertyBuilderExtensions.UseCollation), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(property, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IKey key, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalKeyBuilderExtensions.HasName), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(key, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IForeignKey foreignKey, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalForeignKeyBuilderExtensions.HasConstraintName), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(foreignKey, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            IIndex index, IDictionary<string, IAnnotation> annotations)
+        {
+            var methodCallCodeFragments = new List<MethodCallCodeFragment>();
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Name, nameof(RelationalIndexBuilderExtensions.HasDatabaseName), methodCallCodeFragments);
+
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Filter, nameof(RelationalIndexBuilderExtensions.HasFilter), methodCallCodeFragments);
+
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(index, annotations, GenerateFluentApi));
+
+            return methodCallCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            IEntityType entityType, IDictionary<string, IAnnotation> annotations)
+        {
+            var attributeCodeFragments = new List<AttributeCodeFragment>();
+
+            attributeCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateDataAnnotation));
+
+            return attributeCodeFragments;
+        }
+
+        /// <inheritdoc />
+        public virtual IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            IProperty property, IDictionary<string, IAnnotation> annotations)
+        {
+            var attributeCodeFragments = new List<AttributeCodeFragment>();
+
+            if (TryGetAndRemove(annotations, CoreAnnotationNames.MaxLength, out int maxLength))
+            {
+                attributeCodeFragments.Add(
+                    new AttributeCodeFragment(
+                        property.ClrType == typeof(string)
+                            ? typeof(StringLengthAttribute)
+                            : typeof(MaxLengthAttribute),
+                        maxLength));
+            }
+
+            attributeCodeFragments.AddRange(GenerateFluentApiCallsHelper(property, annotations, GenerateDataAnnotation));
+
+            return attributeCodeFragments;
+        }
+
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="model" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="model"> The <see cref="IModel" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IModel model, IAnnotation annotation)
+        /// <returns>
+        ///     <see langword="true"/> if the annotation is handled by convention;
+        ///     <see langword="false"/> if code must be generated.
+        /// </returns>
+        protected virtual bool IsHandledByConvention([NotNull] IModel model, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
@@ -51,12 +296,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="entityType" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="entityType"> The <see cref="IEntityType" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IEntityType entityType, IAnnotation annotation)
+        protected virtual bool IsHandledByConvention([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(annotation, nameof(annotation));
@@ -65,12 +316,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="key" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="key"> The <see cref="IKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IKey key, IAnnotation annotation)
+        protected virtual bool IsHandledByConvention([NotNull] IKey key, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(key, nameof(key));
             Check.NotNull(annotation, nameof(annotation));
@@ -79,12 +336,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="property" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="property"> The <see cref="IProperty" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IProperty property, IAnnotation annotation)
+        protected virtual bool IsHandledByConvention([NotNull] IProperty property, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
@@ -93,12 +356,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="foreignKey" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IForeignKey foreignKey, IAnnotation annotation)
+        protected virtual bool IsHandledByConvention([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(annotation, nameof(annotation));
@@ -107,12 +376,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="false" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Checks if the given <paramref name="annotation" /> is handled by convention when
+        ///         applied to the given <paramref name="index" />.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="false" />.
+        ///     </para>
         /// </summary>
         /// <param name="index"> The <see cref="IIndex" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="false" />. </returns>
-        public virtual bool IsHandledByConvention(IIndex index, IAnnotation annotation)
+        protected virtual bool IsHandledByConvention([NotNull] IIndex index, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(index, nameof(index));
             Check.NotNull(annotation, nameof(annotation));
@@ -121,12 +396,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="model"> The <see cref="IModel" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IModel model, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IModel model, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
@@ -135,12 +416,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="entityType"> The <see cref="IEntityType" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IEntityType entityType, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(annotation, nameof(annotation));
@@ -149,12 +436,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="key"> The <see cref="IKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IKey key, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IKey key, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(key, nameof(key));
             Check.NotNull(annotation, nameof(annotation));
@@ -163,12 +456,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="property"> The <see cref="IProperty" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IProperty property, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IProperty property, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(property, nameof(property));
             Check.NotNull(annotation, nameof(annotation));
@@ -177,12 +476,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IForeignKey foreignKey, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(annotation, nameof(annotation));
@@ -191,17 +496,128 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Returns <see langword="null" /> unless overridden to do otherwise.
+        ///     <para>
+        ///         Returns a fluent API call for the given <paramref name="annotation" />, or <see langword="null" />
+        ///         if no fluent API call exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
         /// </summary>
         /// <param name="index"> The <see cref="IIndex" />. </param>
         /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
         /// <returns> <see langword="null" />. </returns>
-        public virtual MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
+        protected virtual MethodCallCodeFragment GenerateFluentApi([NotNull] IIndex index, [NotNull] IAnnotation annotation)
         {
             Check.NotNull(index, nameof(index));
             Check.NotNull(annotation, nameof(annotation));
 
             return null;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         Returns a data annotation attribute code fragment for the given <paramref name="annotation" />,
+        ///         or <see langword="null" /> if no data annotation exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
+        /// </summary>
+        /// <param name="entityType"> The <see cref="IEntityType" />. </param>
+        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
+        /// <returns> <see langword="null" />. </returns>
+        protected virtual AttributeCodeFragment GenerateDataAnnotation([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return null;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Returns a data annotation attribute code fragment for the given <paramref name="annotation" />,
+        ///         or <see langword="null" /> if no data annotation exists for it.
+        ///     </para>
+        ///     <para>
+        ///         The default implementation always returns <see langword="null" />.
+        ///     </para>
+        /// </summary>
+        /// <param name="property"> The <see cref="IProperty" />. </param>
+        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
+        /// <returns> <see langword="null" />. </returns>
+        protected virtual AttributeCodeFragment GenerateDataAnnotation([NotNull] IProperty property, [NotNull] IAnnotation annotation)
+        {
+            Check.NotNull(property, nameof(property));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return null;
+        }
+
+        private IEnumerable<TCodeFragment> GenerateFluentApiCallsHelper<TAnnotatable, TCodeFragment>(
+            TAnnotatable annotatable,
+            IDictionary<string, IAnnotation> annotations,
+            Func<TAnnotatable, IAnnotation, TCodeFragment> generateCodeFragment)
+        {
+            foreach (var (name, annotation) in EnumerateForRemoval(annotations))
+            {
+                var codeFragment = generateCodeFragment(annotatable, annotation);
+                if (codeFragment != null)
+                {
+                    yield return codeFragment;
+                    annotations.Remove(name);
+                }
+            }
+        }
+
+        private void RemoveConventionalAnnotationsHelper<TAnnotatable>(
+            TAnnotatable annotatable,
+            IDictionary<string, IAnnotation> annotations,
+            Func<TAnnotatable, IAnnotation, bool> isHandledByConvention)
+        {
+            foreach (var (name, annotation) in EnumerateForRemoval(annotations))
+            {
+                if (isHandledByConvention(annotatable, annotation))
+                {
+                    annotations.Remove(name);
+                }
+            }
+        }
+
+        private static bool TryGetAndRemove<T>(IDictionary<string, IAnnotation> annotations, string annotationName, out T annotationValue)
+        {
+            if (annotations.TryGetValue(annotationName, out var annotation)
+                && annotation.Value != null)
+            {
+                annotations.Remove(annotationName);
+                annotationValue = (T)annotation.Value;
+                return true;
+            }
+
+            annotationValue = default;
+            return false;
+        }
+
+        private static void GenerateSimpleFluentApiCall(
+            IDictionary<string, IAnnotation> annotations,
+            string annotationName,
+            string methodName,
+            List<MethodCallCodeFragment> methodCallCodeFragments)
+        {
+            if (annotations.TryGetValue(annotationName, out var annotation)
+                && annotation.Value is object annotationValue)
+            {
+                annotations.Remove(annotationName);
+                methodCallCodeFragments.Add(
+                    new MethodCallCodeFragment(methodName, annotationValue));
+            }
+        }
+
+        // Dictionary is safe for removal during enumeration
+        private static IEnumerable<KeyValuePair<string, IAnnotation>> EnumerateForRemoval(IDictionary<string, IAnnotation> annotations)
+            => annotations is Dictionary<string, IAnnotation>
+                ? (IEnumerable<KeyValuePair<string, IAnnotation>>)annotations
+                : annotations.ToList();
     }
 }

--- a/src/EFCore.Relational/Design/AnnotationCodeGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGeneratorDependencies.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
@@ -44,8 +47,17 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     </para>
         /// </summary>
         [EntityFrameworkInternal]
-        public AnnotationCodeGeneratorDependencies()
+        public AnnotationCodeGeneratorDependencies(
+            [NotNull] IRelationalTypeMappingSource relationalTypeMappingSource)
         {
+            Check.NotNull(relationalTypeMappingSource, nameof(relationalTypeMappingSource));
+
+            RelationalTypeMappingSource = relationalTypeMappingSource;
         }
+
+        /// <summary>
+        ///     The type mapper.
+        /// </summary>
+        public IRelationalTypeMappingSource RelationalTypeMappingSource { get; }
     }
 }

--- a/src/EFCore.Relational/Design/AttributeCodeFragment.cs
+++ b/src/EFCore.Relational/Design/AttributeCodeFragment.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    /// <summary>
+    ///     Represents usage of an attribute.
+    /// </summary>
+    public class AttributeCodeFragment
+    {
+        private readonly List<object> _arguments;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AttributeCodeFragment" /> class.
+        /// </summary>
+        /// <param name="type"> The attribute's CLR type. </param>
+        /// <param name="arguments"> The attribute's arguments. </param>
+        public AttributeCodeFragment([NotNull] Type type, [NotNull] params object[] arguments)
+        {
+            Check.NotNull(type, nameof(type));
+            Check.NotNull(arguments, nameof(arguments));
+
+            Type = type;
+            _arguments = new List<object>(arguments);
+        }
+
+        /// <summary>
+        ///     Gets or sets the attribute's type.
+        /// </summary>
+        /// <value> The attribute's type. </value>
+        public virtual Type Type { get; }
+
+        /// <summary>
+        ///     Gets the method call's arguments.
+        /// </summary>
+        /// <value> The method call's arguments. </value>
+        public virtual IReadOnlyList<object> Arguments => _arguments;
+    }
+}

--- a/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/IAnnotationCodeGenerator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -15,123 +17,138 @@ namespace Microsoft.EntityFrameworkCore.Design
     public interface IAnnotationCodeGenerator
     {
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IModel" />.
+        ///     Filters out annotations in <paramref name="annotations" /> for which code should never be generated.
         /// </summary>
-        /// <param name="model"> The <see cref="IModel" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IModel model, [NotNull] IAnnotation annotation);
+        /// <param name="annotations"> The annotations from which to filter the ignored ones. </param>
+        /// <returns> The filtered annotations. </returns>
+        IEnumerable<IAnnotation> FilterIgnoredAnnotations([NotNull] IEnumerable<IAnnotation> annotations);
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IEntityType" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="entityType"> The <see cref="IEntityType" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation);
+        /// <param name="model"> The model to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IModel model, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IKey" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="key"> The <see cref="IKey" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IKey key, [NotNull] IAnnotation annotation);
+        /// <param name="entity"> The entity to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IEntityType entity, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IProperty" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="property"> The <see cref="IProperty" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IProperty property, [NotNull] IAnnotation annotation);
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IForeignKey" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="foreignKey"> The <see cref="IForeignKey" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation);
+        /// <param name="key"> The key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IKey key, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Checks if the given <see cref="IAnnotation" /> is handled by convention when
-        ///     applied to the given <see cref="IIndex" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="index"> The <see cref="IIndex" />. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" />. </param>
-        /// <returns>
-        ///     <see langword="true"/> if the annotation is handled by convention;
-        ///     <see langword="false"/> if code must be generated.
-        /// </returns>
-        bool IsHandledByConvention([NotNull] IIndex index, [NotNull] IAnnotation annotation);
+        /// <param name="foreignKey"> The foreign key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IForeignKey foreignKey, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     Removes annotation whose configuration is already applied by convention, and do not need to be
+        ///     specified explicitly.
         /// </summary>
-        /// <param name="model"> The <see cref="IModel" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IModel model, [NotNull] IAnnotation annotation);
+        /// <param name="index"> The index to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to remove the conventional ones. </param>
+        void RemoveAnnotationsHandledByConventions([NotNull] IIndex index, [NotNull] IDictionary<string, IAnnotation> annotations) { }
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="entityType"> The <see cref="IEntityType" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IEntityType entityType, [NotNull] IAnnotation annotation);
+        /// <param name="model"> The model to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IModel model, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="key"> The <see cref="IKey" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IKey key, [NotNull] IAnnotation annotation);
+        /// <param name="entityType"> The entity type to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IEntityType entityType, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="property"> The <see cref="IProperty" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IProperty property, [NotNull] IAnnotation annotation);
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="foreignKey"> The <see cref="IForeignKey" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IForeignKey foreignKey, [NotNull] IAnnotation annotation);
+        /// <param name="key"> The key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IKey key, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
 
         /// <summary>
-        ///     Generates fluent API calls for the given <see cref="IAnnotation" />.
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
         /// </summary>
-        /// <param name="index"> The <see cref="IIndex" /> for which code should be generated. </param>
-        /// <param name="annotation"> The <see cref="IAnnotation" /> for which code should be generated.</param>
-        /// <returns> The generated code. </returns>
-        MethodCallCodeFragment GenerateFluentApi([NotNull] IIndex index, [NotNull] IAnnotation annotation);
+        /// <param name="foreignKey"> The foreign key to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IForeignKey foreignKey, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding fluent API calls, returns those fluent API calls
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="index"> The index to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
+            [NotNull] IIndex index, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<MethodCallCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding data annotation attributes, returns those attribute code fragments
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="entityType"> The entity type to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            [NotNull] IEntityType entityType, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<AttributeCodeFragment>();
+
+        /// <summary>
+        ///     For the given annotations which have corresponding data annotation attributes, returns those attribute code fragments
+        ///     and removes the annotations.
+        /// </summary>
+        /// <param name="property"> The property to which the annotations are applied. </param>
+        /// <param name="annotations"> The set of annotations from which to generate fluent API calls. </param>
+        IReadOnlyList<AttributeCodeFragment> GenerateDataAnnotationAttributes(
+            [NotNull] IProperty property, [NotNull] IDictionary<string, IAnnotation> annotations)
+            => Array.Empty<AttributeCodeFragment>();
     }
 }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -35,7 +38,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override bool IsHandledByConvention(IModel model, IAnnotation annotation)
+        public override IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(IModel model, IDictionary<string, IAnnotation> annotations)
+            => base.GenerateFluentApiCalls(model, annotations)
+                .Concat(GenerateValueGenerationStrategy(annotations, onModel: true))
+                .ToList();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(IProperty property, IDictionary<string, IAnnotation> annotations)
+            => base.GenerateFluentApiCalls(property, annotations)
+                .Concat(GenerateValueGenerationStrategy(annotations, onModel: false))
+                .ToList();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override bool IsHandledByConvention(IModel model, IAnnotation annotation)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
@@ -55,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override MethodCallCodeFragment GenerateFluentApi(IKey key, IAnnotation annotation)
+        protected override MethodCallCodeFragment GenerateFluentApi(IKey key, IAnnotation annotation)
             => annotation.Name == SqlServerAnnotationNames.Clustered
                 ? (bool)annotation.Value == false
                     ? new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.IsClustered), false)
@@ -68,26 +93,79 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
-        {
-            if (annotation.Name == SqlServerAnnotationNames.Clustered)
+        protected override MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
+            => annotation.Name switch
             {
-                return (bool)annotation.Value == false
+                SqlServerAnnotationNames.Clustered => (bool)annotation.Value == false
                     ? new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.IsClustered), false)
-                    : new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.IsClustered));
-            }
+                    : new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.IsClustered)),
 
-            if (annotation.Name == SqlServerAnnotationNames.Include)
+                SqlServerAnnotationNames.Include => new MethodCallCodeFragment(
+                    nameof(SqlServerIndexBuilderExtensions.IncludeProperties), annotation.Value),
+
+                SqlServerAnnotationNames.FillFactor => new MethodCallCodeFragment(
+                    nameof(SqlServerIndexBuilderExtensions.HasFillFactor), annotation.Value),
+
+                _ => null
+            };
+
+        private IReadOnlyList<MethodCallCodeFragment> GenerateValueGenerationStrategy(
+            IDictionary<string, IAnnotation> annotations, bool onModel)
+        {
+            var strategy = GetAndRemove<SqlServerValueGenerationStrategy>(SqlServerAnnotationNames.ValueGenerationStrategy);
+
+            switch (strategy)
             {
-                return new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.IncludeProperties), annotation.Value);
+                case SqlServerValueGenerationStrategy.IdentityColumn:
+                    var seed = GetAndRemove<int?>(SqlServerAnnotationNames.IdentitySeed);
+                    var increment = GetAndRemove<int?>(SqlServerAnnotationNames.IdentityIncrement);
+                    return new List<MethodCallCodeFragment>
+                    {
+                        new MethodCallCodeFragment(
+                            onModel
+                                ? nameof(SqlServerModelBuilderExtensions.UseIdentityColumns)
+                                : nameof(SqlServerPropertyBuilderExtensions.UseIdentityColumn),
+                            (seed, increment) switch
+                            {
+                                (null, null) => Array.Empty<object>(),
+                                (_, null) => new object[] { seed },
+                                _ => new object[] { seed, increment }
+                            })
+                    };
+
+                case SqlServerValueGenerationStrategy.SequenceHiLo:
+                    var name = GetAndRemove<string>(SqlServerAnnotationNames.HiLoSequenceName);
+                    var schema = GetAndRemove<string>(SqlServerAnnotationNames.HiLoSequenceSchema);
+                    return new List<MethodCallCodeFragment>
+                    {
+                        new MethodCallCodeFragment(
+                            nameof(SqlServerModelBuilderExtensions.UseHiLo),
+                            (name, schema) switch
+                            {
+                                (null, null) => Array.Empty<object>(),
+                                (_, null) => new object[] { name },
+                                _ => new object[] { name, schema }
+                            })
+                    };
+
+                case SqlServerValueGenerationStrategy.None:
+                    return Array.Empty<MethodCallCodeFragment>();
+
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
 
-            if (annotation.Name == SqlServerAnnotationNames.FillFactor)
-            { 
-                return new MethodCallCodeFragment(nameof(SqlServerIndexBuilderExtensions.HasFillFactor), annotation.Value);
-            }
+            T GetAndRemove<T>(string annotationName)
+            {
+                if (annotations.TryGetValue(annotationName, out var annotation)
+                    && annotation.Value != null)
+                {
+                    annotations.Remove(annotationName);
+                    return (T)annotation.Value;
+                }
 
-            return null;
+                return default;
+            }
         }
     }
 }

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -11,6 +11,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
@@ -219,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual void DetectChanges()
         {
-            if ((string)_model[Internal.ChangeDetector.SkipDetectChangesAnnotation] != "true")
+            if ((string)_model[CoreAnnotationNames.SkipDetectChangesAnnotation] != "true")
             {
                 ChangeDetector.DetectChanges(StateManager);
             }

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 var targetType = Metadata.TargetEntityType;
                 var context = InternalEntry.StateManager.Context;
                 var changeDetector = context.ChangeTracker.AutoDetectChangesEnabled
-                    && (string)context.Model[ChangeDetector.SkipDetectChangesAnnotation] != "true"
+                    && (string)context.Model[CoreAnnotationNames.SkipDetectChangesAnnotation] != "true"
                         ? context.GetDependencies().ChangeDetector
                         : null;
                 foreach (var entity in collection.OfType<object>().ToList())

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -99,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual void DetectChanges()
         {
-            if ((string)Context.Model[ChangeDetector.SkipDetectChangesAnnotation] != "true")
+            if ((string)Context.Model[CoreAnnotationNames.SkipDetectChangesAnnotation] != "true")
             {
                 Context.GetDependencies().ChangeDetector.DetectChanges(InternalEntry);
             }

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -31,15 +31,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
     {
         private readonly IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> _logger;
         private readonly ILoggingOptions _loggingOptions;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public const string SkipDetectChangesAnnotation = "ChangeDetector.SkipDetectChanges";
-
         private bool _suspended;
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
@@ -56,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 {
                     var context = InternalEntry.StateManager.Context;
                     if (context.ChangeTracker.AutoDetectChangesEnabled
-                        && (string)context.Model[ChangeDetector.SkipDetectChangesAnnotation] != "true")
+                        && (string)context.Model[CoreAnnotationNames.SkipDetectChangesAnnotation] != "true")
                     {
                         context.GetDependencies().ChangeDetector.DetectChanges(target);
                     }

--- a/src/EFCore/Metadata/Conventions/ChangeTrackingStrategyConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ChangeTrackingStrategyConvention.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -39,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
 
-            modelBuilder.HasAnnotation(ChangeDetector.SkipDetectChangesAnnotation, "true");
+            modelBuilder.HasAnnotation(CoreAnnotationNames.SkipDetectChangesAnnotation, "true");
         }
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -262,6 +262,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public const string SkipDetectChangesAnnotation = "ChangeDetector.SkipDetectChanges";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public const string SkipChangeTrackingStrategyValidationAnnotation = "ModelValidator.SkipChangeTrackingStrategyValidation";
 
         /// <summary>
@@ -304,6 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             AmbiguousNavigations,
             DuplicateServiceProperties,
             AmbiguousField,
+            SkipDetectChangesAnnotation,
             SkipChangeTrackingStrategyValidationAnnotation
         };
     }

--- a/src/EFCore/Update/Internal/UpdateAdapter.cs
+++ b/src/EFCore/Update/Internal/UpdateAdapter.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Update.Internal
 {
@@ -114,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         /// </summary>
         public virtual void DetectChanges()
         {
-            if ((string)_stateManager.Model[ChangeDetector.SkipDetectChangesAnnotation] != "true")
+            if ((string)_stateManager.Model[CoreAnnotationNames.SkipDetectChangesAnnotation] != "true")
             {
                 _changeDetector.DetectChanges(_stateManager);
             }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -16,6 +16,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -117,8 +118,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     RelationalAnnotationNames.Comment, ("My Comment",
                         _toTable
                         + _nl
-                        + "modelBuilder.HasComment"
-                        + @"(""My Comment"");"
+                        + "modelBuilder"
+                        + _nl
+                        + @"    .HasComment(""My Comment"");"
                         + _nl)
                 }
             };
@@ -171,9 +173,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             // Note that other tests should be added to check code is generated correctly
             var forProperty = new Dictionary<string, (object, string)>
             {
-                { CoreAnnotationNames.MaxLength, (256, $@"{columnMapping}{_nl}.{nameof(PropertyBuilder.HasMaxLength)}(256)") },
-                { CoreAnnotationNames.Precision, (4, $@"{columnMapping}{_nl}.{nameof(PropertyBuilder.HasPrecision)}(4)") },
-                { CoreAnnotationNames.Unicode, (false, $@"{columnMapping}{_nl}.{nameof(PropertyBuilder.IsUnicode)}(false)") },
+                { CoreAnnotationNames.MaxLength, (256, $@"{_nl}.{nameof(PropertyBuilder.HasMaxLength)}(256){columnMapping}") },
+                { CoreAnnotationNames.Precision, (4, $@"{_nl}.{nameof(PropertyBuilder.HasPrecision)}(4){columnMapping}") },
+                { CoreAnnotationNames.Unicode, (false, $@"{_nl}.{nameof(PropertyBuilder.IsUnicode)}(false){columnMapping}") },
                 {
                     CoreAnnotationNames.ValueConverter, (new ValueConverter<int, long>(v => v, v => (int)v),
                         $@"{_nl}.{nameof(RelationalPropertyBuilderExtensions.HasColumnType)}(""default_long_mapping"")")
@@ -184,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 },
                 {
                     RelationalAnnotationNames.ColumnName,
-                    ("MyColumn", $@"{_nl}.{nameof(RelationalPropertyBuilderExtensions.HasColumnName)}(""MyColumn""){columnMapping}")
+                    ("MyColumn", $@"{columnMapping}{_nl}.{nameof(RelationalPropertyBuilderExtensions.HasColumnName)}(""MyColumn"")")
                 },
                 {
                     RelationalAnnotationNames.ColumnType,
@@ -238,11 +240,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
 
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
+
             var codeHelper = new CSharpHelper(
                 sqlServerTypeMappingSource);
 
             var generator = new TestCSharpSnapshotGenerator(
-                new CSharpSnapshotGeneratorDependencies(codeHelper, sqlServerTypeMappingSource));
+                new CSharpSnapshotGeneratorDependencies(codeHelper, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator));
 
             var coreAnnotations = typeof(CoreAnnotationNames).GetFields().Where(f => f.FieldType == typeof(string)).ToList();
 
@@ -327,8 +332,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var codeHelper = new CSharpHelper(
                 sqlServerTypeMappingSource);
 
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
+
             var generator = new CSharpMigrationsGenerator(
-                new MigrationsCodeGeneratorDependencies(sqlServerTypeMappingSource),
+                new MigrationsCodeGeneratorDependencies(
+                    sqlServerTypeMappingSource,
+                    sqlServerAnnotationCodeGenerator),
                 new CSharpMigrationsGeneratorDependencies(
                     codeHelper,
                     new CSharpMigrationOperationGenerator(
@@ -336,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             codeHelper)),
                     new CSharpSnapshotGenerator(
                         new CSharpSnapshotGeneratorDependencies(
-                            codeHelper, sqlServerTypeMappingSource))));
+                            codeHelper, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))));
 
             var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
             modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
@@ -378,8 +388,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             var codeHelper = new CSharpHelper(sqlServerTypeMappingSource);
 
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
+
             var generator = new TestCSharpSnapshotGenerator(
-                new CSharpSnapshotGeneratorDependencies(codeHelper, sqlServerTypeMappingSource));
+                new CSharpSnapshotGeneratorDependencies(
+                    codeHelper, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator));
 
             var sb = new IndentedStringBuilder();
 

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -13,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -70,6 +72,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var sqlServerTypeMappingSource = new SqlServerTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
                 TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>());
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
             var code = new CSharpHelper(sqlServerTypeMappingSource);
             var reporter = new TestOperationReporter();
             var migrationAssembly
@@ -103,7 +107,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         new[]
                         {
                             new CSharpMigrationsGenerator(
-                                new MigrationsCodeGeneratorDependencies(sqlServerTypeMappingSource),
+                                new MigrationsCodeGeneratorDependencies(
+                                    sqlServerTypeMappingSource,
+                                    sqlServerAnnotationCodeGenerator),
                                 new CSharpMigrationsGeneratorDependencies(
                                     code,
                                     new CSharpMigrationOperationGenerator(
@@ -111,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                             code)),
                                     new CSharpSnapshotGenerator(
                                         new CSharpSnapshotGeneratorDependencies(
-                                            code, sqlServerTypeMappingSource))))
+                                            code, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))))
                         }),
                     historyRepository,
                     reporter,

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -16,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -278,15 +280,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 AddBoilerPlate(
                     @"
             modelBuilder
+                .UseIdentityColumns()
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
                 .HasAnnotation(""SqlServer:DatabaseMaxSize"", ""100 MB"")
                 .HasAnnotation(""SqlServer:PerformanceLevelSql"", ""'S0'"")
-                .HasAnnotation(""SqlServer:ServiceTierSql"", ""'basic'"")
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""SqlServer:ServiceTierSql"", ""'basic'"");"),
                 o =>
                 {
-                    Assert.Equal(7, o.GetAnnotations().Count());
+                    Assert.Equal(9, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                 });
         }
@@ -304,12 +306,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     @"
             modelBuilder
                 .HasDefaultSchema(""DefaultSchema"")
+                .UseIdentityColumns()
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
                 o =>
                 {
-                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(7, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                     Assert.Equal("DefaultSchema", o[RelationalAnnotationNames.DefaultSchema]);
                 });
@@ -332,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -344,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -383,7 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .HasColumnType(""nvarchar(max)"");
@@ -404,7 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
 
                     Assert.Equal("DerivedEntity",
                         o.FindEntityType("Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity").GetTableName());
@@ -444,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .IsCyclic();"),
                 o =>
                 {
-                    Assert.Equal(4, o.GetAnnotations().Count());
+                    Assert.Equal(6, o.GetAnnotations().Count());
                 });
         }
 
@@ -466,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -479,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
                 });
         }
 
@@ -501,7 +503,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -527,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
                 });
         }
 
@@ -552,13 +554,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
                     b.ToTable(""EntityWithOneProperty"");
 
-                    b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
                 });"),
                 o =>
                 {
@@ -584,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -652,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -712,7 +715,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -810,7 +813,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -848,7 +851,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -884,7 +887,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -925,7 +928,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -937,7 +940,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1060,7 +1063,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -1097,7 +1100,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -1129,7 +1132,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -1199,7 +1202,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
@@ -1230,7 +1233,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""AlternateId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<string>(""EntityWithStringKeyId"")
                                 .HasColumnType(""nvarchar(450)"");
@@ -1273,7 +1276,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<int?>(""EntityWithOnePropertyId"")
                                 .HasColumnType(""int"");
@@ -1376,7 +1379,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1390,7 +1393,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1404,7 +1407,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderDetailsOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1423,7 +1426,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1437,7 +1440,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderDetailsOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1456,7 +1459,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.Property<int>(""OrderId"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.HasKey(""OrderId"");
 
@@ -1470,7 +1473,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                     b2.Property<int>(""OrderInfoOrderId"")
                                         .ValueGeneratedOnAdd()
                                         .HasColumnType(""int"")
-                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                        .UseIdentityColumn();
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -1539,15 +1542,15 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1564,7 +1567,7 @@ namespace RootNamespace
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .UseIdentityColumn();
 
                             b1.Property<int>(""TestEnum"")
                                 .HasColumnType(""int"");
@@ -1641,8 +1644,8 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn()
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.HasKey(""Id"");
 
@@ -1669,7 +1672,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -1692,7 +1695,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -1722,7 +1725,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -1749,11 +1752,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
-                        .HasColumnType(""nvarchar(100)"")
-                        .HasMaxLength(100);
+                        .HasMaxLength(100)
+                        .HasColumnType(""nvarchar(100)"");
 
                     b.HasKey(""Id"");
 
@@ -1775,11 +1778,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
-                        .HasColumnType(""varchar(max)"")
-                        .IsUnicode(false);
+                        .IsUnicode(false)
+                        .HasColumnType(""varchar(max)"");
 
                     b.HasKey(""Id"");
 
@@ -1801,12 +1804,12 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
+                        .HasMaxLength(100)
                         .HasColumnType(""nchar(100)"")
-                        .IsFixedLength(true)
-                        .HasMaxLength(100);
+                        .IsFixedLength(true);
 
                     b.HasKey(""Id"");
 
@@ -1835,12 +1838,12 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
-                        .HasColumnType(""varchar(100)"")
                         .HasMaxLength(100)
                         .IsUnicode(false)
+                        .HasColumnType(""varchar(100)"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.HasKey(""Id"");
@@ -1873,7 +1876,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .IsConcurrencyToken()
@@ -1903,11 +1906,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
-                        .HasColumnName(""CName"")
-                        .HasColumnType(""int"");
+                        .HasColumnType(""int"")
+                        .HasColumnName(""CName"");
 
                     b.HasKey(""Id"");
 
@@ -1933,7 +1936,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""CType"");
@@ -1962,7 +1965,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -1993,7 +1996,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -2024,7 +2027,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -2051,7 +2054,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .ValueGeneratedOnAdd()
@@ -2085,7 +2088,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -2126,7 +2129,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long?>(""Day"")
                         .HasColumnType(""bigint"");
@@ -2152,7 +2155,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -2177,7 +2180,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Day"")
                         .HasColumnType(""nvarchar(max)"");
@@ -2207,11 +2210,11 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
-                        .HasColumnName(""CName"")
                         .HasColumnType(""int"")
+                        .HasColumnName(""CName"")
                         .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.HasKey(""Id"");
@@ -2254,14 +2257,14 @@ namespace RootNamespace
                 AddBoilerPlate(
                     @"
             modelBuilder
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns();
 
             modelBuilder.Entity(""Building"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -2296,7 +2299,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2329,7 +2332,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2363,7 +2366,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2407,7 +2410,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2439,7 +2442,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2473,7 +2476,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2511,7 +2514,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2546,7 +2549,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2588,7 +2591,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
@@ -2618,7 +2621,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2661,7 +2664,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2709,7 +2712,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2769,7 +2772,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -2781,7 +2784,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2838,7 +2841,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -2892,7 +2895,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(450)"");
@@ -2943,7 +2946,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -2994,7 +2997,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3048,7 +3051,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -3116,7 +3119,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3128,7 +3131,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3175,7 +3178,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3187,7 +3190,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3237,7 +3240,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -3260,7 +3263,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.HasKey(""Id"");
 
@@ -3313,7 +3316,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3371,7 +3374,7 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3563,15 +3566,15 @@ namespace RootNamespace
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithManyProperties"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .UseIdentityColumn();
 
                     b.Property<bool>(""Boolean"")
                         .HasColumnType(""bit"");
@@ -3908,8 +3911,8 @@ namespace RootNamespace
 
         protected virtual string GetHeading(bool empty = false) => @"
             modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"
             + (empty
                 ? null
                 : @"
@@ -3974,11 +3977,17 @@ namespace RootNamespace
                     {
                         new SqlServerNetTopologySuiteTypeMappingSourcePlugin(NtsGeometryServices.Instance)
                     }));
+
             var codeHelper = new CSharpHelper(
                 sqlServerTypeMappingSource);
 
+            var sqlServerAnnotationCodeGenerator = new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(sqlServerTypeMappingSource));
+
             var generator = new CSharpMigrationsGenerator(
-                new MigrationsCodeGeneratorDependencies(sqlServerTypeMappingSource),
+                new MigrationsCodeGeneratorDependencies(
+                    sqlServerTypeMappingSource,
+                    sqlServerAnnotationCodeGenerator),
                 new CSharpMigrationsGeneratorDependencies(
                     codeHelper,
                     new CSharpMigrationOperationGenerator(
@@ -3986,7 +3995,7 @@ namespace RootNamespace
                             codeHelper)),
                     new CSharpSnapshotGenerator(
                         new CSharpSnapshotGeneratorDependencies(
-                            codeHelper, sqlServerTypeMappingSource))));
+                            codeHelper, sqlServerTypeMappingSource, sqlServerAnnotationCodeGenerator))));
 
             var code = generator.GenerateSnapshot("RootNamespace", typeof(DbContext), "Snapshot", model);
             Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -247,20 +247,20 @@ namespace TestNamespace
         }
 
         [ConditionalFact]
-        public void ModelInDiferentNamespaceDbContext_works()
+        public void ModelInDifferentNamespaceDbContext_works()
         {
             var modelGenerationOptions = new ModelCodeGenerationOptions
             {
                 ContextNamespace = "TestNamespace", ModelNamespace = "AnotherNamespaceOfModel"
             };
 
-            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+            const string entityInAnotherNamespaceTypeName = "EntityInAnotherNamespace";
 
             Test(
-                modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                modelBuilder => modelBuilder.Entity(entityInAnotherNamespaceTypeName)
                 , modelGenerationOptions
                 , code => Assert.Contains(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
-                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnotherNamespaceTypeName)))
             );
         }
 
@@ -269,13 +269,13 @@ namespace TestNamespace
         {
             var modelGenerationOptions = new ModelCodeGenerationOptions { ContextNamespace = "TestNamespace" };
 
-            const string entityInAnoterNamespaceTypeName = "EntityInAnotherNamespace";
+            const string entityInAnotherNamespaceTypeName = "EntityInAnotherNamespace";
 
             Test(
-                modelBuilder => modelBuilder.Entity(entityInAnoterNamespaceTypeName)
+                modelBuilder => modelBuilder.Entity(entityInAnotherNamespaceTypeName)
                 , modelGenerationOptions
                 , code => Assert.DoesNotContain(string.Concat("using ", modelGenerationOptions.ModelNamespace, ";"), code.ContextFile.Code)
-                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnoterNamespaceTypeName)))
+                , model => Assert.NotNull(model.FindEntityType(string.Concat(modelGenerationOptions.ModelNamespace, ".", entityInAnotherNamespaceTypeName)))
             );
         }
 
@@ -422,7 +422,7 @@ namespace TestNamespace
                     .HasFilter(""Filter SQL"")
                     .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                entity.Property(e => e.Id).HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                entity.Property(e => e.Id).UseIdentityColumn();
             });
 
             OnModelCreatingPartial(modelBuilder);
@@ -503,7 +503,7 @@ namespace TestNamespace
                     .HasFilter(""Filter SQL"")
                     .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-                entity.Property(e => e.Id).HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                entity.Property(e => e.Id).UseIdentityColumn();
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Design/Internal/SqlServerAnnotationCodeGeneratorTest.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Design.Internal
@@ -14,7 +20,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IKey_works_when_clustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
+
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -24,9 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     x.HasKey("Id").IsClustered();
                 });
             var key = modelBuilder.Model.FindEntityType("Post").GetKeys().Single();
-            var annotation = key.FindAnnotation(SqlServerAnnotationNames.Clustered);
 
-            var result = generator.GenerateFluentApi(key, annotation);
+            var result = generator.GenerateFluentApiCalls(key, key.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("IsClustered", result.Method);
 
@@ -36,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IKey_works_when_nonclustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -46,9 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     x.HasKey("Id").IsClustered(false);
                 });
             var key = modelBuilder.Model.FindEntityType("Post").GetKeys().Single();
-            var annotation = key.FindAnnotation(SqlServerAnnotationNames.Clustered);
 
-            var result = generator.GenerateFluentApi(key, annotation);
+            var result = generator.GenerateFluentApiCalls(key, key.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("IsClustered", result.Method);
 
@@ -59,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_when_clustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -70,9 +77,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     x.HasIndex("Name").IsClustered();
                 });
             var index = modelBuilder.Model.FindEntityType("Post").GetIndexes().Single();
-            var annotation = index.FindAnnotation(SqlServerAnnotationNames.Clustered);
 
-            var result = generator.GenerateFluentApi(index, annotation);
+            var result = generator.GenerateFluentApiCalls(index, index.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("IsClustered", result.Method);
 
@@ -82,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_when_nonclustered()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -93,9 +100,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     x.HasIndex("Name").IsClustered(false);
                 });
             var index = modelBuilder.Model.FindEntityType("Post").GetIndexes().Single();
-            var annotation = index.FindAnnotation(SqlServerAnnotationNames.Clustered);
 
-            var result = generator.GenerateFluentApi(index, annotation);
+            var result = generator.GenerateFluentApiCalls(index, index.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("IsClustered", result.Method);
 
@@ -106,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_with_fillfactor()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -118,8 +125,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 });
 
             var index = modelBuilder.Model.FindEntityType("Post").GetIndexes().Single();
-            var annotation = index.FindAnnotation(SqlServerAnnotationNames.FillFactor); 
-            var result = generator.GenerateFluentApi(index, annotation);
+            var result = generator.GenerateFluentApiCalls(index, index.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("HasFillFactor", result.Method);
             Assert.Equal(1, result.Arguments.Count);
@@ -129,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void GenerateFluentApi_IIndex_works_with_includes()
         {
-            var generator = new SqlServerAnnotationCodeGenerator(new AnnotationCodeGeneratorDependencies());
+            var generator = CreateGenerator();
             var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
             modelBuilder.Entity(
                 "Post",
@@ -141,9 +148,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     x.HasIndex("LastName").IncludeProperties("FirstName");
                 });
             var index = modelBuilder.Model.FindEntityType("Post").GetIndexes().Single();
-            var annotation = index.FindAnnotation(SqlServerAnnotationNames.Include);
 
-            var result = generator.GenerateFluentApi(index, annotation);
+            var result = generator.GenerateFluentApiCalls(index, index.GetAnnotations().ToDictionary(a => a.Name, a => a))
+                .Single();
 
             Assert.Equal("IncludeProperties", result.Method);
 
@@ -151,5 +158,86 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var properties = Assert.IsType<string[]>(result.Arguments[0]);
             Assert.Equal(new[] { "FirstName" }, properties.AsEnumerable());
         }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IModel_works_with_identity()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.UseIdentityColumns(seed: 5, increment: 10);
+
+            var annotations = modelBuilder.Model.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(modelBuilder.Model, annotations).Single();
+
+            Assert.Equal("UseIdentityColumns", result.Method);
+
+            Assert.Collection(result.Arguments,
+                seed => Assert.Equal(5, seed),
+                increment => Assert.Equal(10, increment));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IProperty_works_with_identity()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.Entity("Post", x => x.Property<int>("Id").UseIdentityColumn(5, 10));
+            var property = modelBuilder.Model.FindEntityType("Post").FindProperty("Id");
+
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(property, annotations).Single();
+
+            Assert.Equal("UseIdentityColumn", result.Method);
+
+            Assert.Collection(result.Arguments,
+                seed => Assert.Equal(5, seed),
+                increment => Assert.Equal(10, increment));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IModel_works_with_HiLo()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.UseHiLo("HiLoIndexName", "HiLoIndexSchema");
+
+            var annotations = modelBuilder.Model.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(modelBuilder.Model, annotations).Single();
+
+            Assert.Equal("UseHiLo", result.Method);
+
+            Assert.Collection(result.Arguments,
+                name => Assert.Equal("HiLoIndexName", name),
+                schema => Assert.Equal("HiLoIndexSchema", schema));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IProperty_works_with_HiLo()
+        {
+            var generator = CreateGenerator();
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            modelBuilder.Entity("Post", x => x.Property<int>("Id").UseHiLo("HiLoIndexName", "HiLoIndexSchema"));
+            var property = modelBuilder.Model.FindEntityType("Post").FindProperty("Id");
+
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = generator.GenerateFluentApiCalls(property, annotations).Single();
+
+            Assert.Equal("UseHiLo", result.Method);
+
+            Assert.Collection(result.Arguments,
+                name => Assert.Equal("HiLoIndexName", name),
+                schema => Assert.Equal("HiLoIndexSchema", schema));
+        }
+
+        private SqlServerAnnotationCodeGenerator CreateGenerator()
+            => new SqlServerAnnotationCodeGenerator(
+                new AnnotationCodeGeneratorDependencies(
+                    new SqlServerTypeMappingSource(
+                        new TypeMappingSourceDependencies(
+                            new ValueConverterSelector(
+                                new ValueConverterSelectorDependencies()),
+                            Array.Empty<ITypeMappingSourcePlugin>()),
+                        new RelationalTypeMappingSourceDependencies(
+                            Array.Empty<IRelationalTypeMappingSourcePlugin>()))));
     }
 }


### PR DESCRIPTION
* IAnnotationCodeGenerator now exposes an API to generate all fluent API calls, not one-by-one as before. This allows generating multiple annotations as a single fluent API call. 
* Use this in SQL Server to properly generate a fluent API for identity (increment/seed) and HiLo.
* The AnnotationCodeGenerator base class exposes the same one-by-one API as before, so this is totally backwards compatible (unless the interface is implemented directly).
* Use IAnnotationCodeGenerator when generating the model snapshot, to have proper fluent API calls instead of raw annotations. This also DRYs lots of logic between CSharpSnapshotGenerator and CSharpDbContextGenerator.
* IAnnotationCodeGenerator centralizes ignoring annotations that shouldn't be generated in code (also DRY between CSharpSnapshotGenerator and CSharpDbContextGenerator, #15675).
* This is also a step towards helping non-C# language support, since it moves generic logic out of C#-specific types to AnnotationCodeGenerator, which isn't.
* For now, I've only moved logic from CSharpDbContextGenerator/CSharpSnapshotGenerator to AnnotationCodeGenerator where annotations are translated into a fluent API/data annotation. We could consider also moving other cases - e.g. IsConcurrencyToken which isn't annotation-based - but that means AnnotationCodeGenerator becomes something like a general CodeGenerationHelper.

## Notes

* AnnotationCodeGenerator currently references CoreAnnotationNames which is internal (warning is suppressed). In Design we weren't enforcing the analyzer warning, but this is in Relational... We should consider making annotation names public.
* Annotations with null values were ignored in various places, I centralized this in AnnotationCodeGenerator.RemoveIgnoredAnnotations. I hope that's correct.
* Should we always generate fluent API calls with all defaults explicitly, to bake in the values (e.g. pass seed/increment 1 in UseIdentityColumn)? The more we bake in, the better, it seems.
* This doesn't currently support scaffolding data annotations on keys/foreign keys/indexes (e.g. a future SQL Server [Clustered] attribute). This shouldn't be too hard, but I propose scoping it out until we decide to actually implement one.
* The annotation ignore list is currently global and not per-type (model, entity, property...) - that's the way it already was in MigrationsCodeGenerator. I think it should be fine, just sayin'.

Supercedes #21210