### PR TITLE
SQLite RevEng: Include computed columns

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -787,8 +787,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         /// </summary>
         public virtual string UnknownLiteral(object value)
         {
-            if (value == null
-                || value == DBNull.Value)
+            if (value == null)
             {
                 return "null";
             }

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -1290,18 +1290,28 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             [NotNull] IProperty property,
             [NotNull] IndentedStringBuilder stringBuilder)
         {
-            if (property.GetDefaultValue() is object defaultValue)
+            var defaultValue = property.GetDefaultValue();
+            if (defaultValue == null)
+            {
+                return;
+            }
+
+            stringBuilder
+                .AppendLine()
+                .Append(".")
+                .Append(nameof(RelationalPropertyBuilderExtensions.HasDefaultValue))
+                .Append("(");
+
+            if (defaultValue != DBNull.Value)
             {
                 stringBuilder
-                    .AppendLine()
-                    .Append(".")
-                    .Append(nameof(RelationalPropertyBuilderExtensions.HasDefaultValue))
-                    .Append("(")
                     .Append(Code.UnknownLiteral(FindValueConverter(property) is ValueConverter valueConverter
                         ? valueConverter.ConvertToProvider(defaultValue)
-                        : defaultValue))
-                    .Append(")");
+                        : defaultValue));
             }
+
+            stringBuilder
+                .Append(")");
         }
 
         /// <summary>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -626,11 +626,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     $"({(property.IsUnicode() == false ? "false" : "")})");
             }
 
-            if (property.GetDefaultValue() != null)
+            var defaultValue = property.GetDefaultValue();
+            if (defaultValue == DBNull.Value)
+            {
+                lines.Add($".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}()");
+                annotations.Remove(RelationalAnnotationNames.DefaultValue);
+            }
+            else if (defaultValue != null)
             {
                 lines.Add(
                     $".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}" +
-                    $"({_code.UnknownLiteral(property.GetDefaultValue())})");
+                    $"({_code.UnknownLiteral(defaultValue)})");
                 annotations.Remove(RelationalAnnotationNames.DefaultValue);
             }
 

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -145,15 +145,24 @@ namespace Microsoft.EntityFrameworkCore.Design
                 annotations,
                 RelationalAnnotationNames.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), methodCallCodeFragments);
 
-            GenerateSimpleFluentApiCall(
-                annotations,
-                RelationalAnnotationNames.DefaultValueSql, nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
-                methodCallCodeFragments);
-
-            if (TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnSql, out object computedColumnSql))
+            if (TryGetAndRemove(annotations, RelationalAnnotationNames.DefaultValueSql, out string defaultValueSql))
             {
                 methodCallCodeFragments.Add(
-                    TryGetAndRemove(annotations, RelationalAnnotationNames.IsStored, out bool isStored)
+                    defaultValueSql?.Length == 0
+                        ? new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql))
+                        : new MethodCallCodeFragment(
+                            nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
+                            defaultValueSql));
+            }
+
+            if (TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnSql, out string computedColumnSql))
+            {
+                methodCallCodeFragments.Add(
+                    computedColumnSql?.Length == 0
+                    ? new MethodCallCodeFragment(
+                        nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql))
+                    : TryGetAndRemove(annotations, RelationalAnnotationNames.IsStored, out bool isStored)
                         ? new MethodCallCodeFragment(
                             nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
                             computedColumnSql,

--- a/src/EFCore.Relational/Extensions/RelationalPropertyBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyBuilderExtensions.cs
@@ -267,6 +267,28 @@ namespace Microsoft.EntityFrameworkCore
             => propertyBuilder.CanSetAnnotation(RelationalAnnotationNames.IsFixedLength, fixedLength, fromDataAnnotation);
 
         /// <summary>
+        ///     <para>
+        ///         Configures the default value expression for the column that the property maps to when targeting a
+        ///         relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no argument, this method tells EF that a column has a default value constraint of
+        ///         some sort without needing to specify exactly what it is. This can be useful when mapping EF to an
+        ///         existing database.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder HasDefaultValueSql([NotNull] this PropertyBuilder propertyBuilder)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            propertyBuilder.Metadata.SetDefaultValueSql(string.Empty);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
         ///     Configures the default value expression for the column that the property maps to when targeting a relational database.
         /// </summary>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
@@ -283,6 +305,24 @@ namespace Microsoft.EntityFrameworkCore
 
             return propertyBuilder;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the default value expression for the column that the property maps to when targeting a
+        ///         relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no argument, this method tells EF that a column has a default value constraint of
+        ///         some sort without needing to specify exactly what it is. This can be useful when mapping EF to an
+        ///         existing database.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder<TProperty> HasDefaultValueSql<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder)
+            => (PropertyBuilder<TProperty>)HasDefaultValueSql((PropertyBuilder)propertyBuilder);
 
         /// <summary>
         ///     Configures the default value expression for the column that the property maps to when targeting a relational database.
@@ -333,8 +373,29 @@ namespace Microsoft.EntityFrameworkCore
             bool fromDataAnnotation = false)
             => propertyBuilder.CanSetAnnotation(
                 RelationalAnnotationNames.DefaultValueSql,
-                Check.NullButNotEmpty(sql, nameof(sql)),
+                sql,
                 fromDataAnnotation);
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the property to map to a computed column when targeting a relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no arguments, this method tells EF that a column is computed without needing to
+        ///         specify the actual SQL used to computed it. This can be useful when mapping EF to an existing
+        ///         database.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder HasComputedColumnSql([NotNull] this PropertyBuilder propertyBuilder)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            propertyBuilder.Metadata.SetComputedColumnSql(string.Empty);
+
+            return propertyBuilder;
+        }
 
         /// <summary>
         ///     Configures the property to map to a computed column when targeting a relational database.
