### PR TITLE
DbContextPool default size set to 100

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddDbContextPool<TContext>(
             [NotNull] this IServiceCollection serviceCollection,
             [NotNull] Action<DbContextOptionsBuilder> optionsAction,
-            int poolSize = 128)
+            int poolSize = 100)
             where TContext : DbContext
             => AddDbContextPool<TContext, TContext>(serviceCollection, optionsAction, poolSize);
 
@@ -205,7 +205,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddDbContextPool<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
             [NotNull] Action<DbContextOptionsBuilder> optionsAction,
-            int poolSize = 128)
+            int poolSize = 100)
             where TContextImplementation : DbContext, TContextService
             where TContextService : class
         {
@@ -263,7 +263,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddDbContextPool<TContext>(
             [NotNull] this IServiceCollection serviceCollection,
             [NotNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-            int poolSize = 128)
+            int poolSize = 100)
             where TContext : DbContext
             => AddDbContextPool<TContext, TContext>(serviceCollection, optionsAction, poolSize);
 
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddDbContextPool<TContextService, TContextImplementation>(
             [NotNull] this IServiceCollection serviceCollection,
             [NotNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction,
-            int poolSize = 128)
+            int poolSize = 100)
             where TContextImplementation : DbContext, TContextService
             where TContextService : class
         {


### PR DESCRIPTION
**Summary of the changes:**

Default DbContextPool poolSize decrease to 100 since database providers connection default max pool size is setted to 100.

Default context pool size 120 can lead to problem of database provider connection pool exhausted.
