### PR TITLE
Fix Issue 13919: Translation error using negative

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -737,8 +737,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 case ExpressionType.Negate:
                 {
-                    _relationalCommandBuilder.Append("-");
+                    _relationalCommandBuilder.Append("-(");
                     Visit(sqlUnaryExpression.Operand);
+                    _relationalCommandBuilder.Append(")");
                     break;
                 }
             }

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -737,9 +737,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 case ExpressionType.Negate:
                 {
-                    _relationalCommandBuilder.Append("-(");
+                    _relationalCommandBuilder.Append("-");
+                    var requiresBrackets = RequiresBrackets(sqlUnaryExpression.Operand);
+                    if (requiresBrackets)
+                    {
+                        _relationalCommandBuilder.Append("(");
+                    }
+
                     Visit(sqlUnaryExpression.Operand);
-                    _relationalCommandBuilder.Append(")");
+                    if (requiresBrackets)
+                    {
+                        _relationalCommandBuilder.Append(")");
+                    }
                     break;
                 }
             }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -38,11 +38,29 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Negate_binary_expression(bool async)
+        public virtual Task Negate_on_binary_expression(bool async)
         {
             return AssertQuery(
                 async,
                 ss => ss.Set<Squad>().Where(s => s.Id == -(s.Id + s.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Negate_on_column(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(s => s.Id == -s.Id));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Negate_on_like_expression(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(s => !s.Name.StartsWith("us")));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -38,6 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Negate_binary_expression(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>().Where(s => s.Id == -(s.Id + s.Id)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Entity_equality_empty(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -23,6 +23,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override bool CanExecuteQueryString => true;
 
+        public override async Task Negate_binary_expression(bool async)
+        {
+            await base.Negate_binary_expression(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE [s].[Id] = -([s].[Id] + [s].[Id])");
+        }
+
         public override async Task Entity_equality_empty(bool async)
         {
             await base.Entity_equality_empty(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -23,14 +23,34 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override bool CanExecuteQueryString => true;
 
-        public override async Task Negate_binary_expression(bool async)
+        public override async Task Negate_on_binary_expression(bool async)
         {
-            await base.Negate_binary_expression(async);
+            await base.Negate_on_binary_expression(async);
 
             AssertSql(
                 @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
 WHERE [s].[Id] = -([s].[Id] + [s].[Id])");
+        }
+
+        public override async Task Negate_on_column(bool async)
+        {
+            await base.Negate_on_column(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE [s].[Id] = -[s].[Id]");
+        }
+
+        public override async Task Negate_on_like_expression(bool async)
+        {
+            await base.Negate_on_like_expression(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+WHERE [s].[Name] IS NOT NULL AND NOT ([s].[Name] LIKE N'us%')");
         }
 
         public override async Task Entity_equality_empty(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -78,14 +78,34 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override Task Subquery_projecting_non_nullable_scalar_contains_non_nullable_value_doesnt_need_null_expansion_negated(bool async) => null;
 
-        public override async Task Negate_binary_expression(bool async)
+        public override async Task Negate_on_binary_expression(bool async)
         {
-            await base.Negate_binary_expression(async);
+            await base.Negate_on_binary_expression(async);
 
             AssertSql(
                 @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
 FROM ""Squads"" AS ""s""
 WHERE ""s"".""Id"" = -(""s"".""Id"" + ""s"".""Id"")");
+        }
+
+        public override async Task Negate_on_column(bool async)
+        {
+            await base.Negate_on_column(async);
+
+            AssertSql(
+                @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
+FROM ""Squads"" AS ""s""
+WHERE ""s"".""Id"" = -""s"".""Id""");
+        }
+
+        public override async Task Negate_on_like_expression(bool async)
+        {
+            await base.Negate_on_like_expression(async);
+
+            AssertSql(
+                @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
+FROM ""Squads"" AS ""s""
+WHERE ""s"".""Name"" IS NOT NULL AND NOT (""s"".""Name"" LIKE 'us%')");
         }
 
         public override async Task Select_datetimeoffset_comparison_in_projection(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -78,6 +78,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override Task Subquery_projecting_non_nullable_scalar_contains_non_nullable_value_doesnt_need_null_expansion_negated(bool async) => null;
 
+        public override async Task Negate_binary_expression(bool async)
+        {
+            await base.Negate_binary_expression(async);
+
+            AssertSql(
+                @"SELECT ""s"".""Id"", ""s"".""Banner"", ""s"".""Banner5"", ""s"".""InternalNumber"", ""s"".""Name""
+FROM ""Squads"" AS ""s""
+WHERE ""s"".""Id"" = -(""s"".""Id"" + ""s"".""Id"")");
+        }
+
         public override async Task Select_datetimeoffset_comparison_in_projection(bool async)
         {
             await base.Select_datetimeoffset_comparison_in_projection(async);


### PR DESCRIPTION
This pull request resolves Issue #13919: Translation error using negative.

### Summary of Issue
If a LINQ query references an entity property and uses a negated expression, negation only applies to the first term in the expression.

Example: 
`db.Entities.Where(e => e.Num1 == -(e.Num2 + 100))`
Expected translation: 
`SELECT ... FROM Entities e WHERE e.Num1 = -(e.Num2 + 100)`
Actual translation: 
`SELECT ... FROM Entities e WHERE e.Num1 = -e.Num2 + 100`

---

### Summary of Changes
- On translation, add opening and closing parentheses around expression if expression type is `ExpressionType.Negate`
- Add unit test for SQL Server and SQLite providers

---

### Concerns
- Are these tests placed in the right place? I couldn't find a set of unit tests for unary expressions.
