### PR TITLE
Use default property names for join entity type

### DIFF
--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -509,7 +509,13 @@ namespace Microsoft.EntityFrameworkCore
         public static IConventionProperty AddProperty(
             [NotNull] this IConventionEntityType entityType, [NotNull] string name, [NotNull] Type propertyType,
             bool setTypeConfigurationSource = true, bool fromDataAnnotation = false)
-            => entityType.AddProperty(name, propertyType, null, setTypeConfigurationSource, fromDataAnnotation);
+            => ((EntityType)entityType).AddProperty(
+                name,
+                propertyType,
+                setTypeConfigurationSource
+                    ? fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention
+                    : (ConfigurationSource?)null,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
         ///     Adds a property backed by and indexer to this entity type.

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -470,7 +470,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The newly created property. </returns>
         public static IMutableProperty AddProperty(
             [NotNull] this IMutableEntityType entityType, [NotNull] string name, [NotNull] Type propertyType)
-            => entityType.AddProperty(name, propertyType, null);
+            => ((EntityType)entityType).AddProperty(name, propertyType, ConfigurationSource.Explicit, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Adds a property backed up by an indexer to this entity type.

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -118,21 +118,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(configureRight, nameof(configureRight));
             Check.NotNull(configureLeft, nameof(configureLeft));
 
-            var existingjoinEntityType = (EntityType)
+            var existingJoinEntityType = (EntityType)
                 (LeftNavigation.ForeignKey?.DeclaringEntityType
                     ?? RightNavigation.ForeignKey?.DeclaringEntityType);
             EntityType joinEntityType = null;
-            if (existingjoinEntityType != null)
+            if (existingJoinEntityType != null)
             {
-                if (existingjoinEntityType.ClrType == joinEntityClrType
-                    && !existingjoinEntityType.HasSharedClrType)
+                if (existingJoinEntityType.ClrType == joinEntityClrType
+                    && !existingJoinEntityType.HasSharedClrType)
                 {
-                    joinEntityType = existingjoinEntityType;
+                    joinEntityType = existingJoinEntityType;
                 }
                 else
                 {
-                    ModelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                        existingjoinEntityType, removeSkipNavigations: false, ConfigurationSource.Explicit);
+                    ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType);
                 }
             }
 
@@ -183,8 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 }
                 else
                 {
-                    ModelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                        existingJoinEntityType, removeSkipNavigations: false, ConfigurationSource.Explicit);
+                    ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType);
                 }
             }
 
@@ -281,13 +279,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var leftBuilder = ((SkipNavigation)LeftNavigation).Builder;
             var rightBuilder = ((SkipNavigation)RightNavigation).Builder;
 
+            leftBuilder = leftBuilder.HasInverse(rightBuilder.Metadata, ConfigurationSource.Explicit);
+
             leftBuilder = leftBuilder.HasForeignKey((ForeignKey)leftForeignKey, ConfigurationSource.Explicit);
             rightBuilder = rightBuilder.HasForeignKey((ForeignKey)rightForeignKey, ConfigurationSource.Explicit);
 
-            leftBuilder = leftBuilder.HasInverse(rightBuilder.Metadata, ConfigurationSource.Explicit);
-
             LeftNavigation = leftBuilder.Metadata;
-            RightNavigation = leftBuilder.Metadata.Inverse;
+            RightNavigation = rightBuilder.Metadata;
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -88,8 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 }
                 else
                 {
-                    ModelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                        existingJoinEntityType, removeSkipNavigations: false, ConfigurationSource.Explicit);
+                    ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType);
                 }
             }
 
@@ -139,8 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 }
                 else
                 {
-                    ModelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                        existingJoinEntityType, removeSkipNavigations: false, ConfigurationSource.Explicit);
+                    ModelBuilder.RemoveImplicitJoinEntity(existingJoinEntityType);
                 }
             }
 

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -170,11 +170,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
                 var navigationName = SkipNavigation.Name;
                 var declaringEntityType = (EntityType)DeclaringEntityType;
