### PR TITLE
Remove hacky mappings for SQL types that only work on .NET Framework

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -152,14 +152,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                 "nvarchar"
             };
 
-        private readonly IReadOnlyDictionary<string, Func<Type, RelationalTypeMapping>> _namedClrMappings
-            = new Dictionary<string, Func<Type, RelationalTypeMapping>>(StringComparer.Ordinal)
-            {
-                { "Microsoft.SqlServer.Types.SqlHierarchyId", t => SqlServerUdtTypeMapping.CreateSqlHierarchyIdMapping(t) },
-                { "Microsoft.SqlServer.Types.SqlGeography", t => SqlServerUdtTypeMapping.CreateSqlSpatialMapping(t, "geography") },
-                { "Microsoft.SqlServer.Types.SqlGeometry", t => SqlServerUdtTypeMapping.CreateSqlSpatialMapping(t, "geometry") }
-            };
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -300,11 +292,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                 if (_clrTypeMappings.TryGetValue(clrType, out var mapping))
                 {
                     return mapping;
-                }
-
-                if (_namedClrMappings.TryGetValue(clrType.FullName, out var mappingFunc))
-                {
-                    return mappingFunc(clrType);
                 }
 
                 if (clrType == typeof(string))

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
@@ -140,51 +140,5 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                 paramParam,
                 valueParam).Compile();
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public static SqlServerUdtTypeMapping CreateSqlHierarchyIdMapping([NotNull] Type udtType)
-            => new SqlServerUdtTypeMapping(
-                udtType,
-                "hierarchyid",
-                v => Expression.Call(
-                    v.GetType().GetMethod("Parse"),
-                    Expression.New(
-                        typeof(SqlString).GetConstructor(new[] { typeof(string) }),
-                        Expression.Constant(v.ToString(), typeof(string)))));
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public static SqlServerUdtTypeMapping CreateSqlSpatialMapping([NotNull] Type udtType, [NotNull] string storeName)
-            => new SqlServerUdtTypeMapping(
-                udtType,
-                storeName,
-                v =>
-                {
-                    var spatialType = v.GetType();
-                    var noParams = new object[0];
-
-                    var wkt = ((SqlChars)spatialType.GetMethod("AsTextZM").Invoke(v, noParams)).ToSqlString().ToString();
-                    var srid = ((SqlInt32)spatialType.GetMethod("get_STSrid").Invoke(v, noParams)).Value;
-
-                    return Expression.Call(
-                        spatialType.GetMethod("STGeomFromText"),
-                        Expression.New(
-                            typeof(SqlChars).GetConstructor(
-                                new[] { typeof(SqlString) }),
-                            Expression.New(
-                                typeof(SqlString).GetConstructor(
-                                    new[] { typeof(string) }),
-                                Expression.Constant(wkt, typeof(string)))),
-                        Expression.Constant(srid, typeof(int)));
-                });
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlTypes;
 using System.Linq.Expressions;
 using System.Numerics;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -11,7 +10,6 @@ using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
-using Microsoft.SqlServer.Types;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Design.Internal
@@ -600,51 +598,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                     () => new CSharpHelper(typeMapping).UnknownLiteral(new SimpleTestType())).Message);
         }
 
