### PR TITLE
Generate ProductVersion in model snapshot again

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -55,7 +55,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .FilterIgnoredAnnotations(model.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            if (annotations.Count > 0)
+            var productVersion = model.GetProductVersion();
+
+            if (annotations.Count > 0 || productVersion != null)
             {
                 stringBuilder.Append(builderName);
 
@@ -69,7 +71,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             .Append(Code.Fragment(methodCallCodeFragment));
                     }
 
-                    GenerateAnnotations(annotations.Values, stringBuilder);
+                    IEnumerable<IAnnotation> remainingAnnotations = annotations.Values;
+                    if (productVersion != null)
+                    {
+                        remainingAnnotations = remainingAnnotations.Append(
+                            new Annotation(CoreAnnotationNames.ProductVersion, productVersion));
+                    }
+                    GenerateAnnotations(remainingAnnotations, stringBuilder);
                 }
 
                 stringBuilder.AppendLine(";");


### PR DESCRIPTION
Fixup to #21329

Note that since there's no ModelBuilder API for setting the version (and there probably shouldn't be), this is the one place where the snapshot generator accesses the (internal) annotation directly, at least for now.