-                declaringEntityType.Model.Builder
-                    .RemoveJoinEntityIfCreatedImplicitly(
-                        (EntityType)SkipNavigation.JoinEntityType,
-                        removeSkipNavigations: true,
-                        ConfigurationSource.Explicit);
+
+                if (SkipNavigation.Inverse != null)
+                {
+                    ((EntityType)SkipNavigation.Inverse.DeclaringEntityType).Builder.HasNoSkipNavigation(
+                        (SkipNavigation)SkipNavigation.Inverse, ConfigurationSource.Explicit);
+                }
+
+                declaringEntityType.Builder.HasNoSkipNavigation((SkipNavigation)SkipNavigation, ConfigurationSource.Explicit);
 
                 Builder = declaringEntityType.Builder
                     .HasRelationship(

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -585,6 +585,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         bool CanRemoveRelationship([NotNull] IConventionForeignKey foreignKey, bool fromDataAnnotation = false);
 
         /// <summary>
+        ///     Removes a skip navigation from this entity type.
+        /// </summary>
+        /// <param name="skipNavigation"> The skip navigation to be removed. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     The same builder instance if the skip navigation was removed,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionEntityTypeBuilder HasNoSkipNavigation([NotNull] ISkipNavigation skipNavigation, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns a value indicating whether the skip navigation can be removed from this entity type.
+        /// </summary>
+        /// <param name="skipNavigation"> The skip navigation to be removed. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> <see langword="true" /> if the skip navigation can be removed from this entity type. </returns>
+        bool CanRemoveSkipNavigation([NotNull] ISkipNavigation skipNavigation, bool fromDataAnnotation = false);
+
+        /// <summary>
         ///     Returns a value indicating whether the given navigation can be added to this entity type.
         /// </summary>
         /// <param name="navigationName"> The name of the navigation. </param>

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -179,11 +179,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.NavigationAddedConventions.Add(foreignKeyAttributeConvention);
 
+            var manyToManyJoinEntityTypeConvention = new ManyToManyJoinEntityTypeConvention(Dependencies);
             conventionSet.SkipNavigationAddedConventions.Add(backingFieldConvention);
+            conventionSet.SkipNavigationAddedConventions.Add(manyToManyJoinEntityTypeConvention);
+
+            conventionSet.SkipNavigationRemovedConventions.Add(manyToManyJoinEntityTypeConvention);
+
+            conventionSet.SkipNavigationInverseChangedConventions.Add(manyToManyJoinEntityTypeConvention);
+
+            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(manyToManyJoinEntityTypeConvention);
+            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(keyDiscoveryConvention);            
 
             conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
-
-            conventionSet.SkipNavigationAddedConventions.Add(new ManyToManyJoinEntityTypeConvention(Dependencies));
 
             conventionSet.IndexAddedConventions.Add(foreignKeyIndexConvention);
 

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ImmediateConventionScope.cs
@@ -779,13 +779,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     _foreignKeyConventionContext.ResetState(foreignKey);
                     foreach (var skipNavigationConvention in _conventionSet.SkipNavigationForeignKeyChangedConventions)
                     {
-                        if (navigationBuilder.Metadata.Builder == null
-                            || navigationBuilder.Metadata.ForeignKey != foreignKey)
-                        {
-                            Check.DebugAssert(false, "Foreign key changed");
-                            return null;
-                        }
-
                         skipNavigationConvention.ProcessSkipNavigationForeignKeyChanged(
                             navigationBuilder, foreignKey, oldForeignKey, _foreignKeyConventionContext);
                         if (_foreignKeyConventionContext.ShouldStopProcessing())
@@ -824,13 +817,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     _skipNavigationConventionContext.ResetState(inverse);
                     foreach (var skipNavigationConvention in _conventionSet.SkipNavigationInverseChangedConventions)
                     {
-                        if (navigationBuilder.Metadata.Builder == null
-                            || navigationBuilder.Metadata.Inverse != inverse)
-                        {
-                            Check.DebugAssert(false, "inverse changed");
-                            return null;
-                        }
-
                         skipNavigationConvention.ProcessSkipNavigationInverseChanged(
                             navigationBuilder, inverse, oldInverse, _skipNavigationConventionContext);
                         if (_skipNavigationConventionContext.ShouldStopProcessing())

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -747,20 +747,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
             else
             {
-                var joinEntityType = (EntityType)declaringEntityType
-                    .FindDeclaredSkipNavigation(navigationPropertyName)?
-                    .ForeignKey?.DeclaringEntityType;
-                if (joinEntityType != null)
+                var skipNavigation = declaringEntityType.FindDeclaredSkipNavigation(navigationPropertyName);
+                if (skipNavigation != null)
                 {
-                    var modelBuilder = joinEntityType.Model.Builder;
-                    // The PropertyInfo underlying this skip navigation has become
-                    // ambiguous since we used it, so remove the join entity
-                    // if it was implicitly created.
-                    if (modelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                            joinEntityType, removeSkipNavigations: true, ConfigurationSource.Convention) == null)
+                    var inverse = skipNavigation.Inverse;
+                    if (declaringEntityType.Builder.HasNoSkipNavigation(skipNavigation) == null)
                     {
                         // Navigations of higher configuration source are not ambiguous
                         toRemoveFrom.Remove(navigationProperty);
+                    }
+                    else if (inverse?.Builder != null)
+                    {
+                        inverse.DeclaringEntityType.Builder.HasNoSkipNavigation(inverse);
                     }
                 }
             }

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -1089,6 +1089,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         IConventionNavigation IConventionForeignKey.SetPrincipalToDependent(MemberInfo property, bool fromDataAnnotation)
             => HasPrincipalToDependent(property, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        IEnumerable<ISkipNavigation> IForeignKey.GetReferencingSkipNavigations()
+            => GetReferencingSkipNavigations();        
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -340,22 +340,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             AssertCanRemove(entityType);
 
-            foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
-            {
-                if (foreignKey.PrincipalEntityType != entityType)
-                {
-                    entityType.RemoveForeignKey(foreignKey);
-                }
-            }
-
-            foreach (var skipNavigation in entityType.GetSkipNavigations().ToList())
-            {
-                if (skipNavigation.TargetEntityType != entityType)
-                {
-                    entityType.RemoveSkipNavigation(skipNavigation);
-                }
-            }
-
             var entityTypeName = entityType.Name;
             if (entityType.HasDefiningNavigation())
             {

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1125,15 +1125,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     + @"
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
                 {
-                    b.Property<int?>(""ManyToManyLeft_Id"")
+                    b.Property<int>(""ManyToManyLeftId"")
                         .HasColumnType(""int"");
 
-                    b.Property<int?>(""ManyToManyRight_Id"")
+                    b.Property<int>(""ManyToManyRightId"")
                         .HasColumnType(""int"");
 
-                    b.HasKey(""ManyToManyLeft_Id"", ""ManyToManyRight_Id"");
+                    b.HasKey(""ManyToManyLeftId"", ""ManyToManyRightId"");
 
-                    b.HasIndex(""ManyToManyRight_Id"");
+                    b.HasIndex(""ManyToManyRightId"");
 
                     b.ToTable(""ManyToManyLeftManyToManyRight"");
                 });
@@ -1172,16 +1172,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyLeft_Id"")
+                        .HasForeignKey(""ManyToManyLeftId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyRight_Id"")
+                        .HasForeignKey(""ManyToManyRightId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-                });", usingSystem: true),
+                });"),
                 model =>
                 {
                     var joinEntity = model.FindEntityType("ManyToManyLeftManyToManyRight");
@@ -1189,22 +1189,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Collection(joinEntity.GetDeclaredProperties(),
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeft_Id", p.Name);
+                            Assert.Equal("ManyToManyLeftId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRight_Id", p.Name);
+                            Assert.Equal("ManyToManyRightId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         });
                     Assert.Collection(joinEntity.FindDeclaredPrimaryKey().Properties,
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeft_Id", p.Name);
+                            Assert.Equal("ManyToManyLeftId", p.Name);
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRight_Id", p.Name);
+                            Assert.Equal("ManyToManyRightId", p.Name);
                         });
                     Assert.Collection(joinEntity.GetDeclaredForeignKeys(),
                         fk =>
@@ -1218,7 +1218,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyLeft_Id", p.Name);
+                                    Assert.Equal("ManyToManyLeftId", p.Name);
                                 });
                         },
                         fk =>
