### PR TITLE
Configure OnDelete for join entity types on SQL Server

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -73,6 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
+            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(new SqlServerOnDeleteConvention(Dependencies, RelationalDependencies));
+
             conventionSet.IndexAddedConventions.Add(sqlServerInMemoryTablesConvention);
             conventionSet.IndexAddedConventions.Add(sqlServerIndexConvention);
 

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         /// <inheritdoc />
-        public void ProcessSkipNavigationForeignKeyChanged(
+        public virtual void ProcessSkipNavigationForeignKeyChanged(
             IConventionSkipNavigationBuilder skipNavigationBuilder,
             IConventionForeignKey foreignKey,
             IConventionForeignKey oldForeignKey,
@@ -35,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var selfReferencingSkipNavigation = skipNavigationBuilder.Metadata;
             if (foreignKey == null
+                || foreignKey.DeleteBehavior != DeleteBehavior.Cascade
                 || selfReferencingSkipNavigation.Inverse == null
                 || selfReferencingSkipNavigation.TargetEntityType != selfReferencingSkipNavigation.DeclaringEntityType)
             {

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures the OnDelete behavior for foreign keys on the join entity type for
+    ///     self-referencing skip navigations
+    /// </summary>
+    public class SqlServerOnDeleteConvention : ISkipNavigationForeignKeyChangedConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="SqlServerOnDeleteConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies">  Parameter object containing relational dependencies for this convention. </param>
+        public SqlServerOnDeleteConvention(
+            [NotNull] ProviderConventionSetBuilderDependencies dependencies,
+            [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
+        {
+        }
+
+        /// <inheritdoc />
+        public void ProcessSkipNavigationForeignKeyChanged(
+            IConventionSkipNavigationBuilder skipNavigationBuilder,
+            IConventionForeignKey foreignKey,
+            IConventionForeignKey oldForeignKey,
+            IConventionContext<IConventionForeignKey> context)
+        {
+            var selfReferencingSkipNavigation = skipNavigationBuilder.Metadata;
+            if (foreignKey == null
+                || selfReferencingSkipNavigation.Inverse == null
+                || selfReferencingSkipNavigation.TargetEntityType != selfReferencingSkipNavigation.DeclaringEntityType)
+            {
+                return;
+            }
+
+            if (selfReferencingSkipNavigation == selfReferencingSkipNavigation.DeclaringEntityType.GetDeclaredSkipNavigations()
+                .First(s => s == selfReferencingSkipNavigation || s == selfReferencingSkipNavigation.Inverse))
+            {
+                foreignKey.Builder.OnDelete(DeleteBehavior.ClientCascade);
+                selfReferencingSkipNavigation.Inverse.ForeignKey?.Builder.OnDelete(null);
+            }
+        }
+    }
+}

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerValueGenerationStrategyConvention.cs
@@ -23,13 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] ProviderConventionSetBuilderDependencies dependencies,
             [NotNull] RelationalConventionSetBuilderDependencies relationalDependencies)
         {
-            Dependencies = dependencies;
         }
-
-        /// <summary>
-        ///     Parameter object containing service dependencies.
-        /// </summary>
-        protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
 
         /// <summary>
         ///     Called after a model is initialized.

--- a/src/EFCore/Metadata/Conventions/IForeignKeyAddedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IForeignKeyAddedConvention.cs
@@ -14,10 +14,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// <summary>
         ///     Called after a foreign key is added to the entity type.
         /// </summary>
-        /// <param name="relationshipBuilder"> The builder for the foreign key. </param>
+        /// <param name="foreignKeyBuilder"> The builder for the foreign key. </param>
         /// <param name="context"> Additional information associated with convention execution. </param>
         void ProcessForeignKeyAdded(
-            [NotNull] IConventionForeignKeyBuilder relationshipBuilder,
+            [NotNull] IConventionForeignKeyBuilder foreignKeyBuilder,
             [NotNull] IConventionContext<IConventionForeignKeyBuilder> context);
     }
 }

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             {
                 var manyToManyForeignKeys = entityType.GetForeignKeys()
                     .Where(fk => fk.GetReferencingSkipNavigations().Any(n => n.IsCollection)).ToList();
-                if (manyToManyForeignKeys.Count() == 2)
+                if (manyToManyForeignKeys.Count == 2)
                 {
                     keyProperties.AddRange(manyToManyForeignKeys.SelectMany(fk => fk.Properties));
                 }

--- a/src/EFCore/Metadata/Conventions/ManyToManyJoinEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ManyToManyJoinEntityTypeConvention.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -109,7 +110,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var inverseEntityType = inverseSkipNavigation.DeclaringEntityType;
             var model = declaringEntityType.Model;
 
-            var joinEntityTypeName = declaringEntityType.ShortName() + inverseEntityType.ShortName();
+            var joinEntityTypeName = declaringEntityType.ShortName();
+            var inverseName = inverseEntityType.ShortName();
+            joinEntityTypeName = StringComparer.Ordinal.Compare(joinEntityTypeName, inverseName) < 0
+                ? joinEntityTypeName + inverseName
+                : inverseName + joinEntityTypeName;
+
             if (model.FindEntityType(joinEntityTypeName) != null)
             {
                 var otherIdentifiers = model.GetEntityTypes().ToDictionary(et => et.Name, et => 0);

--- a/src/EFCore/Metadata/Conventions/ManyToManyJoinEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ManyToManyJoinEntityTypeConvention.cs
@@ -153,7 +153,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .HasRelationship(
                     skipNavigation.DeclaringEntityType,
                     ConfigurationSource.Convention,
-                    required: true)
+                    required: true,
+                    skipNavigation.Inverse.Name)
                 .IsUnique(false, ConfigurationSource.Convention)
                 .Metadata;
     }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1124,15 +1124,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     + @"
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
                 {
-                    b.Property<int>(""ManyToManyLeftId"")
+                    b.Property<int>(""LeftsId"")
                         .HasColumnType(""int"");
 
-                    b.Property<int>(""ManyToManyRightId"")
+                    b.Property<int>(""RightsId"")
                         .HasColumnType(""int"");
 
-                    b.HasKey(""ManyToManyLeftId"", ""ManyToManyRightId"");
+                    b.HasKey(""LeftsId"", ""RightsId"");
 
-                    b.HasIndex(""ManyToManyRightId"");
+                    b.HasIndex(""RightsId"");
 
                     b.ToTable(""ManyToManyLeftManyToManyRight"");
                 });
