### PR TITLE
Use FindEntityType(Type) as appropriate

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -304,6 +304,11 @@ namespace Microsoft.EntityFrameworkCore
                     throw new InvalidOperationException(CoreStrings.InvalidSetTypeWeak(type.ShortDisplayName()));
                 }
 
+                if (Model.IsShared(type))
+                {
+                    throw new InvalidOperationException(CoreStrings.InvalidSetSharedType(type.ShortDisplayName()));
+                }
+
                 throw new InvalidOperationException(CoreStrings.InvalidSetType(type.ShortDisplayName()));
             }
 

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 serviceCollection,
                 optionsAction == null
                     ? (Action<IServiceProvider, DbContextOptionsBuilder>)null
-                    : (p, b) => optionsAction.Invoke(b), contextLifetime, optionsLifetime);
+                    : (p, b) => optionsAction(b), contextLifetime, optionsLifetime);
 
         /// <summary>
         ///     <para>
@@ -672,7 +672,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 serviceCollection,
                 optionsAction == null
                     ? (Action<IServiceProvider, DbContextOptionsBuilder>)null
-                    : (p, b) => optionsAction.Invoke(b),
+                    : (p, b) => optionsAction(b),
                 lifetime);
 
         /// <summary>

--- a/src/EFCore/Extensions/ModelExtensions.cs
+++ b/src/EFCore/Extensions/ModelExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore
     {
         /// <summary>
         ///     Gets the entity that maps the given entity class. Returns <see langword="null" /> if no entity type with
-        ///     the given CLR type is found or the entity type has a defining navigation.
+        ///     the given CLR type is found or the given CLR type is being used by shared type entity type
+        ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="model"> The model to find the entity type in. </param>
         /// <param name="type"> The type to find the corresponding entity type for. </param>
@@ -34,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Gets the entity that maps the given entity class, where the class may be a proxy derived from the
         ///     actual entity type. Returns <see langword="null" /> if no entity type with the given CLR type is found
+        ///     or the given CLR type is being used by shared type entity type
         ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="model"> The model to find the entity type in. </param>
@@ -118,6 +120,16 @@ namespace Microsoft.EntityFrameworkCore
         public static bool HasEntityTypeWithDefiningNavigation([NotNull] this IModel model, [NotNull] string name)
             => Check.NotNull(model, nameof(model)).AsModel()
                 .HasEntityTypeWithDefiningNavigation(Check.NotNull(name, nameof(name)));
+
+        /// <summary>
+        ///     Gets whether the CLR type is used by shared type entities in the model.
+        /// </summary>
+        /// <param name="model"> The model to find the entity type in. </param>
+        /// <param name="clrType"> The CLR type. </param>
+        /// <returns> Whether the CLR type is used by shared type entities in the model. </returns>
+        [DebuggerStepThrough]
+        public static bool IsShared([NotNull] this IModel model, [NotNull] Type clrType)
+            => Check.NotNull(model, nameof(model)).AsModel().IsShared(Check.NotNull(clrType, nameof(clrType)));
 
         /// <summary>
         ///     Gets the default change tracking strategy being used for entities in the model. This strategy indicates how the

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -18,7 +18,9 @@ namespace Microsoft.EntityFrameworkCore
     public static class MutableModelExtensions
     {
         /// <summary>
-        ///     Gets the entity that maps the given entity class. Returns <see langword="null" /> if no entity type with the given name is found.
+        ///     Gets the entity that maps the given entity class. Returns <see langword="null" /> if no entity type with
+        ///     the given CLR type is found or the given CLR type is being used by shared type entity type
+        ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="model"> The model to find the entity type in. </param>
         /// <param name="type"> The type to find the corresponding entity type for. </param>

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -207,6 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                     if (targetType?.IsValidEntityType() == true
                         && (isTargetWeakOrOwned
+                            || conventionModel.IsShared(targetType)
                             || conventionModel.FindEntityType(targetType) != null
                             || targetType.GetRuntimeProperties().Any(p => p.IsCandidateProperty())))
                     {

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         private readonly IStateManager _stateManager;
         private readonly IDbSetSource _setSource;
         private readonly IDbSetCache _setCache;
-        private readonly IModel _model;
+        private readonly IEntityType _entityType;
         private readonly IQueryable<TEntity> _queryRoot;
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             _stateManager = stateManager;
             _setSource = setSource;
             _setCache = setCache;
-            _model = entityType.Model;
+            _entityType = entityType;
             _queryRoot = (IQueryable<TEntity>)BuildQueryRoot(entityType);
         }
 
@@ -274,7 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
         private TEntity FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
         {
-            var key = _model.FindEntityType(typeof(TEntity)).FindPrimaryKey();
+            var key = _entityType.FindPrimaryKey();
             keyProperties = key.Properties;
 
             if (keyProperties.Count != keyValues.Length)

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -74,6 +74,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         throw new InvalidOperationException(CoreStrings.InvalidSetTypeWeak(typeof(TEntity).ShortDisplayName()));
                     }
 
+                    if (_context.Model.IsShared(typeof(TEntity)))
+                    {
+                        throw new InvalidOperationException(CoreStrings.InvalidSetSharedType(typeof(TEntity).ShortDisplayName()));
+                    }
+
                     throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TEntity).ShortDisplayName()));
                 }
 

