### PR TITLE
Allow DbContextFactory to use a pool

### DIFF
--- a/src/EFCore/Internal/DbContextLease.cs
+++ b/src/EFCore/Internal/DbContextLease.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public struct DbContextLease
+    {
+        private IDbContextPool _contextPool;
+        private readonly bool _standalone;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static DbContextLease InactiveLease { get; } = new DbContextLease();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public DbContextLease([NotNull] IDbContextPool contextPool, bool standalone)
+        {
+            _contextPool = contextPool;
+            _standalone = standalone;
+
+            var context = _contextPool.Rent();
+            Context = context;
+
+            context.SetLease(this);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public IDbContextPoolable Context { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public bool IsActive => _contextPool != null;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public bool ContextDisposed()
+        {
+            if (_standalone)
+            {
+                Release();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public void Release()
+        {
+            if (Release(out var pool, out var context))
+            {
+                pool.Return(context);
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public ValueTask ReleaseAsync()
+            => Release(out var pool, out var context) ? pool.ReturnAsync(context) : new ValueTask();
+
+        private bool Release(out IDbContextPool pool, out IDbContextPoolable context)
+        {
+            pool = _contextPool;
+            context = Context;
+            _contextPool = null;
+            Context = null;
+
+            return pool != null;
+        }
+    }
+}

--- a/src/EFCore/Internal/IDbContextPool`.cs
+++ b/src/EFCore/Internal/IDbContextPool`.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public interface IDbContextPool<TContext> : IDbContextPool
+        where TContext : DbContext
+    {
+    }
+}

--- a/src/EFCore/Internal/IDbContextPoolable.cs
+++ b/src/EFCore/Internal/IDbContextPoolable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -12,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPoolable : IResettableService
+    public interface IDbContextPoolable : IResettableService, IDisposable, IAsyncDisposable
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void SetPool([CanBeNull] IDbContextPool contextPool);
+        void SetLease(DbContextLease lease);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        DbContextPoolConfigurationSnapshot SnapshotConfiguration();
+        void ClearLease();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -36,6 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void Resurrect([NotNull] DbContextPoolConfigurationSnapshot configurationSnapshot);
+        void SnapshotConfiguration();
     }
 }

--- a/src/EFCore/Internal/IScopedDbContextLease.cs
+++ b/src/EFCore/Internal/IScopedDbContextLease.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public interface IScopedDbContextLease<out TContext>
+        where TContext : DbContext
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        TContext Context { get; }
+    }
+}

--- a/src/EFCore/Internal/PooledDbContextFactory.cs
+++ b/src/EFCore/Internal/PooledDbContextFactory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -13,15 +11,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public interface IDbContextPool
+    public class PooledDbContextFactory<TContext> : IDbContextFactory<TContext>
+        where TContext : DbContext
     {
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        IDbContextPoolable Rent();
+        private readonly IDbContextPool<TContext> _pool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -29,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void Return([NotNull] IDbContextPoolable context);
+        public PooledDbContextFactory([NotNull] IDbContextPool<TContext> pool)
+            => _pool = pool;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -37,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        ValueTask ReturnAsync([NotNull] IDbContextPoolable context, CancellationToken cancellationToken = default);
+        public virtual TContext CreateDbContext()
+            => (TContext)new DbContextLease(_pool, standalone: true).Context;
     }
 }

--- a/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
@@ -25,7 +25,8 @@ namespace Microsoft.EntityFrameworkCore
         private IDbContextPool _contextPool;
 
         private IDbContextPool ContextPool
-            => _contextPool ??= (IDbContextPool)ServiceProvider.GetRequiredService(typeof(DbContextPool<>).MakeGenericType(ContextType));
+            => _contextPool ??= (IDbContextPool)ServiceProvider
+                .GetRequiredService(typeof(IDbContextPool<>).MakeGenericType(ContextType));
 
         private ListLoggerFactory _listLoggerFactory;
 
@@ -61,16 +62,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public virtual TContext CreateContext()
-        {
-            if (UsePooling)
-            {
-                var context = (PoolableDbContext)ContextPool.Rent();
-                context.SetPool(ContextPool);
-                return (TContext)(object)context;
-            }
-
-            return (TContext)ServiceProvider.GetRequiredService(ContextType);
-        }
+            => UsePooling
+                ? (TContext)new DbContextLease(ContextPool, standalone: true).Context
+                : (TContext)ServiceProvider.GetRequiredService(ContextType);
 
         public DbContextOptions CreateOptions()
             => ConfigureOptions(ServiceProvider, new DbContextOptionsBuilder()).Options;

--- a/test/EFCore.Specification.Tests/TestUtilities/PoolableDbContext.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/PoolableDbContext.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Internal;
-
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class PoolableDbContext : DbContext
     {
-        private IDbContextPool _contextPool;
-
         protected PoolableDbContext()
             : this(new DbContextOptions<PoolableDbContext>())
         {
@@ -17,26 +13,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public PoolableDbContext(DbContextOptions options)
             : base(options)
         {
-        }
-
-        public virtual void SetPool(IDbContextPool contextPool) => _contextPool = contextPool;
-
-        public override void Dispose()
-        {
-            if (_contextPool != null)
-            {
-                if (!_contextPool.Return(this))
-                {
-                    ((IDbContextPoolable)this).SetPool(null);
-                    base.Dispose();
-                }
-
-                _contextPool = null;
-            }
-            else
-            {
-                base.Dispose();
-            }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         private static readonly MethodInfo _addDbContextPool
             = typeof(EntityFrameworkServiceCollectionExtensions)
-                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkServiceCollectionExtensions.AddDbContextPool))
+                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory))
                 .Single(
                     mi => mi.GetParameters().Length == 3
                         && mi.GetParameters()[1].ParameterType == typeof(Action<IServiceProvider, DbContextOptionsBuilder>)

--- a/test/EFCore.Tests/DbContextFactoryTest.cs
+++ b/test/EFCore.Tests/DbContextFactoryTest.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -40,6 +40,79 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
         }
 
