### PR TITLE
Query: Add logging

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Common;
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -75,8 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             // Query events
             QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
             QueryPossibleUnintendedUseOfEqualsWarning,
-            QueryPossibleExceptionWithAggregateOperatorWarning,
-            ValueConversionSqlLiteralWarning, // This warning has been removed.
+            Obsolete_QueryPossibleExceptionWithAggregateOperatorWarning,
+            Obsolete_ValueConversionSqlLiteralWarning,
             MultipleCollectionIncludeWarning,
 
             // Model validation events
@@ -611,8 +612,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
         ///     </para>
         /// </summary>
+        [Obsolete]
         public static readonly EventId QueryPossibleExceptionWithAggregateOperatorWarning =
-            MakeQueryId(Id.QueryPossibleExceptionWithAggregateOperatorWarning);
+            MakeQueryId(Id.Obsolete_QueryPossibleExceptionWithAggregateOperatorWarning);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggerExtensions.cs
@@ -4163,6 +4163,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     Logs for the <see cref="RelationalEventId.QueryPossibleExceptionWithAggregateOperatorWarning" /> event.
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        [Obsolete]
         public static void QueryPossibleExceptionWithAggregateOperatorWarning(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics)
         {

--- a/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalLoggingDefinitions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -239,6 +240,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
+        [Obsolete]
         public EventDefinitionBase LogQueryPossibleExceptionWithAggregateOperatorWarning;
 
         /// <summary>
@@ -411,15 +413,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         [EntityFrameworkInternal]
         public EventDefinitionBase LogMigrationAttributeMissingWarning;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
-        public EventDefinitionBase LogValueConversionSqlLiteralWarning;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1644,6 +1644,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         /// <summary>
         ///     Possible unintended use of a potentially throwing aggregate method (Min, Max, Average) in a subquery. Client evaluation will be used and operator will throw if no data exists. Changing the subquery result type to a nullable type will allow full translation.
         /// </summary>
+        [Obsolete]
         public static EventDefinition LogQueryPossibleExceptionWithAggregateOperatorWarning([NotNull] IDiagnosticsLogger logger)
         {
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogQueryPossibleExceptionWithAggregateOperatorWarning;

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -272,7 +272,7 @@
   </data>
   <data name="LogQueryPossibleExceptionWithAggregateOperatorWarning" xml:space="preserve">
     <value>Possible unintended use of a potentially throwing aggregate method (Min, Max, Average) in a subquery. Client evaluation will be used and operator will throw if no data exists. Changing the subquery result type to a nullable type will allow full translation.</value>
-    <comment>Warning RelationalEventId.QueryPossibleExceptionWithAggregateOperatorWarning</comment>
+    <comment>Obsolete Warning RelationalEventId.QueryPossibleExceptionWithAggregateOperatorWarning</comment>
   </data>
   <data name="LogGeneratingDown" xml:space="preserve">
     <value>Generating down script for migration '{migration}'.</value>

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -420,6 +420,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             var selectExpression = (SelectExpression)source.QueryExpression;
+            if (selectExpression.Predicate == null
+                && selectExpression.Orderings.Count == 0)
+            {
+                _queryCompilationContext.Logger.FirstWithoutOrderByAndFilterWarning();
+            }
             selectExpression.ApplyLimit(TranslateExpression(Expression.Constant(1)));
 
             return source.ShaperExpression.Type != returnType
@@ -1035,6 +1040,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return null;
             }
 
+            if (selectExpression.Orderings.Count == 0)
+            {
+                _queryCompilationContext.Logger.RowLimitingOperationWithoutOrderByWarning();
+            }
+
             selectExpression.ApplyOffset(translation);
 
             return source;
@@ -1094,6 +1104,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (translation == null)
             {
                 return null;
+            }
+
+            if (selectExpression.Orderings.Count == 0)
+            {
+                _queryCompilationContext.Logger.RowLimitingOperationWithoutOrderByWarning();
             }
 
             selectExpression.ApplyLimit(translation);

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -59,15 +59,16 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             // Query events
             QueryIterationFailed = CoreBaseId + 100,
             Obsolete_QueryModelCompiling,
-            Obsolete_RowLimitingOperationWithoutOrderByWarning,
-            Obsolete_FirstWithoutOrderByAndFilterWarning,
+            RowLimitingOperationWithoutOrderByWarning,
+            FirstWithoutOrderByAndFilterWarning,
             Obsolete_QueryModelOptimized,
-            Obsolete_NavigationIncluded,
+            NavigationIncluded,
             Obsolete_IncludeIgnoredWarning,
             QueryExecutionPlanned,
             PossibleUnintendedCollectionNavigationNullComparisonWarning,
             PossibleUnintendedReferenceComparisonWarning,
             InvalidIncludePathError,
+            QueryCompilationStarting,
 
             // Infrastructure events
             SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
@@ -214,6 +215,56 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId InvalidIncludePathError
             = MakeQueryId(Id.InvalidIncludePathError);
+
+        /// <summary>
+        ///     <para>
+        ///         Starting query compilation.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId QueryCompilationStarting
+            = MakeQueryId(Id.QueryCompilationStarting);
+
+        /// <summary>
+        ///     <para>
+        ///         A navigation was included in the query.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="QueryExpressionEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NavigationIncluded
+            = MakeQueryId(Id.NavigationIncluded);
+
+        /// <summary>
+        ///     <para>
+        ///         A query uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId RowLimitingOperationWithoutOrderByWarning
+            = MakeQueryId(Id.RowLimitingOperationWithoutOrderByWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         A query uses First/FirstOrDefault operation without OrderBy and filter which may lead to unpredictable results.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId FirstWithoutOrderByAndFilterWarning
+            = MakeQueryId(Id.FirstWithoutOrderByAndFilterWarning);
 
         private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
         private static EventId MakeInfraId(Id id) => new EventId((int)id, _infraPrefix + id);

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -278,196 +278,170 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             return d.GenerateMessage(p.ContextType, Environment.NewLine, p.Exception);
         }
 
-        // TODO: Commenting this since we need to add similar logging in ExpressionTrees
-        ///// <summary>
-        /////     Logs for the <see cref="CoreEventId.QueryModelCompiling" /> event.
-        ///// </summary>
-        ///// <param name="diagnostics"> The diagnostics logger to use. </param>
-        ///// <param name="queryModel"> The query model. </param>
-        //public static void QueryModelCompiling(
-        //    [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-        //    [NotNull] QueryModel queryModel)
-        //{
-        //    var definition = CoreResources.LogCompilingQueryModel(diagnostics);
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.QueryCompilationStarting" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="expressionPrinter"> Used to create a human-readable representation of the expression tree. </param>
+        /// <param name="queryExpression"> The query expression tree. </param>
+        public static void QueryCompilationStarting(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] ExpressionPrinter expressionPrinter,
+            [NotNull] Expression queryExpression)
+        {
+            var definition = CoreResources.LogQueryCompilationStarting(diagnostics);
 
-        //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-        //    if (warningBehavior != WarningBehavior.Ignore)
-        //    {
-        //        definition.Log(
-        //            diagnostics,
-        //            warningBehavior,
-        //            Environment.NewLine, queryModel.Print());
-        //    }
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, Environment.NewLine, expressionPrinter.Print(queryExpression));
+            }
 
