### PR TITLE
#21396 Fix error when HasNoDiscrimination is set and primary key is the same as partition key

### DIFF
--- a/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
+++ b/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
@@ -45,13 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
                 builder.Append("|");
             }
 
-            var partitionKey = entityType.GetPartitionKeyPropertyName();
             foreach (var property in primaryKey.Properties)
             {
-                if (property.Name == partitionKey)
-                {
-                    continue;
-                }
 
                 var value = entry.Property(property.Name).CurrentValue;
 
@@ -66,7 +61,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
                 builder.Append("|");
             }
 
-            builder.Remove(builder.Length - 1, 1);
+            if (builder.Length > 1)
+            {
+                builder.Remove(builder.Length - 1, 1);
+            }
+            else
+            {
+                builder.Append("null");
+            }
 
             return builder.ToString();
         }


### PR DESCRIPTION
Fix error "start index must be greater than 0" when HasNoDiscrimination is set and primary key is the same as partition key
In relation to issue: 21396.
Issue can be found here:
https://github.com/dotnet/efcore/issues/21396