### PR TITLE
Allow to exclude a table from migrations

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 {

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -24,13 +24,26 @@ namespace Microsoft.EntityFrameworkCore
         public static EntityTypeBuilder ToTable(
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name)
+            => ToTable(entityTypeBuilder, name, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static EntityTypeBuilder ToTable(
+            [NotNull] this EntityTypeBuilder entityTypeBuilder,
+            [CanBeNull] string name,
+            bool excludedFromMigrations)
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
             entityTypeBuilder.Metadata.SetTableName(name);
             entityTypeBuilder.Metadata.SetSchema(null);
-            entityTypeBuilder.Metadata.RemoveAnnotation(RelationalAnnotationNames.ViewDefinitionSql);
+            entityTypeBuilder.Metadata.SetIsTableExcludedFromMigrations(excludedFromMigrations);
 
             return entityTypeBuilder;
         }
@@ -46,7 +59,22 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [CanBeNull] string name)
             where TEntity : class
-            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name);
+            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static EntityTypeBuilder<TEntity> ToTable<TEntity>(
+            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            [CanBeNull] string name,
+            bool excludedFromMigrations)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, excludedFromMigrations);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -59,6 +87,21 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this EntityTypeBuilder entityTypeBuilder,
             [CanBeNull] string name,
             [CanBeNull] string schema)
+            => entityTypeBuilder.ToTable(name, schema, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static EntityTypeBuilder ToTable(
+        [NotNull] this EntityTypeBuilder entityTypeBuilder,
+        [CanBeNull] string name,
+        [CanBeNull] string schema,
+        bool excludedFromMigrations)
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
@@ -66,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore
 
             entityTypeBuilder.Metadata.SetTableName(name);
             entityTypeBuilder.Metadata.SetSchema(schema);
-            entityTypeBuilder.Metadata.RemoveAnnotation(RelationalAnnotationNames.ViewDefinitionSql);
+            entityTypeBuilder.Metadata.SetIsTableExcludedFromMigrations(excludedFromMigrations);
 
             return entityTypeBuilder;
         }
@@ -84,7 +127,24 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string name,
             [CanBeNull] string schema)
             where TEntity : class
-            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, schema);
+            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, schema, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static EntityTypeBuilder<TEntity> ToTable<TEntity>(
+            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            [CanBeNull] string name,
+            [CanBeNull] string schema,
+            bool excludedFromMigrations)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)ToTable((EntityTypeBuilder)entityTypeBuilder, name, schema, excludedFromMigrations);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -95,11 +155,26 @@ namespace Microsoft.EntityFrameworkCore
         public static OwnedNavigationBuilder ToTable(
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name)
+            => referenceOwnershipBuilder.ToTable(name, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static OwnedNavigationBuilder ToTable(
+            [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
+            [CanBeNull] string name,
+            bool excludedFromMigrations)
         {
             Check.NotNull(referenceOwnershipBuilder, nameof(referenceOwnershipBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
             referenceOwnershipBuilder.OwnedEntityType.SetTableName(name);
+            referenceOwnershipBuilder.OwnedEntityType.SetSchema(null);
+            referenceOwnershipBuilder.OwnedEntityType.SetIsTableExcludedFromMigrations(excludedFromMigrations);
 
             return referenceOwnershipBuilder;
         }
@@ -117,7 +192,26 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string name)
             where TEntity : class
             where TRelatedEntity : class
-            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable((OwnedNavigationBuilder)referenceOwnershipBuilder, name);
+            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
+                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static OwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
+            [NotNull] this OwnedNavigationBuilder<TEntity, TRelatedEntity> referenceOwnershipBuilder,
+            [CanBeNull] string name,
+            bool excludedFromMigrations)
+            where TEntity : class
+            where TRelatedEntity : class
+            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
+                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, excludedFromMigrations);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -130,6 +224,21 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name,
             [CanBeNull] string schema)
+            => referenceOwnershipBuilder.ToTable(name, schema, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static OwnedNavigationBuilder ToTable(
+            [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
+            [CanBeNull] string name,
+            [CanBeNull] string schema,
+            bool excludedFromMigrations)
         {
             Check.NotNull(referenceOwnershipBuilder, nameof(referenceOwnershipBuilder));
             Check.NullButNotEmpty(name, nameof(name));
@@ -137,6 +246,7 @@ namespace Microsoft.EntityFrameworkCore
 
             referenceOwnershipBuilder.OwnedEntityType.SetTableName(name);
             referenceOwnershipBuilder.OwnedEntityType.SetSchema(schema);
+            referenceOwnershipBuilder.OwnedEntityType.SetIsTableExcludedFromMigrations(excludedFromMigrations);
 
             return referenceOwnershipBuilder;
         }
@@ -156,7 +266,28 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string schema)
             where TEntity : class
             where TRelatedEntity : class
-            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable((OwnedNavigationBuilder)referenceOwnershipBuilder, name, schema);
+            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
+                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, schema, excludedFromMigrations: false);
+
+        /// <summary>
+        ///     Configures the table that the entity type maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="referenceOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the table. </param>
+        /// <param name="schema"> The schema of the table. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static OwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
+            [NotNull] this OwnedNavigationBuilder<TEntity, TRelatedEntity> referenceOwnershipBuilder,
+            [CanBeNull] string name,
+            [CanBeNull] string schema,
+            bool excludedFromMigrations)
+            where TEntity : class
+            where TRelatedEntity : class
+            => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
+                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, schema, excludedFromMigrations);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -209,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Returns a value indicating whether the view or table name can be set for this entity type
-        ///     from the current configuration source
+        ///     using the specified configuration source.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="name"> The name of the view or table. </param>
@@ -249,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Returns a value indicating whether the schema of the view or table name can be set for this entity type
-        ///     from the current configuration source
+        ///     using the specified configuration source.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="schema"> The schema of the view or table. </param>
@@ -264,6 +395,43 @@ namespace Microsoft.EntityFrameworkCore
 
             return entityTypeBuilder.CanSetAnnotation(RelationalAnnotationNames.Schema, schema, fromDataAnnotation);
         }