-        //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-        //    {
-        //        diagnostics.DiagnosticSource.Write(
-        //            definition.EventId.Name,
-        //            new QueryModelEventData(
-        //                definition,
-        //                QueryModelCompiling,
-        //                queryModel));
-        //    }
-        //}
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new QueryExpressionEventData(
+                    definition,
+                    QueryCompilationStarting,
+                    queryExpression,
+                    expressionPrinter);
 
-        //private static string QueryModelCompiling(EventDefinitionBase definition, EventData payload)
-        //{
-        //    var d = (EventDefinition<string, string>)definition;
-        //    var p = (QueryModelEventData)payload;
-        //    return d.GenerateMessage(Environment.NewLine, p.QueryModel.Print());
-        //}
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
 
-        ///// <summary>
-        /////     Logs for the <see cref="CoreEventId.RowLimitingOperationWithoutOrderByWarning" /> event.
-        ///// </summary>
-        ///// <param name="diagnostics"> The diagnostics logger to use. </param>
-        ///// <param name="queryModel"> The query model. </param>
-        //public static void RowLimitingOperationWithoutOrderByWarning(
-        //    [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-        //    [NotNull] QueryModel queryModel)
-        //{
-        //    var definition = CoreResources.LogRowLimitingOperationWithoutOrderBy(diagnostics);
+        private static string QueryCompilationStarting(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (QueryExpressionEventData)payload;
+            return d.GenerateMessage(Environment.NewLine, p.ExpressionPrinter.Print(p.Expression));
+        }
 
-        //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-        //    if (warningBehavior != WarningBehavior.Ignore)
-        //    {
-        //        definition.Log(
-        //            diagnostics,
-        //            warningBehavior,
-        //            queryModel.Print(removeFormatting: true, characterLimit: QueryModelStringLengthLimit));
-        //    }
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.FirstWithoutOrderByAndFilterWarning" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        public static void FirstWithoutOrderByAndFilterWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics)
+        {
+            var definition = CoreResources.LogFirstWithoutOrderByAndFilter(diagnostics);
 
-        //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-        //    {
-        //        diagnostics.DiagnosticSource.Write(
-        //            definition.EventId.Name,
-        //            new QueryModelEventData(
-        //                definition,
-        //                RowLimitingOperationWithoutOrderByWarning,
-        //                queryModel));
-        //    }
-        //}
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics);
+            }
 
