### PR TITLE
Query: Self-bootstrapping functions returning IQueryable

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -1707,16 +1707,13 @@ namespace Microsoft.EntityFrameworkCore
         IServiceProvider IInfrastructure<IServiceProvider>.Instance => InternalServiceProvider;
 
         /// <summary>
-        /// Creates a query expression, which represents a function call, against the query store.
+        ///     Creates a queryable for given query expression.
         /// </summary>
-        /// <typeparam name="TResult"> The result type of the query expression </typeparam>
+        /// <typeparam name="TResult"> The result type of the query expression. </typeparam>
         /// <param name="expression"> The query expression to create. </param>
-        /// <returns> An IQueryable representing the query. </returns>
-        protected virtual IQueryable<TResult> CreateQuery<TResult>([NotNull] Expression<Func<IQueryable<TResult>>> expression)
+        /// <returns> An <see cref="IQueryable{T}"/> representing the query. </returns>
+        public virtual IQueryable<TResult> FromExpression<TResult>([NotNull] Expression<Func<IQueryable<TResult>>> expression)
         {
-            //should we add this method as an extension in relational?  That would require making DbContextDependencies public.
-            //Is there a 3rd way?
-
             Check.NotNull(expression, nameof(expression));
 
             return DbContextDependencies.QueryProvider.CreateQuery<TResult>(expression.Body);

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -171,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public IQueryable<OrderByYear> GetCustomerOrderCountByYear(int customerId)
             {
-                return CreateQuery(() => GetCustomerOrderCountByYear(customerId));
+                return FromExpression(() => GetCustomerOrderCountByYear(customerId));
             }
 
             public class TopSellingProduct
@@ -184,17 +184,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public IQueryable<TopSellingProduct> GetTopTwoSellingProducts()
             {
-                return CreateQuery(() => GetTopTwoSellingProducts());
+                return FromExpression(() => GetTopTwoSellingProducts());
             }
 
             public IQueryable<TopSellingProduct> GetTopSellingProductsForCustomer(int customerId)
             {
-                return CreateQuery(() => GetTopSellingProductsForCustomer(customerId));
+                return FromExpression(() => GetTopSellingProductsForCustomer(customerId));
             }
 
             public IQueryable<MultProductOrders> GetOrdersWithMultipleProducts(int customerId)
             {
-                return CreateQuery(() => GetOrdersWithMultipleProducts(customerId));
+                return FromExpression(() => GetOrdersWithMultipleProducts(customerId));
             }
 
             #endregion

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -727,7 +727,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask());
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 42 + 1;
+            var expectedMethodCount = 42 + 2;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "


### PR DESCRIPTION
Public method FromExpression on DbContext to tie up our query provider with the expression

Resolves #9810
