### PR TITLE
SqlServer Migrations: Add EXEC calls to idempotent script

### DIFF
--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         public virtual string ScriptMigration(
             [CanBeNull] string fromMigration,
             [CanBeNull] string toMigration,
-            bool idempotent,
+            MigrationsSqlGenerationOptions options,
             [CanBeNull] string contextType)
         {
             using var context = _contextOperations.CreateContext(contextType);
@@ -174,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var migrator = services.GetRequiredService<IMigrator>();
 
-            return migrator.GenerateScript(fromMigration, toMigration, idempotent);
+            return migrator.GenerateScript(fromMigration, toMigration, options);
         }
 
         /// <summary>

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -297,11 +297,19 @@ namespace Microsoft.EntityFrameworkCore.Design
             [CanBeNull] string toMigration,
             bool idempotent,
             [CanBeNull] string contextType)
-            => MigrationsOperations.ScriptMigration(
+        {
+            var options = MigrationsSqlGenerationOptions.Default;
+            if (idempotent)
+            {
+                options |= MigrationsSqlGenerationOptions.Idempotent;
+            }
+
+            return MigrationsOperations.ScriptMigration(
                 fromMigration,
                 toMigration,
-                idempotent,
+                options,
                 contextType);
+        }
 
         /// <summary>
         ///     Represents an operation to remove the last migration.

--- a/src/EFCore.Relational/Migrations/IMigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrationsSqlGenerator.cs
@@ -28,9 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="operations"> The operations. </param>
         /// <param name="model"> The target model which may be <see langword="null" /> if the operations exist without a model. </param>
+        /// <param name="options"> The options to use when generating commands. </param>
         /// <returns> The list of commands to be executed or scripted. </returns>
         IReadOnlyList<MigrationCommand> Generate(
             [NotNull] IReadOnlyList<MigrationOperation> operations,
-            [CanBeNull] IModel model = null);
+            [CanBeNull] IModel model = null,
+            MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default);
     }
 }

--- a/src/EFCore.Relational/Migrations/IMigrator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrator.cs
@@ -54,12 +54,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="toMigration">
         ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
         /// </param>
-        /// <param name="idempotent">
-        ///     If <see langword="true" />, then idempotent scripts will be generated, otherwise
-        ///     scripts will be generated that assume none of the migrations in the range specified have
-        ///     already been applied to the database.
+        /// <param name="options">
+        ///     The options to use when generating SQL for migrations.
         /// </param>
         /// <returns> The generated script. </returns>
-        string GenerateScript([CanBeNull] string fromMigration = null, [CanBeNull] string toMigration = null, bool idempotent = false);
+        string GenerateScript([CanBeNull] string fromMigration = null, [CanBeNull] string toMigration = null, MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default);
     }
 }

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerationOptions.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerationOptions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.Migrations
+{
+    /// <summary>
+    ///     The options to use when generating SQL for migrations.
+    /// </summary>
+    [Flags]
+    public enum MigrationsSqlGenerationOptions
+    {
+        /// <summary>
+        ///     Generate SQL to execute at runtime.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        ///     Generate SQL for a script. Automatically added by <see cref="IMigrator.GenerateScript" />.
+        /// </summary>
+        Script = 1,
+
+        /// <summary>
+        ///     Generate SQL for an idempotent script.
+        /// </summary>
+        Idempotent = 1 << 1
+    }
+}

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -108,21 +108,37 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         protected virtual IComparer<string> VersionComparer { get; } = new SemanticVersionComparer();
 
         /// <summary>
+        ///     Gets or sets the options to use when generating commands.
+        /// </summary>
+        protected virtual MigrationsSqlGenerationOptions Options { get; set; }
+
+        /// <summary>
         ///     Generates commands from a list of operations.
         /// </summary>
         /// <param name="operations"> The operations. </param>
         /// <param name="model"> The target model which may be <see langword="null" /> if the operations exist without a model. </param>