-        //private static string RowLimitingOperationWithoutOrderByWarning(EventDefinitionBase definition, EventData payload)
-        //{
-        //    var d = (EventDefinition<string>)definition;
-        //    var p = (QueryModelEventData)payload;
-        //    return d.GenerateMessage(p.QueryModel.Print(removeFormatting: true, characterLimit: QueryModelStringLengthLimit));
-        //}
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new EventData(
+                    definition,
+                    FirstWithoutOrderByAndFilterWarning);
 
-        ///// <summary>
-        /////     Logs for the <see cref="CoreEventId.FirstWithoutOrderByAndFilterWarning" /> event.
-        ///// </summary>
-        ///// <param name="diagnostics"> The diagnostics logger to use. </param>
-        ///// <param name="queryModel"> The query model. </param>
-        //public static void FirstWithoutOrderByAndFilterWarning(
-        //    [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-        //    [NotNull] QueryModel queryModel)
-        //{
-        //    var definition = CoreResources.LogFirstWithoutOrderByAndFilter(diagnostics);
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
 
-        //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-        //    if (warningBehavior != WarningBehavior.Ignore)
-        //    {
-        //        definition.Log(
-        //            diagnostics,
-        //            warningBehavior,
-        //            queryModel.Print(removeFormatting: true, characterLimit: QueryModelStringLengthLimit));
-        //    }
+        private static string FirstWithoutOrderByAndFilterWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition)definition;
+            return d.GenerateMessage();
+        }
 
-        //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-        //    {
-        //        diagnostics.DiagnosticSource.Write(
-        //            definition.EventId.Name,
-        //            new QueryModelEventData(
-        //                definition,
-        //                FirstWithoutOrderByAndFilterWarning,
-        //                queryModel));
-        //    }
-        //}
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.RowLimitingOperationWithoutOrderByWarning" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        public static void RowLimitingOperationWithoutOrderByWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics)
+        {
+            var definition = CoreResources.LogRowLimitingOperationWithoutOrderBy(diagnostics);
 
-        //private static string FirstWithoutOrderByAndFilterWarning(EventDefinitionBase definition, EventData payload)
-        //{
-        //    var d = (EventDefinition<string>)definition;
-        //    var p = (QueryModelEventData)payload;
-        //    return d.GenerateMessage(p.QueryModel.Print(removeFormatting: true, characterLimit: QueryModelStringLengthLimit));
-        //}
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics);
+            }
 
-        ///// <summary>
-        /////     Logs for the <see cref="CoreEventId.QueryModelOptimized" /> event.
-        ///// </summary>
-        ///// <param name="diagnostics"> The diagnostics logger to use. </param>
-        ///// <param name="queryModel"> The query model. </param>
-        //public static void QueryModelOptimized(
-        //    [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-        //    [NotNull] QueryModel queryModel)
-        //{
-        //    var definition = CoreResources.LogOptimizedQueryModel(diagnostics);
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new EventData(
+                    definition,
+                    RowLimitingOperationWithoutOrderByWarning);
 
-        //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-        //    if (warningBehavior != WarningBehavior.Ignore)
-        //    {
-        //        definition.Log(
-        //            diagnostics,
-        //            warningBehavior,
-        //            Environment.NewLine, queryModel.Print());
-        //    }
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
 
-        //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-        //    {
-        //        diagnostics.DiagnosticSource.Write(
-        //            definition.EventId.Name,
-        //            new QueryModelEventData(
-        //                definition,
-        //                QueryModelOptimized,
-        //                queryModel));
-        //    }
-        //}
+        private static string RowLimitingOperationWithoutOrderByWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition)definition;
+            return d.GenerateMessage();
+        }
 
-        //private static string QueryModelOptimized(EventDefinitionBase definition, EventData payload)
-        //{
-        //    var d = (EventDefinition<string, string>)definition;
-        //    var p = (QueryModelEventData)payload;
-        //    return d.GenerateMessage(Environment.NewLine, p.QueryModel.Print());
-        //}
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.NavigationIncluded" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="navigation"> The navigation being included. </param>
+        public static void NavigationIncluded(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] INavigation navigation)
+        {
+            var definition = CoreResources.LogNavigationIncluded(diagnostics);
 
-        ///// <summary>
-        /////     Logs for the <see cref="CoreEventId.NavigationIncluded" /> event.
-        ///// </summary>
-        ///// <param name="diagnostics"> The diagnostics logger to use. </param>
-        ///// <param name="includeResultOperator"> The result operator for the Include. </param>
-        //public static void NavigationIncluded(
-        //    [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
-        //    [NotNull] IncludeResultOperator includeResultOperator)
-        //{
-        //    var definition = CoreResources.LogIncludingNavigation(diagnostics);
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, navigation.DeclaringEntityType.ShortName() + "." + navigation.Name);
+            }
 
-        //    var warningBehavior = definition.GetLogBehavior(diagnostics);
-        //    if (warningBehavior != WarningBehavior.Ignore)
-        //    {
-        //        definition.Log(
-        //            diagnostics,
-        //            warningBehavior,
-        //            includeResultOperator.DisplayString());
-        //    }
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new NavigationEventData(
+                    definition,
+                    NavigationIncluded,
+                    navigation);
 
