### PR TITLE
Use nullable backing field to check for default value

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -563,6 +563,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 equals = ValuesEqualFunc(property);
             }
 
+            if (!PropertyHasDefaultValue(property))
+            {
+                return CurrentValueType.Normal;
+            }
+
             var defaultValue = property.ClrType.GetDefaultValue();
             var value = ReadPropertyValue(property);
             if (!equals(value, defaultValue))

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -3,11 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -21,6 +22,42 @@ namespace Microsoft.EntityFrameworkCore.Internal
     /// </summary>
     public static class ExpressionExtensions
     {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static Expression MakeHasDefaultValue<TProperty>(
+            [NotNull] this Expression currentValueExpression, [NotNull] IPropertyBase propertyBase)
+        {
+            if (!currentValueExpression.Type.IsValueType)
+            {
+                return Expression.ReferenceEqual(
+                    currentValueExpression,
+                    Expression.Constant(null, currentValueExpression.Type));
+            }
+
+            if (currentValueExpression.Type.IsGenericType
+                && currentValueExpression.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return Expression.Not(
+                    Expression.Call(
+                        currentValueExpression,
+                        currentValueExpression.Type.GetMethod("get_HasValue")));
+            }
+
+            var property = propertyBase as IProperty;
+            var comparer = property?.GetValueComparer()
+                ?? ValueComparer.CreateDefault(typeof(TProperty), favorStructuralComparisons: false);
+
+            return comparer.ExtractEqualsBody(
+                comparer.Type != typeof(TProperty)
+                    ? Expression.Convert(currentValueExpression, comparer.Type)
+                    : currentValueExpression,
+                Expression.Default(comparer.Type));
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 
@@ -76,7 +77,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (currentValueExpression.Type != typeof(TProperty))
                 {
-                    currentValueExpression = Expression.Convert(currentValueExpression, typeof(TProperty));
+                    currentValueExpression = Expression.Condition(
+                        currentValueExpression.MakeHasDefaultValue<TProperty>(propertyBase),
+                        Expression.Constant(default(TProperty), typeof(TProperty)),
+                        Expression.Convert(currentValueExpression, typeof(TProperty)));
                 }
             }
 

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -1916,7 +1916,7 @@ namespace Microsoft.EntityFrameworkCore
                         DateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
                         TimeSpan = new TimeSpan(0, 10, 9, 8, 7),
                         Single = -1.234F,
-                        Boolean = false,
+                        Boolean = true,
                         Byte = 255,
                         UnsignedInt16 = 1234,
                         UnsignedInt32 = 1234565789U,
@@ -1953,7 +1953,7 @@ namespace Microsoft.EntityFrameworkCore
                     () => dt.DateTimeOffset);
                 AssertEqualIfMapped(entityType, new TimeSpan(0, 10, 9, 8, 7), () => dt.TimeSpan);
                 AssertEqualIfMapped(entityType, -1.234F, () => dt.Single);
-                AssertEqualIfMapped(entityType, false, () => dt.Boolean);
+                AssertEqualIfMapped(entityType, true, () => dt.Boolean);
                 AssertEqualIfMapped(entityType, (byte)255, () => dt.Byte);
                 AssertEqualIfMapped(entityType, Enum64.SomeValue, () => dt.Enum64);
                 AssertEqualIfMapped(entityType, Enum32.SomeValue, () => dt.Enum32);

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class LoginSession
         {
-            private object _id = 0;
+            private object _id;
             private IUser2 _user;
             private object _users;
 

--- a/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.EntityFrameworkCore
                 });
         }
 
-        [ConditionalFact(Skip = "Issue #15182")]
+        [ConditionalFact]
         public virtual void Nullable_fields_get_defaults_when_not_set()
         {
             ExecuteWithStrategyInTransaction(
@@ -1212,64 +1212,189 @@ namespace Microsoft.EntityFrameworkCore
                     context.SaveChanges();
 
                     Assert.NotEqual(0, entity.Id);
-                    Assert.True(entity.NullableBackedBool);
-                    Assert.Equal(-1, entity.NullableBackedInt);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntNonZeroDefault);
+                    Assert.False(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(0, entity.NullableBackedIntZeroDefault);
                 },
                 context =>
                 {
                     var entity = context.Set<WithNullableBackingFields>().Single();
-                    Assert.True(entity.NullableBackedBool);
-                    Assert.Equal(-1, entity.NullableBackedInt);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntNonZeroDefault);
+                    Assert.False(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(0, entity.NullableBackedIntZeroDefault);
                 });
         }
 