--- a/src/EFCore/Metadata/Conventions/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/BaseTypeDiscoveryConvention.cs
@@ -34,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var entityType = entityTypeBuilder.Metadata;
             var clrType = entityType.ClrType;
             if (clrType == null
+                || entityType.HasSharedClrType
                 || entityType.HasDefiningNavigation()
                 || entityType.FindDeclaredOwnership() != null
                 || entityType.Model.FindIsOwnedConfigurationSource(clrType) != null)

--- a/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
@@ -35,7 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var entityType = entityTypeBuilder.Metadata;
             var clrType = entityType.ClrType;
             if (clrType == null
-                || entityType.HasDefiningNavigation())
+                || entityType.HasSharedClrType
+                || entityType.HasDefiningNavigation()
+                || entityType.FindDeclaredOwnership() != null
+                || entityType.Model.FindIsOwnedConfigurationSource(clrType) != null)
             {
                 return;
             }

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -50,7 +50,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IConventionEntityType AddEntityType([NotNull] Type clrType, bool fromDataAnnotation = false);
 
         /// <summary>
-        ///     Adds an entity type to the model.
+        ///     <para>
+        ///         Adds a shared type entity type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shared type entity type is an entity type which can share CLR type with other types in the model but has
+        ///         a unique name and always identified by the name.
+        ///     </para>
         /// </summary>
         /// <param name="name"> The name of the entity to be added. </param>
         /// <param name="clrType"> The CLR class that is used to represent instances of the entity type. </param>
@@ -88,6 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <summary>
         ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found
+        ///     or the given CLR type is being used by shared type entity type
         ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>
@@ -136,10 +143,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         string RemoveIgnored([NotNull] string typeName);
 
         /// <summary>
-        ///     Gets whether the CLR type is used by shared entities in the model.
+        ///     Gets whether the CLR type is used by shared type entities in the model.
         /// </summary>
         /// <param name="clrType"> The CLR type. </param>
-        /// <returns> Whether the CLR type is used by shared entities in the model. </returns>
+        /// <returns> Whether the CLR type is used by shared type entities in the model. </returns>
         bool IsShared([NotNull] Type clrType);
 
         /// <summary>

--- a/src/EFCore/Metadata/IModel.cs
+++ b/src/EFCore/Metadata/IModel.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <summary>
         ///     Gets the entity type with the given name. Returns null if no entity type with the given name is found
+        ///     or the given CLR type is being used by shared type entity type
         ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -42,7 +42,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IMutableEntityType AddEntityType([NotNull] Type clrType);
 
         /// <summary>