-        [ConditionalFact]
-        public virtual void Can_generate_SqlHierarchyId_literal()
-        {
-            var typeMapping = CreateTypeMappingSource(
-                new TestTypeMappingPlugin<FakeSqlHierarchyId>(
-                    SqlServerUdtTypeMapping.CreateSqlHierarchyIdMapping(
-                        typeof(FakeSqlHierarchyId)).LiteralGenerator));
-
-            Assert.Equal(
-                "Microsoft.SqlServer.Types.FakeSqlHierarchyId.Parse(new System.Data.SqlTypes.SqlString(\"/1/1/3/\"))",
-                new CSharpHelper(typeMapping).UnknownLiteral(
-                    FakeSqlHierarchyId.Parse(
-                        new SqlString("/1/1/3/"))));
-        }
-
-        [ConditionalFact]
-        public virtual void Can_generate_SqlGeometry_literal()
-        {
-            var typeMapping = CreateTypeMappingSource(
-                new TestTypeMappingPlugin<FakeSqlGeometry>(
-                    SqlServerUdtTypeMapping.CreateSqlSpatialMapping(
-                            typeof(FakeSqlGeometry),
-                            "geometry")
-                        .LiteralGenerator));
-
-            Assert.Equal(
-                "Microsoft.SqlServer.Types.FakeSqlGeometry.STGeomFromText(new System.Data.SqlTypes.SqlChars(new System.Data.SqlTypes.SqlString(\"POINT (1 2)\")), 0)",
-                new CSharpHelper(typeMapping).UnknownLiteral(new FakeSqlGeometry("POINT (1 2)", 0)));
-        }
-
-        [ConditionalFact]
-        public virtual void Can_generate_SqlGeography_literal()
-        {
-            var typeMapping = CreateTypeMappingSource(
-                new TestTypeMappingPlugin<FakeSqlGeography>(
-                    SqlServerUdtTypeMapping.CreateSqlSpatialMapping(
-                            typeof(FakeSqlGeography),
-                            "geography")
-                        .LiteralGenerator));
-
-            Assert.Equal(
-                "Microsoft.SqlServer.Types.FakeSqlGeography.STGeomFromText(new System.Data.SqlTypes.SqlChars(new System.Data.SqlTypes.SqlString(\"POINT (1 2)\")), 4326)",
-                new CSharpHelper(typeMapping).UnknownLiteral(new FakeSqlGeography("POINT (1 2)", 4326)));
-        }
-
         private IRelationalTypeMappingSource TypeMappingSource { get; } = CreateTypeMappingSource();
 
         private static SqlServerTypeMappingSource CreateTypeMappingSource<T>(
@@ -767,67 +720,5 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
     internal class MultiGeneric<T1, T2>
     {
-    }
-}
-
-namespace Microsoft.SqlServer.Types
-{
-    // Has the same shape as Microsoft.SqlServer.Types.SqlHierarchyId for testing code gen
-    public class FakeSqlHierarchyId
-    {
-        private readonly SqlString _value;
-
-        private FakeSqlHierarchyId(SqlString value)
-            => _value = value;
-
-        public static FakeSqlHierarchyId Parse(SqlString input)
-            => new FakeSqlHierarchyId(input);
-
-        public override string ToString()
-            => _value.Value;
-    }
-
-    // Has the same shape as Microsoft.SqlServer.Types.SqlGeometry for testing code gen
-    public class FakeSqlGeometry
-    {
-        private readonly string _text;
-        private readonly int _srid;
-
-        public FakeSqlGeometry(string text, int srid)
-        {
-            _text = text;
-            _srid = srid;
-        }
-
-        public SqlChars AsTextZM() => new SqlChars(_text);
-
-        public SqlInt32 STSrid => _srid;
-
-        public static FakeSqlGeometry STGeomFromText(SqlChars geometryTaggedText, int srid)
-        {
-            return new FakeSqlGeometry(geometryTaggedText.ToSqlString().ToString(), srid);
-        }
-    }
-
-    // Has the same shape as Microsoft.SqlServer.Types.SqlGeography for testing code gen
-    public class FakeSqlGeography
-    {
-        private readonly string _text;
-        private readonly int _srid;
-
-        public FakeSqlGeography(string text, int srid)
-        {
-            _text = text;
-            _srid = srid;
-        }
-
-        public SqlChars AsTextZM() => new SqlChars(_text);
-
-        public SqlInt32 STSrid => _srid;
-
-        public static FakeSqlGeography STGeomFromText(SqlChars geometryTaggedText, int srid)
-        {
-            return new FakeSqlGeography(geometryTaggedText.ToSqlString().ToString(), srid);
-        }
     }
 }

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -284,21 +284,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())
                 .FindMapping(type);
 
-        [ConditionalTheory]
-        [InlineData("Microsoft.SqlServer.Types.SqlHierarchyId", "hierarchyid")]
-        [InlineData("Microsoft.SqlServer.Types.SqlGeography", "geography")]
-        [InlineData("Microsoft.SqlServer.Types.SqlGeometry", "geometry")]
-        public virtual void Get_named_mappings_for_sql_type(string typeName, string udtName)
-        {
-            var type = new FakeType(typeName);
-
-            var mapping = GetMapping(type);
-
-            Assert.Equal(udtName, mapping.StoreType);
-            Assert.Equal(udtName, ((SqlServerUdtTypeMapping)mapping).UdtTypeName);
-            Assert.Same(type, mapping.ClrType);
-        }
-
         private class FakeType : Type
         {
             public FakeType(string fullName)


### PR DESCRIPTION
Fixes #20442
