### PR TITLE
Fix to #18871 - Support for indirect joins which are using non-equal conditions

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -1041,7 +1041,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return result;
                 }
 
-                if (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso)
+                if (sqlBinaryExpression.OperatorType == ExpressionType.AndAlso
+                    || sqlBinaryExpression.OperatorType == ExpressionType.NotEqual
+                    || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThan
+                    || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThanOrEqual
+                    || sqlBinaryExpression.OperatorType == ExpressionType.LessThan
+                    || sqlBinaryExpression.OperatorType == ExpressionType.LessThanOrEqual)
                 {
                     return Visit(sqlBinaryExpression, allowOptimizedExpansion: true, out _);
                 }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -135,13 +135,34 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
                     });
 
                 sqliteConnection.CreateFunction(
+                    name: "ef_add",
+                    (decimal? left, decimal? right) => left + right,
+                    isDeterministic: true);
+
+                sqliteConnection.CreateFunction(
+                    name: "ef_divide",
+                    (decimal? dividend, decimal? divisor) => dividend / divisor,
+                    isDeterministic: true);
+
+                sqliteConnection.CreateFunction(
                     name: "ef_compare",
                     (decimal? left, decimal? right) => left.HasValue && right.HasValue
                         ? decimal.Compare(left.Value, right.Value)
                         : default(int?),
                     isDeterministic: true);
+
+                sqliteConnection.CreateFunction(
+                    name: "ef_multiply",
+                    (decimal? left, decimal? right) => left * right,
+                    isDeterministic: true);
+
+                sqliteConnection.CreateFunction(
+                    name: "ef_negate",
+                    (decimal? m) => -m,
+                    isDeterministic: true);
             }
             else
+
             {
                 _logger.UnexpectedConnectionTypeWarning(connection.GetType());
             }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -2651,6 +2651,12 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
         }
 
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
+        {
+            return base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async);
+        }
+
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task OrderBy_skip_take(bool async)
         {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -963,6 +963,24 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
         [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task SelectMany_correlated_with_outer_5(bool async)
+        {
+            return base.SelectMany_correlated_with_outer_5(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task SelectMany_correlated_with_outer_6(bool async)
+        {
+            return base.SelectMany_correlated_with_outer_6(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task SelectMany_correlated_with_outer_7(bool async)
+        {
+            return base.SelectMany_correlated_with_outer_7(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#17246")]
         public override Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
         {
             return base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async);

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -70,5 +70,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory(Skip = "issue #17386")]
         public override Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
             => base.Client_eval_followed_by_set_operation_throws_meaningful_exception(async);
+
+        [ConditionalTheory(Skip = "issue #17537")]
+        public override Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async)
+            => base.SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(async);
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -787,7 +787,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Replace("\r", "").Replace("\n", ""));
         }
 
-        // When adding include test here always add a split version in relational layer.
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_many_over_skip_navigation_where_non_equality(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from r in ss.Set<EntityOne>()
+                      from t in r.TwoSkip.Where(x => x.Id != r.Id).DefaultIfEmpty()
+                      select t);
+        }
+
+        // When adding include test here always add a tracking version and a split version in relational layer.
         // Keep this line at the bottom for next dev writing tests to see.
 
         protected ManyToManyContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -468,6 +468,21 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>().Include(c => c.Orders)
+                      from o in ss.Set<Order>().Where(o => o.CustomerID != c.CustomerID)
+                           .OrderBy(o => c.CustomerID).Take(5).DefaultIfEmpty()
+                      where c.CustomerID.StartsWith("F")
+                      select c,
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)),
+                entryCount: 71);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Include_collection_on_join_clause_with_order_by_and_filter(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -4150,6 +4150,28 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss =>
+                    (from c in ss.Set<Customer>().Where(c => c.City == "Seattle")
+                     from o1 in ss.Set<Order>().Where(o => o.OrderID > 15000).DefaultIfEmpty()
+                     from o2 in ss.Set<Order>().Where(o => o.OrderID <= c.CustomerID.Length).DefaultIfEmpty()
+                     where o1 != null && o2 != null
+                     orderby o1.OrderID, o2.OrderDate
+                     select new
+                     {
+                         c.CustomerID,
+                         o1.OrderID,
+                         o2.OrderDate
+                     }),
+                e => (e.CustomerID, e.OrderID));
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_skip_take(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1377,6 +1377,62 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_5(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>()
+                      from o in ss.Set<Order>().Where(o => c.CustomerID != o.CustomerID).Select(o => c.City).DefaultIfEmpty()
+                      select new { c, o },
+                elementSorter: e => (e.c.CustomerID, e.o),
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.c, a.c);
+                    Assert.Equal(e.o, a.o);
+                },
+                entryCount: 91);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_6(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>()
+                      from o in ss.Set<Order>().Where(o => c.CustomerID != o.CustomerID)
+                          .OrderBy(o => c.City).ThenBy(o => o.OrderID).Take(2).DefaultIfEmpty()
+                      select new { c, o },
+                elementSorter: e => (e.c.CustomerID, e.o?.OrderID),
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.c, a.c);
+                    AssertEqual(e.o, a.o);
+                },
+                entryCount: 94);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_correlated_with_outer_7(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>()
+                      from o in ss.Set<Order>().Where(o => c.CustomerID.Length >= o.CustomerID.Length)
+                          .OrderBy(o => c.City).ThenBy(o => o.OrderID).Take(2).DefaultIfEmpty()
+                      select new { c, o },
+                elementSorter: e => (e.c.CustomerID, e.o?.OrderID),
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.c, a.c);
+                    AssertEqual(e.o, a.o);
+                },
+                entryCount: 93);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -4407,11 +4407,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 INNER JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
-OUTER APPLY (
-    SELECT [l3].[Id], [l3].[Date], [l3].[Name], [l3].[OneToMany_Optional_Self_Inverse1Id], [l3].[OneToMany_Required_Self_Inverse1Id], [l3].[OneToOne_Optional_Self1Id]
-    FROM [LevelOne] AS [l3]
-    WHERE ([l3].[Id] <= [l0].[Id]) AND (([l2].[Name] = [l3].[Name]) OR ([l2].[Name] IS NULL AND [l3].[Name] IS NULL))
-) AS [t]");
+LEFT JOIN [LevelOne] AS [l3] ON ([l0].[Id] >= [l3].[Id]) AND (([l2].[Name] = [l3].[Name]) OR ([l2].[Name] IS NULL AND [l3].[Name] IS NULL))");
         }
 
         public override async Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5971,6 +5971,44 @@ LEFT JOIN (
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]");
         }
 
