### PR TITLE
Rename defining query APIs

### DIFF
--- a/src/EFCore.InMemory/Extensions/InMemoryEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryEntityTypeBuilderExtensions.cs
@@ -23,14 +23,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="query"> The query that will provide the underlying data for the entity type. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> ToQuery<TEntity>(
+        public static EntityTypeBuilder<TEntity> ToInMemoryQuery<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [NotNull] Expression<Func<IQueryable<TEntity>>> query)
             where TEntity : class
         {
             Check.NotNull(query, nameof(query));
 
-            InMemoryEntityTypeExtensions.SetDefiningQuery(entityTypeBuilder.Metadata, query);
+            entityTypeBuilder.Metadata.SetInMemoryQuery(query);
 
             return entityTypeBuilder;
         }
@@ -44,14 +44,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The same builder instance if the query was set, <see langword="null" /> otherwise.
         /// </returns>
-        public static IConventionEntityTypeBuilder ToQuery(
+        public static IConventionEntityTypeBuilder ToInMemoryQuery(
             [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
             [CanBeNull] LambdaExpression query,
             bool fromDataAnnotation = false)
         {
-            if (CanSetDefiningQuery(entityTypeBuilder, query, fromDataAnnotation))
+            if (CanSetInMemoryQuery(entityTypeBuilder, query, fromDataAnnotation))
             {
-                InMemoryEntityTypeExtensions.SetDefiningQuery(entityTypeBuilder.Metadata, query, fromDataAnnotation);
+                entityTypeBuilder.Metadata.SetInMemoryQuery(query, fromDataAnnotation);
 
                 return entityTypeBuilder;
             }
@@ -60,13 +60,13 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Returns a value indicating whether the given defining query can be set from the current configuration source.
+        ///     Returns a value indicating whether the given in-memory query can be set from the current configuration source.
         /// </summary>
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="query"> The query that will provide the underlying data for the keyless entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        /// <returns> <see langword="true" /> if the given defining query can be set. </returns>
-        public static bool CanSetDefiningQuery(
+        /// <returns> <see langword="true" /> if the given in-memory query can be set. </returns>
+        public static bool CanSetInMemoryQuery(
             [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder,
             [CanBeNull] LambdaExpression query,
             bool fromDataAnnotation = false)

--- a/src/EFCore.InMemory/Extensions/InMemoryEntityTypeExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryEntityTypeExtensions.cs
@@ -18,9 +18,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         ///     Gets the LINQ query used as the default source for queries of this type.
         /// </summary>
-        /// <param name="entityType"> The entity type to get the defining query for. </param>
+        /// <param name="entityType"> The entity type to get the in-memory query for. </param>
         /// <returns> The LINQ query used as the default source. </returns>
-        public static LambdaExpression GetDefiningQuery([NotNull] this IEntityType entityType)
+        public static LambdaExpression GetInMemoryQuery([NotNull] this IEntityType entityType)
 #pragma warning disable EF1001 // Internal EF Core API usage.
 #pragma warning disable CS0612 // Type or member is obsolete
             => (LambdaExpression)Check.NotNull(entityType, nameof(entityType))[CoreAnnotationNames.DefiningQuery];
@@ -31,14 +31,14 @@ namespace Microsoft.EntityFrameworkCore
         ///     Sets the LINQ query used as the default source for queries of this type.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        /// <param name="definingQuery"> The LINQ query used as the default source. </param>
-        public static void SetDefiningQuery(
+        /// <param name="inMemoryQuery"> The LINQ query used as the default source. </param>
+        public static void SetInMemoryQuery(
             [NotNull] this IMutableEntityType entityType,
-            [CanBeNull] LambdaExpression definingQuery)
+            [CanBeNull] LambdaExpression inMemoryQuery)
             => Check.NotNull(entityType, nameof(entityType))
 #pragma warning disable EF1001 // Internal EF Core API usage.
 #pragma warning disable CS0612 // Type or member is obsolete
-                .SetOrRemoveAnnotation(CoreAnnotationNames.DefiningQuery, definingQuery);
+                .SetOrRemoveAnnotation(CoreAnnotationNames.DefiningQuery, inMemoryQuery);
 #pragma warning restore CS0612 // Type or member is obsolete
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
@@ -46,26 +46,26 @@ namespace Microsoft.EntityFrameworkCore
         ///     Sets the LINQ query used as the default source for queries of this type.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        /// <param name="definingQuery"> The LINQ query used as the default source. </param>
+        /// <param name="inMemoryQuery"> The LINQ query used as the default source. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured entity type. </returns>
-        public static LambdaExpression SetDefiningQuery(
+        public static LambdaExpression SetInMemoryQuery(
             [NotNull] this IConventionEntityType entityType,
-            [CanBeNull] LambdaExpression definingQuery,
+            [CanBeNull] LambdaExpression inMemoryQuery,
             bool fromDataAnnotation = false)
             => (LambdaExpression)Check.NotNull(entityType, nameof(entityType))
 #pragma warning disable EF1001 // Internal EF Core API usage.
 #pragma warning disable CS0612 // Type or member is obsolete
-                .SetOrRemoveAnnotation(CoreAnnotationNames.DefiningQuery, definingQuery, fromDataAnnotation)
+                .SetOrRemoveAnnotation(CoreAnnotationNames.DefiningQuery, inMemoryQuery, fromDataAnnotation)
 #pragma warning restore CS0612 // Type or member is obsolete
 #pragma warning restore EF1001 // Internal EF Core API usage.
                 ?.Value;
 
         /// <summary>
-        ///     Returns the configuration source for <see cref="EntityTypeExtensions.GetDefiningQuery" />.
+        ///     Returns the configuration source for <see cref="GetInMemoryQuery" />.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        /// <returns> The configuration source for <see cref="EntityTypeExtensions.GetDefiningQuery" />. </returns>
+        /// <returns> The configuration source for <see cref="GetInMemoryQuery" />. </returns>
         public static ConfigurationSource? GetDefiningQueryConfigurationSource([NotNull] this IConventionEntityType entityType)
 #pragma warning disable EF1001 // Internal EF Core API usage.
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/EFCore.InMemory/Internal/InMemoryModelValidator.cs
+++ b/src/EFCore.InMemory/Internal/InMemoryModelValidator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                if (InMemoryEntityTypeExtensions.GetDefiningQuery(entityType) != null)
+                if (entityType.GetInMemoryQuery() != null)
                 {
                     if (entityType.BaseType != null)
                     {

--- a/src/EFCore.InMemory/Metadata/Conventions/DefiningQueryRewritingConvention.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/DefiningQueryRewritingConvention.cs
@@ -32,11 +32,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                var definingQuery = InMemoryEntityTypeExtensions.GetDefiningQuery(entityType);
+                var definingQuery = entityType.GetInMemoryQuery();
                 if (definingQuery != null)
                 {
-                    InMemoryEntityTypeExtensions.SetDefiningQuery(
-                        entityType, (LambdaExpression)DbSetAccessRewriter.Rewrite(modelBuilder.Metadata, definingQuery));
+                    entityType.SetInMemoryQuery((LambdaExpression)DbSetAccessRewriter.Rewrite(modelBuilder.Metadata, definingQuery));
                 }
             }
         }

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -603,14 +603,14 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="query"> The SQL query that will provide the underlying data for the entity type. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> ToQuerySql<TEntity>(
+        public static EntityTypeBuilder<TEntity> ToSqlQuery<TEntity>(
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder,
             [NotNull] string query)
             where TEntity : class
         {
             Check.NotNull(query, nameof(query));
 
-            entityTypeBuilder.Metadata.SetQuerySql(query);
+            entityTypeBuilder.Metadata.SetSqlQuery(query);
 
             return entityTypeBuilder;
         }
@@ -624,16 +624,16 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
         /// </returns>
-        public static IConventionEntityTypeBuilder ToQuerySql(
+        public static IConventionEntityTypeBuilder ToSqlQuery(
             [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder, [CanBeNull] string name, bool fromDataAnnotation = false)
         {
-            if (!entityTypeBuilder.CanSetQuerySql(name, fromDataAnnotation))
+            if (!entityTypeBuilder.CanSetSqlQuery(name, fromDataAnnotation))
             {
                 return null;
             }
 
             var entityType = entityTypeBuilder.Metadata;
-            entityType.SetQuerySql(name, fromDataAnnotation);
+            entityType.SetSqlQuery(name, fromDataAnnotation);
 
             return entityTypeBuilder;
         }
@@ -646,12 +646,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The SQL query that will provide the underlying data for the entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> <see langword="true" /> if the configuration can be applied. </returns>
-        public static bool CanSetQuerySql(
+        public static bool CanSetSqlQuery(
             [NotNull] this IConventionEntityTypeBuilder entityTypeBuilder, [CanBeNull] string name, bool fromDataAnnotation = false)
         {
             Check.NullButNotEmpty(name, nameof(name));
 
-            return entityTypeBuilder.CanSetAnnotation(RelationalAnnotationNames.QuerySql, name, fromDataAnnotation);
+            return entityTypeBuilder.CanSetAnnotation(RelationalAnnotationNames.SqlQuery, name, fromDataAnnotation);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
 #pragma warning disable CS0618 // Type or member is obsolete
                 && ((entityType as IConventionEntityType)?.GetDefiningQueryConfigurationSource() == null)
 #pragma warning restore CS0618 // Type or member is obsolete
-                && ((entityType as IConventionEntityType)?.GetQuerySqlConfigurationSource() == null)
+                && ((entityType as IConventionEntityType)?.GetSqlQueryConfigurationSource() == null)
                 ? GetDefaultTableName(entityType)
                 : null;
         }
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore
 #pragma warning disable CS0618 // Type or member is obsolete
                 && (entityType as IConventionEntityType)?.GetDefiningQueryConfigurationSource() == null
 #pragma warning restore CS0618 // Type or member is obsolete
-                && ((entityType as IConventionEntityType)?.GetQuerySqlConfigurationSource() == null)
+                && ((entityType as IConventionEntityType)?.GetSqlQueryConfigurationSource() == null)
                 ? GetDefaultViewName(entityType)
                 : null;
         }
@@ -402,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     Gets the default SQL query name that would be used for this entity type when mapped using
-        ///     <see cref="M:RelationalEntityTypeBuilderExtensions.ToQuerySql" />.
+        ///     <see cref="M:RelationalEntityTypeBuilderExtensions.ToSqlQuery" />.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Gets the default SQL query name. </returns>
@@ -414,9 +414,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The SQL string used to provide data for the entity type. </returns>
-        public static string GetQuerySql([NotNull] this IEntityType entityType)
+        public static string GetSqlQuery([NotNull] this IEntityType entityType)
         {
-            var nameAnnotation = (string)entityType[RelationalAnnotationNames.QuerySql];
+            var nameAnnotation = (string)entityType[RelationalAnnotationNames.SqlQuery];
             if (nameAnnotation != null)
             {
                 return nameAnnotation;
@@ -424,7 +424,7 @@ namespace Microsoft.EntityFrameworkCore
 
             if (entityType.BaseType != null)
             {
-                return entityType.GetRootType().GetQuerySql();
+                return entityType.GetRootType().GetSqlQuery();
             }
 
             return null;
@@ -435,9 +435,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The SQL string to set. </param>
-        public static void SetQuerySql([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
+        public static void SetSqlQuery([NotNull] this IMutableEntityType entityType, [CanBeNull] string name)
             => entityType.SetAnnotation(
-                RelationalAnnotationNames.QuerySql,
+                RelationalAnnotationNames.SqlQuery,
                 Check.NullButNotEmpty(name, nameof(name)));
 
         /// <summary>
@@ -447,10 +447,10 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The SQL string to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        public static string SetQuerySql(
+        public static string SetSqlQuery(
             [NotNull] this IConventionEntityType entityType, [CanBeNull] string name, bool fromDataAnnotation = false)
             => (string)entityType.SetAnnotation(
-                RelationalAnnotationNames.QuerySql,
+                RelationalAnnotationNames.SqlQuery,
                 Check.NullButNotEmpty(name, nameof(name)),
                 fromDataAnnotation)?.Value;
 
@@ -459,8 +459,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to find configuration source for. </param>
         /// <returns> The <see cref="ConfigurationSource" /> for the query SQL string. </returns>
-        public static ConfigurationSource? GetQuerySqlConfigurationSource([NotNull] this IConventionEntityType entityType)
-            => entityType.FindAnnotation(RelationalAnnotationNames.QuerySql)
+        public static ConfigurationSource? GetSqlQueryConfigurationSource([NotNull] this IConventionEntityType entityType)
+            => entityType.FindAnnotation(RelationalAnnotationNames.SqlQuery)
             ?.GetConfigurationSource();
 
         /// <summary>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             foreach (var entityType in model.GetEntityTypes())
             {
-                var sqlQuery = entityType.GetQuerySql();
+                var sqlQuery = entityType.GetSqlQuery();
                 if (sqlQuery == null)
                 {
                     continue;
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                 if (entityType.BaseType != null
                     && (entityType.GetDiscriminatorProperty() == null
-                        || sqlQuery != entityType.BaseType.GetQuerySql()))
+                        || sqlQuery != entityType.BaseType.GetSqlQuery()))
                 {
                     throw new InvalidOperationException(
                         RelationalStrings.InvalidMappedSqlQueryDerivedType(

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -481,8 +481,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private static void AddSqlQueries(RelationalModel databaseModel, IConventionEntityType entityType)
         {
-            var querySql = entityType.GetQuerySql();
-            if (querySql == null)
+            var entityTypeSqlQuery = entityType.GetSqlQuery();
+            if (entityTypeSqlQuery == null)
             {
                 return;
             }
@@ -491,10 +491,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var definingType = entityType;
             while (definingType != null)
             {
-                var mappedSql = definingType.GetQuerySql();
-                if (mappedSql == null
+                var definingTypeSqlQuery = definingType.GetSqlQuery();
+                if (definingTypeSqlQuery == null
                     || definingType.BaseType == null
-                    || (mappedSql == querySql
+                    || (definingTypeSqlQuery == entityTypeSqlQuery
                         && definingType != entityType))
                 {
                     break;
@@ -506,9 +506,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var mappedType = entityType;
             while (mappedType != null)
             {
-                var mappedSql = mappedType.GetQuerySql();
-                if (mappedSql == null
-                    || (mappedSql == querySql
+                var mappedTypeSqlQuery = mappedType.GetSqlQuery();
+                if (mappedTypeSqlQuery == null
+                    || (mappedTypeSqlQuery == entityTypeSqlQuery
                         && mappedType != entityType))
                 {
                     break;
@@ -517,8 +517,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var mappedQuery = StoreObjectIdentifier.SqlQuery(definingType);
                 if (!databaseModel.Queries.TryGetValue(mappedQuery.Name, out var sqlQuery))
                 {
-                    sqlQuery = new SqlQuery(mappedQuery.Name, databaseModel);
-                    sqlQuery.Sql = mappedSql;
+                    sqlQuery = new SqlQuery(mappedQuery.Name, databaseModel)
+                    {
+                        Sql = mappedTypeSqlQuery
+                    };
                     databaseModel.Queries.Add(mappedQuery.Name, sqlQuery);
                 }
 

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -72,9 +72,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string FunctionName = Prefix + "FunctionName";
 
         /// <summary>
-        ///     The name for mapped query sql annotations.
+        ///     The name for mapped sql query annotations.
         /// </summary>
-        public const string QuerySql = Prefix + "QuerySql";
+        public const string SqlQuery = Prefix + "SqlQuery";
 
         /// <summary>
         ///     The name for comment annotations.
@@ -154,12 +154,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string RelationalModel = Prefix + "RelationalModel";
 
         /// <summary>
-        ///     The name for view mappings annotations.
+        ///     The name for default mappings annotations.
         /// </summary>
         public const string DefaultMappings = Prefix + "DefaultMappings";
 
         /// <summary>
-        ///     The name for view column mappings annotations.
+        ///     The name for default column mappings annotations.
         /// </summary>
         public const string DefaultColumnMappings = Prefix + "DefaultColumnMappings";
 
@@ -184,22 +184,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public const string ViewColumnMappings = Prefix + "ViewColumnMappings";
 
         /// <summary>
-        ///     The name for view mappings annotations.
+        ///     The name for function mappings annotations.
         /// </summary>
         public const string FunctionMappings = Prefix + "FunctionMappings";
 
         /// <summary>
-        ///     The name for view column mappings annotations.
+        ///     The name for function column mappings annotations.
         /// </summary>
         public const string FunctionColumnMappings = Prefix + "FunctionColumnMappings";
 
         /// <summary>
-        ///     The name for view mappings annotations.
+        ///     The name for sql query mappings annotations.
         /// </summary>
         public const string SqlQueryMappings = Prefix + "SqlQueryMappings";
 
         /// <summary>
-        ///     The name for view column mappings annotations.
+        ///     The name for sql query column mappings annotations.
         /// </summary>
         public const string SqlQueryColumnMappings = Prefix + "SqlQueryColumnMappings";
 

--- a/src/EFCore.Relational/Metadata/SqlQueryExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SqlQueryExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     {
         /// <summary>
         ///     Gets the name used for the <see cref="ISqlQuery" /> mapped using
-        ///     <see cref="M:RelationalEntityTypeBuilderExtensions.ToQuerySql" />.
+        ///     <see cref="M:RelationalEntityTypeBuilderExtensions.ToSqlQuery" />.
         /// </summary>
         public static readonly string DefaultQueryNameBase = "MappedSqlQuery";
 

--- a/src/EFCore.Relational/Metadata/StoreObjectIdentifier.cs
+++ b/src/EFCore.Relational/Metadata/StoreObjectIdentifier.cs
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         /// <summary>
-        ///     Creates an id for the SQL query mapped using <see cref="M:RelationalEntityTypeBuilderExtensions.ToQuerySql" />.
+        ///     Creates an id for the SQL query mapped using <see cref="M:RelationalEntityTypeBuilderExtensions.ToSqlQuery" />.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The SQL query id. </returns>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -135,9 +135,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                     return CreateShapedQueryExpression(entityType, queryExpression);
 
                 case QueryRootExpression queryRootExpression
-                when queryRootExpression.EntityType.GetSqlQueryMappings().FirstOrDefault(m => m.IsDefaultSqlQueryMapping)?.SqlQuery is ISqlQuery querySql:
+                when queryRootExpression.EntityType.GetSqlQueryMappings().FirstOrDefault(m => m.IsDefaultSqlQueryMapping)?.SqlQuery is ISqlQuery sqlQuery:
                     return Visit(new FromSqlQueryRootExpression(
-                        queryRootExpression.EntityType, querySql.Sql, Expression.Constant(Array.Empty<object>(), typeof(object[]))));
+                        queryRootExpression.EntityType, sqlQuery.Sql, Expression.Constant(Array.Empty<object>(), typeof(object[]))));
 
                 default:
                     return base.VisitExtension(extensionExpression);

--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -640,7 +640,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="definingQuery"> The LINQ query used as the default source. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured entity type. </returns>
-        [Obsolete("Use InMemoryEntityTypeExtensions.SetDefiningQuery")]
+        [Obsolete("Use InMemoryEntityTypeExtensions.SetInMemoryQuery")]
         public static LambdaExpression SetDefiningQuery(
             [NotNull] this IConventionEntityType entityType,
             [CanBeNull] LambdaExpression definingQuery,
@@ -655,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The configuration source for <see cref="EntityTypeExtensions.GetDefiningQuery" />. </returns>
-        [Obsolete("Use InMemoryEntityTypeExtensions.GetDefiningQueryConfigurationSource")]
+        [Obsolete("Use InMemoryEntityTypeExtensions.GetInMemoryQueryConfigurationSource")]
         public static ConfigurationSource? GetDefiningQueryConfigurationSource([NotNull] this IConventionEntityType entityType)
             => entityType.FindAnnotation(CoreAnnotationNames.DefiningQuery)?.GetConfigurationSource();
 

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -730,7 +730,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to get the defining query for. </param>
         /// <returns> The LINQ query used as the default source. </returns>
-        [Obsolete("Use InMemoryEntityTypeExtensions.GetDefiningQuery")]
+        [Obsolete("Use InMemoryEntityTypeExtensions.GetInMemoryQuery")]
         public static LambdaExpression GetDefiningQuery([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -556,7 +556,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="definingQuery"> The LINQ query used as the default source. </param>
-        [Obsolete("Use InMemoryEntityTypeExtensions.SetDefiningQuery")]
+        [Obsolete("Use InMemoryEntityTypeExtensions.SetInMemoryQuery")]
         public static void SetDefiningQuery(
             [NotNull] this IMutableEntityType entityType,
             [CanBeNull] LambdaExpression definingQuery)

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="query"> The query that will provide the underlying data for the keyless entity type. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.ToQuery")]
+        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.ToInMemoryQuery")]
         public virtual EntityTypeBuilder<TEntity> ToQuery([NotNull] Expression<Func<IQueryable<TEntity>>> query)
         {
             Check.NotNull(query, nameof(query));

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -689,7 +689,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns>
         ///     The same builder instance if the query was set, <see langword="null" /> otherwise.
         /// </returns>
-        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.ToQuery")]
+        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.ToInMemoryQuery")]
         IConventionEntityTypeBuilder HasDefiningQuery([CanBeNull] LambdaExpression query, bool fromDataAnnotation = false);
 
         /// <summary>
@@ -698,7 +698,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="query"> The query that will provide the underlying data for the keyless entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> <see langword="true" /> if the given defining query can be set. </returns>
-        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.CanSetDefiningQuery")]
+        [Obsolete("Use InMemoryEntityTypeBuilderExtensions.CanSetInMemoryQuery")]
         bool CanSetDefiningQuery([CanBeNull] LambdaExpression query, bool fromDataAnnotation = false);
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/QueryFilterRewritingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/QueryFilterRewritingConvention.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     /// <summary>
-    ///     Convention that converts accesses of <see cref="DbSet{TEntity}"/> inside query filters and defining queries into <see cref="QueryRootExpression"/>.
+    ///     Convention that converts accesses of <see cref="DbSet{TEntity}"/> inside query filters into <see cref="QueryRootExpression"/>.
     ///     This makes them consistent with how DbSet accesses in the actual queries are represented, which allows for easier processing in the
     ///     query pipeline.
     /// </summary>
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
 
         /// <summary>
-        ///     Visitor used to rewrite <see cref="DbSet{TEntity}"/> accesses encountered in query filters and defining queries to <see cref="QueryRootExpression"/>.
+        ///     Visitor used to rewrite <see cref="DbSet{TEntity}"/> accesses encountered in query filters to <see cref="QueryRootExpression"/>.
         /// </summary>
         protected virtual DbSetAccessRewritingExpressionVisitor DbSetAccessRewriter { get; [param: NotNull] set; }
 
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         /// <summary>
-        ///     A visitor that rewrites DbSet accesses encountered in query filters and defining queries to <see cref="QueryRootExpression"/>.
+        ///     A visitor that rewrites DbSet accesses encountered in an expression to <see cref="QueryRootExpression"/>.
         /// </summary>
         protected class DbSetAccessRewritingExpressionVisitor : ExpressionVisitor
         {
@@ -71,10 +71,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
 
             /// <summary>
-            ///     Rewrites DbSet accesses encountered in query filters and defining queries to <see cref="QueryRootExpression"/>.
+            ///     Rewrites DbSet accesses encountered in the expression to <see cref="QueryRootExpression"/>.
             /// </summary>
             /// <param name="model"> The model to look for entity types. </param>
-            /// <param name="expression"> The query filter or defining query expression to rewrite. </param>
+            /// <param name="expression"> The query expression to rewrite. </param>
             public Expression Rewrite(IModel model, Expression expression)
             {
                 _model = model;

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceQueryInMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceQueryInMemoryFixture.cs
@@ -21,9 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.OnModelCreating(modelBuilder, context);
 
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<AnimalQuery>().HasNoKey(),
-                () => context.Set<Bird>().Select(b => MaterializeView(b)));
+            modelBuilder.Entity<AnimalQuery>().ToInMemoryQuery(() => context.Set<Bird>().Select(b => MaterializeView(b)));
         }
 
         private static AnimalQuery MaterializeView(Bird bird)

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindInMemoryContext.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindInMemoryContext.cs
@@ -17,8 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.OnModelCreating(modelBuilder);
 
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<CustomerQuery>(),
+            modelBuilder.Entity<CustomerQuery>().ToInMemoryQuery(
                 () => Customers.Select(
                     c => new CustomerQuery
                     {
@@ -29,12 +28,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         ContactTitle = c.ContactTitle
                     }));
 
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<OrderQuery>(),
+            modelBuilder.Entity<OrderQuery>().ToInMemoryQuery(
                 () => Orders.Select(o => new OrderQuery { CustomerID = o.CustomerID }));
 
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<ProductQuery>(),
+            modelBuilder.Entity<ProductQuery>().ToInMemoryQuery(
                 () => Products.Where(p => !p.Discontinued)
                         .Select(
                             p => new ProductQuery
@@ -44,8 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 CategoryName = "Food"
                             }));
 
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<CustomerQueryWithQueryFilter>(),
+            modelBuilder.Entity<CustomerQueryWithQueryFilter>().ToInMemoryQuery(
                 () => Customers.Select(
                     c => new CustomerQueryWithQueryFilter
                     {

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -709,8 +709,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                InMemoryEntityTypeBuilderExtensions.ToQuery(
-                    modelBuilder.Entity<CustomerView19708>().HasNoKey(), Build_Customers_Sql_View_InMemory());
+                modelBuilder.Entity<CustomerView19708>().HasNoKey().ToInMemoryQuery(Build_Customers_Sql_View_InMemory());
             }
 
             private Expression<Func<IQueryable<CustomerView19708>>> Build_Customers_Sql_View_InMemory()

--- a/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
@@ -32,10 +32,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                InMemoryEntityTypeBuilderExtensions.ToQuery(
-                    modelBuilder
-                    .Entity<BlogQuery>()
-                    .HasNoKey(),
+                modelBuilder.Entity<BlogQuery>().HasNoKey().ToInMemoryQuery(
                     () => context.Set<Blog>().Select(b => new BlogQuery(b.Title, b.MonthlyRevenue)));
             }
         }

--- a/test/EFCore.InMemory.Tests/Infrastructure/InMemoryModelValidatorTest.cs
+++ b/test/EFCore.InMemory.Tests/Infrastructure/InMemoryModelValidatorTest.cs
@@ -14,10 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             var modelBuilder = base.CreateConventionalModelBuilder();
             var context = new DbContext(new DbContextOptions<DbContext>());
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<Abstract>().HasNoKey(), () => context.Set<Abstract>());
-            InMemoryEntityTypeBuilderExtensions.ToQuery(
-                modelBuilder.Entity<Generic<int>>(), () => context.Set<Generic<int>>());
+            modelBuilder.Entity<Abstract>().HasNoKey().ToInMemoryQuery(() => context.Set<Abstract>());
+            modelBuilder.Entity<Generic<int>>().ToInMemoryQuery(() => context.Set<Generic<int>>());
 
             VerifyError(
                 CoreStrings.DerivedTypeDefiningQuery("Generic<int>", nameof(Abstract)),

--- a/test/EFCore.Relational.Specification.Tests/Query/InheritanceQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/InheritanceQueryRelationalFixture.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<Lilt>().Property(e => e.SugarGrams).HasColumnName("SugarGrams");
             modelBuilder.Entity<Tea>().Property(e => e.CaffeineGrams).HasColumnName("CaffeineGrams");
 
-            modelBuilder.Entity<AnimalQuery>().HasNoKey().ToQuerySql("SELECT * FROM Animals");
+            modelBuilder.Entity<AnimalQuery>().HasNoKey().ToSqlQuery("SELECT * FROM Animals");
             modelBuilder.Entity<KiwiQuery>().HasDiscriminator().HasValue("Kiwi");
             modelBuilder.Entity<EagleQuery>().HasDiscriminator().HasValue("Eagle");
         }

--- a/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -26,9 +26,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
             modelBuilder.Entity<CustomerOrderHistory>().HasKey(coh => coh.ProductName);
             modelBuilder.Entity<MostExpensiveProduct>().HasKey(mep => mep.TenMostExpensiveProducts);
 
-            modelBuilder.Entity<CustomerQuery>().ToQuerySql("SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
+            modelBuilder.Entity<CustomerQuery>().ToSqlQuery("SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
 
-            modelBuilder.Entity<OrderQuery>().ToQuerySql(@"select * from ""Orders""");
+            modelBuilder.Entity<OrderQuery>().ToSqlQuery(@"select * from ""Orders""");
             modelBuilder.Entity<ProductView>().ToView("Alphabetical list of products");
         }
     }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -618,7 +618,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var modelBuilder = CreateConventionModelBuilder();
             modelBuilder.Entity<Order>(cb =>
             {
-                cb.ToQuerySql("GetOrders()");
+                cb.ToSqlQuery("GetOrders()");
                 cb.Ignore(c => c.Customer);
                 cb.Ignore(c => c.Details);
                 cb.Ignore(c => c.DateDetails);

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         {
             Execute(
                 _ => { },
-                modelBuilder => modelBuilder.Entity<TestKeylessType>().HasNoKey().ToQuerySql("SELECT * FROM Vista"),
+                modelBuilder => modelBuilder.Entity<TestKeylessType>().HasNoKey().ToSqlQuery("SELECT * FROM Vista"),
                 result => Assert.Empty(result));
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -4436,7 +4436,7 @@ ORDER BY [p].[Id], [a].[Id]");
             {
                 modelBuilder.Entity<OrderSummary13346>()
                     .HasNoKey()
-                    .ToQuerySql("SELECT o.Amount From Orders AS o");
+                    .ToSqlQuery("SELECT o.Amount From Orders AS o");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                modelBuilder.Entity<BlogQuery>().HasNoKey().ToQuerySql("SELECT * FROM Blog");
+                modelBuilder.Entity<BlogQuery>().HasNoKey().ToSqlQuery("SELECT * FROM Blog");
             }
         }
     }

--- a/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                modelBuilder.Entity<BlogQuery>().HasNoKey().ToQuerySql("SELECT * FROM Blog");
+                modelBuilder.Entity<BlogQuery>().HasNoKey().ToSqlQuery("SELECT * FROM Blog");
             }
         }
     }


### PR DESCRIPTION
Rename InMemoryEntityTypeBuilderExtensions.ToQuery to ToInMemoryQuery
Rename ToQuerySql to ToSqlQuery

Part of #20409
