### PR TITLE
Query: Allow terminating operator on GroupBy without aggregate when n…

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -1059,6 +1059,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     expressionPrinter.Visit(ServerQueryExpression);
                 }
 
+                expressionPrinter.AppendLine();
                 expressionPrinter.AppendLine("ProjectionMapping:");
                 using (expressionPrinter.Indent())
                 {

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -462,8 +462,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         {
             if (IsDistinct
                 || Limit != null
-                || Offset != null
-                || GroupBy.Count > 0)
+                || Offset != null)
             {
                 PushdownIntoSubquery();
             }
@@ -1652,7 +1651,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             bool allowNonEquality)
         {
             if (sqlBinaryExpression.OperatorType == ExpressionType.Equal
-                || (allowNonEquality && 
+                || (allowNonEquality &&
                     (sqlBinaryExpression.OperatorType == ExpressionType.NotEqual
                     || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThan
                     || sqlBinaryExpression.OperatorType == ExpressionType.GreaterThanOrEqual

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2518,7 +2518,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)));
         }
 
-        [ConditionalTheory(Skip = "Issue#15097")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Count_after_GroupBy_without_aggregate(bool async)
         {
@@ -2527,13 +2527,62 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID));
         }
 
-        [ConditionalTheory(Skip = "Issue#15097")]
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Count_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            return AssertCount(
+                async,
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID),
+                g => g.Count() > 1);
+        }
+
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task LongCount_after_GroupBy_without_aggregate(bool async)
         {
             return AssertLongCount(
                 async,
                 ss => ss.Set<Order>().GroupBy(o => o.CustomerID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task LongCount_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            return AssertLongCount(
+                async,
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID),
+                g => g.Count() > 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Any_after_GroupBy_without_aggregate(bool async)
+        {
+            return AssertAny(
+                async,
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Any_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            return AssertAny(
+                async,
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID),
+                g => g.Count() > 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task All_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            return AssertAll(
+                async,
+                ss => ss.Set<Order>().GroupBy(o => o.CustomerID),
+                g => g.Count() > 1);
         }
 
         #endregion
@@ -2656,8 +2705,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }),
                 elementSorter: e => e.Key);
         }
-
-
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -400,9 +400,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected Task AssertLongCount<TResult>(
             bool async,
+            Func<ISetSource, IQueryable<TResult>> query,
+            Expression<Func<TResult, bool>> predicate)
+            => AssertLongCount(async, query, query, predicate, predicate);
+
+        protected Task AssertLongCount<TResult>(
+            bool async,
             Func<ISetSource, IQueryable<TResult>> actualQuery,
             Func<ISetSource, IQueryable<TResult>> expectedQuery)
             => QueryAsserter.AssertLongCount(actualQuery, expectedQuery, async);
