### PR TITLE
Fix seed data inseration with ValueGeneratedOnAddOrUpdate

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1913,7 +1913,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                         foreach (var targetProperty in entry.EntityType.GetProperties())
                         {
-                            if (!(targetProperty.ValueGenerated == ValueGenerated.Never || targetProperty.ValueGenerated.HasFlag(ValueGenerated.OnAdd)))
+                            if (!(targetProperty.ValueGenerated == ValueGenerated.Never || targetProperty.ValueGenerated?.HasFlag(ValueGenerated.OnAdd)))
                             {
                                 continue;
                             }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1913,7 +1913,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                         foreach (var targetProperty in entry.EntityType.GetProperties())
                         {
-                            if (!(targetProperty.ValueGenerated == ValueGenerated.Never || targetProperty.ValueGenerated == ValueGenerated.OnAdd))
+                            if (!(targetProperty.ValueGenerated == ValueGenerated.Never || targetProperty.ValueGenerated.HasFlag(ValueGenerated.OnAdd)))
                             {
                                 continue;
                             }


### PR DESCRIPTION
If just given equality to `ValueGenerated.OnAdd`, the case "ValueGenerated.OnAdd | ValueGenerated.OnUpdated" is not handled properly.

This is set by builder method (Fluent API) myProperty.ValueGeneratedOnAddOrUpdate() instead of .ValueGeneratedOnAdd()