+        /// <param name="options"> The options to use when generating commands. </param>
         /// <returns> The list of commands to be executed or scripted. </returns>
         public virtual IReadOnlyList<MigrationCommand> Generate(
             IReadOnlyList<MigrationOperation> operations,
-            IModel model = null)
+            IModel model = null,
+            MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
         {
             Check.NotNull(operations, nameof(operations));
 
+            Options = options;
+
             var builder = new MigrationCommandListBuilder(Dependencies);
-            foreach (var operation in operations)
+            try
             {
-                Generate(operation, model, builder);
+                foreach (var operation in operations)
+                {
+                    Generate(operation, model, builder);
+                }
+            }
+            finally
+            {
+                Options = MigrationsSqlGenerationOptions.Default;
             }
 
             return builder.GetCommandList();

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -137,10 +137,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the commands that will create all tables from the model.
         /// </summary>
+        /// <param name="options"> The options to use when generating commands. </param>
         /// <returns> The generated commands. </returns>
-        protected virtual IReadOnlyList<MigrationCommand> GetCreateTablesCommands()
+        protected virtual IReadOnlyList<MigrationCommand> GetCreateTablesCommands(MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
             => Dependencies.MigrationsSqlGenerator.Generate(
-                Dependencies.ModelDiffer.GetDifferences(null, Dependencies.Model.GetRelationalModel()), Dependencies.Model);
+                Dependencies.ModelDiffer.GetDifferences(null, Dependencies.Model.GetRelationalModel()), Dependencies.Model, options);
 
         /// <summary>
         ///     Determines whether the database contains any tables. No attempt is made to determine if
@@ -291,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </returns>
         public virtual string GenerateCreateScript()
         {
-            var commands = GetCreateTablesCommands();
+            var commands = GetCreateTablesCommands(MigrationsSqlGenerationOptions.Script);
             var builder = new StringBuilder();
             foreach (var command in commands)
             {

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -49,9 +49,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="operations"> The operations. </param>
         /// <param name="model"> The target model which may be <see langword="null" /> if the operations exist without a model. </param>
+        /// <param name="options"> The options to use when generating commands. </param>
         /// <returns> The list of commands to be executed or scripted. </returns>
-        public override IReadOnlyList<MigrationCommand> Generate(IReadOnlyList<MigrationOperation> operations, IModel model = null)
-            => base.Generate(RewriteOperations(operations, model), model);
+        public override IReadOnlyList<MigrationCommand> Generate(IReadOnlyList<MigrationOperation> operations, IModel model = null, MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
+            => base.Generate(RewriteOperations(operations, model), model, options);
 
         private bool IsSpatialiteColumn(AddColumnOperation operation, IModel model)
             => SqliteTypeMappingSource.IsSpatialiteType(

--- a/test/EFCore.Relational.Specification.Tests/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsInfrastructureTestBase.cs
@@ -207,7 +207,7 @@ namespace Microsoft.EntityFrameworkCore
             using var db = Fixture.CreateContext();
             var migrator = db.GetService<IMigrator>();
 
-            SetSql(migrator.GenerateScript(idempotent: true));
+            SetSql(migrator.GenerateScript(options: MigrationsSqlGenerationOptions.Idempotent));
         }
 
         [ConditionalFact]
@@ -256,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore
                 migrator.GenerateScript(
                     fromMigration: "Migration2",
                     toMigration: Migration.InitialDatabase,
-                    idempotent: true));
+                    MigrationsSqlGenerationOptions.Idempotent));
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore
             public Task MigrateAsync(string targetMigration = null, CancellationToken cancellationToken = new CancellationToken()) =>
                 throw new NotImplementedException();
 
-            public string GenerateScript(string fromMigration = null, string toMigration = null, bool idempotent = false) =>
+            public string GenerateScript(string fromMigration = null, string toMigration = null, MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default) =>
                 throw new NotImplementedException();
         }
 

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
@@ -1042,13 +1042,5 @@ PRAGMA foreign_keys = 1;
                   .OptionsBuilder).Options)
         {
         }
-
-        protected virtual void Generate(Action<ModelBuilder> buildAction, Action<MigrationBuilder> migrateAction)
-        {
-            var migrationBuilder = new MigrationBuilder(activeProvider: null);
-            migrateAction(migrationBuilder);
-
-            Generate(buildAction, migrationBuilder.Operations.ToArray());
-        }
     }
 }


### PR DESCRIPTION
Also adds the ability for providers to detected whether a script is being generated and whether its idempotent. (resolves #14746)

Fixes #12911

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


