### PR TITLE
Fix to #19178 - Invalid SQL with CROSS APPLY generated on SQLite

### DIFF
--- a/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/CollectionJoinApplyingExpressionVisitor.cs
@@ -4,7 +4,6 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IQuerySqlGeneratorFactory, SqliteQuerySqlGeneratorFactory>()
                 .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, SqliteQueryableMethodTranslatingExpressionVisitorFactory>()
                 .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, SqliteSqlTranslatingExpressionVisitorFactory>()
+                .TryAdd<IQueryTranslationPostprocessorFactory, SqliteQueryTranslationPostprocessorFactory>()
                 .TryAddProviderSpecificServices(
                     b => b.TryAddScoped<ISqliteRelationalConnection, SqliteRelationalConnection>());
 

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -65,6 +65,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
                 GetString("AggregateOperationNotSupported", nameof(aggregateOperator), nameof(type)),
                 aggregateOperator, type);
 
+        /// <summary>
+        ///     Translating this query requires APPLY operation which is not supported on SQLite.
+        /// </summary>
+        public static string ApplyNotSupported
+            => GetString("ApplyNotSupported");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -187,4 +187,7 @@
   <data name="AggregateOperationNotSupported" xml:space="preserve">
     <value>SQLite cannot apply aggregate operator '{aggregateOperator}' on expression of type '{type}'. Convert the values to a supported type or use LINQ to Objects to aggregate the results.</value>
   </data>
