### PR TITLE
Query: Clean up query validation for various negative cases

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -787,14 +787,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 annotation);
 
         /// <summary>
-        ///     The property '{property}' is not a navigation property of entity type '{entityType}'. The 'Include(string)' method can only be used with a '.' separated list of navigation property names.
-        /// </summary>
-        public static string IncludeBadNavigation([CanBeNull] object property, [CanBeNull] object entityType)
-            => string.Format(
-                GetString("IncludeBadNavigation", nameof(property), nameof(entityType)),
-                property, entityType);
-
-        /// <summary>
         ///     The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.
         /// </summary>
         public static string CannotBeNullable([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)
@@ -1735,14 +1727,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property, modelType, providerType);
 
         /// <summary>
-        ///     The Include operation '{include}' is not supported. '{invalidNavigation}' must be a navigation property defined on an entity type.
-        /// </summary>
-        public static string IncludeNotSpecifiedDirectlyOnEntityType([CanBeNull] object include, [CanBeNull] object invalidNavigation)
-            => string.Format(
-                GetString("IncludeNotSpecifiedDirectlyOnEntityType", nameof(include), nameof(invalidNavigation)),
-                include, invalidNavigation);
-
-        /// <summary>
         ///     The instance of entity type '{entityType}' cannot be tracked because another instance with the same key value for {keyProperties} is already being tracked. When replacing owned entities modify the properties without changing the instance or detach the previous owned entity entry first. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting key values.
         /// </summary>
         public static string IdentityConflictOwned([CanBeNull] object entityType, [CanBeNull] object keyProperties)
@@ -2609,10 +2593,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <summary>
         ///     Translation of method '{declaringTypeName}.{methodName}' failed. If you are trying to map your custom function, see https://go.microsoft.com/fwlink/?linkid=2132413 for more information.
         /// </summary>
-        public static string QueryUnableToTranslateMethod([CanBeNull] object methodName, [CanBeNull] object declaringTypeName)
+        public static string QueryUnableToTranslateMethod([CanBeNull] object declaringTypeName, [CanBeNull] object methodName)
             => string.Format(
-                GetString("QueryUnableToTranslateMethod", nameof(methodName), nameof(declaringTypeName)),
-                methodName, declaringTypeName);
+                GetString("QueryUnableToTranslateMethod", nameof(declaringTypeName), nameof(methodName)),
+                declaringTypeName, methodName);
 
         /// <summary>
         ///     Invalid {state} encountered.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -534,9 +534,6 @@
   <data name="AnnotationNotFound" xml:space="preserve">
     <value>The annotation '{annotation}' was not found. Ensure that the annotation has been added.</value>
   </data>
-  <data name="IncludeBadNavigation" xml:space="preserve">
-    <value>The property '{property}' is not a navigation property of entity type '{entityType}'. The 'Include(string)' method can only be used with a '.' separated list of navigation property names.</value>
-  </data>
   <data name="LogQueryExecutionPlanned" xml:space="preserve">
     <value>{plan}</value>
     <comment>Debug CoreEventId.QueryExecutionPlanned string</comment>
@@ -907,9 +904,6 @@
   </data>
   <data name="NonComparableKeyTypes" xml:space="preserve">
     <value>Property '{entityType}.{property}' cannot be used as a key because it has type '{modelType}' and provider type '{providerType}' neither of which implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Make '{modelType}' implement one of these interfaces to use it as a key.</value>
-  </data>
-  <data name="IncludeNotSpecifiedDirectlyOnEntityType" xml:space="preserve">
-    <value>The Include operation '{include}' is not supported. '{invalidNavigation}' must be a navigation property defined on an entity type.</value>
   </data>
   <data name="LogPossibleUnintendedCollectionNavigationNullComparison" xml:space="preserve">
     <value>Collection navigations are only considered null if their parent entity is null. Use '.Any()' to check whether collection navigation '{navigationPath}' is empty.</value>

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -3572,7 +3573,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
         }
 
-        [ConditionalTheory(Skip = "Issue#15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_collection_and_invalid_navigation_using_string_throws(bool async)
         {
@@ -3581,9 +3582,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     async,
                     ss => ss.Set<Gear>().Include("Reports.Foo")))).Message;
 
-            Assert.Equal(
-                CoreStrings.IncludeBadNavigation("Foo", "Gear"),
-                message);
+            Assert.Contains(CoreResources.LogInvalidIncludePath(new TestLogger<TestLoggingDefinitions>())
+                .GenerateMessage("Reports.Foo", "Foo"), message);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -100,36 +100,36 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalTheory(Skip = "issue #15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_property_after_navigation(bool async)
         {
             Assert.Equal(
-                CoreStrings.IncludeBadNavigation("CustomerID", nameof(Customer)),
+                CoreStrings.InvalidLambdaExpressionInsideInclude,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,
                         ss => ss.Set<Order>().Include(o => o.Customer.CustomerID)))).Message);
         }
 
-        [ConditionalTheory(Skip = "issue #15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_property(bool async)
         {
             Assert.Equal(
-                CoreStrings.IncludeBadNavigation("OrderDate", nameof(Order)),
+                CoreStrings.InvalidLambdaExpressionInsideInclude,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,
                         ss => ss.Set<Order>().Include(o => o.OrderDate)))).Message);
         }
 
-        [ConditionalTheory(Skip = "issue #15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_property_expression_invalid(bool async)
         {
             Assert.Equal(
-                CoreStrings.InvalidIncludeExpression(" "),
+                CoreStrings.InvalidIncludeExpression("new <>f__AnonymousType358`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,
@@ -153,12 +153,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 55);
         }
 
-        [ConditionalTheory(Skip = "issue#15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Then_include_property_expression_invalid(bool async)
         {
             Assert.Equal(
-                CoreStrings.InvalidIncludeExpression(" "),
+                CoreStrings.InvalidIncludeExpression("new <>f__AnonymousType358`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,
@@ -1303,12 +1303,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 921);
         }
 
-        [ConditionalTheory(Skip = "issue #15312")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task Include_specified_on_non_entity_not_supported(bool async)
         {
             Assert.Equal(
-                CoreStrings.IncludeNotSpecifiedDirectlyOnEntityType(@"Include(""Item1.Orders"")", "Item1"),
+                CoreStrings.IncludeOnNonEntity,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,


### PR DESCRIPTION
Resolves #15312