@@ -1232,12 +1232,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyRight_Id", p.Name);
+                                    Assert.Equal("ManyToManyRightId", p.Name);
                                 });
                         });
                 });
         }
-
 
         [ConditionalFact]
         public virtual void Can_override_table_name_for_many_to_many_join_table_stored_in_snapshot()
@@ -1256,15 +1255,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     + @"
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
                 {
-                    b.Property<int?>(""ManyToManyLeft_Id"")
+                    b.Property<int>(""ManyToManyLeftId"")
                         .HasColumnType(""int"");
 
-                    b.Property<int?>(""ManyToManyRight_Id"")
+                    b.Property<int>(""ManyToManyRightId"")
                         .HasColumnType(""int"");
 
-                    b.HasKey(""ManyToManyLeft_Id"", ""ManyToManyRight_Id"");
+                    b.HasKey(""ManyToManyLeftId"", ""ManyToManyRightId"");
 
-                    b.HasIndex(""ManyToManyRight_Id"");
+                    b.HasIndex(""ManyToManyRightId"");
 
                     b.ToTable(""MyJoinTable"");
                 });
@@ -1303,16 +1302,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyLeft_Id"")
+                        .HasForeignKey(""ManyToManyLeftId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyRight_Id"")
+                        .HasForeignKey(""ManyToManyRightId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-                });", usingSystem: true),
+                });"),
                 model =>
                 {
                     var joinEntity = model.FindEntityType("ManyToManyLeftManyToManyRight");
@@ -1321,22 +1320,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Collection(joinEntity.GetDeclaredProperties(),
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeft_Id", p.Name);
+                            Assert.Equal("ManyToManyLeftId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRight_Id", p.Name);
+                            Assert.Equal("ManyToManyRightId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         });
                     Assert.Collection(joinEntity.FindDeclaredPrimaryKey().Properties,
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeft_Id", p.Name);
+                            Assert.Equal("ManyToManyLeftId", p.Name);
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRight_Id", p.Name);
+                            Assert.Equal("ManyToManyRightId", p.Name);
                         });
                     Assert.Collection(joinEntity.GetDeclaredForeignKeys(),
                         fk =>
@@ -1350,7 +1349,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyLeft_Id", p.Name);
+                                    Assert.Equal("ManyToManyLeftId", p.Name);
                                 });
                         },
                         fk =>