+        public override async Task SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector_not_equal(bool async)
+        {
+            await base.SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector_not_equal(async);
+
+            AssertSql(
+                @"@__isAutomatic_0='True'
+
+SELECT [g].[Nickname], [g].[FullName], CASE
+    WHEN [t].[Id] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Collection]
+FROM [Gears] AS [g]
+LEFT JOIN (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+    WHERE [w].[IsAutomatic] <> @__isAutomatic_0
+) AS [t] ON [g].[FullName] = [t].[OwnerFullName]");
+        }
+
+        public override async Task SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector_order_comparison(bool async)
+        {
+            await base.SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector_order_comparison(async);
+
+            AssertSql(
+                @"@__prm_0='1'
+
+SELECT [g].[Nickname], [g].[FullName], CASE
+    WHEN [t].[Id] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Collection]
+FROM [Gears] AS [g]
+LEFT JOIN (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+    WHERE [w].[Id] > @__prm_0
+) AS [t] ON [g].[FullName] = [t].[OwnerFullName]");
+        }
+
         public override async Task Join_with_inner_being_a_subquery_projecting_single_property(bool async)
         {
             await base.Join_with_inner_being_a_subquery_projecting_single_property(async);
@@ -7046,6 +7084,101 @@ LEFT JOIN [Gears] AS [g] ON [w].[OwnerFullName] = [g].[FullName]
 LEFT JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 GROUP BY [c].[Name], [c].[Location]
 ORDER BY [c].[Location]");
+        }
+
+        public override async Task SelectMany_predicate_with_non_equality_comparison_converted_to_inner_join(bool async)
+        {
+            await base.SelectMany_predicate_with_non_equality_comparison_converted_to_inner_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+INNER JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+ORDER BY [g].[Nickname], [w].[Id]");
+        }
+
+        public override async Task SelectMany_predicate_with_non_equality_comparison_DefaultIfEmpty_converted_to_left_join(bool async)
+        {
+            await base.SelectMany_predicate_with_non_equality_comparison_DefaultIfEmpty_converted_to_left_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL
+ORDER BY [g].[Nickname], [w].[Id]");
+        }
+
+        public override async Task SelectMany_predicate_after_navigation_with_non_equality_comparison_DefaultIfEmpty_converted_to_left_join(bool async)
+        {
+            await base.SelectMany_predicate_after_navigation_with_non_equality_comparison_DefaultIfEmpty_converted_to_left_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[AmmunitionType], [t].[IsAutomatic], [t].[Name], [t].[OwnerFullName], [t].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN (
+    SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId], [w].[Id] AS [Id0]
+    FROM [Weapons] AS [w]
+    LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
+) AS [t] ON ([g].[FullName] <> [t].[OwnerFullName]) OR [t].[OwnerFullName] IS NULL
+ORDER BY [g].[Nickname], [t].[Id]");
+        }
+
+        public override async Task SelectMany_without_result_selector_and_non_equality_comparison_converted_to_join(bool async)
+        {
+            await base.SelectMany_without_result_selector_and_non_equality_comparison_converted_to_join(async);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[OwnerFullName] IS NULL");
+        }
+
+        public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join(bool async)
+        {
+            await base.Filtered_collection_projection_with_order_comparison_predicate_converted_to_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] < [w].[Id])
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+        }
+
+        public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join2(bool async)
+        {
+            await base.Filtered_collection_projection_with_order_comparison_predicate_converted_to_join2(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] <= [w].[Id])
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+        }
+
+        public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join3(bool async)
+        {
+            await base.Filtered_collection_projection_with_order_comparison_predicate_converted_to_join3(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Gears] AS [g]
+LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] >= [w].[Id])
+ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+        }
+
+        public override async Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async)
+        {
+            await base.SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [t].[Id], [t].[AmmunitionType], [t].[IsAutomatic], [t].[Name], [t].[OwnerFullName], [t].[SynergyWithId]
+FROM [Gears] AS [g]
+CROSS APPLY (
+    SELECT TOP(3) [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+    WHERE ([w].[OwnerFullName] <> [g].[FullName]) OR [w].[OwnerFullName] IS NULL
+) AS [t]
+ORDER BY [g].[Nickname], [t].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -1566,6 +1566,20 @@ INNER JOIN (
 ORDER BY [e].[Id], [t].[Id]");
         }
 
+        public override async Task Select_many_over_skip_navigation_where_non_equality(bool async)
+        {
+            await base.Select_many_over_skip_navigation_where_non_equality(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+LEFT JOIN (
+    SELECT [e0].[Id], [e0].[CollectionInverseId], [e0].[Name], [e0].[ReferenceInverseId], [j].[OneId], [j].[TwoId]
+    FROM [JoinOneToTwo] AS [j]
+    INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
+) AS [t] ON ([e].[Id] = [t].[OneId]) AND ([e].[Id] <> [t].[Id])");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -627,6 +627,24 @@ WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+        {
+            await base.Include_collection_with_outer_apply_with_filter_non_equality(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0]
+    FROM [Orders] AS [o]
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
+        }
+
         public override async Task Include_collection_on_additional_from_clause2(bool async)
         {
             await base.Include_collection_on_additional_from_clause2(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -3362,6 +3362,33 @@ WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [o0].[OrderI
 ORDER BY [t0].[OrderID], [o0].[OrderDate]");
         }
 
+        public override async Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
+        {
+            await base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t0].[OrderID], [t1].[OrderDate]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+    FROM (
+        SELECT NULL AS [empty]
+    ) AS [empty]
+    LEFT JOIN (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE [o].[OrderID] > 15000
+    ) AS [t] ON 1 = 1
+) AS [t0]
+OUTER APPLY (
+    SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] <= CAST(LEN([c].[CustomerID]) AS int)
+) AS [t1]
+WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t1].[OrderID] IS NOT NULL)
+ORDER BY [t0].[OrderID], [t1].[OrderDate]");
+        }
+
         public override async Task OrderBy_skip_take(bool async)
         {
             await base.OrderBy_skip_take(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1078,6 +1078,50 @@ OUTER APPLY (
 ) AS [t]");
         }
 
+        public override async Task SelectMany_correlated_with_outer_5(bool async)
+        {
+            await base.SelectMany_correlated_with_outer_5(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[City] AS [o]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [c].[City], [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR [o].[CustomerID] IS NULL
+) AS [t]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_6(bool async)
+        {
+            await base.SelectMany_correlated_with_outer_6(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] <> [o].[CustomerID]) OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[City], [o].[OrderID]
+) AS [t]");
+        }
+
+        public override async Task SelectMany_correlated_with_outer_7(bool async)
+        {
+            await base.SelectMany_correlated_with_outer_7(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[City]
+    FROM [Orders] AS [o]
+    WHERE CAST(LEN([c].[CustomerID]) AS int) >= CAST(LEN([o].[CustomerID]) AS int)
+    ORDER BY [c].[City], [o].[OrderID]
+) AS [t]");
+        }
+
         public override async Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
         {
             await base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -930,6 +930,35 @@ WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]");
         }
 
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+        {
+            await base.Include_collection_with_outer_apply_with_filter_non_equality(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0]
+    FROM [Orders] AS [o]
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]",
+                //
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID] AS [CustomerID0]
+    FROM [Orders] AS [o]
+    WHERE ([o].[CustomerID] <> [c].[CustomerID]) OR [o].[CustomerID] IS NULL
+    ORDER BY [c].[CustomerID]
+) AS [t]
+INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+        }
+
         public override async Task Include_collection_on_additional_from_clause2(bool async)
         {
             await base.Include_collection_on_additional_from_clause2(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -20,7 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         // Sqlite does not support cross/outer apply
-        public override Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async) => null;
         public override Task Filtered_include_after_different_filtered_include_different_level(bool async) => null;
         public override void Filtered_include_outer_parameter_used_inside_filter() { }
         public override Task Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation(bool async) => null;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
@@ -15,7 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         // Sqlite does not support cross/outer apply
-        public override Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async) => null;
         public override Task Filtered_include_after_different_filtered_include_different_level(bool async) => null;
         public override Task Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation(bool async) => null;
         public override Task Filtered_include_complex_three_level_with_middle_having_filter1(bool async) => null;

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -77,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Subquery_projecting_non_nullable_scalar_contains_non_nullable_value_doesnt_need_null_expansion(bool async) => null;
 
         public override Task Subquery_projecting_non_nullable_scalar_contains_non_nullable_value_doesnt_need_null_expansion_negated(bool async) => null;
