### PR TITLE
Fix to #20180 - Query: Apply null semantics processing to QueryableFunctionExpression

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -152,8 +152,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return Visit(selectExpression);
 
                 case TableValuedFunctionExpression tableValuedFunctionExpression:
-                    // See issue#20180
-                    return tableValuedFunctionExpression;
+                {
+                    var arguments = new List<SqlExpression>();
+                    foreach (var argument in tableValuedFunctionExpression.Arguments)
+                    {
+                        arguments.Add(Visit(argument, out _));
+                    }
+
+                    return tableValuedFunctionExpression.Update(arguments);
+                }
 
                 case TableExpression tableExpression:
                     return tableExpression;

--- a/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SearchConditionConvertingExpressionVisitor.cs
@@ -457,8 +457,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         {
             Check.NotNull(tableValuedFunctionExpression, nameof(tableValuedFunctionExpression));
 
-            // TODO: See issue#20180
-            return tableValuedFunctionExpression;
+            var parentSearchCondition = _isSearchCondition;
+            _isSearchCondition = false;
+
+            var arguments = new SqlExpression[tableValuedFunctionExpression.Arguments.Count];
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                arguments[i] = (SqlExpression)Visit(tableValuedFunctionExpression.Arguments[i]);
+            }
+
+            _isSearchCondition = parentSearchCondition;
+            return tableValuedFunctionExpression.Update(arguments);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #20180