### PR TITLE
Query: Identify Count(*) in different SelectExpression differently

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFragmentExpression.cs
@@ -61,7 +61,8 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
 
         private bool Equals(SqlFragmentExpression sqlFragmentExpression)
             => base.Equals(sqlFragmentExpression)
-                && string.Equals(Sql, sqlFragmentExpression.Sql);
+                && string.Equals(Sql, sqlFragmentExpression.Sql)
+                && !string.Equals(Sql, "*"); // We make star projection different because it could be coming from different table.
 
         /// <inheritdoc />
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Sql);

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2285,6 +2285,25 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 10);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_join_another_GroupBy_aggregate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                        .GroupBy(o => o.CustomerID)
+                        .Select(g => new { g.Key, Total = g.Count() })
+                        .Join(
+                            ss.Set<Order>().Where(o => o.OrderDate.Value.Year == 1997)
+                                .GroupBy(o => o.CustomerID)
+                                .Select(g => new { g.Key, ThatYear = g.Count() }),
+                            o => o.Key,
+                            i => i.Key,
+                            (o, i) => new { o.Key, o.Total, i.ThatYear }),
+                elementSorter: o => o.Key);
+        }
+
         #endregion
 
         #region GroupByAggregateChainComposition

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2269,6 +2269,25 @@ ORDER BY [t].[c], [c].[CustomerID]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY");
         }
 
+        public override async Task GroupBy_aggregate_join_another_GroupBy_aggregate(bool async)
+        {
+            await base.GroupBy_aggregate_join_another_GroupBy_aggregate(async);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID] AS [Key], [t].[c] AS [Total], [t0].[c] AS [ThatYear]
+FROM (
+    SELECT [o].[CustomerID], COUNT(*) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [t]
+INNER JOIN (
+    SELECT [o0].[CustomerID], COUNT(*) AS [c]
+    FROM [Orders] AS [o0]
+    WHERE DATEPART(year, [o0].[OrderDate]) = 1997
+    GROUP BY [o0].[CustomerID]
+) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]");
+        }
+
         public override async Task GroupBy_with_grouping_key_using_Like(bool async)
         {
             await base.GroupBy_with_grouping_key_using_Like(async);


### PR DESCRIPTION
Resolves #19202