@@ -1364,7 +1363,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyRight_Id", p.Name);
+                                    Assert.Equal("ManyToManyRightId", p.Name);
                                 });
                         });
                 });

--- a/test/EFCore.Tests/Metadata/Conventions/ManyToManyAssociationEntityTypeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ManyToManyAssociationEntityTypeConventionTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     public class ManyToManyJoinEntityTypeConventionTest
     {
         [ConditionalFact]
-        public void Join_entity_type_is_not_created_for_self_join()
+        public void Join_entity_type_is_created_for_self_join()
         {
             var modelBuilder = CreateInternalModeBuilder();
             var manyToManySelf = modelBuilder.Entity(typeof(ManyToManySelf), ConfigurationSource.Convention);
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             RunConvention(firstSkipNav);
 
-            Assert.Empty(manyToManySelf.Metadata.Model.GetEntityTypes()
+            Assert.Single(manyToManySelf.Metadata.Model.GetEntityTypes()
                 .Where(et => et.IsImplicitlyCreatedJoinEntityType));
         }
 
@@ -243,13 +243,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal(2, joinEntityType.GetForeignKeys().Count());
             Assert.Equal(manyToManyFirstForeignKey.DeclaringEntityType, joinEntityType);
             Assert.Equal(manyToManySecondForeignKey.DeclaringEntityType, joinEntityType);
-
-            var key = joinEntityType.FindPrimaryKey();
-            Assert.Equal(
-                new[] {
-                        nameof(ManyToManyFirst) + "_" + nameof(ManyToManyFirst.Id),
-                        nameof(ManyToManySecond) + "_" + nameof(ManyToManySecond.Id) },
-                key.Properties.Select(p => p.Name));
         }
 
         public ListLoggerFactory ListLoggerFactory { get; }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -65,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public IModel Model { get; }
             public string Name { get; }
             public bool HasSharedClrType { get; }
+            public bool IsPropertyBag { get; }
             public Type ClrType { get; }
             public IEntityType BaseType { get; }
             public string DefiningNavigationName { get; }

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -348,10 +348,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.Owned(typeof(Details), ConfigurationSource.Explicit)).Message);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Can_remove_implicitly_created_join_entity_type(bool removeSkipNavs)
+        [ConditionalFact]
+        public void Can_remove_implicitly_created_join_entity_type()
         {
             var model = new Model();
             var modelBuilder = CreateModelBuilder(model);
@@ -401,31 +399,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var joinEntityType = joinEntityTypeBuilder.Metadata;
 
             Assert.NotNull(joinEntityType);
-
-            Assert.NotNull(modelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                joinEntityType, removeSkipNavs, ConfigurationSource.Convention));
+            Assert.NotNull(modelBuilder.RemoveImplicitJoinEntity(joinEntityType));
 
             Assert.Empty(model.GetEntityTypes()
                 .Where(e => e.IsImplicitlyCreatedJoinEntityType));
 
             var leftSkipNav = manyToManyLeft.Metadata.FindDeclaredSkipNavigation(nameof(ManyToManyLeft.Rights));
             var rightSkipNav = manyToManyRight.Metadata.FindDeclaredSkipNavigation(nameof(ManyToManyRight.Lefts));