@@ -1171,13 +1171,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyLeftId"")
+                        .HasForeignKey(""LeftsId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyRightId"")
+                        .HasForeignKey(""RightsId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });"),
@@ -1188,22 +1188,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Collection(joinEntity.GetDeclaredProperties(),
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeftId", p.Name);
+                            Assert.Equal("LeftsId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRightId", p.Name);
+                            Assert.Equal("RightsId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         });
                     Assert.Collection(joinEntity.FindDeclaredPrimaryKey().Properties,
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeftId", p.Name);
+                            Assert.Equal("LeftsId", p.Name);
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRightId", p.Name);
+                            Assert.Equal("RightsId", p.Name);
                         });
                     Assert.Collection(joinEntity.GetDeclaredForeignKeys(),
                         fk =>
@@ -1217,7 +1217,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyLeftId", p.Name);
+                                    Assert.Equal("LeftsId", p.Name);
                                 });
                         },
                         fk =>
@@ -1231,7 +1231,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyRightId", p.Name);
+                                    Assert.Equal("RightsId", p.Name);
                                 });
                         });
                 });
@@ -1254,15 +1254,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     + @"
             modelBuilder.Entity(""ManyToManyLeftManyToManyRight"", b =>
                 {
-                    b.Property<int>(""ManyToManyLeftId"")
+                    b.Property<int>(""LeftsId"")
                         .HasColumnType(""int"");
 
-                    b.Property<int>(""ManyToManyRightId"")
+                    b.Property<int>(""RightsId"")
                         .HasColumnType(""int"");
 
-                    b.HasKey(""ManyToManyLeftId"", ""ManyToManyRightId"");
+                    b.HasKey(""LeftsId"", ""RightsId"");
 
-                    b.HasIndex(""ManyToManyRightId"");
+                    b.HasIndex(""RightsId"");
 
                     b.ToTable(""MyJoinTable"");
                 });