+  <data name="ApplyNotSupported" xml:space="preserve">
+    <value>Translating this query requires APPLY operation which is not supported on SQLite.</value>
+  </data>
 </root>

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessor.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class SqliteQueryTranslationPostprocessor : RelationalQueryTranslationPostprocessor
+    {
+        private readonly ApplyValidatingVisitor _applyValidator = new ApplyValidatingVisitor();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqliteQueryTranslationPostprocessor(
+            [NotNull] QueryTranslationPostprocessorDependencies dependencies,
+            [NotNull] RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
+            [NotNull] QueryCompilationContext queryCompilationContext)
+            : base(dependencies, relationalDependencies, queryCompilationContext)
+        {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override Expression Process(Expression query)
+        {
+            var result = base.Process(query);
+            _applyValidator.Visit(result);
+
+            return result;
+        }
+
+        private sealed class ApplyValidatingVisitor : ExpressionVisitor
+        {
+            protected override Expression VisitExtension(Expression extensionExpression)
+            {
+                if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
+                {
+                    Visit(shapedQueryExpression.QueryExpression);
+                    Visit(shapedQueryExpression.ShaperExpression);
+
+                    return extensionExpression;
+                }
+
+                if (extensionExpression is SelectExpression selectExpression
+                    && selectExpression.Tables.Any(t => t is CrossApplyExpression || t is OuterApplyExpression))
+                {
+                    throw new InvalidOperationException(SqliteStrings.ApplyNotSupported);
+                }
+
+                return base.VisitExtension(extensionExpression);
+            }
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteQueryTranslationPostprocessorFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
@@ -13,10 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class SqliteQueryableMethodTranslatingExpressionVisitorFactory : IQueryableMethodTranslatingExpressionVisitorFactory
+    public class SqliteQueryTranslationPostprocessorFactory : IQueryTranslationPostprocessorFactory
     {
-        private readonly QueryableMethodTranslatingExpressionVisitorDependencies _dependencies;
-        private readonly RelationalQueryableMethodTranslatingExpressionVisitorDependencies _relationalDependencies;
+        private readonly QueryTranslationPostprocessorDependencies _dependencies;
+        private readonly RelationalQueryTranslationPostprocessorDependencies _relationalDependencies;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -24,13 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public SqliteQueryableMethodTranslatingExpressionVisitorFactory(
-            [NotNull] QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
-            [NotNull] RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies)
+        public SqliteQueryTranslationPostprocessorFactory(
+            [NotNull] QueryTranslationPostprocessorDependencies dependencies,
+            [NotNull] RelationalQueryTranslationPostprocessorDependencies relationalDependencies)
         {
-            Check.NotNull(dependencies, nameof(dependencies));
-            Check.NotNull(relationalDependencies, nameof(relationalDependencies));
-
             _dependencies = dependencies;
             _relationalDependencies = relationalDependencies;
         }
@@ -41,11 +38,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
+        public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
         {
-            Check.NotNull(queryCompilationContext, nameof(queryCompilationContext));
-
-            return new SqliteQueryableMethodTranslatingExpressionVisitor(_dependencies, _relationalDependencies, queryCompilationContext);
+            return new SqliteQueryTranslationPostprocessor(
+                _dependencies,
+                _relationalDependencies,
+                queryCompilationContext);
         }
     }
 }
+

--- a/test/EFCore.InMemory.FunctionalTests/Query/ManyToManyQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ManyToManyQueryInMemoryTest.cs
@@ -13,8 +13,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
-
-        public override Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
-            => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -489,17 +489,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
+        public virtual Task Include_skip_navigation_then_include_inverse_works_for_tracking_query(bool async)
         {
-            Assert.Equal(
-                CoreStrings.IncludeWithCycle(nameof(EntityThree.OneSkipPayloadFullShared), nameof(EntityOne.ThreeSkipPayloadFullShared)),
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => AssertQuery(
-                        async,
-                        ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFullShared).ThenInclude(e => e.ThreeSkipPayloadFullShared),
-                        elementAsserter: (e, a) => AssertInclude(e, a,
-                            new ExpectedInclude<EntityThree>(et => et.OneSkipPayloadFullShared),
-                            new ExpectedInclude<EntityOne>(et => et.ThreeSkipPayloadFullShared, "OneSkipPayloadFullShared"))))).Message);
+            return AssertQuery(
+                async,
+                ss => ss.Set<EntityThree>().Include(e => e.OneSkipPayloadFullShared).ThenInclude(e => e.ThreeSkipPayloadFullShared),
+                entryCount: 76,
+                elementAsserter: (e, a) => AssertInclude(e, a,
+                    new ExpectedInclude<EntityThree>(et => et.OneSkipPayloadFullShared),
+                    new ExpectedInclude<EntityOne>(et => et.ThreeSkipPayloadFullShared, "OneSkipPayloadFullShared")));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -1581,9 +1581,6 @@ LEFT JOIN (
 ) AS [t] ON ([e].[Id] = [t].[OneId]) AND ([e].[Id] <> [t].[Id])");
         }
 
-        public override Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
-            => Task.CompletedTask;
-
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -17,9 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override bool CanExecuteQueryString => true;
 
-        public override Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
-            => Task.CompletedTask;
-
         public override async Task Skip_navigation_all(bool async)
         {
             await base.Skip_navigation_all(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyNoTrackingQuerySqliteTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -16,9 +18,17 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // Sqlite does not support Apply operations
 
-        public override Task Skip_navigation_order_by_single_or_default(bool async) => Task.CompletedTask;
+        public override async Task Skip_navigation_order_by_single_or_default(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_navigation_order_by_single_or_default(async))).Message);
 
-        public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#21541")]
         public override Task Left_join_with_skip_navigation(bool async) => base.Left_join_with_skip_navigation(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyQuerySqliteTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -13,19 +15,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        // Sqlite does not support Apply operations
+        public override async Task Skip_navigation_order_by_single_or_default(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_navigation_order_by_single_or_default(async))).Message);
 
-        public override Task Skip_navigation_order_by_single_or_default(bool async)
-            => Task.CompletedTask;
-
-        public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
-            => Task.CompletedTask;
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#21541")]
         public override Task Left_join_with_skip_navigation(bool async)
-            => Task.CompletedTask;
-
-        public override Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
             => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,13 +18,28 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