-        //    if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
-        //    {
-        //        diagnostics.DiagnosticSource.Write(
-        //            definition.EventId.Name,
-        //            new IncludeEventData(
-        //                definition,
-        //                NavigationIncluded,
-        //                includeResultOperator));
-        //    }
-        //}
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
 
-        //private static string NavigationIncluded(EventDefinitionBase definition, EventData payload)
-        //{
-        //    var d = (EventDefinition<string>)definition;
-        //    var p = (IncludeEventData)payload;
-        //    return d.GenerateMessage(p.IncludeResultOperator.DisplayString());
-        //}
+        private static string NavigationIncluded(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (NavigationEventData)payload;
+            return d.GenerateMessage(p.Navigation.DeclaringEntityType.ShortName() + "." + p.Navigation.Name);
+        }
+
+        /// <summary>
+        ///     Logs for the <see cref="CoreEventId.NavigationIncluded" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="skipNavigation"> The navigation being included. </param>
+        public static void NavigationIncluded(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] ISkipNavigation skipNavigation)
+        {
+            var definition = CoreResources.LogNavigationIncluded(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, skipNavigation.DeclaringEntityType.ShortName() + "." + skipNavigation.Name);
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new SkipNavigationEventData(
+                    definition,
+                    SkipNavigationIncluded,
+                    skipNavigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
+
+        private static string SkipNavigationIncluded(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (SkipNavigationEventData)payload;
+            return d.GenerateMessage(p.Navigation.DeclaringEntityType.ShortName() + "." + p.Navigation.Name);
+        }
 
         /// <summary>
         ///     Logs for the <see cref="CoreEventId.QueryExecutionPlanned" /> event.

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -321,24 +321,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        public EventDefinitionBase LogCompilingQueryModel;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
-        public EventDefinitionBase LogOptimizedQueryModel;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
         public EventDefinitionBase LogIncludingNavigation;
 
         /// <summary>
@@ -358,15 +340,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         [EntityFrameworkInternal]
         public EventDefinitionBase LogSensitiveDataLoggingEnabled;
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        [EntityFrameworkInternal]
-        public EventDefinitionBase LogIgnoredInclude;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -697,5 +670,23 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         [EntityFrameworkInternal]
         public EventDefinitionBase LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public EventDefinitionBase LogNavigationIncluded;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public EventDefinitionBase LogQueryCompilationStarting;
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -4491,5 +4491,101 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
 
             return (EventDefinition<string, string>)definition;
         }
+
+        /// <summary>
+        ///     Query uses First/FirstOrDefault operation without OrderBy and filter, which may lead to unpredictable results.
+        /// </summary>
+        public static EventDefinition LogFirstWithoutOrderByAndFilter([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogFirstWithoutOrderByAndFilter;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogFirstWithoutOrderByAndFilter,
+                    () => new EventDefinition(
+                        logger.Options,
+                        CoreEventId.FirstWithoutOrderByAndFilterWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.FirstWithoutOrderByAndFilterWarning",
+                        level => LoggerMessage.Define(
+                            level,
+                            CoreEventId.FirstWithoutOrderByAndFilterWarning,
+                            _resourceManager.GetString("LogFirstWithoutOrderByAndFilter"))));
+            }
+
+            return (EventDefinition)definition;
+        }
+
+        /// <summary>
+        ///     Including navigation: '{navigation}'.
+        /// </summary>
+        public static EventDefinition<string> LogNavigationIncluded([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogNavigationIncluded;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogNavigationIncluded,
+                    () => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.NavigationIncluded,
+                        LogLevel.Debug,
+                        "CoreEventId.NavigationIncluded",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.NavigationIncluded,
+                            _resourceManager.GetString("LogNavigationIncluded"))));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
+        ///     Compiling query expression: {newline}'{queryExpression}'
+        /// </summary>
+        public static EventDefinition<string, string> LogQueryCompilationStarting([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogQueryCompilationStarting;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogQueryCompilationStarting,
+                    () => new EventDefinition<string, string>(
+                        logger.Options,
+                        CoreEventId.QueryCompilationStarting,
+                        LogLevel.Debug,
+                        "CoreEventId.QueryCompilationStarting",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            CoreEventId.QueryCompilationStarting,
+                            _resourceManager.GetString("LogQueryCompilationStarting"))));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
+        /// <summary>
+        ///     Query uses a row limiting operation (Skip/Take) without OrderBy, which may lead to unpredictable results.
+        /// </summary>
+        public static EventDefinition LogRowLimitingOperationWithoutOrderBy([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogRowLimitingOperationWithoutOrderBy;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogRowLimitingOperationWithoutOrderBy,
+                    () => new EventDefinition(
+                        logger.Options,
+                        CoreEventId.RowLimitingOperationWithoutOrderByWarning,
+                        LogLevel.Warning,
+                        "CoreEventId.RowLimitingOperationWithoutOrderByWarning",
+                        level => LoggerMessage.Define(
+                            level,
+                            CoreEventId.RowLimitingOperationWithoutOrderByWarning,
+                            _resourceManager.GetString("LogRowLimitingOperationWithoutOrderBy"))));
+            }
+
+            return (EventDefinition)definition;
+        }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1469,4 +1469,20 @@
     <value>The RequiredAttribute on '{principalEntityType}.{principalNavigation}' was ignored because it is a skip navigation. Instead configure the underlying foreign keys.</value>
     <comment>Debug CoreEventId.RequiredAttributeOnSkipNavigation string string</comment>
   </data>