-        [ConditionalFact(Skip = "Issue #15182")]
+        [ConditionalFact]
         public virtual void Nullable_fields_store_non_defaults_when_set()
         {
             ExecuteWithStrategyInTransaction(
                 context =>
                 {
-                    var entity = context.Add(new WithNullableBackingFields { NullableBackedBool = false, NullableBackedInt = 0 }).Entity;
+                    var entity = context.Add(
+                        new WithNullableBackingFields
+                        {
+                            NullableBackedBoolTrueDefault = false,
+                            NullableBackedIntNonZeroDefault = 0,
+                            NullableBackedBoolFalseDefault = true,
+                            NullableBackedIntZeroDefault = -1
+                        }).Entity;
 
                     context.SaveChanges();
 
                     Assert.NotEqual(0, entity.Id);
-                    Assert.False(entity.NullableBackedBool);
-                    Assert.Equal(0, entity.NullableBackedInt);
+                    Assert.False(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(0, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntZeroDefault);
                 },
                 context =>
                 {
                     var entity = context.Set<WithNullableBackingFields>().Single();
-                    Assert.False(entity.NullableBackedBool);
-                    Assert.Equal(0, entity.NullableBackedInt);
+                    Assert.False(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(0, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntZeroDefault);
                 });
         }
 
-        [ConditionalFact(Skip = "Issue #15182")]
+        [ConditionalFact]
         public virtual void Nullable_fields_store_any_value_when_set()
         {
             ExecuteWithStrategyInTransaction(
                 context =>
                 {
-                    var entity = context.Add(new WithNullableBackingFields { NullableBackedBool = true, NullableBackedInt = 3 }).Entity;
+                    var entity = context.Add(
+                        new WithNullableBackingFields
+                        {
+                            NullableBackedBoolTrueDefault = true,
+                            NullableBackedIntNonZeroDefault = 3,
+                            NullableBackedBoolFalseDefault = true,
+                            NullableBackedIntZeroDefault = 5
+                        }).Entity;
 
                     context.SaveChanges();
 
                     Assert.NotEqual(0, entity.Id);
-                    Assert.True(entity.NullableBackedBool);
-                    Assert.Equal(3, entity.NullableBackedInt);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(3, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(5, entity.NullableBackedIntZeroDefault);
                 },
                 context =>
                 {
                     var entity = context.Set<WithNullableBackingFields>().Single();
-                    Assert.True(entity.NullableBackedBool);
-                    Assert.Equal(3, entity.NullableBackedInt);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(3, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(5, entity.NullableBackedIntZeroDefault);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Object_fields_get_defaults_when_not_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(new WithObjectBackingFields()).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntNonZeroDefault);
+                    Assert.False(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(0, entity.NullableBackedIntZeroDefault);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithObjectBackingFields>().Single();
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntNonZeroDefault);
+                    Assert.False(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(0, entity.NullableBackedIntZeroDefault);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Object_fields_store_non_defaults_when_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(
+                        new WithObjectBackingFields
+                        {
+                            NullableBackedBoolTrueDefault = false,
+                            NullableBackedIntNonZeroDefault = 0,
+                            NullableBackedBoolFalseDefault = true,
+                            NullableBackedIntZeroDefault = -1
+                        }).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.False(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(0, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntZeroDefault);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithObjectBackingFields>().Single();
+                    Assert.False(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(0, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(-1, entity.NullableBackedIntZeroDefault);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Object_fields_store_any_value_when_set()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entity = context.Add(
+                        new WithObjectBackingFields
+                        {
+                            NullableBackedBoolTrueDefault = true,
+                            NullableBackedIntNonZeroDefault = 3,
+                            NullableBackedBoolFalseDefault = true,
+                            NullableBackedIntZeroDefault = 5
+                        }).Entity;
+
+                    context.SaveChanges();
+
+                    Assert.NotEqual(0, entity.Id);
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(3, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(5, entity.NullableBackedIntZeroDefault);
+                },
+                context =>
+                {
+                    var entity = context.Set<WithObjectBackingFields>().Single();
+                    Assert.True(entity.NullableBackedBoolTrueDefault);
+                    Assert.Equal(3, entity.NullableBackedIntNonZeroDefault);
+                    Assert.True(entity.NullableBackedBoolFalseDefault);
+                    Assert.Equal(5, entity.NullableBackedIntZeroDefault);
                 });
         }
 
         protected class Darwin
         {
-            public int Id { get; set; }
+            public int? _id;
+
+            public int Id
+            {
+                get => _id ?? 0;
+                set => _id = value;
+            }
+
             public string Name { get; set; }
         }
 
@@ -1380,24 +1505,83 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get => _id ?? 0;
+                get => _id ?? throw new Exception("Bang!");
                 set => _id = value;
             }
 
-            private bool? _nullableBackedBool;
+            private bool? _nullableBackedBoolTrueDefault;
 
-            public bool NullableBackedBool
+            public bool NullableBackedBoolTrueDefault
             {
-                get => _nullableBackedBool ?? false;
-                set => _nullableBackedBool = value;
+                get => _nullableBackedBoolTrueDefault ?? true;
+                set => _nullableBackedBoolTrueDefault = value;
             }
 
-            private int? _nullableBackedInt;
+            private int? _nullableBackedIntNonZeroDefault;
 
-            public int NullableBackedInt
+            public int NullableBackedIntNonZeroDefault
             {
-                get => _nullableBackedInt ?? 0;
-                set => _nullableBackedInt = value;
+                get => _nullableBackedIntNonZeroDefault ?? -1;
+                set => _nullableBackedIntNonZeroDefault = value;
+            }
+
+            private bool? _nullableBackedBoolFalseDefault;
+
+            public bool NullableBackedBoolFalseDefault
+            {
+                get => _nullableBackedBoolFalseDefault ?? false;
+                set => _nullableBackedBoolFalseDefault = value;
+            }
+
+            private int? _nullableBackedIntZeroDefault;
+
+            public int NullableBackedIntZeroDefault
+            {
+                get => _nullableBackedIntZeroDefault ?? 0;
+                set => _nullableBackedIntZeroDefault = value;
+            }
+        }
+
+        protected class WithObjectBackingFields
+        {
+            private object _id;
+
+            public int Id
+            {
+                get => (int)(_id ?? 0);
+                set => _id = value;
+            }
+
+            private object _nullableBackedBoolTrueDefault;
+
+            public bool NullableBackedBoolTrueDefault
+            {
+                get => (bool)(_nullableBackedBoolTrueDefault ?? throw new Exception("Bang!"));
+                set => _nullableBackedBoolTrueDefault = value;
+            }
+
+            private object _nullableBackedIntNonZeroDefault;
+
+            public int NullableBackedIntNonZeroDefault
+            {
+                get => (int)(_nullableBackedIntNonZeroDefault ?? throw new Exception("Bang!"));
+                set => _nullableBackedIntNonZeroDefault = value;
+            }
+
+            private object _nullableBackedBoolFalseDefault;
+
+            public bool NullableBackedBoolFalseDefault
+            {
+                get => (bool)(_nullableBackedBoolFalseDefault ?? false);
+                set => _nullableBackedBoolFalseDefault = value;
+            }
+
+            private object _nullableBackedIntZeroDefault;
+
+            public int NullableBackedIntZeroDefault
+            {
+                get => (int)(_nullableBackedIntZeroDefault ?? 0);
+                set => _nullableBackedIntZeroDefault = value;
             }
         }
 

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
@@ -7,7 +7,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Employee
     {
-        public uint EmployeeID { get; set; }
+        private uint? _employeeId;
+
+        public uint EmployeeID
+        {
+            get => _employeeId ?? (uint)0;
+            set => _employeeId = value;
+        }
+
         public string LastName { get; set; }
         public string FirstName { get; set; }
         public string Title { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
@@ -8,7 +8,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Order
     {
-        public int OrderID { get; set; }
+        private int? _orderId;
+
+        public int OrderID
+        {
+            get => _orderId ?? 0;
+            set => _orderId = value;
+        }
+
         public string CustomerID { get; set; }
         public uint? EmployeeID { get; set; }
         public DateTime? OrderDate { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
@@ -7,8 +7,21 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class OrderDetail : IComparable<OrderDetail>
     {
-        public int OrderID { get; set; }
-        public int ProductID { get; set; }
+        private int? _orderId;
+        private int? _productId;
+
+        public int OrderID
+        {
+            get => _orderId ?? 0;
+            set => _orderId = value;
+        }
+
+        public int ProductID
+        {
+            get => _productId ?? 0;
+            set => _productId = value;
+        }
+
         public decimal UnitPrice { get; set; }
         public short Quantity { get; set; }
         public float Discount { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
@@ -7,12 +7,19 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Product
     {
+        private int? _productId;
+
         public Product()
         {
             OrderDetails = new List<OrderDetail>();
         }
 
-        public int ProductID { get; set; }
+        public int ProductID
+        {
+            get => _productId ?? 0;
+            set => _productId = value;
+        }
+
         public string ProductName { get; set; }
         public int? SupplierID { get; set; }
         public int? CategoryID { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -45,6 +45,7 @@ namespace Microsoft.EntityFrameworkCore
                         foreach (var entity in entities.Take(100))
                         {
                             Assert.Equal(0, entity.Id);
+                            Assert.Null(entity._id);
                         }
 
                         Assert.Equal(1777, entities[100].Id);
@@ -70,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore
                         foreach (var entity in entities.Take(100))
                         {
                             Assert.Equal(0, entity.Id);
+                            Assert.Null(entity._id);
                         }
 
                         Assert.Equal(1777, entities[100].Id);
@@ -172,8 +174,19 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<WithNullableBackingFields>(
                     b =>
                     {
-                        b.Property(e => e.NullableBackedBool).HasDefaultValue(true);
-                        b.Property(e => e.NullableBackedInt).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolTrueDefault).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedIntNonZeroDefault).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolFalseDefault).HasDefaultValue(false);
+                        b.Property(e => e.NullableBackedIntZeroDefault).HasDefaultValue(0);
+                    });
+
+                modelBuilder.Entity<WithObjectBackingFields>(
+                    b =>
+                    {
+                        b.Property(e => e.NullableBackedBoolTrueDefault).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedIntNonZeroDefault).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolFalseDefault).HasDefaultValue(false);
+                        b.Property(e => e.NullableBackedIntZeroDefault).HasDefaultValue(0);
                     });
 
                 base.OnModelCreating(modelBuilder, context);

--- a/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -110,8 +110,19 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<WithNullableBackingFields>(
                     b =>
                     {
-                        b.Property(e => e.NullableBackedBool).HasDefaultValue(true);
-                        b.Property(e => e.NullableBackedInt).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolTrueDefault).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedIntNonZeroDefault).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolFalseDefault).HasDefaultValue(false);
+                        b.Property(e => e.NullableBackedIntZeroDefault).HasDefaultValue(0);
+                    });
+
+                modelBuilder.Entity<WithObjectBackingFields>(
+                    b =>
+                    {
+                        b.Property(e => e.NullableBackedBoolTrueDefault).HasDefaultValue(true);
+                        b.Property(e => e.NullableBackedIntNonZeroDefault).HasDefaultValue(-1);
+                        b.Property(e => e.NullableBackedBoolFalseDefault).HasDefaultValue(false);
+                        b.Property(e => e.NullableBackedIntZeroDefault).HasDefaultValue(0);
                     });
 
                 modelBuilder.Entity<Zach>().Property(e => e.Id)


### PR DESCRIPTION
Fixes #15182

This allows a null backing field to be used for a non-nullable property while at the same time checking the backing field for null in order to determine if a property value has been set.
