### PR TITLE
Fix to #19609 - Query: allow user functions to be annotated with nullability propagation information

### DIFF
--- a/src/EFCore.Abstractions/DbFunctionAttribute.cs
+++ b/src/EFCore.Abstractions/DbFunctionAttribute.cs
@@ -17,9 +17,12 @@ namespace Microsoft.EntityFrameworkCore
     public class DbFunctionAttribute : Attribute
 #pragma warning restore CA1813 // Avoid unsealed attributes
     {
+        private static readonly bool DefaultNullable = true;
+
         private string _name;
         private string _schema;
         private bool _builtIn;
+        private bool? _nullable;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DbFunctionAttribute" /> class.
@@ -68,12 +71,27 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     The value indicating wheather the database function is built-in or not.
+        ///     The value indicating whether the database function is built-in or not.
         /// </summary>
         public virtual bool IsBuiltIn
         {
             get => _builtIn;
             set => _builtIn = value;
         }
+
+        /// <summary>
+        ///     The value indicating whether the database function can return null result or not.
+        /// </summary>
+        public virtual bool IsNullable
+        {
+            get => _nullable ?? DefaultNullable;
+            set => _nullable = value;
+        }
+
+        /// <summary>
+        ///     Use this method if you want to know the nullability of
+        ///     the database function or <see langword="null"/> if it was not specified.
+        /// </summary>
+        public bool? GetIsNullable() => _nullable;
     }
 }

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilder.cs
@@ -45,10 +45,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Marks whether the database function is built-in.
         /// </summary>
-        /// <param name="builtIn"> The value indicating wheather the database function is built-in. </param>
+        /// <param name="builtIn"> The value indicating whether the database function is built-in. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual DbFunctionBuilder IsBuiltIn(bool builtIn = true)
             => (DbFunctionBuilder)base.IsBuiltIn(builtIn);
+
+
+        /// <summary>
+        ///     Marks whether the database function can return null value.
+        /// </summary>
+        /// <param name="nullable"> The value indicating whether the database function can return null. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual DbFunctionBuilderBase IsNullable(bool nullable = true)
+        {
+            Builder.IsNullable(nullable, ConfigurationSource.Explicit);
+
+            return this;
+        }
 
         /// <summary>
         ///     Sets the return store type of the database function.

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilderBase.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionBuilderBase.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Marks whether the database function is built-in.
         /// </summary>
-        /// <param name="builtIn"> The value indicating wheather the database function is built-in. </param>
+        /// <param name="builtIn"> The value indicating whether the database function is built-in. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual DbFunctionBuilderBase IsBuiltIn(bool builtIn = true)
         {

--- a/src/EFCore.Relational/Metadata/Builders/DbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/DbFunctionParameterBuilder.cs
@@ -62,6 +62,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             return this;
         }
 