+        public override Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async) => null;
 
         public override async Task Negate_on_binary_expression(bool async)
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
@@ -16,7 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         // Sqlite does not support Apply operations
 
         public override Task Skip_navigation_order_by_single_or_default(bool async) => Task.CompletedTask;
-
         public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async) => Task.CompletedTask;
 
         [ConditionalTheory(Skip = "Issue#21541")]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -17,15 +19,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         public override Task Sum_with_division_on_decimal(bool async)
-            => AssertTranslationFailed(() => base.Sum_with_division_on_decimal(async));
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Sum_with_division_on_decimal(async));
 
         public override Task Sum_with_division_on_decimal_no_significant_digits(bool async)
-            => AssertTranslationFailed(() => base.Sum_with_division_on_decimal_no_significant_digits(async));
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Sum_with_division_on_decimal_no_significant_digits(async));
 
         public override Task Average_with_division_on_decimal(bool async)
-            => AssertTranslationFailed(() => base.Average_with_division_on_decimal(async));
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Average_with_division_on_decimal(async));
 
         public override Task Average_with_division_on_decimal_no_significant_digits(bool async)
-            => AssertTranslationFailed(() => base.Average_with_division_on_decimal_no_significant_digits(async));
+            => Assert.ThrowsAsync<NotSupportedException>(() => base.Average_with_division_on_decimal_no_significant_digits(async));
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
@@ -21,5 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
 
         public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+