+  <data name="LogFirstWithoutOrderByAndFilter" xml:space="preserve">
+    <value>Query uses First/FirstOrDefault operation without OrderBy and filter, which may lead to unpredictable results.</value>
+    <comment>Warning CoreEventId.FirstWithoutOrderByAndFilterWarning</comment>
+  </data>
+  <data name="LogNavigationIncluded" xml:space="preserve">
+    <value>Including navigation: '{navigation}'.</value>
+    <comment>Debug CoreEventId.NavigationIncluded string</comment>
+  </data>
+  <data name="LogQueryCompilationStarting" xml:space="preserve">
+    <value>Compiling query expression: {newline}'{queryExpression}'</value>
+    <comment>Debug CoreEventId.QueryCompilationStarting string string</comment>
+  </data>
+  <data name="LogRowLimitingOperationWithoutOrderBy" xml:space="preserve">
+    <value>Query uses a row limiting operation (Skip/Take) without OrderBy, which may lead to unpredictable results.</value>
+    <comment>Warning CoreEventId.RowLimitingOperationWithoutOrderByWarning</comment>
+  </data>
 </root>

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -52,6 +52,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly IQueryTranslationPostprocessorFactory _queryTranslationPostprocessorFactory;
         private readonly IShapedQueryCompilingExpressionVisitorFactory _shapedQueryCompilingExpressionVisitorFactory;
 
+        private readonly ExpressionPrinter _expressionPrinter;
+
         private Dictionary<string, LambdaExpression> _runtimeParameters;
 
         /// <summary>
@@ -78,6 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             _queryableMethodTranslatingExpressionVisitorFactory = dependencies.QueryableMethodTranslatingExpressionVisitorFactory;
             _queryTranslationPostprocessorFactory = dependencies.QueryTranslationPostprocessorFactory;
             _shapedQueryCompilingExpressionVisitorFactory = dependencies.ShapedQueryCompilingExpressionVisitorFactory;
+
+            _expressionPrinter = new ExpressionPrinter();
         }
 
         /// <summary>
@@ -156,6 +160,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Check.NotNull(query, nameof(query));
 
+            Logger.QueryCompilationStarting(_expressionPrinter, query);
+
             query = _queryTranslationPreprocessorFactory.Create(this).Process(query);
             // Convert EntityQueryable to ShapedQueryExpression
             query = _queryableMethodTranslatingExpressionVisitorFactory.Create(this).Visit(query);
@@ -179,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
             finally
             {
-                Logger.QueryExecutionPlanned(new ExpressionPrinter(), queryExecutorExpression);
+                Logger.QueryExecutionPlanned(_expressionPrinter, queryExecutorExpression);
             }
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EndToEndCosmosTest.cs
@@ -1042,7 +1042,7 @@ OFFSET 0 LIMIT 1");
                     });
             }
         }
-        
+
         [ConditionalFact]
         public async Task Can_use_detached_entities_without_discriminators()
         {
@@ -1370,7 +1370,7 @@ OFFSET 0 LIMIT 1");
             context.Add(new NonStringDiscriminator { Id = 1 });
             await context.SaveChangesAsync();
 
-            Assert.NotNull(await context.Set<NonStringDiscriminator>().FirstOrDefaultAsync());
+            Assert.NotNull(await context.Set<NonStringDiscriminator>().OrderBy(e => e.Id).FirstOrDefaultAsync());
         }
 
         private class NonStringDiscriminator