@@ -364,6 +425,23 @@ namespace Microsoft.EntityFrameworkCore
 
             return propertyBuilder;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the property to map to a computed column when targeting a relational database.
+        ///     </para>
+        ///     <para>
+        ///         When called with no arguments, this method tells EF that a column is computed without needing to
+        ///         specify the actual SQL used to computed it. This can be useful when mapping EF to an existing
+        ///         database.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder<TProperty> HasComputedColumnSql<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder)
+            => (PropertyBuilder<TProperty>)HasComputedColumnSql((PropertyBuilder)propertyBuilder);
 
         /// <summary>
         ///     Configures the property to map to a computed column when targeting a relational database.
@@ -447,7 +525,7 @@ namespace Microsoft.EntityFrameworkCore
             bool fromDataAnnotation = false)
             => propertyBuilder.CanSetAnnotation(
                 RelationalAnnotationNames.ComputedColumnSql,
-                Check.NullButNotEmpty(sql, nameof(sql)),
+                sql,
                 fromDataAnnotation);
 
         /// <summary>
@@ -482,15 +560,30 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder HasDefaultValue([NotNull] this PropertyBuilder propertyBuilder)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            propertyBuilder.Metadata.SetDefaultValue(DBNull.Value);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the default value for the column that the property maps
+        ///     to when targeting a relational database.
+        /// </summary>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
         /// <param name="value"> The default value of the column. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static PropertyBuilder HasDefaultValue(
             [NotNull] this PropertyBuilder propertyBuilder,
-            [CanBeNull] object value = null)
+            [CanBeNull] object value)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
-            propertyBuilder.Metadata.SetDefaultValue(value ?? DBNull.Value);
+            propertyBuilder.Metadata.SetDefaultValue(value);
 
             return propertyBuilder;
         }
@@ -508,11 +601,22 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
         /// <param name="propertyBuilder"> The builder for the property being configured. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static PropertyBuilder<TProperty> HasDefaultValue<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder)
+            => (PropertyBuilder<TProperty>)HasDefaultValue((PropertyBuilder)propertyBuilder);
+
+        /// <summary>
+        ///     Configures the default value for the column that the property maps
+        ///     to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TProperty"> The type of the property being configured. </typeparam>
+        /// <param name="propertyBuilder"> The builder for the property being configured. </param>
         /// <param name="value"> The default value of the column. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public static PropertyBuilder<TProperty> HasDefaultValue<TProperty>(
             [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
-            [CanBeNull] object value = null)
+            [CanBeNull] object value)
             => (PropertyBuilder<TProperty>)HasDefaultValue((PropertyBuilder)propertyBuilder, value);
 
         /// <summary>

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -400,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetDefaultValueSql([NotNull] this IMutableProperty property, [CanBeNull] string value)
             => property.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.DefaultValueSql,
