### PR TITLE
Query: Introduce context level configuration for split query

### DIFF
--- a/src/EFCore.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
@@ -99,6 +99,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => (TExtension)e.WithUseRelationalNulls(useRelationalNulls));
 
         /// <summary>
+        ///     Configures the <see cref="QuerySplittingBehavior"/> to use when loading related collections in a query.
+        /// </summary>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public virtual TBuilder UseQuerySplittingBehavior(QuerySplittingBehavior querySplittingBehavior)
+            => WithOption(e => (TExtension)e.WithUseQuerySplittingBehavior(querySplittingBehavior));
+
+        /// <summary>
         ///     Configures the context to use the provided <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <param name="getExecutionStrategy"> A function that returns a new instance of an execution strategy. </param>

--- a/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -34,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private int? _maxBatchSize;
         private int? _minBatchSize;
         private bool _useRelationalNulls;
+        private QuerySplittingBehavior? _querySplittingBehavior;
         private string _migrationsAssembly;
         private string _migrationsHistoryTableName;
         private string _migrationsHistoryTableSchema;
@@ -60,6 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _maxBatchSize = copyFrom._maxBatchSize;
             _minBatchSize = copyFrom._minBatchSize;
             _useRelationalNulls = copyFrom._useRelationalNulls;
+            _querySplittingBehavior = copyFrom._querySplittingBehavior;
             _migrationsAssembly = copyFrom._migrationsAssembly;
             _migrationsHistoryTableName = copyFrom._migrationsHistoryTableName;
             _migrationsHistoryTableSchema = copyFrom._migrationsHistoryTableSchema;
@@ -221,6 +223,26 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var clone = Clone();
 
             clone._useRelationalNulls = useRelationalNulls;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     The <see cref="QuerySplittingBehavior"/> to use when loading related collections in a query.
+        /// </summary>
+        public virtual QuerySplittingBehavior? QuerySplittingBehavior => _querySplittingBehavior;
+
+        /// <summary>
+        ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+        ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+        /// </summary>
+        /// <param name="querySplittingBehavior"> The option to change. </param>
+        /// <returns> A new instance with the option changed. </returns>
+        public virtual RelationalOptionsExtension WithUseQuerySplittingBehavior(QuerySplittingBehavior querySplittingBehavior)
+        {
+            var clone = Clone();
+
+            clone._querySplittingBehavior = querySplittingBehavior;
 
             return clone;
         }
@@ -415,6 +437,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         if (Extension._useRelationalNulls)
                         {
                             builder.Append("UseRelationalNulls ");
+                        }
+
+                        if (Extension._querySplittingBehavior != null)
+                        {
+                            builder.Append("QuerySplittingBehavior=").Append(Extension._querySplittingBehavior).Append(' ');
                         }
 
                         if (Extension._migrationsAssembly != null)

