### PR TITLE
API Review Updates

### DIFF
--- a/src/EFCore.Design/Design/DbContextActivator.cs
+++ b/src/EFCore.Design/Design/DbContextActivator.cs
@@ -37,13 +37,13 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="contextType"> The <see cref="DbContext" /> type to instantiate. </param>
         /// <param name="startupAssembly"> The application's startup assembly. </param>
         /// <param name="reportHandler"> The design-time report handler. </param>
-        /// <param name="arguments"> Arguments passed to the application. </param>
+        /// <param name="args"> Arguments passed to the application. </param>
         /// <returns> The newly created object. </returns>
         public static DbContext CreateInstance(
             [NotNull] Type contextType,
             [CanBeNull] Assembly startupAssembly,
             [CanBeNull] IOperationReportHandler reportHandler,
-            [CanBeNull] string[] arguments)
+            [CanBeNull] string[] args)
         {
             Check.NotNull(contextType, nameof(contextType));
 
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                     new OperationReporter(reportHandler),
                     contextType.Assembly,
                     startupAssembly ?? contextType.Assembly,
-                    args: arguments ?? Array.Empty<string>())
+                    args: args ?? Array.Empty<string>())
                 .CreateContext(contextType.FullName);
         }
     }

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -771,7 +771,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var columnsBuilder = new ColumnsBuilder(createTableOperation);
             var columnsObject = columns(columnsBuilder);
-            var columnMap = new Dictionary<MemberInfo, AddColumnOperation>();
+            var columnMap = new Dictionary<PropertyInfo, AddColumnOperation>();
             foreach (var property in typeof(TColumns).GetTypeInfo().DeclaredProperties)
             {
                 var addColumnOperation = ((IInfrastructure<AddColumnOperation>)property.GetMethod.Invoke(columnsObject, null)).Instance;

--- a/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
     /// <typeparam name="TColumns"> Type of a typically anonymous type for building columns. </typeparam>
     public class CreateTableBuilder<TColumns> : OperationBuilder<CreateTableOperation>
     {
-        private readonly IReadOnlyDictionary<MemberInfo, AddColumnOperation> _columnMap;
+        private readonly IReadOnlyDictionary<PropertyInfo, AddColumnOperation> _columnMap;
 
         /// <summary>
         ///     Constructs a new builder for the given <see cref="CreateTableOperation" /> and
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
         /// <param name="columnMap"> The map of CLR properties to <see cref="AddColumnOperation" />s. </param>
         public CreateTableBuilder(
             [NotNull] CreateTableOperation operation,
-            [NotNull] IReadOnlyDictionary<MemberInfo, AddColumnOperation> columnMap)
+            [NotNull] IReadOnlyDictionary<PropertyInfo, AddColumnOperation> columnMap)
             : base(operation)
         {
             Check.NotNull(columnMap, nameof(columnMap));
@@ -191,6 +191,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
             => (CreateTableBuilder<TColumns>)base.Annotation(name, value);
 
         private string[] Map(LambdaExpression columns)
-            => columns.GetMemberAccessList().Select(c => _columnMap[c].Name).ToArray();
+            => columns.GetPropertyAccessList().Select(c => _columnMap[c].Name).ToArray();
     }
 }


### PR DESCRIPTION
Part of #20409 

Rename parameter to `args`.
Make `CreateTableBuilder` use `PropertyInfo` instead of `MemberInfo`.