--- a/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/InheritanceQueryCosmosTest.cs
@@ -358,6 +358,7 @@ WHERE (c[""Discriminator""] IN (""Eagle"", ""Kiwi"") AND (c[""Discriminator""] =
 SELECT DISTINCT c
 FROM root c
 WHERE (c[""Discriminator""] IN (""Eagle"", ""Kiwi"") AND (c[""Discriminator""] = ""Kiwi""))
+ORDER BY c[""Species""]
 OFFSET 0 LIMIT @__p_0");
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindQueryCosmosFixture.cs
@@ -19,6 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public TestSqlLoggerFactory TestSqlLoggerFactory
             => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
+        protected override bool ShouldLogCategory(string logCategory)
+            => logCategory == DbLoggerCategory.Query.Name;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             base.OnModelCreating(modelBuilder, context);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/QueryLoggingCosmosTest.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryLoggingCosmosTest : IClassFixture<NorthwindQueryCosmosFixture<NoopModelCustomizer>>
+    {
+        public QueryLoggingCosmosTest(NorthwindQueryCosmosFixture<NoopModelCustomizer> fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
+        }
+
+        protected NorthwindQueryCosmosFixture<NoopModelCustomizer> Fixture { get; }
+
+        [ConditionalFact]
+        public virtual void Queryable_simple()
+        {
+            using var context = CreateContext();
+            var customers
+                = context.Set<Customer>()
+                    .ToList();
+
+            Assert.NotNull(customers);
+
+            Assert.StartsWith(
+                "Compiling query expression: ",
+                Fixture.TestSqlLoggerFactory.Log[0].Message);
+            Assert.StartsWith(
+                "queryContext => new QueryingEnumerable<Customer>(",
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Queryable_with_parameter_outputs_parameter_value_logging_warning()
+        {
+            using var context = CreateContext();
+            context.GetInfrastructure().GetRequiredService<IDiagnosticsLogger<DbLoggerCategory.Query>>()
+                .Options.IsSensitiveDataLoggingWarned = false;
+            // ReSharper disable once ConvertToConstant.Local
+            var city = "Redmond";
+
+            var customers
+                = context.Customers
+                    .Where(c => c.City == city)
+                    .ToList();
+
+            Assert.NotNull(customers);
+            Assert.Contains(
+                CoreResources.LogSensitiveDataLoggingEnabled(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
+        }
+
+        [ConditionalFact]
+        public virtual void Skip_without_order_by()
+        {
+            using var context = CreateContext();
+            var customers = context.Set<Customer>().Skip(85).Take(5).ToList();
+
+            Assert.NotNull(customers);
+
+            Assert.Equal(
+                CoreResources.LogRowLimitingOperationWithoutOrderBy(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Take_without_order_by()
+        {
+            using var context = CreateContext();
+            var customers = context.Set<Customer>().Take(5).ToList();
+
+            Assert.NotNull(customers);
+
+            Assert.Equal(
+                CoreResources.LogRowLimitingOperationWithoutOrderBy(new TestLogger<CosmosLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
+        }
+
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
@@ -18,8 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
                     c => c
-                        .Log(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning)
-                        .Log(RelationalEventId.QueryPossibleExceptionWithAggregateOperatorWarning))
+                        .Log(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning))
                 .EnableDetailedErrors();
 
         protected override bool ShouldLogCategory(string logCategory)

--- a/test/EFCore.Specification.Tests/ConferencePlannerTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConferencePlannerTestBase.cs
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore
             await ExecuteWithStrategyInTransactionAsync(
                 async context =>
                 {
-                    var track = context.Tracks.AsNoTracking().First();
+                    var track = context.Tracks.AsNoTracking().OrderBy(e => e.Id).First();
 
                     var controller = new SessionsController(context);
 

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -173,13 +173,13 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateContext())
             {
-                var principal = context.Set<OneToOneFieldNavPrincipal>().First();
+                var principal = context.Set<OneToOneFieldNavPrincipal>().OrderBy(e => e.Id).First();
                 var dependent1 = new NavDependent { Id = 1, Name = "FirstName", OneToOneFieldNavPrincipal = principal };
                 context.Set<NavDependent>().Add(dependent1);
                 context.SaveChanges();
 
                 var dependentName =
-                    context.Set<OneToOneFieldNavPrincipal>().Select(p => p.Dependent.Name).First();
+                    context.Set<OneToOneFieldNavPrincipal>().OrderBy(e => e.Id).Select(p => p.Dependent.Name).First();
 
                 Assert.Equal("FirstName", dependentName);
 
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore
                 context.SaveChanges();
 
                 dependentName =
-                    context.Set<OneToOneFieldNavPrincipal>().Select(p => p.Dependent.Name).First();
+                    context.Set<OneToOneFieldNavPrincipal>().OrderBy(e => e.Id).Select(p => p.Dependent.Name).First();
 
                 Assert.Equal("SecondName", dependentName);
             }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -616,6 +616,7 @@ namespace Microsoft.EntityFrameworkCore
             return ModifyQueryRoot(context.Set<Root>())
                 .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
                 .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -627,6 +628,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
                 .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
                 .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -639,6 +641,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleMoreDerived).ThenInclude(e => e.DerivedRoot)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -649,6 +652,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.CompositeChildren)
                 .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -661,6 +665,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
                 .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
                 .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -673,6 +678,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Single)
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.Root)
                 .Include(e => e.RequiredNonPkSingleAkMoreDerived).ThenInclude(e => e.DerivedRoot)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -683,6 +689,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
                 .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
                 .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 
@@ -690,6 +697,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             return ModifyQueryRoot(context.Set<Root>())
                 .Include(e => e.RequiredCompositeChildren).ThenInclude(e => e.CompositeChildren)
+                .OrderBy(e => e.Id)
                 .Single(IsTheRoot);
         }
 

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -2315,6 +2315,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext(lazyLoadingEnabled: true);
             var query = (from p in context.Set<Parent>()
+                         orderby p.Id
                          select DtoFactory.CreateDto(p)).FirstOrDefault();
 
             Assert.NotNull(((dynamic)query).Single);
@@ -2326,7 +2327,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Entity_equality_with_proxy_parameter(bool async)
         {
             using var context = CreateContext(lazyLoadingEnabled: true);
-            var called = context.Set<Parent>().FirstOrDefault();
+            var called = context.Set<Parent>().OrderBy(e => e.Id).FirstOrDefault();
             ClearLog();
 
             var query = from Child q in context.Set<Child>()

--- a/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
@@ -698,7 +698,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public async Task<List<string>> InvokeAsync()
             {
-                var genres = await _context.Genres.Select(g => g.Name).Take(9).ToListAsync();
+                var genres = await _context.Genres.OrderBy(e => e.GenreId).Select(g => g.Name).Take(9).ToListAsync();
 
                 return genres;
             }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -310,7 +310,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
                 c => c
-                    .Log(CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning));
+                    .Log(CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning)
+                    .Log(CoreEventId.RowLimitingOperationWithoutOrderByWarning));
 
         public override ComplexNavigationsContext CreateContext()
         {

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -345,7 +346,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected override void Seed(GearsOfWarContext context) => GearsOfWarContext.Seed(context);
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
-            => base.AddOptions(builder);
+            => base.AddOptions(builder).ConfigureWarnings(w =>
+                w.Log(CoreEventId.RowLimitingOperationWithoutOrderByWarning));
 
         public override GearsOfWarContext CreateContext()
         {

--- a/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceQueryTestBase.cs
@@ -449,6 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Bird>()
+                    .OrderBy(b => b.Species)
                     .Take(5)
                     .Distinct()
                     .OfType<Kiwi>(),

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
@@ -48,6 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
                 c => c
+                    .Log(CoreEventId.RowLimitingOperationWithoutOrderByWarning)
+                    .Log(CoreEventId.FirstWithoutOrderByAndFilterWarning)
                     .Log(CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning)
                     .Log(CoreEventId.PossibleUnintendedReferenceComparisonWarning));
     }

--- a/test/EFCore.Specification.Tests/SpatialTestBase.cs
+++ b/test/EFCore.Specification.Tests/SpatialTestBase.cs
@@ -102,6 +102,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var db = Fixture.CreateContext();
             (from e in db.Set<PointEntity>()
+             orderby e.Id
              select new
              {
                  e.Id,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -479,6 +479,7 @@ FROM (
     SELECT TOP(@__p_0) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
     FROM [Animals] AS [a]
     WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
+    ORDER BY [a].[Species]
 ) AS [t]
 WHERE [t].[Discriminator] = N'Kiwi'");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
@@ -455,6 +455,7 @@ SELECT DISTINCT [t].[Species], [t].[CountryId], [t].[Discriminator], [t].[Name],
 FROM (
     SELECT TOP(@__p_0) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
     FROM [Animals] AS [a]
+    ORDER BY [a].[Species]
 ) AS [t]
 WHERE [t].[Discriminator] = N'Kiwi'");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -4579,12 +4579,13 @@ FROM [InventoryPools] AS [i]");
             using (CreateDatabase12518())
             {
                 using var context = new MyContext12518(_options);
-                var result = context.Parents.Include(p => p.Child).FirstOrDefault();
+                var result = context.Parents.Include(p => p.Child).OrderBy(e => e.Id).FirstOrDefault();
 
                 AssertSql(
                     @"SELECT TOP(1) [p].[Id], [p].[ChildId], [c].[Id], [c].[ParentId], [c].[ULongRowVersion]
 FROM [Parents] AS [p]
-LEFT JOIN [Children] AS [c] ON [p].[ChildId] = [c].[Id]");
+LEFT JOIN [Children] AS [c] ON [p].[ChildId] = [c].[Id]
+ORDER BY [p].[Id]");
             }
         }
 
@@ -7516,7 +7517,7 @@ ORDER BY [p].[Id]"
 
             Assert.Equal(ConnectionState.Closed, dbConnection.State);
 
-            context.Parents.Include(p => p.Children1).Include(p => p.Children2).AsSplitQuery().Single();
+            context.Parents.Include(p => p.Children1).Include(p => p.Children2).OrderBy(e => e.Id).AsSplitQuery().Single();
 
             Assert.Equal(ConnectionState.Closed, dbConnection.State);
         }
@@ -7530,7 +7531,7 @@ ORDER BY [p].[Id]"
 
             Assert.Equal(ConnectionState.Closed, dbConnection.State);
 
-            await context.Parents.Include(p => p.Children1).Include(p => p.Children2).AsSplitQuery().SingleAsync();
+            await context.Parents.Include(p => p.Children1).Include(p => p.Children2).OrderBy(e => e.Id).AsSplitQuery().SingleAsync();
 
             Assert.Equal(ConnectionState.Closed, dbConnection.State);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -17,8 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryLoggingSqlServerTest : IClassFixture<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
-        private static readonly string _eol = Environment.NewLine;
-
         public QueryLoggingSqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
         {
             Fixture = fixture;
@@ -36,9 +34,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .ToList();
 
             Assert.NotNull(customers);
+
+            Assert.StartsWith(
+                "Compiling query expression: ",
+                Fixture.TestSqlLoggerFactory.Log[0].Message);
             Assert.StartsWith(
                 "queryContext => new SingleQueryingEnumerable<Customer>(",
-                Fixture.TestSqlLoggerFactory.Log[0].Message);
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
         }
 
         [ConditionalFact]
@@ -52,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.NotNull(customers);
             Assert.StartsWith(
                 "queryContext => new SplitQueryingEnumerable<Customer>(",
-                Fixture.TestSqlLoggerFactory.Log[0].Message);
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
         }
 
         [ConditionalFact]
@@ -75,35 +77,60 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
         }
 
-        [ConditionalFact(Skip = "Issue#17498")]
+        [ConditionalFact]
         public virtual void Include_navigation()
         {
             using var context = CreateContext();
             var customers
                 = context.Set<Customer>()
+                    .Where(c => c.CustomerID == "ALFKI")
                     .Include(c => c.Orders)
                     .ToList();
 
             Assert.NotNull(customers);
 
             Assert.Equal(
-                "Compiling query model: " + _eol + "'(from Customer c in DbSet<Customer>" + _eol + @"select [c]).Include(""Orders"")'"
-                ,
-                Fixture.TestSqlLoggerFactory.Log[0].Message);
-            Assert.Equal(
-                "Including navigation: '[c].Orders'"
-                ,
+                "Including navigation: 'Customer.Orders'.",
                 Fixture.TestSqlLoggerFactory.Log[1].Message);
-            Assert.StartsWith(
-                "Optimized query model: "
-                + _eol
-                + "'from Customer c in DbSet<Customer>"
-                + _eol
-                + @"order by EF.Property(?[c]?, ""CustomerID"") asc"
-                + _eol
-                + "select Customer _Include("
-                ,
-                Fixture.TestSqlLoggerFactory.Log[2].Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Skip_without_order_by()
+        {
+            using var context = CreateContext();
+            var customers = context.Set<Customer>().Skip(85).ToList();
+
+            Assert.NotNull(customers);
+
+            Assert.Equal(
+                CoreResources.LogRowLimitingOperationWithoutOrderBy(new TestLogger<SqlServerLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
+        }
+
+        [ConditionalFact]
+        public virtual void Take_without_order_by()
+        {
+            using var context = CreateContext();
+            var customers = context.Set<Customer>().Take(5).ToList();
+
+            Assert.NotNull(customers);
+
+            Assert.Equal(
+                CoreResources.LogRowLimitingOperationWithoutOrderBy(new TestLogger<SqlServerLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
+        }
+
+        [ConditionalFact]
+        public virtual void FirstOrDefault_without_filter_order_by()
+        {
+            using var context = CreateContext();
+            var customer = context.Set<Customer>().FirstOrDefault();
+
+            Assert.NotNull(customer);
+
+            Assert.Equal(
+                CoreResources.LogFirstWithoutOrderByAndFilter(new TestLogger<SqlServerLoggingDefinitions>()).GenerateMessage(),
+                Fixture.TestSqlLoggerFactory.Log[1].Message);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
@@ -545,6 +545,7 @@ FROM (
     INNER JOIN [Birds] AS [b] ON [a].[Species] = [b].[Species]
     LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
     LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
+    ORDER BY [a].[Species]
 ) AS [t]
 WHERE [t].[Discriminator] = N'Kiwi'");
         }

--- a/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
@@ -34,7 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .ToList();
 
             var loggerMethods = declaredMethods
-                .ToDictionary(m => m.Name);
+                .GroupBy(e => e.Name)
+                .ToDictionary(m => m.Key, e => e.First());
 
             foreach (var eventIdField in eventIdFields)
             {


### PR DESCRIPTION
Part of #17498

Added messages
- Starting query compilation
- Navigation included
- Skip/Take without order by (infra is in core but providers use to generate the warning)
- First without order by or predicate  (infra is in core but providers use to generate the warning)

Removed messages
- Include ignored (they get removed due to automatic pruning based on expression tree visitation
- Obsolete exception with aggregate operator in relational. We logged that when doing client eval of aggregate operation
- Optimized query model - there is no more optimization phase.

Other fixes
- Don't log parameter values in Cosmos when sensitive data logging is not enabled.
