### PR TITLE
Query: Bind projection member in client eval

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -127,6 +127,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 return new ProjectionBindingExpression(_selectExpression, newIndex, expression.Type);
                             }
 
+                            if (projectionBindingExpression.ProjectionMember != null)
+                            {
+                                // This would be SqlExpression. EntityProjectionExpression would be wrapped inside EntityShaperExpression.
+                                var mappedProjection = (SqlExpression)_selectExpression.GetMappedProjection(
+                                    projectionBindingExpression.ProjectionMember);
+
+                                return new ProjectionBindingExpression(
+                                    _selectExpression, _selectExpression.AddToProjection(mappedProjection), expression.Type);
+                            }
+
                             throw new InvalidOperationException(CoreStrings.TranslationFailed(projectionBindingExpression.Print()));
 
                         case ParameterExpression parameterExpression:

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4139,6 +4139,12 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
             return base.Single_non_scalar_projection_after_skip_uses_join(async);
         }
 
+        [ConditionalTheory(Skip = "No Select after Distinct issue#17246")]
+        public override Task Select_distinct_Select_with_client_bindings(bool async)
+        {
+            return base.Select_distinct_Select_with_client_bindings(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -5980,5 +5980,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderDate).ThenBy(o => o.OrderID).Skip(2).FirstOrDefault()),
                 entryCount: 86);
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_distinct_Select_with_client_bindings(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID < 10000).Select(o => o.OrderDate.Value.Year).Distinct()
+                        .Select(e => new DTO<int> { Property = ClientMethod(e) }));
+        }
+
+        private static int ClientMethod(int s) => s;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5120,6 +5120,19 @@ LEFT JOIN (
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]");
         }
 
+        public override async Task Select_distinct_Select_with_client_bindings(bool async)
+        {
+            await base.Select_distinct_Select_with_client_bindings(async);
+
+            AssertSql(
+                @"SELECT [t].[c]
+FROM (
+    SELECT DISTINCT DATEPART(year, [o].[OrderDate]) AS [c]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10000
+) AS [t]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #21445
