### PR TITLE
Query: Fix bug in FromSqlExpression.Equals

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/FromSqlExpression.cs
@@ -102,7 +102,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         private bool Equals(FromSqlExpression fromSqlExpression)
             => base.Equals(fromSqlExpression)
-                && string.Equals(Sql, fromSqlExpression.Sql);
+                && string.Equals(Sql, fromSqlExpression.Sql)
+                && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
 
         /// <inheritdoc />
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Sql);


### PR DESCRIPTION
Resolves #19206