-                Check.NullButNotEmpty(value, nameof(value)));
+                value);
 
         /// <summary>
         ///     Sets the SQL expression that is used as the default value for the column this property is mapped to.
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             property.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.DefaultValueSql,
-                Check.NullButNotEmpty(value, nameof(value)),
+                value,
                 fromDataAnnotation);
 
             return value;
@@ -475,7 +475,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetComputedColumnSql([NotNull] this IMutableProperty property, [CanBeNull] string value)
             => property.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.ComputedColumnSql,
-                Check.NullButNotEmpty(value, nameof(value)));
+                value);
 
         /// <summary>
         ///     Sets the SQL expression that is used as the computed value for the column this property is mapped to.
@@ -489,7 +489,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             property.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.ComputedColumnSql,
-                Check.NullButNotEmpty(value, nameof(value)),
+                value,
                 fromDataAnnotation);
 
             return value;

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -927,6 +927,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string QueryUnableToIdentifyConcreteTypeInTPT
             => GetString("QueryUnableToIdentifyConcreteTypeInTPT");
 
+        /// <summary>
+        ///     The column '{column}' on table {table} has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.
+        /// </summary>
+        public static string ComputedColumnSqlUnspecified([CanBeNull] object column, [CanBeNull] object table)
+            => string.Format(
+                GetString("ComputedColumnSqlUnspecified", nameof(column), nameof(table)),
+                column, table);
+
+        /// <summary>
+        ///     The column '{column}' on table {table} has an unspecified default value. Specify a value before using EF Core to create the database schema.
+        /// </summary>
+        public static string DefaultValueUnspecified([CanBeNull] object column, [CanBeNull] object table)
+            => string.Format(
+                GetString("DefaultValueUnspecified", nameof(column), nameof(table)),
+                column, table);
+
+        /// <summary>
+        ///     The column '{column}' on table {table} has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.
+        /// </summary>
+        public static string DefaultValueSqlUnspecified([CanBeNull] object column, [CanBeNull] object table)
+            => string.Format(
+                GetString("DefaultValueSqlUnspecified", nameof(column), nameof(table)),
+                column, table);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -682,4 +682,13 @@
   <data name="QueryUnableToIdentifyConcreteTypeInTPT" xml:space="preserve">
     <value>Unable to identify the concrete entity type to materialize in TPT hierarchy.</value>
   </data>
+  <data name="ComputedColumnSqlUnspecified" xml:space="preserve">
+    <value>The column '{column}' on table {table} has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.</value>
+  </data>
+  <data name="DefaultValueUnspecified" xml:space="preserve">
+    <value>The column '{column}' on table {table} has an unspecified default value. Specify a value before using EF Core to create the database schema.</value>
+  </data>
+  <data name="DefaultValueSqlUnspecified" xml:space="preserve">
+    <value>The column '{column}' on table {table} has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1998,7 +1998,7 @@ namespace RootNamespace
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasDefaultValue(null);
+                        .HasDefaultValue();
 
                     b.HasKey(""Id"");
 
@@ -2248,6 +2248,69 @@ namespace RootNamespace
         }
 
         [ConditionalFact]
+        public virtual void Property_default_value_annotation_is_stored_in_snapshot_as_fluent_api_unspecified()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasDefaultValue();
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn();
+
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .HasDefaultValue();
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });",
+                usingSystem: true),
+                o => Assert.Equal(DBNull.Value, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValue"]));
+        }
+
+        [ConditionalFact]
+        public virtual void Property_default_value_sql_annotation_is_stored_in_snapshot_as_fluent_api_unspecified()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasDefaultValueSql();
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn();
+
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .HasDefaultValueSql();
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
+                o => Assert.Equal(string.Empty, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValueSql"]));
+        }
+
+        [ConditionalFact]
         public virtual void Property_default_value_sql_annotation_is_stored_in_snapshot_as_fluent_api()
         {
             Test(
@@ -2307,6 +2370,72 @@ namespace RootNamespace
                     b.ToTable(""EntityWithTwoProperties"");
                 });"),
                 o => Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]));
