### PR TITLE
UsingEntity was returning the wrong side of the association.

### DIFF
--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var entityTypeBuilder = UsingEntity(joinEntity, configureRight, configureLeft);
             configureAssociation(entityTypeBuilder);
 
-            return new EntityTypeBuilder(LeftEntityType);
+            return new EntityTypeBuilder(RightEntityType);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="configureAssociation"> The configuration of the association type. </param>
         /// <typeparam name="TAssociationEntity"> The type of the association entity. </typeparam>
         /// <returns> The builder for the originating entity type so that multiple configuration calls can be chained. </returns>
-        public virtual EntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+        public virtual EntityTypeBuilder<TRightEntity> UsingEntity<TAssociationEntity>(
             [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
             [NotNull] Func<EntityTypeBuilder<TAssociationEntity>, ReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft,
             [NotNull] Action<EntityTypeBuilder<TAssociationEntity>> configureAssociation)
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var entityTypeBuilder = UsingEntity<TAssociationEntity>(configureRight, configureLeft);
             configureAssociation(entityTypeBuilder);
 
-            return new EntityTypeBuilder<TLeftEntity>(LeftEntityType);
+            return new EntityTypeBuilder<TRightEntity>(RightEntityType);
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Category>().Ignore(c => c.Products);
                 modelBuilder.Entity<Product>().Ignore(p => p.Categories);
 
-                modelBuilder.Entity<Category>()
+                var manyToMany = modelBuilder.Entity<Category>()
                     .HasMany(o => o.Products).WithMany(c => c.Categories)
                     .UsingEntity<ProductCategory>(
                         pcb => pcb.HasOne(pc => pc.Product).WithMany(),
@@ -199,6 +199,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         pcb => pcb.HasKey(pc => new { pc.ProductId, pc.CategoryId }));
 
                 modelBuilder.FinalizeModel();
+
+                Assert.Equal(typeof(Category), manyToMany.Metadata.ClrType);
 
                 var productType = model.FindEntityType(typeof(Product));
                 var categoryType = model.FindEntityType(typeof(Category));

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -652,14 +652,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     r => ((GenericTestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>)configureLeft(
                         new GenericTestEntityTypeBuilder<TAssociationEntity>(r))).ReferenceCollectionBuilder));
 
-            public override TestEntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+            public override TestEntityTypeBuilder<TRightEntity> UsingEntity<TAssociationEntity>(
                 Func<TestEntityTypeBuilder<TAssociationEntity>,
                     TestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
                 Func<TestEntityTypeBuilder<TAssociationEntity>,
                     TestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft,
                 Action<TestEntityTypeBuilder<TAssociationEntity>> configureAssociation)
                 where TAssociationEntity : class
-                => new GenericTestEntityTypeBuilder<TLeftEntity>(CollectionCollectionBuilder.UsingEntity<TAssociationEntity>(
+                => new GenericTestEntityTypeBuilder<TRightEntity>(CollectionCollectionBuilder.UsingEntity<TAssociationEntity>(
                     l => ((GenericTestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>)configureRight(
                         new GenericTestEntityTypeBuilder<TAssociationEntity>(l))).ReferenceCollectionBuilder,
                     r => ((GenericTestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>)configureLeft(

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -646,14 +646,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     r => ((NonGenericTestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>)configureLeft(
                         new NonGenericTestEntityTypeBuilder<TAssociationEntity>(r))).ReferenceCollectionBuilder));
 
-            public override TestEntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+            public override TestEntityTypeBuilder<TRightEntity> UsingEntity<TAssociationEntity>(
                 Func<TestEntityTypeBuilder<TAssociationEntity>,
                     TestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
                 Func<TestEntityTypeBuilder<TAssociationEntity>,
                     TestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft,
                 Action<TestEntityTypeBuilder<TAssociationEntity>> configureAssociation)
                 where TAssociationEntity : class
-                => new NonGenericTestEntityTypeBuilder<TLeftEntity>(CollectionCollectionBuilder.UsingEntity(
+                => new NonGenericTestEntityTypeBuilder<TRightEntity>(CollectionCollectionBuilder.UsingEntity(
                     typeof(TAssociationEntity),
                     l => ((NonGenericTestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>)configureRight(
                         new NonGenericTestEntityTypeBuilder<TAssociationEntity>(l))).ReferenceCollectionBuilder,

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -446,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     TestReferenceCollectionBuilder<TRightEntity, TAssociationEntity>> configureLeft)
                 where TAssociationEntity : class;
 
-            public abstract TestEntityTypeBuilder<TLeftEntity> UsingEntity<TAssociationEntity>(
+            public abstract TestEntityTypeBuilder<TRightEntity> UsingEntity<TAssociationEntity>(
                 Func<TestEntityTypeBuilder<TAssociationEntity>,
                     TestReferenceCollectionBuilder<TLeftEntity, TAssociationEntity>> configureRight,
                 Func<TestEntityTypeBuilder<TAssociationEntity>,


### PR DESCRIPTION
The overload of UsingEntity() which configures the association entity type was returning the wrong side of the association.