-        ///     Adds an entity type to the model.
+        ///     <para>
+        ///         Adds a shared type entity type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shared type entity type is an entity type which can share CLR type with other types in the model but has
+        ///         a unique name and always identified by the name.
+        ///     </para>
         /// </summary>
         /// <param name="name"> The name of the entity to be added. </param>
         /// <param name="clrType"> The CLR class that is used to represent instances of the entity type. </param>
@@ -75,6 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <summary>
         ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found
+        ///     or the given CLR type is being used by shared type entity type
         ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1885,7 +1885,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Cannot create a DbSet for '{typeName}' because it is mapped to multiple entity types and should they should be accessed through the defining entities.
+        ///     Cannot create a DbSet for '{typeName}' because it is mapped to multiple entity types and should be accessed through the defining entities.
         /// </summary>
         public static string InvalidSetTypeWeak([CanBeNull] object typeName)
             => string.Format(
@@ -2383,14 +2383,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Cannot find entity type with type '{clrType}' since model contains shared entity type(s) with same type.
-        /// </summary>
-        public static string CannotFindEntityWithClrTypeWhenShared([CanBeNull] object clrType)
-            => string.Format(
-                GetString("CannotFindEntityWithClrTypeWhenShared", nameof(clrType)),
-                clrType);
-
-        /// <summary>
         ///     The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.
         /// </summary>
         public static string SkipNavigationInUseBySkipNavigation([CanBeNull] object skipNavigation, [CanBeNull] object inverseSkipNavigation, [CanBeNull] object referencingEntityType)
@@ -2715,6 +2707,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("PrincipalKeylessType", nameof(entityType), nameof(firstNavigationSpecification), nameof(secondNavigationSpecification)),
                 entityType, firstNavigationSpecification, secondNavigationSpecification);
+
+        /// <summary>
+        ///     The shared type entity type '{entityType}' cannot be added to the model because a shared entity type with the same name but different clr type already exists.
+        /// </summary>
+        public static string ClashingMismatchedSharedType([CanBeNull] object entityType)
+            => string.Format(
+                GetString("ClashingMismatchedSharedType", nameof(entityType)),
+                entityType);
+
+        /// <summary>
+        ///     The shared type entity type '{entityType}' cannot be added to the model because a non shared entity type with the same clr type already exists.
+        /// </summary>
+        public static string ClashingNonSharedType([CanBeNull] object entityType)
+            => string.Format(
+                GetString("ClashingNonSharedType", nameof(entityType)),
+                entityType);
+
+        /// <summary>
+        ///     Cannot create a DbSet for '{typeName}' because it is configured as an shared type entity type and should be accessed through entity type name based Set method.
+        /// </summary>
+        public static string InvalidSetSharedType([CanBeNull] object typeName)
+            => string.Format(
+                GetString("InvalidSetSharedType", nameof(typeName)),
+                typeName);
 
         /// <summary>
         ///     Cannot use UsingEntity() passing type '{clrType}' because the model contains shared entity type(s) with same type. Use a type which uniquely defines an entity type.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1066,7 +1066,7 @@
     <value>The owned entity type '{entityType}' cannot have a base type.</value>
   </data>
   <data name="InvalidSetTypeWeak" xml:space="preserve">
-    <value>Cannot create a DbSet for '{typeName}' because it is mapped to multiple entity types and should they should be accessed through the defining entities.</value>
+    <value>Cannot create a DbSet for '{typeName}' because it is mapped to multiple entity types and should be accessed through the defining entities.</value>
   </data>
   <data name="LogNonDefiningInverseNavigation" xml:space="preserve">
     <value>The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{weakEntityType}.{navigation}' because it's not the defining navigation '{definingNavigation}'</value>
@@ -1286,9 +1286,6 @@
   <data name="ClashingSharedType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be added to the model because a shared entity type with the same clr type already exists.</value>
   </data>
-  <data name="CannotFindEntityWithClrTypeWhenShared" xml:space="preserve">
-    <value>Cannot find entity type with type '{clrType}' since model contains shared entity type(s) with same type.</value>
-  </data>
   <data name="SkipNavigationInUseBySkipNavigation" xml:space="preserve">
     <value>The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.</value>
   </data>
