### PR TITLE
Fix issue where property with `ValueGeneratedOnAdd` is reseeded in every migration

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1914,7 +1914,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                         foreach (var targetProperty in entry.EntityType.GetProperties())
                         {
-                            if (targetProperty.ValueGenerated != ValueGenerated.Never)
+                            if (!(targetProperty.ValueGenerated == ValueGenerated.Never || targetProperty.ValueGenerated == ValueGenerated.OnAdd))
                             {
                                 continue;
                             }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -727,6 +727,32 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [ConditionalFact]
+        public void Dont_reseed_value_with_value_generated_on_add_property()
+        {
+            Execute(
+                common =>
+                {
+                    common.Entity(
+                        "EntityWithValueGeneratedOnAddProperty",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("ValueGeneratedOnAddProperty")
+                                .ValueGeneratedOnAdd();
+                            x.HasData(
+                                new
+                                {
+                                    Id = 1,
+                                    ValueGeneratedOnAddProperty = "Value"
+                                });
+                        });
+                },
+                source => { },
+                target => { },
+                operations => Assert.Equal(0, operations.Count));
+        }
+
+        [ConditionalFact]
         public void Dont_rebuild_index_with_equal_include()
         {
             Execute(


### PR DESCRIPTION
This PR fixes an issue where seeded values that contain a property that is set to `ValueGeneratedOnAdd` get reseeded in every new migration, even though none of the values changed.

Fixes https://github.com/dotnet/efcore/issues/21661