+        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
@@ -21,5 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
 
         public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -277,6 +277,10 @@ FROM ""Orders"" AS ""o""");
 FROM ""Orders"" AS ""o""");
         }
 
+
+        // Sqlite does not support Apply operations
+        public override Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async) => Task.CompletedTask;
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -144,6 +144,12 @@ FROM ""Orders"" AS ""o""");
 
         public override Task SelectMany_correlated_with_outer_4(bool async) => null;
 
+        public override Task SelectMany_correlated_with_outer_5(bool async) => null;
+
+        public override Task SelectMany_correlated_with_outer_6(bool async) => null;
+
+        public override Task SelectMany_correlated_with_outer_7(bool async) => null;
+
         public override Task SelectMany_whose_selector_references_outer_source(bool async) => null;
 
         [ConditionalTheory(Skip = "Issue#17324")]

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqliteTest.cs
@@ -21,5 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
 
         public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+
+        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeQuerySqliteTest.cs
@@ -21,5 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
 
         public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
@@ -21,5 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
 
         public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
+
+        
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
@@ -78,6 +78,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override Task Subquery_projecting_non_nullable_scalar_contains_non_nullable_value_doesnt_need_null_expansion_negated(bool async) => null;
 
+        public override Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async) => null;
+
         public override async Task Negate_on_binary_expression(bool async)
         {
             await base.Negate_on_binary_expression(async);


### PR DESCRIPTION
When validating join key expression we now allow non-equality binary ops on the top level.

Fixes #18871