@@ -1431,6 +1428,15 @@
   </data>
   <data name="PrincipalKeylessType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be on the principal end of the relationship between '{firstNavigationSpecification}' and '{secondNavigationSpecification}'. The principal entity type must have a key.</value>
+  </data>
+  <data name="ClashingMismatchedSharedType" xml:space="preserve">
+    <value>The shared type entity type '{entityType}' cannot be added to the model because a shared entity type with the same name but different clr type already exists.</value>
+  </data>
+  <data name="ClashingNonSharedType" xml:space="preserve">
+    <value>The shared type entity type '{entityType}' cannot be added to the model because a non shared entity type with the same clr type already exists.</value>
+  </data>
+  <data name="InvalidSetSharedType" xml:space="preserve">
+    <value>Cannot create a DbSet for '{typeName}' because it is configured as an shared type entity type and should be accessed through entity type name based Set method.</value>
   </data>
   <data name="DoNotUseUsingEntityOnSharedClrType" xml:space="preserve">
     <value>Cannot use UsingEntity() passing type '{clrType}' because the model contains shared entity type(s) with same type. Use a type which uniquely defines an entity type.</value>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         navigationExpansionExpression = CreateNavigationExpansionExpression(queryRootExpression, entityType);
                     }
 
-                    return ApplyQueryFilter(navigationExpansionExpression);
+                    return ApplyQueryFilter(entityType, navigationExpansionExpression);
 
                 case NavigationExpansionExpression _:
                 case OwnedNavigationReference _:
@@ -1353,12 +1353,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-        private Expression ApplyQueryFilter(NavigationExpansionExpression navigationExpansionExpression)
+        private Expression ApplyQueryFilter(IEntityType entityType, NavigationExpansionExpression navigationExpansionExpression)
         {
             if (!_queryCompilationContext.IgnoreQueryFilters)
             {
                 var sequenceType = navigationExpansionExpression.Type.GetSequenceType();
-                var entityType = _queryCompilationContext.Model.FindEntityType(sequenceType);
                 var rootEntityType = entityType.GetRootType();
                 var queryFilter = rootEntityType.GetQueryFilter();
                 if (queryFilter != null)

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -114,6 +114,22 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public void Set_throws_for_shared_types()
+        {
+            var model = new Model(new ConventionSet());
+            var question = model.AddEntityType("SharedQuestion", typeof(Question), ConfigurationSource.Explicit);
+
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .UseInternalServiceProvider(InMemoryTestHelpers.Instance.CreateServiceProvider())
+                .UseModel(model.FinalizeModel());
+            using var context = new DbContext(optionsBuilder.Options);
+            var ex = Assert.Throws<InvalidOperationException>(() => context.Set<Question>().Local);
+            Assert.Equal(CoreStrings.InvalidSetSharedType(typeof(Question).ShortDisplayName()), ex.Message);
+        }
+
+        [ConditionalFact]
         public void SaveChanges_calls_DetectChanges()
         {
             var services = new ServiceCollection()

--- a/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
@@ -123,10 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.NotNull(((EntityType)entityType).Builder);
 
             Assert.Same(entityType, model.FindEntityType(entityTypeName));
-            Assert.Equal(
-                CoreStrings.CannotFindEntityWithClrTypeWhenShared(typeof(Customer).DisplayName()),
-                Assert.Throws<InvalidOperationException>(
-                    () => model.FindEntityType(typeof(Customer))).Message);
+            Assert.Null(model.FindEntityType(typeof(Customer)));
 
             Assert.Equal(new[] { entityType }, model.GetEntityTypes().ToArray());
 


### PR DESCRIPTION
- Make FindEntityType(Type) return null for shared type entity type
- Add IModel.IsShared(Type) API
- Flow IEntityType info in places when availble rather than doing Type based loopup

Part of #9914