-            if (removeSkipNavs)
-            {
-                Assert.Null(leftSkipNav);
-                Assert.Null(rightSkipNav);
-            }
-            else
-            {
-                Assert.NotNull(leftSkipNav);
-                Assert.NotNull(rightSkipNav);
-            }
+
+            Assert.NotNull(leftSkipNav);
+            Assert.NotNull(rightSkipNav);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Cannot_remove_manually_created_join_entity_type(bool removeSkipNavs)
+        [ConditionalFact]
+        public void Cannot_remove_manually_created_join_entity_type()
         {
             var model = new Model();
             var modelBuilder = CreateModelBuilder(model);
@@ -465,8 +452,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.NotNull(joinEntityType);
             Assert.Same(joinEntityType, skipNavOnRight.Metadata.JoinEntityType);
 
-            Assert.Null(modelBuilder.RemoveJoinEntityIfCreatedImplicitly(
-                joinEntityType, removeSkipNavs, ConfigurationSource.Convention));
+            Assert.Null(modelBuilder.RemoveImplicitJoinEntity(joinEntityType));
 
             var leftSkipNav = manyToManyLeft.Metadata.FindDeclaredSkipNavigation(nameof(ManyToManyLeft.Rights));
             var rightSkipNav = manyToManyRight.Metadata.FindDeclaredSkipNavigation(nameof(ManyToManyRight.Lefts));

--- a/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
@@ -126,7 +126,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = CreateInternalSkipNavigationBuilder();
             IConventionSkipNavigation metadata = builder.Metadata;
 
-            // the skip navigation is pointing to the automatically-generated join entity type
             var originalFK = metadata.ForeignKey;
             Assert.NotNull(originalFK);
             Assert.Equal(ConfigurationSource.Convention, metadata.GetForeignKeyConfigurationSource());
@@ -137,17 +136,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .IsUnique(false)
                 .Metadata;
 
-            // skip navigation is unaffected by the FK created above
             Assert.NotSame(fk, metadata.ForeignKey);
             Assert.Same(originalFK, metadata.ForeignKey);
             Assert.Equal(ConfigurationSource.Convention, metadata.GetForeignKeyConfigurationSource());
+            Assert.NotNull(metadata.Inverse.ForeignKey);
 
-            // now explicitly assign the skip navigation's ForeignKey
             Assert.True(builder.CanSetForeignKey(fk, ConfigurationSource.DataAnnotation));
             Assert.NotNull(builder.HasForeignKey(fk, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(fk, metadata.ForeignKey);
             Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetForeignKeyConfigurationSource());
+            Assert.Null(metadata.Inverse.ForeignKey);
 
             Assert.True(builder.CanSetForeignKey(fk, ConfigurationSource.Convention));
             Assert.False(builder.CanSetForeignKey(null, ConfigurationSource.Convention));


### PR DESCRIPTION
Remove implicit join entity type in a convention
Configure PK for join entity type in a convention
Consolidate `HasNoSkipNavigation` usage

Fixes #21567