-        // Sqlite does not support Apply operations
-        public override Task Include_collection_with_cross_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_cross_apply_with_filter(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter(async))).Message);
 
-        public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_with_multiple_ordering(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_with_multiple_ordering(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,12 +18,28 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
-        // Sqlite does not support Apply operations
-        public override Task Include_collection_with_cross_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_cross_apply_with_filter(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter(async))).Message);
 
-        public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
-        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_with_multiple_ordering(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_with_multiple_ordering(async))).Message);
+
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindJoinQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -16,9 +19,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        // CROSS APPLY is not supported
-        public override Task SelectMany_with_client_eval(bool async) => Task.CompletedTask;
-        public override Task SelectMany_with_client_eval_with_collection_shaper(bool async) => Task.CompletedTask;
-        public override Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async) => Task.CompletedTask;
+        public override async Task SelectMany_with_client_eval(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_with_client_eval(async))).Message);
+
+        public override async Task SelectMany_with_client_eval_with_collection_shaper(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_with_client_eval_with_collection_shaper(async))).Message);
+
+        public override async Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_with_client_eval_with_collection_shaper_ignored(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -277,9 +279,11 @@ FROM ""Orders"" AS ""o""");
 FROM ""Orders"" AS ""o""");
         }
 
-
-        // Sqlite does not support Apply operations
-        public override Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async) => Task.CompletedTask;
+        public override async Task DefaultIfEmpty_in_subquery_nested_filter_order_comparison(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async))).Message);
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,13 +18,28 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
-        // Sqlite does not support Apply operations
-        public override Task Include_collection_with_cross_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_cross_apply_with_filter(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter(async))).Message);
 
-        public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_with_multiple_ordering(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_with_multiple_ordering(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSplitIncludeQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,12 +18,28 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
-        // Sqlite does not support Apply operations
-        public override Task Include_collection_with_cross_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_cross_apply_with_filter(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter(async))).Message);
 
-        public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
-        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_with_multiple_ordering(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_with_multiple_ordering(async))).Message);
+
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,14 +18,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
 
-        // Sqlite does not support Apply operations
-        public override Task Include_collection_with_cross_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_cross_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_cross_apply_with_filter(async))).Message);
 
-        public override Task Include_collection_with_outer_apply_with_filter(bool async) => Task.CompletedTask;
+        public override async Task Include_collection_with_outer_apply_with_filter(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter(async))).Message);
 
-        public override Task Filtered_include_with_multiple_ordering(bool async) => Task.CompletedTask;
-        public override Task Include_collection_with_outer_apply_with_filter_non_equality(bool async) => Task.CompletedTask;
-
-        
+        public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqliteTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -13,11 +15,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        // Sqlite does not support Apply operations
+        public override async Task Skip_navigation_order_by_single_or_default(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_navigation_order_by_single_or_default(async))).Message);
 
-        public override Task Skip_navigation_order_by_single_or_default(bool async) => Task.CompletedTask;
-
-        public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async) => Task.CompletedTask;
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#21541")]
         public override Task Left_join_with_skip_navigation(bool async) => base.Left_join_with_skip_navigation(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTManyToManyQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTManyToManyQuerySqliteTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -13,16 +15,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        // Sqlite does not support Apply operations
+        public override async Task Skip_navigation_order_by_single_or_default(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_navigation_order_by_single_or_default(async))).Message);
 
-        public override Task Skip_navigation_order_by_single_or_default(bool async)
-            => Task.CompletedTask;
-
-        public override Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
-            => Task.CompletedTask;
-
-        public override Task Include_skip_navigation_then_include_inverse_throws_in_no_tracking(bool async)
-            => Task.CompletedTask;
+        public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#21541")]
         public override Task Left_join_with_skip_navigation(bool async) => base.Left_join_with_skip_navigation(async);


### PR DESCRIPTION
Adding logic that checks for APPLY and throws meaningful exception

Fixes #19178