+        [ConditionalFact]
+        public void Factory_can_use_pool()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddPooledDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            var context1 = contextFactory.CreateDbContext();
+            var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+
+            context1.Dispose();
+            context2.Dispose();
+
+            using var context1b = contextFactory.CreateDbContext();
+            using var context2b = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1b, context2b);
+            Assert.Same(context1, context1b);
+            Assert.Same(context2, context2b);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1b));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2b));
+        }
+
+        [ConditionalFact]
+        public void Factory_can_use_shared_pool()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContext<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)), ServiceLifetime.Scoped, ServiceLifetime.Singleton)
+                .AddPooledDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            var scope = serviceProvider.CreateScope();
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+            Assert.Same(contextFactory, scope.ServiceProvider.GetService<IDbContextFactory<WoolacombeContext>>());
+
+            var context1 = contextFactory.CreateDbContext();
+            var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+
+            var context3 = scope.ServiceProvider.GetService<WoolacombeContext>();
+
+            Assert.Same(context3, scope.ServiceProvider.GetService<WoolacombeContext>());
+            Assert.NotSame(context1, context3);
+            Assert.NotSame(context2, context3);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context3));
+
+            context1.Dispose();
+            context2.Dispose();
+            scope.Dispose();
+
+            using var scope1 = serviceProvider.CreateScope();
+
+            using var context1b = contextFactory.CreateDbContext();
+            using var context2b = contextFactory.CreateDbContext();
+            var context3b = scope1.ServiceProvider.GetService<WoolacombeContext>();
+
+            Assert.Same(context3b, scope1.ServiceProvider.GetService<WoolacombeContext>());
+            Assert.NotSame(context1b, context3b);
+            Assert.NotSame(context2b, context3b);
+        }
+
         [ConditionalTheory]
         [InlineData(ServiceLifetime.Singleton)]
         [InlineData(ServiceLifetime.Scoped)]
@@ -62,6 +135,26 @@ namespace Microsoft.EntityFrameworkCore
             var serviceCollection = new ServiceCollection()
                 .AddDbContextFactory<WoolacombeContext>(
                     b => b.UseInMemoryDatabase(nameof(WoolacombeContext)));
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                serviceCollection.Single(e => e.ServiceType == typeof(IDbContextFactory<WoolacombeContext>)).Lifetime);
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                serviceCollection.Single(e => e.ServiceType == typeof(DbContextOptions<WoolacombeContext>)).Lifetime);
+        }
+
+        [ConditionalFact]
+        public void Lifetime_is_singleton_when_pooling()
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddPooledDbContextFactory<WoolacombeContext>(
+                    b => b.UseInMemoryDatabase(nameof(WoolacombeContext)));
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                serviceCollection.Single(e => e.ServiceType == typeof(IDbContextPool<WoolacombeContext>)).Lifetime);
 
             Assert.Equal(
                 ServiceLifetime.Singleton,
@@ -117,6 +210,18 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase(nameof(MortehoeContext));
+        }
+
+        [ConditionalFact]
+        public void Factory_can_use_DbContext_directly()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddDbContextFactory<DbContext>(b => b.UseInMemoryDatabase(nameof(DbContext)))
+                .BuildServiceProvider(validateScopes: true);
+
+            using var context = serviceProvider.GetService<IDbContextFactory<DbContext>>().CreateDbContext();
+
+            Assert.Equal(nameof(DbContext), GetStoreName(context));
         }
 
         [ConditionalTheory]
@@ -270,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddScoped<ScopedService>()
                 .AddTransient<TransientService>()
                 .AddDbContextFactory<WoolacombeContext>(
-                    optionsAction: (p, b) =>
+                    (p, b) =>
                     {
                         Assert.NotNull(p.GetService<SingletonService>());
                         Assert.NotNull(p.GetService<TransientService>());
@@ -289,6 +394,32 @@ namespace Microsoft.EntityFrameworkCore
             {
                 serviceProvider = serviceProvider.CreateScope().ServiceProvider;
             }
+
+            var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+
+            using var context1 = contextFactory.CreateDbContext();
+            using var context2 = contextFactory.CreateDbContext();
+
+            Assert.NotSame(context1, context2);
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
+            Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
+        }
+
+        [ConditionalFact]
+        public void Can_resolve_from_the_service_provider_when_pooling()
+        {
+            var serviceProvider = (IServiceProvider)new ServiceCollection()
+                .AddSingleton<SingletonService>()
+                .AddTransient<TransientService>()
+                .AddDbContextFactory<WoolacombeContext>(
+                    (p, b) =>
+                    {
+                        Assert.NotNull(p.GetService<SingletonService>());
+                        Assert.NotNull(p.GetService<TransientService>());
+
+                        b.UseInMemoryDatabase(nameof(WoolacombeContext));
+                    })
+                .BuildServiceProvider(validateScopes: true);
 
             var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
 


### PR DESCRIPTION
Fixes #21247

Refactors the context pooling code to create a cleaner responsibility of services.

Has the same restrictions as regular pooling since the context instances are reused.