+        }
+
+        [ConditionalFact]
+        public virtual void Property_computed_column_sql_stored_annotation_is_stored_in_snapshot_as_fluent_api()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasComputedColumnSql("SQL", true);
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn();
+
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(""int"")
+                        .HasComputedColumnSql(""SQL"", true);
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
+                o =>
+                {
+                    Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]);
+                    Assert.Equal(true, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:IsStored"]);
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Property_computed_column_sql_annotation_is_stored_in_snapshot_as_fluent_api_unspecified()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasComputedColumnSql();
+                    builder.Ignore<EntityWithOneProperty>();
+                },
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn();
+
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType(""int"")
+                        .HasComputedColumnSql();
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
+                o => Assert.Equal(string.Empty, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -354,6 +354,75 @@ namespace TestNamespace
                 });
         }
 
+        [ConditionalFact]
+        public void ComputedColumnSql_works()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("ComputedColumn").HasComputedColumnSql("1 + 2"),
+                new ModelCodeGenerationOptions(),
+                code => Assert.Contains(".HasComputedColumnSql(\"1 + 2\")", code.ContextFile.Code),
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Equal("1 + 2", entity.GetProperty("ComputedColumn").GetComputedColumnSql());
+                });
+        }
+
+        [ConditionalFact]
+        public void ComputedColumnSql_works_stored()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("ComputedColumn").HasComputedColumnSql("1 + 2", stored: true),
+                new ModelCodeGenerationOptions(),
+                code => Assert.Contains(".HasComputedColumnSql(\"1 + 2\", true)", code.ContextFile.Code),
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.True(entity.GetProperty("ComputedColumn").GetIsStored());
+                });
+        }
+
+        [ConditionalFact]
+        public void ComputedColumnSql_works_unspecified()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("ComputedColumn").HasComputedColumnSql(),
+                new ModelCodeGenerationOptions(),
+                code => Assert.Contains(".HasComputedColumnSql()", code.ContextFile.Code),
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Empty(entity.GetProperty("ComputedColumn").GetComputedColumnSql());
+                });
+        }
+
+        [ConditionalFact]
+        public void DefaultValue_works_unspecified()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("DefaultedColumn").HasDefaultValue(),
+                new ModelCodeGenerationOptions(),
+                code => Assert.Contains(".HasDefaultValue()", code.ContextFile.Code),
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Equal(DBNull.Value, entity.GetProperty("DefaultedColumn").GetDefaultValue());
+                });
+        }
+
+        [ConditionalFact]
+        public void DefaultValueSql_works_unspecified()
+        {
+            Test(
+                modelBuilder => modelBuilder.Entity("Entity").Property<string>("DefaultedColumn").HasDefaultValueSql(),
+                new ModelCodeGenerationOptions(),
+                code => Assert.Contains(".HasDefaultValueSql()", code.ContextFile.Code),
+                model =>
+                {
+                    var entity = model.FindEntityType("TestNamespace.Entity");
+                    Assert.Empty(entity.GetProperty("DefaultedColumn").GetDefaultValueSql());
+                });
+        }
 
         [ConditionalFact]
         public void Entity_with_indexes_and_use_data_annotations_false_always_generates_fluent_API()

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -343,6 +344,28 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Contains("2", sumColumn.DefaultValueSql);
                 });
 
+        [ConditionalFact]
+        public virtual async Task Add_column_with_defaultValueSql_unspecified()
+        {
+            var ex = await TestThrows<InvalidOperationException>(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => { },
+                builder => builder.Entity("People").Property<int?>("Sum")
+                    .HasDefaultValueSql());
+            Assert.Equal(RelationalStrings.DefaultValueSqlUnspecified("Sum", "'People'"), ex.Message);
+        }
+
+        [ConditionalFact]
+        public virtual async Task Add_column_with_defaultValue_unspecified()
+        {
+            var ex = await TestThrows<InvalidOperationException>(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => { },
+                builder => builder.Entity("People").Property<int?>("Sum")
+                    .HasDefaultValue());
+            Assert.Equal(RelationalStrings.DefaultValueUnspecified("Sum", "'People'"), ex.Message);
+        }
+
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
@@ -368,6 +391,17 @@ namespace Microsoft.EntityFrameworkCore
                     if (stored != null)
                         Assert.Equal(stored, sumColumn.IsStored);
                 });
