### PR TITLE
Fix issue https://github.com/dotnet/efcore/issues/21844

### DIFF
--- a/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
@@ -85,17 +85,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             out InstantiationBinding binding,
             out IEnumerable<ParameterInfo> unboundParameters)
         {
-            if (constructor.GetParameters().Any(x =>  string.IsNullOrEmpty(x.Name)))
-            {
-                unboundParameters = constructor.GetParameters().ToList();
-                binding = null;
-                return false;
-            }
-
             IEnumerable<(ParameterInfo Parameter, ParameterBinding Binding)> bindings
                 = constructor.GetParameters().Select(
-                        p => (p, _propertyFactory.FindParameter(entityType, p.ParameterType, p.Name)
-                            ?? bind(_factories.FindFactory(p.ParameterType, p.Name), entityType, p.ParameterType, p.Name)))
+                        p => (p, string.IsNullOrEmpty(p.Name)
+                            ? null
+                            : _propertyFactory.FindParameter(entityType, p.ParameterType, p.Name)
+                                ?? bind(_factories.FindFactory(p.ParameterType, p.Name), entityType, p.ParameterType, p.Name)))
                     .ToList();
 
             if (bindings.Any(b => b.Binding == null))

--- a/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
@@ -85,6 +85,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             out InstantiationBinding binding,
             out IEnumerable<ParameterInfo> unboundParameters)
         {
+            if (constructor.GetParameters().Any(x =>  string.IsNullOrEmpty(x.Name)))
+            {
+                unboundParameters = constructor.GetParameters().ToList();
+                binding = null;
+                return false;
+            }
+
             IEnumerable<(ParameterInfo Parameter, ParameterBinding Binding)> bindings
                 = constructor.GetParameters().Select(
                         p => (p, _propertyFactory.FindParameter(entityType, p.ParameterType, p.Name)

--- a/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Entity Framework Core database providers.</Description>
-    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>    
+    <LangVersion>9.0</LangVersion>
     <AssemblyName>Microsoft.EntityFrameworkCore.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -738,6 +738,49 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(blog, blog.LazyPcsPosts.Skip(1).First().LazyPcsBlog);
         }
 
+#if NET5_0
+        [ConditionalFact]
+        public virtual async Task Add_immutable_record()
+        {
+            using var context = CreateContext();
+            var BlogTitle = "xyzzy";
+            var immutableBlog = new BlogAsImmutableRecord(BlogTitle);
+
+            context.Add(immutableBlog);
+            await context.SaveChangesAsync();
+
+            Assert.NotEqual(0, immutableBlog.BlogId);
+            Assert.Equal(BlogTitle, immutableBlog.Title);
+        }
+#endif
+
+
+#if NET5_0
+        protected record BlogAsImmutableRecord
+        {
+            public int BlogId { get; init; }
+            public string Title { get; init; }
+            public int? MonthlyRevenue { get; init; }
+
+            private BlogAsImmutableRecord(
+               int blogId,
+               string title,
+               int? monthlyRevenue)
+            {
+                BlogId = blogId;
+                Title = title;
+                MonthlyRevenue = monthlyRevenue;
+            }
+
+            public BlogAsImmutableRecord(
+                string title,
+                int? monthlyRevenue = null)
+                : this(0, title, monthlyRevenue)
+            {
+            }
+        }
+#endif
+
         protected class Blog
         {
             private readonly int _blogId;
@@ -1539,6 +1582,16 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
             {
+
+#if NET5_0
+                modelBuilder.Entity<BlogAsImmutableRecord>(
+                   b =>
+                   {
+                       b.HasKey(e => e.BlogId);
+                       b.Property(e => e.Title);
+                   });
+#endif
+
                 modelBuilder.Entity<Blog>(
                     b =>
                     {


### PR DESCRIPTION
EFCore now skips constructors generated with c#9 that contain parameters with no names.  
The nameless constructor parameters were throwing null reference exceptions when
EFCore was trying to modify the strings to the various conventions for matching
properties like pascal-case, camel-case, m_, etc.