@@ -1301,13 +1301,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyLeftId"")
+                        .HasForeignKey(""LeftsId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyRight"", null)
                         .WithMany()
-                        .HasForeignKey(""ManyToManyRightId"")
+                        .HasForeignKey(""RightsId"")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });"),
@@ -1319,22 +1319,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     Assert.Collection(joinEntity.GetDeclaredProperties(),
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeftId", p.Name);
+                            Assert.Equal("LeftsId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRightId", p.Name);
+                            Assert.Equal("RightsId", p.Name);
                             Assert.True(p.IsShadowProperty());
                         });
                     Assert.Collection(joinEntity.FindDeclaredPrimaryKey().Properties,
                         p =>
                         {
-                            Assert.Equal("ManyToManyLeftId", p.Name);
+                            Assert.Equal("LeftsId", p.Name);
                         },
                         p =>
                         {
-                            Assert.Equal("ManyToManyRightId", p.Name);
+                            Assert.Equal("RightsId", p.Name);
                         });
                     Assert.Collection(joinEntity.GetDeclaredForeignKeys(),
                         fk =>
@@ -1348,7 +1348,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyLeftId", p.Name);
+                                    Assert.Equal("LeftsId", p.Name);
                                 });
                         },
                         fk =>
@@ -1362,7 +1362,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             Assert.Collection(fk.Properties,
                                 p =>
                                 {
-                                    Assert.Equal("ManyToManyRightId", p.Name);
+                                    Assert.Equal("RightsId", p.Name);
                                 });
                         });
                 });

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .WithMany(e => e.SelfSkipPayloadRight)
                 .UsingEntity<JoinOneSelfPayload>(
                     l => l.HasOne(x => x.Left).WithMany(x => x.JoinSelfPayloadLeft),
-                    r => r.HasOne(x => x.Right).WithMany(x => x.JoinSelfPayloadRight).OnDelete(DeleteBehavior.ClientCascade));
+                    r => r.HasOne(x => x.Right).WithMany(x => x.JoinSelfPayloadRight));
 
             // Nav:2 Payload:No Join:Concrete Extra:Inheritance
             modelBuilder.Entity<EntityOne>()
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .UsingEntity<Dictionary<string, object>>(
                     "JoinTwoSelfShared",
                     l => l.HasOne<EntityTwo>().WithMany().HasForeignKey("LeftId"),
-                    r => r.HasOne<EntityTwo>().WithMany().HasForeignKey("RightId").OnDelete(DeleteBehavior.NoAction));
+                    r => r.HasOne<EntityTwo>().WithMany().HasForeignKey("RightId"));
 
             // Nav:2 Payload:No Join:Shared Extra:CompositeKey
             modelBuilder.Entity<EntityTwo>()

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -165,6 +165,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .WithOne(e => e.ReferenceInverse)
                 .HasForeignKey<EntityTwo>(e => e.ReferenceInverseId);
 
+            // TODO: Remove UsingEntity
+            modelBuilder.Entity<EntityOne>()
+                .HasMany(e => e.TwoSkipShared)
+                .WithMany(e => e.OneSkipShared)
+                .UsingEntity<Dictionary<string, object>>(
+                    "EntityOneEntityTwo",
+                    r => r.HasOne<EntityTwo>().WithMany().HasForeignKey("EntityTwoId"),
+                    l => l.HasOne<EntityOne>().WithMany().HasForeignKey("EntityOneId"));
+
             // Nav:2 Payload:No Join:Concrete Extra:None
             modelBuilder.Entity<EntityOne>()
                 .HasMany(e => e.TwoSkip)
@@ -226,6 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     l => l.HasOne(x => x.Two).WithMany(e => e.JoinThreeFull));
 
             // Nav:2 Payload:No Join:Shared Extra:Self-ref
