### PR TITLE
Add SaveChanges events

### DIFF
--- a/src/EFCore/SaveChangesEventArgs.cs
+++ b/src/EFCore/SaveChangesEventArgs.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Base event arguments for the <see cref="M:DbContext.SaveChanges" /> and <see cref="M:DbContext.SaveChangesAsync" /> events.
+    /// </summary>
+    public abstract class SaveChangesEventArgs : EventArgs
+    {
+        /// <summary>
+        ///     Creates a base event arguments instance for <see cref="M:DbContext.SaveChanges" />
+        ///     or <see cref="M:DbContext.SaveChangesAsync" /> events.
+        /// </summary>
+        /// <param name="acceptAllChangesOnSuccess"> The value passed to SaveChanges. </param>
+        protected SaveChangesEventArgs(bool acceptAllChangesOnSuccess)
+        {
+            AcceptAllChangesOnSuccess = acceptAllChangesOnSuccess;
+        }
+
+        /// <summary>
+        ///     The value passed to <see cref="M:DbContext.SaveChanges" /> or <see cref="M:DbContext.SaveChangesAsync" />.
+        /// </summary>
+        public virtual bool AcceptAllChangesOnSuccess { get; }
+    }
+}

--- a/src/EFCore/SaveChangesFailedEventArgs.cs
+++ b/src/EFCore/SaveChangesFailedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Event arguments for the <see cref="DbContext.SaveChangesFailed" /> event.
+    /// </summary>
+    public class SaveChangesFailedEventArgs : SaveChangesEventArgs
+    {
+        /// <summary>
+        /// Creates a new <see cref="SaveChangesFailedEventArgs"/> instance with the exception that was thrown.
+        /// </summary>
+        /// <param name="acceptAllChangesOnSuccess"> The value passed to SaveChanges. </param>
+        /// <param name="exception"> The exception thrown. </param>
+        public SaveChangesFailedEventArgs(bool acceptAllChangesOnSuccess, [NotNull] Exception exception)
+            : base(acceptAllChangesOnSuccess)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The exception thrown during<see cref="M:DbContext.SaveChanges"/> or <see cref="M:DbContext.SaveChangesAsync"/>.
+        /// </summary>
+        public virtual Exception Exception { get; }
+    }
+}

--- a/src/EFCore/SavedChangesEventArgs.cs
+++ b/src/EFCore/SavedChangesEventArgs.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Event arguments for the <see cref="DbContext.SavedChanges" /> event.
+    /// </summary>
+    public class SavedChangesEventArgs : SaveChangesEventArgs
+    {
+        /// <summary>
+        ///     Creates a new <see cref="SavedChangesEventArgs" /> instance with the given number of entities saved.
+        /// </summary>
+        /// <param name="acceptAllChangesOnSuccess"> The value passed to SaveChanges. </param>
+        /// <param name="entitiesSavedCount"> The number of entities saved. </param>
+        public SavedChangesEventArgs(bool acceptAllChangesOnSuccess, int entitiesSavedCount)
+            : base(acceptAllChangesOnSuccess)
+        {
+            EntitiesSavedCount = entitiesSavedCount;
+        }
+
+        /// <summary>
+        ///     The number of entities saved.
+        /// </summary>
+        public virtual int EntitiesSavedCount { get; }
+    }
+}

--- a/src/EFCore/SavingChangesEventArgs.cs
+++ b/src/EFCore/SavingChangesEventArgs.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Event arguments for the <see cref="DbContext.SavingChanges" /> event.
+    /// </summary>
+    public class SavingChangesEventArgs : SaveChangesEventArgs
+    {
+        /// <summary>
+        ///     Creates event arguments for the <see cref="M:DbContext.SavingChanges" /> event.
+        /// </summary>
+        /// <param name="acceptAllChangesOnSuccess"> The value passed to SaveChanges. </param>
+        public SavingChangesEventArgs(bool acceptAllChangesOnSuccess)
+            : base(acceptAllChangesOnSuccess)
+        {
+        }
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/InterceptionInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InterceptionInMemoryTest.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -15,6 +16,8 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
+
+        protected override bool SupportsOptimisticConcurrency => false;
 
         public abstract class InterceptionInMemoryFixtureBase : InterceptionFixtureBase
         {

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -743,7 +743,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask());
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 42 + 2;
+            var expectedMethodCount = 42 + 8;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "


### PR DESCRIPTION
Fixes #15910

I realized that the interceptor, while powerful, is hard to attach to without changing the context configuration. Therefore, this PR adds simple .NET events that can easily be attached to from outside the code that defines the context.

Also, fix to call the SaveChanges failed interceptor when the failure is an optimistic concurrency exception.