+
+        [ConditionalFact]
+        public virtual async Task Add_column_with_computedSql_unspecified()
+        {
+            var ex = await TestThrows<InvalidOperationException>(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => { },
+                builder => builder.Entity("People").Property<int?>("Sum")
+                    .HasComputedColumnSql());
+            Assert.Equal(RelationalStrings.ComputedColumnSqlUnspecified("Sum", "'People'"), ex.Message);
+        }
 
         // TODO: Check this out
         [ConditionalFact]
@@ -1128,21 +1162,21 @@ namespace Microsoft.EntityFrameworkCore
                     // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
                 });
 
-            [ConditionalFact]
-            public virtual Task Alter_check_constraint()
-                => Test(
-                    builder => builder.Entity(
-                        "People", e =>
-                        {
-                            e.Property<int>("Id");
-                            e.Property<int>("DriverLicense");
-                        }),
-                    builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
-                    builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 1"),
-                    model =>
+        [ConditionalFact]
+        public virtual Task Alter_check_constraint()
+            => Test(
+                builder => builder.Entity(
+                    "People", e =>
                     {
-                        // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
-                    });
+                        e.Property<int>("Id");
+                        e.Property<int>("DriverLicense");
+                    }),
+                builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 0"),
+                builder => builder.Entity("People").HasCheckConstraint("CK_Foo", $"{DelimitIdentifier("DriverLicense")} > 1"),
+                model =>
+                {
+                    // TODO: no scaffolding support for check constraints, https://github.com/aspnet/EntityFrameworkCore/issues/15408
+                });
 
         [ConditionalFact]
         public virtual Task Drop_check_constraint()

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -370,8 +370,6 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.NotEqual(new DateTime(), blogs[0].CreatedOn);
                 Assert.NotEqual(new DateTime(), blogs[1].CreatedOn);
-                Assert.Null(blogs[0].OtherId);
-                Assert.Null(blogs[1].OtherId);
             }
 
             using (var context = new BlogContextNonKeyDefaultValue(testStore.Name))
@@ -410,9 +408,6 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         b.Property(e => e.CreatedOn)
                             .HasDefaultValueSql("getdate()");
-
-                        b.Property(e => e.OtherId)
-                            .HasDefaultValue();
                     });
             }
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -436,6 +436,33 @@ CREATE TABLE DefaultValue (
                 "DROP TABLE DefaultValue;");
         }
 
+        [ConditionalFact]
+        public void Column_computed_column_sql_is_set()
+        {
+            Test(
+                @"
+CREATE TABLE ComputedColumnSql (
+    Id int,
+    GeneratedColumn AS (1 + 2),
+    GeneratedColumnStored AS (1 + 2) STORED
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single().Columns;
+
+                    var generatedColumn = columns.Single(c => c.Name == "GeneratedColumn");
+                    Assert.NotNull(generatedColumn.ComputedColumnSql);
+                    Assert.Null(generatedColumn.IsStored);
+
+                    var generatedColumnStored = columns.Single(c => c.Name == "GeneratedColumnStored");
+                    Assert.NotNull(generatedColumnStored.ComputedColumnSql);
+                    Assert.True(generatedColumnStored.IsStored);
+                },
+                "DROP TABLE ComputedColumnSql;");
+        }
+
         [ConditionalTheory]
         [InlineData("DOUBLE NOT NULL DEFAULT 0")]
         [InlineData("FLOAT NOT NULL DEFAULT 0")]


### PR DESCRIPTION
Note, we can't get their actual SQL without parsing the entire CREATE TABLE statement, so we just generate HasComputedColumnSql without any arguments to at least make them usable.

Fixes #21557

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