+        /// <summary>
+        ///     Indicates whether parameter propagates nullability, meaning if it's value is null the database function itself returns null.
+        /// </summary>
+        /// <param name="propagatesNullability"> Value which indicates whether parameter propagates nullability. </param>
+        /// <returns> The same builder instance so that further configuration calls can be chained. </returns>
+        public virtual DbFunctionParameterBuilder PropagatesNullability(bool propagatesNullability = true)
+        {
+            Builder.PropagatesNullability(propagatesNullability, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
         #region Hidden System.Object members
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/IConventionDbFunctionBuilder.cs
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         bool CanSetSchema([CanBeNull] string schema, bool fromDataAnnotation = false);
 
         /// <summary>
-        ///     Sets the value indicating wheather the database function is built-in or not.
+        ///     Sets the value indicating whether the database function is built-in or not.
         /// </summary>
         /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
@@ -75,6 +75,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> <see langword="true" /> if the given schema can be set for the database function. </returns>
         bool CanSetIsBuiltIn(bool builtIn, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Sets the value indicating whether the database function can return null value or not.
+        /// </summary>
+        /// <param name="nullable"> The value indicating whether the database function is built-in or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the configuration was applied,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionDbFunctionBuilder IsNullable(bool nullable, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the given nullable can be set for the database function.
+        /// </summary>
+        /// <param name="nullable"> The value indicating whether the database function can return null value or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the given schema can be set for the database function. </returns>
+        bool CanSetIsNullable(bool nullable, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the store type of the function in the database.

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalDbFunctionAttributeConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalDbFunctionAttributeConvention.cs
@@ -92,6 +92,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 {
                     dbFunctionBuilder.IsBuiltIn(dbFunctionAttribute.IsBuiltIn, fromDataAnnotation: true);
                 }
+
+                if (dbFunctionAttribute.GetIsNullable() is bool value)
+                {
+                    dbFunctionBuilder.IsNullable(value, fromDataAnnotation: true);
+                }
             }
         }
     }

--- a/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ConfigurationSource? GetSchemaConfigurationSource();
 
         /// <summary>
-        ///     Sets the value indicating wheather the database function is built-in or not.
+        ///     Sets the value indicating whether the database function is built-in or not.
         /// </summary>
         /// <param name="builtIn"> The value indicating whether the database function is built-in or not. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
@@ -73,6 +73,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The configuration source for <see cref="IDbFunction.IsBuiltIn" />. </returns>
         ConfigurationSource? GetIsBuiltInConfigurationSource();
+
+        /// <summary>
+        ///     Sets the value indicating whether the database function can return null value or not.
+        /// </summary>
+        /// <param name="nullable"> The value indicating whether the database function can return null value or not. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The configured value. </returns>
+        bool SetIsNullable(bool nullable, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Gets the configuration source for <see cref="IDbFunction.IsNullable" />.
+        /// </summary>
+        /// <returns> The configuration source for <see cref="IDbFunction.IsNullable" />. </returns>
+        ConfigurationSource? GetIsNullableConfigurationSource();
 
         /// <summary>
         ///     Sets the store type of the function in the database.

--- a/src/EFCore.Relational/Metadata/IDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunction.cs
@@ -56,6 +56,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         bool IsAggregate { get; }
 
         /// <summary>
+        ///     Gets the value indicating whether the database function can return null.
+        /// </summary>
+        bool IsNullable { get; }
+
+        /// <summary>
         ///     Gets the configured store type string.
         /// </summary>
         string StoreType { get; }

--- a/src/EFCore.Relational/Metadata/IDbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunctionParameter.cs
@@ -33,6 +33,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         string StoreType { get; }
 
         /// <summary>
+        ///     Gets the value which indicates whether parameter propagates nullability, meaning if it's value is null the database function itself returns null.
+        /// </summary>
+        bool PropagatesNullability { get; }
+
+        /// <summary>
         ///     Gets the <see cref="RelationalTypeMapping" /> for this parameter.
         /// </summary>
         RelationalTypeMapping TypeMapping { get; }

--- a/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
@@ -26,9 +26,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new string Schema { get; [param: CanBeNull] set; }
 
         /// <summary>
-        ///     Gets or sets the value indicating wheather the database function is built-in or not.
+        ///     Gets or sets the value indicating whether the database function is built-in or not.
         /// </summary>
         new bool IsBuiltIn { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the value indicating whether the database function can return null value or not.
+        /// </summary>
+        new bool IsNullable { get; set; }
 
         /// <summary>
         ///     Gets or sets the store type of the function in the database.

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Builders.Internal;
@@ -22,9 +23,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         private string _storeType;
         private RelationalTypeMapping _typeMapping;
+        private bool _propagatesNullability;
 
         private ConfigurationSource? _storeTypeConfigurationSource;
         private ConfigurationSource? _typeMappingConfigurationSource;
+        private ConfigurationSource? _propagatesNullabilityConfigurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -119,19 +122,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             _storeType = storeType;
 
-            UpdateStoreTypeConfigurationSource(configurationSource);
+            _storeTypeConfigurationSource = configurationSource.Max(_storeTypeConfigurationSource);
 
             return storeType;
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        private void UpdateStoreTypeConfigurationSource(ConfigurationSource configurationSource)
-            => _storeTypeConfigurationSource = configurationSource.Max(_storeTypeConfigurationSource);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -168,14 +162,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] RelationalTypeMapping typeMapping, ConfigurationSource configurationSource)
         {
             _typeMapping = typeMapping;
-
-            UpdateTypeMappingConfigurationSource(configurationSource);
+            _typeMappingConfigurationSource = configurationSource.Max(_typeMappingConfigurationSource);
 
             return typeMapping;
         }
 
-        private void UpdateTypeMappingConfigurationSource(ConfigurationSource configurationSource)
-            => _typeMappingConfigurationSource = configurationSource.Max(_typeMappingConfigurationSource);
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool PropagatesNullability
+        {
+            get => _propagatesNullability;
+            set => SetPropagatesNullability(value, ConfigurationSource.Explicit);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool SetPropagatesNullability(bool propagatesNullability, ConfigurationSource configurationSource)
+        {
+            if (!Function.IsScalar)
+            {
+                new InvalidOperationException(RelationalStrings.NullabilityInfoOnlyAllowedOnScalarFunctions);
+            }
+
+            _propagatesNullability = propagatesNullability;
+            _propagatesNullabilityConfigurationSource = configurationSource.Max(_storeTypeConfigurationSource);
+
+            return propagatesNullability;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource? GetPropagatesNullabilityConfigurationSource() => _propagatesNullabilityConfigurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
@@ -122,6 +122,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual IConventionDbFunctionBuilder IsNullable(bool nullable, ConfigurationSource configurationSource)
+        {
+            if (CanSetIsNullable(nullable, configurationSource))
+            {
+                Metadata.SetIsNullable(nullable, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetIsNullable(bool nullable, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetIsNullableConfigurationSource())
+                || Metadata.IsNullable == nullable;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IConventionDbFunctionBuilder HasStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
         {
             if (CanSetStoreType(storeType, configurationSource))
@@ -254,6 +281,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         [DebuggerStepThrough]
         bool IConventionDbFunctionBuilder.CanSetIsBuiltIn(bool builtIn, bool fromDataAnnotation)
             => CanSetIsBuiltIn(builtIn, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.IsNullable(bool nullable, bool fromDataAnnotation)
+            => IsNullable(nullable, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        bool IConventionDbFunctionBuilder.CanSetIsNullable(bool nullable, bool fromDataAnnotation)
+            => CanSetIsNullable(nullable, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
             : base(parameter, modelBuilder)
         {
         }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -86,6 +87,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping typeMapping, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetTypeMappingConfigurationSource())
                 || Metadata.TypeMapping == typeMapping;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IConventionDbFunctionParameterBuilder PropagatesNullability(
+            bool propagatesNullability,
+            ConfigurationSource configurationSource)
+        {
+            if (CanSetPropagatesNullability(propagatesNullability, configurationSource))
+            {
+                Metadata.SetPropagatesNullability(propagatesNullability, configurationSource);
+                return this;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetPropagatesNullability(bool propagatesNullability, ConfigurationSource configurationSource)
+            => configurationSource.Overrides(Metadata.GetPropagatesNullabilityConfigurationSource())
+                || Metadata.PropagatesNullability == propagatesNullability;
 
         /// <inheritdoc />
         IConventionDbFunctionParameter IConventionDbFunctionParameterBuilder.Metadata

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1026,6 +1026,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static string CustomQueryMappingOnOwner
             => GetString("CustomQueryMappingOnOwner");
 
+        /// <summary>
+        ///     Nullability information should only be specified for scalar database functions.
+        /// </summary>
+        public static string NullabilityInfoOnlyAllowedOnScalarFunctions
+            => GetString("NullabilityInfoOnlyAllowedOnScalarFunctions");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -729,4 +729,7 @@
   <data name="CustomQueryMappingOnOwner" xml:space="preserve">
     <value>Using 'FromSqlRaw' or 'FromSqlInterpolated' on an entity type which has owned reference navigations sharing same table is not supported.</value>
   </data>
+  <data name="NullabilityInfoOnlyAllowedOnScalarFunctions" xml:space="preserve">
+    <value>Nullability information should only be specified for scalar database functions.</value>
+  </data>
 </root>

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -82,8 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return _sqlExpressionFactory.Function(
                         dbFunction.Name,
                         arguments,
-                        nullable: true,
-                        argumentsPropagateNullability: arguments.Select(a => false).ToList(),
+                        nullable: dbFunction.IsNullable,
+                        argumentsPropagateNullability: dbFunction.Parameters.Select(p => p.PropagatesNullability),
                         method.ReturnType.UnwrapNullableType());
                 }
 
@@ -91,8 +92,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     dbFunction.Schema,
                     dbFunction.Name,
                     arguments,
-                    nullable: true,
-                    argumentsPropagateNullability: arguments.Select(a => false).ToList(),
+                    nullable: dbFunction.IsNullable,
+                    argumentsPropagateNullability: dbFunction.Parameters.Select(p => p.PropagatesNullability),
                     method.ReturnType.UnwrapNullableType());
             }
 

--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -203,30 +203,35 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         ///     The name of the function.
         /// </summary>
         public virtual string Name { get; }
+
         /// <summary>
         ///     The schema in which the function is defined, if any.
         /// </summary>
         public virtual string Schema { get; }
+
         /// <summary>
         ///     A bool value indicating if the function is niladic.
         /// </summary>
         public virtual bool IsNiladic { get; }
+
         /// <summary>
         ///     A bool value indicating if the function is built-in.
         /// </summary>
         public virtual bool IsBuiltIn { get; }
+
         /// <summary>
         ///     The list of arguments of this function.
         /// </summary>
         public virtual IReadOnlyList<SqlExpression> Arguments { get; }
+
         /// <summary>
         ///     The instance on which this function is applied.
         /// </summary>
         public virtual SqlExpression Instance { get; }
+
         /// <summary>
         ///     A bool value indicating if the function can return null result.
         /// </summary>
-
         public virtual bool IsNullable { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Added fluent API for function to specify it's nullability and function parameter to specify whether it propagates null. Also added property to DbFunction attribute to allow specify nullability there.

Fixes #19609