+            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityTwo>()
                 .HasMany(e => e.SelfSkipSharedLeft)
                 .WithMany(e => e.SelfSkipSharedRight)
@@ -235,6 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     r => r.HasOne<EntityTwo>().WithMany().HasForeignKey("RightId"));
 
             // Nav:2 Payload:No Join:Shared Extra:CompositeKey
+            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityTwo>()
                 .HasMany(e => e.CompositeKeySkipShared)
                 .WithMany(e => e.TwoSkipShared)
@@ -253,9 +264,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                     r => r.HasOne(x => x.Three).WithMany(x => x.JoinCompositeKeyFull).IsRequired());
 
             // Nav:2 Payload:No Join:Shared Extra:Inheritance
-            modelBuilder.Entity<EntityThree>().HasMany(e => e.RootSkipShared).WithMany(e => e.ThreeSkipShared);
+            // TODO: Remove UsingEntity
+            modelBuilder.Entity<EntityThree>().HasMany(e => e.RootSkipShared).WithMany(e => e.ThreeSkipShared)
+                .UsingEntity<Dictionary<string, object>>(
+                    "EntityRootEntityThree",
+                    r => r.HasOne<EntityRoot>().WithMany().HasForeignKey("EntityRootId"),
+                    l => l.HasOne<EntityThree>().WithMany().HasForeignKey("EntityThreeId"));
 
             // Nav:2 Payload:No Join:Shared Extra:Inheritance,CompositeKey
+            // TODO: Remove UsingEntity
             modelBuilder.Entity<EntityCompositeKey>()
                 .HasMany(e => e.RootSkipShared)
                 .WithMany(e => e.CompositeKeySkipShared)

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyTrackingSqlServerTestBase.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class ManyToManyTrackingSqlServerTestBase<TFixture> : ManyToManyTrackingTestBase<TFixture>
-        where TFixture : ManyToManyTrackingTestBase<TFixture>.ManyToManyTrackingFixtureBase
+        where TFixture : ManyToManyTrackingSqlServerTestBase<TFixture>.ManyToManyTrackingSqlServerFixtureBase
     {
         protected ManyToManyTrackingSqlServerTestBase(TFixture fixture)
             : base(fixture)

--- a/test/EFCore.Tests/Metadata/Conventions/ManyToManyJoinEntityTypeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ManyToManyJoinEntityTypeConventionTest.cs
@@ -45,8 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             RunConvention(firstSkipNav);
 
-            Assert.Single(manyToManySelf.Metadata.Model.GetEntityTypes()
-                .Where(et => et.IsImplicitlyCreatedJoinEntityType));
+            var joinEntityType = manyToManySelf.Metadata.Model.GetEntityTypes()
+                .Single(et => et.IsImplicitlyCreatedJoinEntityType);
+            Assert.Equal("ManyToManySelfManyToManySelf", joinEntityType.Name);
         }
 
         [ConditionalFact]
@@ -222,7 +223,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 ConfigurationSource.Convention);
             skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
-            RunConvention(skipNavOnFirst);
+            RunConvention(skipNavOnSecond);
 
             var joinEntityType = manyToManyFirst.Metadata.Model.GetEntityTypes()
                 .Single(et => et.IsImplicitlyCreatedJoinEntityType);

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -158,8 +158,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var key = joinEntityType.FindPrimaryKey();
                 Assert.Equal(
                     new[] {
-                        nameof(ImplicitManyToManyA) + nameof(ImplicitManyToManyA.Id),
-                        nameof(ImplicitManyToManyB) + nameof(ImplicitManyToManyB.Id) },
+                        nameof(ImplicitManyToManyB.As) + nameof(ImplicitManyToManyA.Id),
+                        nameof(ImplicitManyToManyA.Bs) + nameof(ImplicitManyToManyB.Id) },
                     key.Properties.Select(p => p.Name));
 
                 Assert.DoesNotContain(joinEntityType.GetProperties(), p => !p.IsIndexerProperty());


### PR DESCRIPTION
Make join entity type name deterministic
Use skip navigation name for the implicit FK name

Fixes #21858
Fixes #21870
Fixes #21915

