### PR TITLE
Query: Make it easy to map built-in functions

### DIFF
--- a/src/EFCore.Abstractions/DbFunctionAttribute.cs
+++ b/src/EFCore.Abstractions/DbFunctionAttribute.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore
     {
         private string _name;
         private string _schema;
+        private bool _builtIn;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DbFunctionAttribute" /> class.
@@ -32,12 +33,14 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="name">The name of the function in the database.</param>
         /// <param name="schema">The schema of the function in the database.</param>
-        public DbFunctionAttribute([NotNull] string name, [CanBeNull] string schema = null)
+        /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
+        public DbFunctionAttribute([NotNull] string name, [CanBeNull] string schema = null, bool builtIn = false)
         {
             Check.NotEmpty(name, nameof(name));
 
             _name = name;
             _schema = schema;
+            _builtIn = builtIn;
         }
 
         /// <summary>
@@ -62,6 +65,15 @@ namespace Microsoft.EntityFrameworkCore
         {
             get => _schema;
             [param: CanBeNull] set => _schema = value;
+        }
+
+        /// <summary>
+        ///     The value indicating wheather the database function is built-in or not.
+        /// </summary>
+        public virtual bool IsBuiltIn
+        {
+            get => _builtIn;
+            set => _builtIn = value;
         }
     }
 }

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
@@ -71,6 +71,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     Marks whether the database function is built-in or not.
+        /// </summary>
+        /// <param name="builtIn"> The value indicating wheather the database function is built-in or not. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual DbFunctionBuilder IsBuiltIn(bool builtIn = true)
+        {
+            Builder.IsBuiltIn(builtIn, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
         ///     Sets the store type of the database function.
         /// </summary>
         /// <param name="storeType"> The store type of the function in the database. </param>

--- a/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
@@ -58,6 +58,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         bool CanSetSchema([CanBeNull] string schema, bool fromDataAnnotation = false);
 
         /// <summary>
+        ///     Sets the value indicating wheather the database function is built-in or not.
+        /// </summary>
+        /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionDbFunctionBuilder IsBuiltIn(bool builtIn, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the given built-in can be set for the database function.
+        /// </summary>
+        /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the given schema can be set for the database function. </returns>
+        bool CanSetIsBuiltIn(bool builtIn, bool fromDataAnnotation = false);
+
+        /// <summary>
         ///     Sets the store type of the function in the database.
         /// </summary>
         /// <param name="storeType"> The store type of the function in the database. </param>

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalDbFunctionAttributeConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalDbFunctionAttributeConvention.cs
@@ -87,6 +87,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 {
                     dbFunctionBuilder.HasSchema(dbFunctionAttribute.Schema, fromDataAnnotation: true);
                 }
+
+                if (dbFunctionAttribute.IsBuiltIn)
+                {
+                    dbFunctionBuilder.IsBuiltIn(dbFunctionAttribute.IsBuiltIn, fromDataAnnotation: true);
+                }
             }
         }
     }

--- a/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
@@ -61,6 +61,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ConfigurationSource? GetSchemaConfigurationSource();
 
         /// <summary>
