### PR TITLE
Rename AreSavepointsSupported to SupportsSavepoints

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         }
 
         /// <inheritdoc />
-        public virtual bool AreSavepointsSupported => true;
+        public virtual bool SupportsSavepoints => true;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -598,7 +598,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <inheritdoc />
-        public virtual bool AreSavepointsSupported
+        public virtual bool SupportsSavepoints
         {
             get
             {
@@ -607,7 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     throw new InvalidOperationException(RelationalStrings.NoActiveTransaction);
                 }
 
-                return CurrentTransaction.AreSavepointsSupported;
+                return CurrentTransaction.SupportsSavepoints;
             }
         }
 

--- a/src/EFCore.Relational/Storage/RelationalTransaction.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransaction.cs
@@ -559,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         protected virtual string GetReleaseSavepointSql([NotNull] string name) => "RELEASE SAVEPOINT " + name;
 
         /// <inheritdoc />
-        public virtual bool AreSavepointsSupported => true;
+        public virtual bool SupportsSavepoints => true;
 
         /// <inheritdoc />
         public virtual void Dispose()

--- a/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 {
                     connection.Open();
 
-                    if (transaction?.AreSavepointsSupported == true)
+                    if (transaction?.SupportsSavepoints == true)
                     {
                         transaction.CreateSavepoint(SavepointName);
                         createdSavepoint = true;
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 {
                     await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-                    if (transaction?.AreSavepointsSupported == true)
+                    if (transaction?.SupportsSavepoints == true)
                     {
                         await transaction.CreateSavepointAsync(SavepointName, cancellationToken).ConfigureAwait(false);
                         createdSavepoint = true;

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     <see langword="true" /> if this <see cref="DatabaseFacade"/> instance supports database savepoints;
         ///     otherwise, <see langword="false" />.
         /// </returns>
-        public virtual bool AreSavepointsSupported => Dependencies.TransactionManager.AreSavepointsSupported;
+        public virtual bool SupportsSavepoints => Dependencies.TransactionManager.SupportsSavepoints;
 
         /// <summary>
         ///     Creates an instance of the configured <see cref="IExecutionStrategy" />.

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -111,6 +111,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     <see langword="true" /> if this <see cref="IDbContextTransaction"/> instance supports database savepoints;
         ///     otherwise, <see langword="false" />.
         /// </returns>
-        bool AreSavepointsSupported => false;
+        bool SupportsSavepoints => false;
     }
 }

--- a/src/EFCore/Storage/IDbContextTransactionManager.cs
+++ b/src/EFCore/Storage/IDbContextTransactionManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     <see langword="true" /> if this <see cref="IDbContextTransactionManager"/> instance supports database savepoints;
         ///     otherwise, <see langword="false" />.
         /// </returns>
-        bool AreSavepointsSupported => false;
+        bool SupportsSavepoints => false;
 
         /// <summary>
         ///     Gets the current transaction.

--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -669,7 +669,7 @@ namespace Microsoft.EntityFrameworkCore
                     lastEntry.State = EntityState.Unchanged;
                     firstEntry.Entity.Name = "John";
                     firstEntry.State = EntityState.Modified;
-                    if (AreSavepointsSupported)
+                    if (SavepointsSupported)
                     {
                         await context.SaveChangesAsync();
                     }
@@ -687,7 +687,7 @@ namespace Microsoft.EntityFrameworkCore
                     lastEntry.State = EntityState.Unchanged;
                     firstEntry.Entity.Name = "John";
                     firstEntry.State = EntityState.Modified;
-                    if (AreSavepointsSupported)
+                    if (SavepointsSupported)
                     {
                         context.SaveChanges();
                     }
@@ -704,7 +704,7 @@ namespace Microsoft.EntityFrameworkCore
                 context.Database.AutoTransactionsEnabled = true;
             }
 
-            if (AreSavepointsSupported)
+            if (SavepointsSupported)
             {
                 using var context = CreateContext();
                 Assert.Equal(Customers.Count, context.Set<TransactionCustomer>().Count());
@@ -1223,7 +1223,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected virtual bool DirtyReadsOccur => true;
 
-        protected virtual bool AreSavepointsSupported => true;
+        protected virtual bool SavepointsSupported => true;
 
         protected DbContext CreateContext() => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalTransaction.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalTransaction.cs
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             await base.CommitAsync(cancellationToken);
         }
 
-        public override bool AreSavepointsSupported => true;
+        public override bool SupportsSavepoints => true;
 
         /// <inheritdoc />
         protected override string GetCreateSavepointSql(string name) => "SAVE TRANSACTION " + name;

--- a/test/EFCore.Tests/DatabaseFacadeTest.cs
+++ b/test/EFCore.Tests/DatabaseFacadeTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore
             public int CreateSavepointCalls;
             public int RollbackSavepointCalls;
             public int ReleaseSavepointCalls;
-            public int AreSavepointsSupportedCalls;
+            public int SupportsSavepointsCalls;
 
             public IDbContextTransaction BeginTransaction()
                 => _transaction;
@@ -202,11 +202,11 @@ namespace Microsoft.EntityFrameworkCore
                 return Task.CompletedTask;
             }
 
-            public bool AreSavepointsSupported
+            public bool SupportsSavepoints
             {
                 get
                 {
-                    AreSavepointsSupportedCalls++;
+                    SupportsSavepointsCalls++;
                     return true;
                 }
             }
@@ -368,9 +368,9 @@ namespace Microsoft.EntityFrameworkCore
             var context = InMemoryTestHelpers.Instance.CreateContext(
                 new ServiceCollection().AddSingleton<IDbContextTransactionManager>(manager));
 
-            _ = context.Database.AreSavepointsSupported;
+            _ = context.Database.SupportsSavepoints;
 
-            Assert.Equal(1, manager.AreSavepointsSupportedCalls);
+            Assert.Equal(1, manager.SupportsSavepointsCalls);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Aligning with the System.Data savepoints API: https://github.com/dotnet/runtime/issues/33397#issuecomment-662004505

Part of #20409 (May 20)
