### PR TITLE
Test: Assert all the SQL

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -48,6 +48,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 {
                     Assert.Equal(expected[i], SqlStatements[i], ignoreLineEndingDifferences: true);
                 }
+
+                Assert.Empty(SqlStatements.Skip(expected.Length));
             }
             catch
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -49,6 +49,11 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [c].[CustomerID], [o].[OrderID]",
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -728,7 +728,13 @@ INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]");
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Order Details] AS [o]
-INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
+                //
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID]");
         }
 
         public override async Task Include_duplicate_reference(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1364,6 +1364,13 @@ END");
         FROM [Customers] AS [c]
         WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
+END",
+                //
+                @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
 END");
         }
 
@@ -2092,6 +2099,18 @@ SELECT CASE
         ) AS [t]
         WHERE [t].[CustomerID] LIKE N'C%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
+END",
+                //
+                @"@__p_0='5'
+@__p_1='7'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]
+        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
 END");
         }
 
@@ -2111,6 +2130,16 @@ SELECT CASE
             ORDER BY [c].[CustomerID]
         ) AS [t]
         WHERE [t].[CustomerID] LIKE N'B%') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END",
+                //
+                @"@__p_0='5'
+
+SELECT CASE
+    WHEN EXISTS (
+        SELECT TOP(@__p_0) 1
+        FROM [Customers] AS [c]
+        ORDER BY [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeQuerySqlServerTest.cs
@@ -1063,7 +1063,13 @@ INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]");
             AssertSql(
                 @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Order Details] AS [o]
-INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
+                //
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID]");
         }
 
         public override async Task Include_duplicate_reference(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3665,6 +3665,12 @@ FROM [Prices] AS [p]",
 FROM [Prices] AS [p]",
                     //
                     @"SELECT AVG([p].[NullableDoubleColumn])
+FROM [Prices] AS [p]",
+                    //
+                    @"SELECT AVG([p].[DecimalColumn])
+FROM [Prices] AS [p]",
+                    //
+                    @"SELECT AVG([p].[NullableDecimalColumn])
 FROM [Prices] AS [p]");
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
@@ -279,7 +279,32 @@ WHERE @@ROWCOUNT = 1 AND [Name] = @p1;",
 
 SET NOCOUNT ON;
 INSERT INTO [LicensedOperators] ([VehicleName], [LicenseType])
-VALUES (@p2, @p3);");
+VALUES (@p2, @p3);",
+                //
+                @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], CASE
+    WHEN [p].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [IsPoweredVehicle], [t0].[Name], [t0].[Operator_Name], [t0].[RequiredInt], [t0].[LicenseType], [t0].[IsLicensedOperator]
+FROM [Vehicles] AS [v]
+LEFT JOIN [PoweredVehicles] AS [p] ON [v].[Name] = [p].[Name]
+LEFT JOIN (
+    SELECT [v0].[Name], [v0].[Operator_Name], [v0].[RequiredInt], [l].[LicenseType], CASE
+        WHEN [l].[VehicleName] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [IsLicensedOperator], [t].[Name] AS [Name0]
+    FROM [Vehicles] AS [v0]
+    LEFT JOIN [LicensedOperators] AS [l] ON [v0].[Name] = [l].[VehicleName]
+    INNER JOIN (
+        SELECT [v1].[Name], [v1].[SeatingCapacity], CASE
+            WHEN [p0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [IsPoweredVehicle]
+        FROM [Vehicles] AS [v1]
+        LEFT JOIN [PoweredVehicles] AS [p0] ON [v1].[Name] = [p0].[Name]
+    ) AS [t] ON [v0].[Name] = [t].[Name]
+    WHERE [v0].[RequiredInt] IS NOT NULL
+) AS [t0] ON [v].[Name] = [t0].[Name]
+WHERE [v].[Name] = N'Trek Pro Fit Madone 6 Series'");
         }
 
         public override void Can_change_principal_instance_non_derived()
@@ -293,7 +318,32 @@ VALUES (@p2, @p3);");
 SET NOCOUNT ON;
 UPDATE [Vehicles] SET [SeatingCapacity] = @p0
 WHERE [Name] = @p1;