+        ///     Sets the value indicating wheather the database function is built-in or not.
+        /// </summary>
+        /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The configured value. </returns>
+        bool SetIsBuiltIn(bool builtIn, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Gets the configuration source for <see cref="IDbFunction.IsBuiltIn" />.
+        /// </summary>
+        /// <returns> The configuration source for <see cref="IDbFunction.IsBuiltIn" />. </returns>
+        ConfigurationSource? GetIsBuiltInConfigurationSource();
+
+        /// <summary>
         ///     Sets the store type of the function in the database.
         /// </summary>
         /// <param name="storeType"> The store type of the function in the database. </param>

--- a/src/EFCore.Relational/Metadata/IDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunction.cs
@@ -26,6 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         string Schema { get; }
 
         /// <summary>
+        ///     Gets the value indicating wheather the database function is built-in or not.
+        /// </summary>
+        bool IsBuiltIn { get; }
+
+        /// <summary>
         ///     Gets the name of the function in the model.
         /// </summary>
         string ModelName { get; }

--- a/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
@@ -26,6 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new string Schema { get; [param: CanBeNull] set; }
 
         /// <summary>
+        ///     Gets or sets the value indicating wheather the database function is built-in or not.
+        /// </summary>
+        new bool IsBuiltIn { get; set; }
+
+        /// <summary>
         ///     Gets or sets the store type of the function in the database.
         /// </summary>
         new string StoreType { get; [param: CanBeNull] set; }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private readonly List<DbFunctionParameter> _parameters;
         private string _schema;
         private string _name;
+        private bool _builtIn;
         private string _storeType;
         private RelationalTypeMapping _typeMapping;
         private Func<IReadOnlyCollection<SqlExpression>, SqlExpression> _translation;
@@ -36,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ConfigurationSource _configurationSource;
         private ConfigurationSource? _schemaConfigurationSource;
         private ConfigurationSource? _nameConfigurationSource;
+        private ConfigurationSource? _builtInConfigurationSource;
         private ConfigurationSource? _storeTypeConfigurationSource;
         private ConfigurationSource? _typeMappingConfigurationSource;
         private ConfigurationSource? _translationConfigurationSource;
@@ -379,6 +381,40 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual bool IsBuiltIn
+        {
+            get => _builtIn;
+            set => SetIsBuiltIn(value, ConfigurationSource.Explicit);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool SetIsBuiltIn(bool builtIn, ConfigurationSource configurationSource)
+        {
+            _builtIn = builtIn;
+            _builtInConfigurationSource = configurationSource.Max(_builtInConfigurationSource);
+
+            return builtIn;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource? GetIsBuiltInConfigurationSource() => _builtInConfigurationSource;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual string StoreType
         {
             get => _storeType;
@@ -581,6 +617,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         string IConventionDbFunction.SetSchema(string schema, bool fromDataAnnotation)
             => SetSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunction.SetIsBuiltIn(bool builtIn, bool fromDataAnnotation)
+            => SetIsBuiltIn(builtIn, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
@@ -95,6 +95,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual IConventionDbFunctionBuilder IsBuiltIn(bool builtIn, ConfigurationSource configurationSource)
+        {
+            if (CanSetIsBuiltIn(builtIn, configurationSource))
+            {
+                Metadata.SetIsBuiltIn(builtIn, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetIsBuiltIn(bool builtIn, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetIsBuiltInConfigurationSource())
+                || Metadata.IsBuiltIn == builtIn;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IConventionDbFunctionBuilder HasStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
         {
             if (CanSetStoreType(storeType, configurationSource))
@@ -217,6 +244,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         [DebuggerStepThrough]
         bool IConventionDbFunctionBuilder.CanSetSchema(string schema, bool fromDataAnnotation)
             => CanSetSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.IsBuiltIn(bool builtIn, bool fromDataAnnotation)
+            => IsBuiltIn(builtIn, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetIsBuiltIn(bool builtIn, bool fromDataAnnotation)
+            => CanSetIsBuiltIn(builtIn, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -70,15 +70,29 @@ namespace Microsoft.EntityFrameworkCore.Query
             var dbFunction = model.FindDbFunction(method);
             if (dbFunction != null)
             {
-                return dbFunction.Translation?.Invoke(
-                        arguments.Select(e => _sqlExpressionFactory.ApplyDefaultTypeMapping(e)).ToList())
-                    ?? _sqlExpressionFactory.Function(
-                        dbFunction.Schema,
+                if (dbFunction.Translation != null)
+                {
+                    return dbFunction.Translation.Invoke(
+                        arguments.Select(e => _sqlExpressionFactory.ApplyDefaultTypeMapping(e)).ToList());
+                }
+
+                if (dbFunction.IsBuiltIn)
+                {
+                    return _sqlExpressionFactory.Function(
                         dbFunction.Name,
                         arguments,
                         nullable: true,
                         argumentsPropagateNullability: arguments.Select(a => false).ToList(),
                         method.ReturnType);
+                }
+
+                return _sqlExpressionFactory.Function(
+                    dbFunction.Schema,
+                    dbFunction.Name,
+                    arguments,
+                    nullable: true,
+                    argumentsPropagateNullability: arguments.Select(a => false).ToList(),
+                    method.ReturnType);
             }
 
             return _plugins.Concat(_translators)

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerDbFunctionConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerDbFunctionConvention.cs
@@ -10,7 +10,8 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     /// <summary>
-    ///     A convention that ensures that <see cref="IDbFunction.Schema"/> is populated for database functions which are not built-in.
+    ///     A convention that ensures that <see cref="IDbFunction.Schema"/> is populated for database functions which
+    ///     have <see cref="IDbFunction.IsBuiltIn"/> flag set to <see langword="false"/>.
     /// </summary>
     public class SqlServerDbFunctionConvention : IModelFinalizingConvention
     {
@@ -39,7 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var dbFunction in modelBuilder.Metadata.GetDbFunctions())
             {
-                if (string.IsNullOrEmpty(dbFunction.Schema))
+                if (!dbFunction.IsBuiltIn
+                    && string.IsNullOrEmpty(dbFunction.Schema))
                 {
                     dbFunction.SetSchema("dbo");
                 }

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -94,6 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Fall
             }
 
+            [DbFunction(Name = "len", IsBuiltIn = true)]
             public static long MyCustomLengthStatic(string s) => throw new Exception();
             public static bool IsDateStatic(string date) => throw new Exception();
             public static int AddOneStatic(int num) => num + 1;
@@ -220,15 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(GetSqlFragmentStatic)))
                     .HasTranslation(args => new SqlFragmentExpression("'Two'"));
                 var isDateMethodInfo = typeof(UDFSqlContext).GetMethod(nameof(IsDateStatic));
-                modelBuilder.HasDbFunction(isDateMethodInfo)
-                    .HasTranslation(args => new SqlFunctionExpression(
-                        "IsDate", args, nullable: true, argumentsPropagateNullability: args.Select(a => true).ToList(), isDateMethodInfo.ReturnType, null));
-
-                var methodInfo = typeof(UDFSqlContext).GetMethod(nameof(MyCustomLengthStatic));
-
-                modelBuilder.HasDbFunction(methodInfo)
-                    .HasTranslation(args => new SqlFunctionExpression(
-                        "len", args, nullable: true, argumentsPropagateNullability: args.Select(a => true).ToList(), methodInfo.ReturnType, null));
+                modelBuilder.HasDbFunction(isDateMethodInfo).HasName("IsDate").IsBuiltIn();
 
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(AddValues), new[] { typeof(int), typeof(int) }));
 
@@ -244,27 +237,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(GetReportingPeriodStartDateInstance)))
                     .HasName("GetReportingPeriodStartDate");
                 var isDateMethodInfo2 = typeof(UDFSqlContext).GetMethod(nameof(IsDateInstance));
-                modelBuilder.HasDbFunction(isDateMethodInfo2)
-                    .HasTranslation(args => new SqlFunctionExpression(
-                        "IsDate",
-                        args,
-                        nullable: true,
-                        argumentsPropagateNullability: args.Select(a => true).ToList(),
-                        isDateMethodInfo2.ReturnType,
-                        null));
+                modelBuilder.HasDbFunction(isDateMethodInfo2).HasName("IsDate").IsBuiltIn();
 
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(DollarValueInstance))).HasName("DollarValue");
 
                 var methodInfo2 = typeof(UDFSqlContext).GetMethod(nameof(MyCustomLengthInstance));
 
-                modelBuilder.HasDbFunction(methodInfo2)
-                    .HasTranslation(args => new SqlFunctionExpression(
-                        "len",
-                        args,
-                        nullable: true,
-                        argumentsPropagateNullability: args.Select(a => true).ToList(),
-                        methodInfo2.ReturnType,
-                        null));
+                modelBuilder.HasDbFunction(methodInfo2).HasName("len").IsBuiltIn();
 
                 modelBuilder.Entity<MultProductOrders>().ToTable("MultProductOrders").HasKey(mpo => mpo.OrderId);
 

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -595,6 +595,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         [ConditionalFact]
+        public void DbFunction_IsBuiltIn()
+        {
+            var modelBuilder = GetModelBuilder();
+
+            var methodA = typeof(OuterA.Inner).GetMethod(nameof(OuterA.Inner.Min));
+
+            var funcA = modelBuilder.HasDbFunction(methodA);
+
+            Assert.False(funcA.Metadata.IsBuiltIn);
+
+            funcA.IsBuiltIn();
+
+            Assert.True(funcA.Metadata.IsBuiltIn);
+        }
+
+        [ConditionalFact]
         public virtual void Set_empty_function_name_throws()
         {
             var modelBuilder = GetModelBuilder();


### PR DESCRIPTION
Resolves #17268

- Introduces new API `IsBuiltIn` on DbFunctionBuilder which marks the function as built-in and we translate it accordingly.
- Add `DbFunctionAttribute.IsBuiltIn` and convention to set the flag appropriately.