### PR TITLE
Include key values in the update topological sort

### DIFF
--- a/src/EFCore.Relational/Update/Internal/IKeyValueIndexFactory.cs
+++ b/src/EFCore.Relational/Update/Internal/IKeyValueIndexFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IKeyValueIndex CreatePrincipalKeyValue([NotNull] IUpdateEntry entry, [NotNull] IForeignKey foreignKey);
+        IKeyValueIndex CreatePrincipalKeyValue([NotNull] IUpdateEntry entry, [CanBeNull] IForeignKey foreignKey);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues([NotNull] IUpdateEntry entry, [NotNull] IForeignKey foreignKey);
+        IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues([NotNull] IUpdateEntry entry, [CanBeNull] IForeignKey foreignKey);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
+++ b/src/EFCore.Relational/Update/Internal/KeyValueIndex.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public KeyValueIndex(
-            [NotNull] IForeignKey foreignKey,
+            [CanBeNull] IForeignKey foreignKey,
             [NotNull] TKey keyValue,
             [NotNull] IEqualityComparer<TKey> keyComparer,
             bool fromOriginalValues)

--- a/src/EFCore/ChangeTracking/Internal/IdentityMap.cs
+++ b/src/EFCore/ChangeTracking/Internal/IdentityMap.cs
@@ -289,7 +289,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                 }
 
-                if (!bothStatesEquivalent)
+                if (!bothStatesEquivalent
+                    && Key.IsPrimaryKey())
                 {
                     entry.SharedIdentityEntry = existingEntry;
                     existingEntry.SharedIdentityEntry = entry;
@@ -413,7 +414,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (otherEntry == null)
             {
-                _identityMap.Remove(key);
+                if (_identityMap.TryGetValue(key, out var existingEntry)
+                    && existingEntry == entry)
+                {
+                    _identityMap.Remove(key);
+                }
             }
             else
             {

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
@@ -327,6 +327,13 @@ namespace Microsoft.EntityFrameworkCore
                         new1d.Parent = null;
                         new1dd.Parent = null;
 
+                        var old1 = root.RequiredChildrenAk.OrderBy(c => c.Id).Last();
+
+                        // Test replacing entity with the same AK, but different PK
+                        new1.AlternateId = old1.AlternateId;
+                        context.Remove(old1);
+                        context.RemoveRange(old1.Children);
+                        context.RemoveRange(old1.CompositeChildren);
                         context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
                     }
 


### PR DESCRIPTION
Don't use entry sharing for entities with the same AK values
Only remove the entry with duplicate key value from the identity map if it's still there

Fixes #20870