--- a/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -16,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     public class CollectionJoinApplyingExpressionVisitor : ExpressionVisitor
     {
         private readonly bool _splitQuery;
+        private readonly bool _userConfiguredBehavior;
         private int _collectionId;
 
         /// <summary>
@@ -24,9 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public CollectionJoinApplyingExpressionVisitor(bool splitQuery)
+        public CollectionJoinApplyingExpressionVisitor([NotNull] RelationalQueryCompilationContext queryCompilationContext)
         {
-            _splitQuery = splitQuery;
+            Check.NotNull(queryCompilationContext, nameof(queryCompilationContext));
+
+            _splitQuery = queryCompilationContext.QuerySplittingBehavior == QuerySplittingBehavior.SplitQuery;
+            _userConfiguredBehavior = RelationalOptionsExtension.Extract(queryCompilationContext.ContextOptions).QuerySplittingBehavior.HasValue;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Internal/RelationalQueryMetadataExtractingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalQueryMetadataExtractingExpressionVisitor.cs
@@ -43,7 +43,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 var innerQueryable = Visit(methodCallExpression.Arguments[0]);
 
-                _relationalQueryCompilationContext.IsSplitQuery = true;
+                _relationalQueryCompilationContext.QuerySplittingBehavior = QuerySplittingBehavior.SplitQuery;
+
+                return innerQueryable;
+            }
+
+            if (methodCallExpression.Method.IsGenericMethod
+                && methodCallExpression.Method.GetGenericMethodDefinition() == RelationalQueryableExtensions.AsSingleQueryMethodInfo)
+            {
+                var innerQueryable = Visit(methodCallExpression.Arguments[0]);
+
+                _relationalQueryCompilationContext.QuerySplittingBehavior = QuerySplittingBehavior.SingleQuery;
 
                 return innerQueryable;
             }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -64,10 +64,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="async"> A value indicating whether the query will be executed asynchronously. </param>
         /// <returns> The cache key. </returns>
         protected new RelationalCompiledQueryCacheKey GenerateCacheKeyCore([NotNull] Expression query, bool async) // Intentionally non-virtual
-            => new RelationalCompiledQueryCacheKey(
+        {
+            var relationalOptions = RelationalOptionsExtension.Extract(RelationalDependencies.ContextOptions);
+
+            return new RelationalCompiledQueryCacheKey(
                 base.GenerateCacheKeyCore(query, async),
-                RelationalOptionsExtension.Extract(RelationalDependencies.ContextOptions).UseRelationalNulls,
+                relationalOptions.UseRelationalNulls,
+                relationalOptions.QuerySplittingBehavior,
                 shouldBuffer: Dependencies.IsRetryingExecutionStrategy);
+        }
 
         /// <summary>
         ///     <para>
@@ -83,6 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             private readonly CompiledQueryCacheKey _compiledQueryCacheKey;
             private readonly bool _useRelationalNulls;
+            private readonly QuerySplittingBehavior? _querySplittingBehavior;
             private readonly bool _shouldBuffer;
 
             /// <summary>
@@ -90,12 +96,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// </summary>
             /// <param name="compiledQueryCacheKey"> The non-relational cache key. </param>
             /// <param name="useRelationalNulls"> True to use relational null logic. </param>
+            /// <param name="querySplittingBehavior"> <see cref="QuerySplittingBehavior"/> to use when loading related collections. </param>
             /// <param name="shouldBuffer"> <see langword="true"/> if the query should be buffered. </param>
             public RelationalCompiledQueryCacheKey(
-                CompiledQueryCacheKey compiledQueryCacheKey, bool useRelationalNulls, bool shouldBuffer)
+                CompiledQueryCacheKey compiledQueryCacheKey, bool useRelationalNulls,
+                QuerySplittingBehavior? querySplittingBehavior, bool shouldBuffer)
             {
                 _compiledQueryCacheKey = compiledQueryCacheKey;
                 _useRelationalNulls = useRelationalNulls;
+                _querySplittingBehavior = querySplittingBehavior;
                 _shouldBuffer = shouldBuffer;
             }
 
@@ -117,6 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             private bool Equals(RelationalCompiledQueryCacheKey other)
                 => _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey)
                     && _useRelationalNulls == other._useRelationalNulls
+                    && _querySplittingBehavior == other._querySplittingBehavior
                     && _shouldBuffer == other._shouldBuffer;
 
             /// <summary>
@@ -125,7 +135,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             /// <returns>
             ///     The hash code for the key.
             /// </returns>
-            public override int GetHashCode() => HashCode.Combine(_compiledQueryCacheKey, _useRelationalNulls, _shouldBuffer);
+            public override int GetHashCode() => HashCode.Combine(
+                _compiledQueryCacheKey, _useRelationalNulls, _querySplittingBehavior, _shouldBuffer);
         }
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -32,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(relationalDependencies, nameof(relationalDependencies));
 
             RelationalDependencies = relationalDependencies;
