### PR TITLE
Use Azure Artifacts instead of MyGet

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,10 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--
-      Restore sources should be defined in build/sources.props.
-      The only allowed feed here is myget.org/aspnet-tools which is required to workaround https://github.com/Microsoft/msbuild/issues/2914
-    -->
-    <add key="myget.org aspnetcore-tools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
+    <add key="myget.org aspnetcore-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="myget.org aspnetcore-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <!--
+      Restore sources should be defined in build/sources.props.
+      The only allowed feed here is myget-legacy which is required to workaround https://github.com/Microsoft/msbuild/issues/2914
+    -->
+    <add key="myget-legacy internal" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -5,9 +5,8 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
       $(RestoreSources);
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json;
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);


### PR DESCRIPTION
As part of [moving to Azure Artifacts from MyGet](https://github.com/dotnet/arcade/blob/master/Documentation/MigrationPlan/MyGetFeeds.md), point all MyGet feed sources to new Azure Artifacts feed.

@dougbu FYI, from email.