### PR TITLE
Stop scaffolding IsTableExcludedFromMigrations

### DIFF
--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -80,7 +80,11 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <inheritdoc />
         public virtual void RemoveAnnotationsHandledByConventions(
             IEntityType entityType, IDictionary<string, IAnnotation> annotations)
-            => RemoveConventionalAnnotationsHelper(entityType, annotations, IsHandledByConvention);
+        {
+            annotations.Remove(RelationalAnnotationNames.IsTableExcludedFromMigrations);
+
+            RemoveConventionalAnnotationsHelper(entityType, annotations, IsHandledByConvention);
+        }
 
         /// <inheritdoc />
         public virtual void RemoveAnnotationsHandledByConventions(

--- a/test/EFCore.Relational.Tests/Design/AnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Design/AnnotationCodeGeneratorTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public class AnnotationCodeGeneratorTest
+    {
+        [ConditionalFact]
+        public void IsTableExcludedFromMigrations_false_is_handled_by_convention()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity("foo").ToTable("foo");
+            var entityType = modelBuilder.Model.GetEntityTypes().Single();
+
+            var annotations = entityType.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            CreateGenerator().RemoveAnnotationsHandledByConventions(entityType, annotations);
+
+            Assert.DoesNotContain(RelationalAnnotationNames.IsTableExcludedFromMigrations, annotations.Keys);
+        }
+
+        private ModelBuilder CreateModelBuilder() => RelationalTestHelpers.Instance.CreateConventionBuilder();
+
+        private AnnotationCodeGenerator CreateGenerator() => new AnnotationCodeGenerator(
+            new AnnotationCodeGeneratorDependencies(
+                new TestRelationalTypeMappingSource(
+                    TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                    TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
+    }
+}


### PR DESCRIPTION
Fixes #21470

Note: this excludes from scaffolding only, we still always include this in the snapshot.