-SELECT @@ROWCOUNT;");
+SELECT @@ROWCOUNT;",
+                //
+                @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], CASE
+    WHEN [p].[Name] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [IsPoweredVehicle], [t0].[Name], [t0].[Operator_Name], [t0].[RequiredInt], [t0].[LicenseType], [t0].[IsLicensedOperator]
+FROM [Vehicles] AS [v]
+LEFT JOIN [PoweredVehicles] AS [p] ON [v].[Name] = [p].[Name]
+LEFT JOIN (
+    SELECT [v0].[Name], [v0].[Operator_Name], [v0].[RequiredInt], [l].[LicenseType], CASE
+        WHEN [l].[VehicleName] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [IsLicensedOperator], [t].[Name] AS [Name0]
+    FROM [Vehicles] AS [v0]
+    LEFT JOIN [LicensedOperators] AS [l] ON [v0].[Name] = [l].[VehicleName]
+    INNER JOIN (
+        SELECT [v1].[Name], [v1].[SeatingCapacity], CASE
+            WHEN [p0].[Name] IS NOT NULL THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [IsPoweredVehicle]
+        FROM [Vehicles] AS [v1]
+        LEFT JOIN [PoweredVehicles] AS [p0] ON [v1].[Name] = [p0].[Name]
+    ) AS [t] ON [v0].[Name] = [t].[Name]
+    WHERE [v0].[RequiredInt] IS NOT NULL
+) AS [t0] ON [v].[Name] = [t0].[Name]
+WHERE [v].[Name] = N'Trek Pro Fit Madone 6 Series'");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -228,7 +228,17 @@ WHERE [v1].[FuelType] IS NOT NULL AND [v1].[Capacity] IS NOT NULL");
 SET NOCOUNT ON;
 UPDATE [Vehicles] SET [Operator_Discriminator] = @p0, [Operator_Name] = @p1, [LicenseType] = @p2
 WHERE [Name] = @p3;
-SELECT @@ROWCOUNT;");
+SELECT @@ROWCOUNT;",
+                //
+                @"SELECT TOP(2) [v].[Name], [v].[Discriminator], [v].[SeatingCapacity], [t].[Name], [t].[Operator_Discriminator], [t].[Operator_Name], [t].[LicenseType]
+FROM [Vehicles] AS [v]
+LEFT JOIN (
+    SELECT [v0].[Name], [v0].[Operator_Discriminator], [v0].[Operator_Name], [v0].[LicenseType], [v1].[Name] AS [Name0]
+    FROM [Vehicles] AS [v0]
+    INNER JOIN [Vehicles] AS [v1] ON [v0].[Name] = [v1].[Name]
+    WHERE [v0].[Operator_Discriminator] IS NOT NULL
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[Name] = N'Trek Pro Fit Madone 6 Series'");
         }
 
         public override void Can_change_principal_instance_non_derived()
@@ -242,7 +252,17 @@ SELECT @@ROWCOUNT;");
 SET NOCOUNT ON;
 UPDATE [Vehicles] SET [SeatingCapacity] = @p0
 WHERE [Name] = @p1;
-SELECT @@ROWCOUNT;");
+SELECT @@ROWCOUNT;",
+                //
+                @"SELECT TOP(2) [v].[Name], [v].[Discriminator], [v].[SeatingCapacity], [t].[Name], [t].[Operator_Discriminator], [t].[Operator_Name], [t].[LicenseType]
+FROM [Vehicles] AS [v]
+LEFT JOIN (
+    SELECT [v0].[Name], [v0].[Operator_Discriminator], [v0].[Operator_Name], [v0].[LicenseType], [v1].[Name] AS [Name0]
+    FROM [Vehicles] AS [v0]
+    INNER JOIN [Vehicles] AS [v1] ON [v0].[Name] = [v1].[Name]
+    WHERE [v0].[Operator_Discriminator] IS NOT NULL
+) AS [t] ON [v].[Name] = [t].[Name]
+WHERE [v].[Name] = N'Trek Pro Fit Madone 6 Series'");
         }
     }
 }


### PR DESCRIPTION
Makes `AssertSql()` assert that no SQL was generated (used to no-op)

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