+
+        protected Task AssertLongCount<TResult>(
+            bool async,
+            Func<ISetSource, IQueryable<TResult>> actualQuery,
+            Func<ISetSource, IQueryable<TResult>> expectedQuery,
+            Expression<Func<TResult, bool>> actualPredicate,
+            Expression<Func<TResult, bool>> expectedPredicate)
+            => QueryAsserter.AssertLongCount(
+                actualQuery, expectedQuery, actualPredicate, expectedPredicate, async);
 
         protected Task AssertMin<TResult>(
             bool async,

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -237,28 +237,15 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Expression<Func<TResult, bool>> expectedPredicate,
             bool async = false)
         {
-            using (var context = _contextCreator())
-            {
-                var actual = async
-                    ? await RewriteServerQuery(actualQuery(SetSourceCreator(context))).AnyAsync(actualPredicate)
-                    : RewriteServerQuery(actualQuery(SetSourceCreator(context))).Any(actualPredicate);
+            using var context = _contextCreator();
+            var actual = async
+                ? await RewriteServerQuery(actualQuery(SetSourceCreator(context))).AnyAsync(actualPredicate)
+                : RewriteServerQuery(actualQuery(SetSourceCreator(context))).Any(actualPredicate);
 
-                var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
-                var expected = RewriteExpectedQuery(expectedQuery(ExpectedData)).Any(rewrittenExpectedPredicate);
+            var rewrittenExpectedPredicate = (Expression<Func<TResult, bool>>)new ExpectedQueryRewritingVisitor().Visit(expectedPredicate);
+            var expected = RewriteExpectedQuery(expectedQuery(ExpectedData)).Any(rewrittenExpectedPredicate);
 
-                Assert.Equal(expected, actual);
-            }
-
-            using (var context = _contextCreator())
-            {
-                var actual = async
-                    ? await RewriteServerQuery(actualQuery(SetSourceCreator(context))).AnyAsync()
-                    : RewriteServerQuery(actualQuery(SetSourceCreator(context))).Any();
-
-                var expected = expectedQuery(ExpectedData).Any();
-
-                Assert.Equal(expected, actual);
-            }
+            Assert.Equal(expected, actual);
         }
 
         public async Task AssertAll<TResult>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1662,7 +1662,7 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT COALESCE(SUM([o].[OrderID]), 0) AS [c]
+    SELECT [o].[CustomerID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
 ) AS [t]");
@@ -1746,14 +1746,98 @@ END");
         {
             await base.Count_after_GroupBy_without_aggregate(async);
 
-            AssertSql(" ");
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [t]");
+        }
+
+        public override async Task Count_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            await base.Count_with_predicate_after_GroupBy_without_aggregate(async);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 1
+) AS [t]");
         }
 
         public override async Task LongCount_after_GroupBy_without_aggregate(bool async)
         {
             await base.LongCount_after_GroupBy_without_aggregate(async);
 
-            AssertSql(" ");
+            AssertSql(
+                @"SELECT COUNT_BIG(*)
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [t]");
+        }
+
+        public override async Task LongCount_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            await base.LongCount_with_predicate_after_GroupBy_without_aggregate(async);
+
+            AssertSql(
+                @"SELECT COUNT_BIG(*)
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 1
+) AS [t]");
+        }
+
+        public override async Task Any_after_GroupBy_without_aggregate(bool async)
+        {
+            await base.Any_after_GroupBy_without_aggregate(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        GROUP BY [o].[CustomerID]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+        }
+
+        public override async Task Any_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            await base.Any_with_predicate_after_GroupBy_without_aggregate(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        GROUP BY [o].[CustomerID]
+        HAVING COUNT(*) > 1) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
+        }
+
+        public override async Task All_with_predicate_after_GroupBy_without_aggregate(bool async)
+        {
+            await base.All_with_predicate_after_GroupBy_without_aggregate(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        GROUP BY [o].[CustomerID]
+        HAVING COUNT(*) <= 1) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END");
         }
 
         public override async Task GroupBy_based_on_renamed_property_simple(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -1364,13 +1364,6 @@ END");
         FROM [Customers] AS [c]
         WHERE [c].[ContactName] IS NOT NULL AND ([c].[ContactName] LIKE N'A%')) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END",
-                //
-                @"SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Customers] AS [c]) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
 END");
         }
 
@@ -2099,18 +2092,6 @@ SELECT CASE
         ) AS [t]
         WHERE [t].[CustomerID] LIKE N'C%') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END",
-                //
-                @"@__p_0='5'
-@__p_1='7'
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID]
-        OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
 END");
         }
 
@@ -2130,16 +2111,6 @@ SELECT CASE
             ORDER BY [c].[CustomerID]
         ) AS [t]
         WHERE [t].[CustomerID] LIKE N'B%') THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END",
-                //
-                @"@__p_0='5'
-
-SELECT CASE
-    WHEN EXISTS (
-        SELECT TOP(@__p_0) 1
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID]) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END");
         }


### PR DESCRIPTION
…ot returning group

Resolves #15097