+
+        /// <summary>
+        ///     Mark the table that this entity type is mapped to as excluded from migrations.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        public static IConventionEntityTypeBuilder ExcludeTableFromMigrations(
+            [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
+            bool? excludedFromMigrations,
+            bool fromDataAnnotation = false)
+        {
+            if (!entityTypeBuilder.CanExcludeTableFromMigrations(excludedFromMigrations, fromDataAnnotation))
+            {
+                return null;
+            }
+
+            entityTypeBuilder.Metadata.SetIsTableExcludedFromMigrations(excludedFromMigrations, fromDataAnnotation);
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the table that this entity type is mapped to can be excluded from migrations
+        ///     using the specified configuration source.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="excludedFromMigrations"> A value indicating whether the table should be managed by migrations. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the configuration can be applied. </returns>
+        public static bool CanExcludeTableFromMigrations(
+            [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder, bool? excludedFromMigrations, bool fromDataAnnotation = false)
+            => entityTypeBuilder.CanSetAnnotation
+                (RelationalAnnotationNames.IsTableExcludedFromMigrations, excludedFromMigrations, fromDataAnnotation);
 
         /// <summary>
         ///     Configures the view that the entity type maps to when targeting a relational database.
@@ -522,7 +690,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Returns a value indicating whether a comment can be set for this entity type
-        ///     from the current configuration source
+        ///     using the specified configuration source.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="comment"> The comment for the table. </param>

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -101,8 +102,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             databaseModel.Tables.Add((mappedTable, mappedSchema), table);
                         }
 
-                        table.IsExcludedFromMigrations = table.IsExcludedFromMigrations
-                            && entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinitionSql) != null;
+                        if (mappedType == entityType)
+                        {
+                            Check.DebugAssert(table.EntityTypeMappings.Count == 0
+                                || table.IsExcludedFromMigrations == entityType.IsTableExcludedFromMigrations(),
+                                "Table should be excluded on all entity types");
+
+                            table.IsExcludedFromMigrations = entityType.IsTableExcludedFromMigrations();
+                        }
 
                         var tableMapping = new TableMapping(entityType, table, includesDerivedTypes: true);
                         foreach (var property in mappedType.GetProperties())

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -139,6 +139,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string ViewDefinitionSql = Prefix + "ViewDefinitionSql";
 
         /// <summary>
+        ///     The name for the annotation determining whether the table is excluded from migrations.
+        /// </summary>
+        public const string IsTableExcludedFromMigrations = Prefix + "IsTableExcludedFromMigrations";
+
+        /// <summary>
         ///     The name for database model annotation.
         /// </summary>
         public const string RelationalModel = Prefix + "RelationalModel";

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -873,6 +873,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("IncompatibleTableDerivedRelationship", nameof(table), nameof(entityType), nameof(otherEntityType)),
                 table, entityType, otherEntityType);
 
+        /// <summary>
+        ///     Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and it excluded from migration on one entity type, but not the other. Exclude the table from migrations on all entity types mapped to the table.
+        /// </summary>
+        public static string IncompatibleTableExcludedMismatch([CanBeNull] object table, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
+            => string.Format(
+                GetString("IncompatibleTableExcludedMismatch", nameof(table), nameof(entityType), nameof(otherEntityType)),
+                table, entityType, otherEntityType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -657,4 +657,7 @@
   <data name="IncompatibleTableDerivedRelationship" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}', there is a relationship between their primary keys in which '{entityType}' is the dependent and '{entityType}' has a base entity type mapped to a different table. Either map '{otherEntityType}' to a different table or invert the relationship between '{entityType}' and '{otherEntityType}'.</value>
   </data>
+  <data name="IncompatibleTableExcludedMismatch" xml:space="preserve">
+    <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and it excluded from migration on one entity type, but not the other. Exclude the table from migrations on all entity types mapped to the table.</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         _nl
                         + "modelBuilder."
                         + nameof(RelationalEntityTypeBuilderExtensions.ToTable)
-                        + @"(""WithAnnotations"",""MySchema"");"
+                        + @"(""WithAnnotations"", ""MySchema"");"
                         + _nl)
                 },
                 {

--- a/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalApiConsistencyTest.cs
@@ -123,7 +123,8 @@ namespace Microsoft.EntityFrameworkCore
             public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } = new HashSet<MethodInfo>
             {
                 typeof(IDbFunction).GetMethod("get_ReturnEntityType"),
-                typeof(RelationalPropertyExtensions).GetMethod(nameof(RelationalPropertyExtensions.FindOverrides))
+                typeof(RelationalPropertyExtensions).GetMethod(nameof(RelationalPropertyExtensions.FindOverrides)),
+                typeof(RelationalEntityTypeBuilderExtensions).GetMethod(nameof(RelationalEntityTypeBuilderExtensions.ExcludeTableFromMigrations))
             };
 
             public override HashSet<MethodInfo> AsyncMethodExceptions { get; } = new HashSet<MethodInfo>

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -491,7 +491,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.FinalizeModel();
 
                 Assert.Equal("blah", owned.GetTableName());
-                Assert.Equal("foo", owned.GetSchema());
+                Assert.Null(owned.GetSchema());
             }
 
             [ConditionalFact]


### PR DESCRIPTION
Store the entity types mapped to views in the snapshot

Fixes #2725