+            QuerySplittingBehavior = RelationalOptionsExtension.Extract(ContextOptions).QuerySplittingBehavior
+                ?? QuerySplittingBehavior.SingleQuery;
         }
 
         /// <summary>
@@ -40,8 +43,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected virtual RelationalQueryCompilationContextDependencies RelationalDependencies { get; }
 
         /// <summary>
-        ///     A value indicating if the query should load collections using separate database queries.
+        ///     A value indicating the <see cref="EntityFrameworkCore.QuerySplittingBehavior"/> of the query.
         /// </summary>
-        public virtual bool IsSplitQuery { get; internal set; }
+        public virtual QuerySplittingBehavior QuerySplittingBehavior { get; internal set; }
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             query = base.Process(query);
             query = new SelectExpressionProjectionApplyingExpressionVisitor().Visit(query);
-            query = new CollectionJoinApplyingExpressionVisitor(((RelationalQueryCompilationContext)QueryCompilationContext).IsSplitQuery).Visit(query);
+            query = new CollectionJoinApplyingExpressionVisitor((RelationalQueryCompilationContext)QueryCompilationContext).Visit(query);
             query = new TableAliasUniquifyingExpressionVisitor().Visit(query);
             query = new CaseSimplifyingExpressionVisitor(RelationalDependencies.SqlExpressionFactory).Visit(query);
             query = new RelationalValueConverterCompensatingExpressionVisitor(RelationalDependencies.SqlExpressionFactory).Visit(query);

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPreprocessor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             query = base.Process(query);
 
-            return _relationalQueryCompilationContext.IsSplitQuery
+            return _relationalQueryCompilationContext.QuerySplittingBehavior == QuerySplittingBehavior.SplitQuery
                 ? new SplitIncludeRewritingExpressionVisitor().Visit(query)
                 : query;
         }

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             VerifyNoClientConstant(shapedQueryExpression.ShaperExpression);
             var nonComposedFromSql = selectExpression.IsNonComposedFromSql();
-            var splitQuery = ((RelationalQueryCompilationContext)QueryCompilationContext).IsSplitQuery;
+            var splitQuery = ((RelationalQueryCompilationContext)QueryCompilationContext).QuerySplittingBehavior == QuerySplittingBehavior.SplitQuery;
             var shaper = new ShaperProcessingExpressionVisitor(this, selectExpression, _tags, splitQuery, nonComposedFromSql).ProcessShaper(
                 shapedQueryExpression.ShaperExpression, out var relationalCommandCache, out var relatedDataLoaders);
 

--- a/src/EFCore.Relational/QuerySplittingBehavior.cs
+++ b/src/EFCore.Relational/QuerySplittingBehavior.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Indicates how the related collections in a query should be loaded from database.
+    /// </summary>
+    public enum QuerySplittingBehavior
+    {
+        /// <summary>
+        ///     <para>
+        ///         The related collections will be loaded in same database query as parent query.
+        ///     </para>
+        ///     <para>
+        ///         This behavior generally guarantees result consistency in the face of concurrent updates
+        ///         (but details may vary based on the database and transaction isolation level in use).
+        ///         However, this can cause performance issues when the query loads multiple related collections.
+        ///     </para>
+        /// </summary>
+        SingleQuery = 0,
+
+        /// <summary>
+        ///     <para>
+        ///         The related collections will be loaded in separate database queries from the parent query.
+        ///     </para>
+        ///     <para>
+        ///         This behavior can significantly improve performance when the query loads multiple collections.
+        ///         However, since separate queries are used, this can result in inconsistent results when concurrent updates occur.
+        ///         Serializable or snapshot transactions can be used to mitigate this
+        ///         and achieve consistency with split queries, but that may bring other performance costs and behavioral difference.
+        ///     </para>
+        /// </summary>
+        SplitQuery
+    }
+}


### PR DESCRIPTION
- Add enum QuerySplittingBehavior
- Add RelationalDbContextOptionsBuilder.UseQuerySplittingBehavior
- Add AsSingleQuery

Resolves #21355
