### PR TITLE
Query: Fix bug in CaseExpression.VisitChildren

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/CaseExpression.cs
@@ -98,7 +98,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             changed |= elseResult != ElseResult;
 
             return changed
-                ? new CaseExpression(operand, whenClauses, elseResult)
+                ? operand == null
+                    ? new CaseExpression(whenClauses, elseResult)
+                    : new CaseExpression(operand, whenClauses, elseResult)
                 : this;
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4155,6 +4155,12 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
             return base.Max_on_empty_sequence_throws(async);
         }
 
+        [ConditionalTheory(Skip = "string.IndexOf Issue#17246")]
+        public override Task Distinct_followed_by_ordering_on_condition(bool async)
+        {
+            return base.Distinct_followed_by_ordering_on_condition(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -6099,5 +6099,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }),
                 assertOrder: true);
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Distinct_followed_by_ordering_on_condition(bool async)
+        {
+            var searchTerm = "c";
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                        .Where(c => c.CustomerID != "VAFFE" && c.CustomerID != "DRACD")
+                        .Select(e => e.City)
+                        .Distinct()
+                        .OrderBy(x => x.IndexOf(searchTerm))
+                        .ThenBy(x => x)
+                        .Take(5),
+                assertOrder: true);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5222,6 +5222,26 @@ WHERE [c1].[CustomerID] LIKE N'F%'
 ORDER BY [c1].[CustomerID]");
         }
 
+        public override async Task Distinct_followed_by_ordering_on_condition(bool async)
+        {
+            await base.Distinct_followed_by_ordering_on_condition(async);
+
+            AssertSql(
+                @"@__p_1='5'
+@__searchTerm_0='c' (Size = 4000)
+
+SELECT TOP(@__p_1) [t].[City]
+FROM (
+    SELECT DISTINCT [c].[City]
+    FROM [Customers] AS [c]
+    WHERE [c].[CustomerID] NOT IN (N'VAFFE', N'DRACD')
+) AS [t]
+ORDER BY CASE
+    WHEN @__searchTerm_0 = N'' THEN 0
+    ELSE CAST(CHARINDEX(@__searchTerm_0, [t].[City]) AS int) - 1
+END, [t].[City]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #21934
