### PR TITLE
RevEng: Scaffold MaxLength attribute when using data annotations

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -287,6 +287,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             GenerateKeyAttribute(property);
             GenerateRequiredAttribute(property);
             GenerateColumnAttribute(property);
+            GenerateMaxLengthAttribute(property);
 
             var annotations = _annotationCodeGenerator
                 .FilterIgnoredAnnotations(property.GetAnnotations())
@@ -345,6 +346,23 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 && !property.IsPrimaryKey())
             {
                 _sb.AppendLine(new AttributeWriter(nameof(RequiredAttribute)).ToString());
+            }
+        }
+
+        private void GenerateMaxLengthAttribute(IProperty property)
+        {
+            var maxLength = property.GetMaxLength();
+
+            if (maxLength.HasValue)
+            {
+                var lengthAttribute = new AttributeWriter(
+                    property.ClrType == typeof(string)
+                        ? nameof(StringLengthAttribute)
+                        : nameof(MaxLengthAttribute));
+
+                lengthAttribute.AddParameter(_code.Literal(maxLength.Value));
+
+                _sb.AppendLine(lengthAttribute.ToString());
             }
         }
 


### PR DESCRIPTION
Resolves #21816

Also added regression tests for other property attributes
