### PR TITLE
Increase timeout for windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ stages:
         helixRepo: dotnet/efcore
         jobs:
           - job: Windows
+            timeoutInMinutes: 90
             enablePublishTestResults: true
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
After https://github.com/dotnet/efcore/pull/21605 now it is crossing an hour mark and fails to complete.
