### PR TITLE
[SMALL] Adding regression test for #21434 - Making a sub-query inside a projection from a filtered Queryable results in all the results being added to a single object.

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1138,6 +1138,12 @@ ORDER BY c[""CustomerID""]");
             return base.Projecting_multiple_collection_with_same_constant_works(async);
         }
 
+        [ConditionalTheory(Skip = "Issue#17246")]
+        public override Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        {
+            return base.Projecting_after_navigation_and_distinct_works_correctly(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1454,6 +1454,25 @@ WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
+        public override async Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        {
+            await base.Projecting_after_navigation_and_distinct_works_correctly(async);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t0].[CustomerID], [t0].[OrderID], [t0].[OrderDate]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[CustomerID], [o0].[OrderID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+) AS [t0]
+ORDER BY [t].[CustomerID], [t0].[OrderID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -7840,7 +7840,6 @@ FROM [Businesses] AS [b]");
 
         #endregion
 
-
         private DbContextOptions _options;
 
         private SqlServerTestStore CreateTestStore<TContext>(

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -135,22 +137,59 @@ FROM ""Orders"" AS ""o""");
         public override Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool async)
             => base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(async);
 
-        // Sqlite does not support cross/outer apply
-        public override Task SelectMany_correlated_with_outer_1(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_1(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_1(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_2(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_2(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_2(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_3(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_3(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_3(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_4(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_4(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_4(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_5(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_5(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_5(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_6(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_6(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_6(async))).Message);
 
-        public override Task SelectMany_correlated_with_outer_7(bool async) => null;
+        public override async Task SelectMany_correlated_with_outer_7(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_correlated_with_outer_7(async))).Message);
 
-        public override Task SelectMany_whose_selector_references_outer_source(bool async) => null;
+        public override async Task SelectMany_whose_selector_references_outer_source(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.SelectMany_whose_selector_references_outer_source(async))).Message);
+
+        public override async Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Projecting_after_navigation_and_distinct_works_correctly(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#17324")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool async)


### PR DESCRIPTION
Actual issue has been fixed in previous commit.

Resolves #21434