### PR TITLE
MemberEntry support for skip navigations

### DIFF
--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -141,7 +141,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 return new PropertyEntry(InternalEntry, propertyName);
             }
 
-            var navigation = InternalEntry.EntityType.FindNavigation(propertyName);
+            var navigation = (INavigationBase)InternalEntry.EntityType.FindNavigation(propertyName)
+                ?? InternalEntry.EntityType.FindSkipNavigation(propertyName);
             if (navigation != null)
             {
                 return navigation.IsCollection
@@ -170,7 +171,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             Check.NotEmpty(propertyName, nameof(propertyName));
 
-            var navigation = InternalEntry.EntityType.FindNavigation(propertyName);
+            var navigation = (INavigationBase)InternalEntry.EntityType.FindNavigation(propertyName)
+                ?? InternalEntry.EntityType.FindSkipNavigation(propertyName);
+
             if (navigation != null)
             {
                 return navigation.IsCollection

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -847,7 +847,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                     try
                                     {
                                         _inFixup = false;
-                                        joinEntry.SetEntityState(EntityState.Added);
+                                        joinEntry.SetEntityState(setModified ? EntityState.Added : EntityState.Unchanged);
                                     }
                                     finally
                                     {
@@ -892,7 +892,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         try
                         {
                             _inFixup = false;
-                            joinEntry.SetEntityState(EntityState.Added);
+                            joinEntry.SetEntityState(setModified ? EntityState.Added : EntityState.Unchanged);
                         }
                         finally
                         {

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void Load(INavigation navigation, InternalEntityEntry entry)
+        public virtual void Load(INavigationBase navigation, InternalEntityEntry entry)
         {
             if (entry.EntityState == EntityState.Detached)
             {
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual async Task LoadAsync(
-            INavigation navigation,
+            INavigationBase navigation,
             InternalEntityEntry entry,
             CancellationToken cancellationToken = default)
         {
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IQueryable<TEntity> Query(INavigation navigation, InternalEntityEntry entry)
+        public virtual IQueryable<TEntity> Query(INavigationBase navigation, InternalEntityEntry entry)
         {
             if (entry.EntityState == EntityState.Detached)
             {
@@ -236,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 .Select(BuildProjection(entityType));
         }
 
-        private IQueryable<TEntity> Query(INavigation navigation, object[] keyValues)
+        private IQueryable<TEntity> Query(INavigationBase navigation, object[] keyValues)
             => _queryRoot.Where(BuildLambda(GetLoadProperties(navigation), new ValueBuffer(keyValues))).AsTracking();
 
         /// <summary>
@@ -245,14 +245,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IQueryable IEntityFinder.Query(INavigation navigation, InternalEntityEntry entry)
+        IQueryable IEntityFinder.Query(INavigationBase navigation, InternalEntityEntry entry)
             => Query(navigation, entry);
 
-        private static object[] GetLoadValues(INavigation navigation, InternalEntityEntry entry)
+        private static object[] GetLoadValues(INavigationBase navigation, InternalEntityEntry entry)
         {
-            var properties = navigation.IsOnDependent
-                ? navigation.ForeignKey.Properties
-                : navigation.ForeignKey.PrincipalKey.Properties;
+            var properties = ((INavigation)navigation).IsOnDependent
+                ? ((INavigation)navigation).ForeignKey.Properties
+                : ((INavigation)navigation).ForeignKey.PrincipalKey.Properties;
 
             var values = new object[properties.Count];
 
@@ -270,10 +270,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return values;
         }
 
-        private static IReadOnlyList<IProperty> GetLoadProperties(INavigation navigation)
-            => navigation.IsOnDependent
-                ? navigation.ForeignKey.PrincipalKey.Properties
-                : navigation.ForeignKey.Properties;
+        private static IReadOnlyList<IProperty> GetLoadProperties(INavigationBase navigation)
+            => ((INavigation)navigation).IsOnDependent
+                ? ((INavigation)navigation).ForeignKey.PrincipalKey.Properties
+                : ((INavigation)navigation).ForeignKey.Properties;
 
         private TEntity FindTracked(object[] keyValues, out IReadOnlyList<IProperty> keyProperties)
         {

--- a/src/EFCore/Internal/IEntityFinder.cs
+++ b/src/EFCore/Internal/IEntityFinder.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        void Load([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
+        void Load([NotNull] INavigationBase navigation, [NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         Task LoadAsync(
-            [NotNull] INavigation navigation,
+            [NotNull] INavigationBase navigation,
             [NotNull] InternalEntityEntry entry,
             CancellationToken cancellationToken = default);
 
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IQueryable Query([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
+        IQueryable Query([NotNull] INavigationBase navigation, [NotNull] InternalEntityEntry entry);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IEntityFinder`.cs
+++ b/src/EFCore/Internal/IEntityFinder`.cs
@@ -41,6 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        new IQueryable<TEntity> Query([NotNull] INavigation navigation, [NotNull] InternalEntityEntry entry);
+        new IQueryable<TEntity> Query([NotNull] INavigationBase navigation, [NotNull] InternalEntityEntry entry);
     }
 }

--- a/src/EFCore/Update/UpdateEntryExtensions.cs
+++ b/src/EFCore/Update/UpdateEntryExtensions.cs
@@ -145,7 +145,8 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             if ((options & ChangeTrackerDebugStringOptions.IncludeNavigations) != 0)
             {
-                foreach (var navigation in entry.EntityType.GetNavigations())
+                foreach (var navigation in entry.EntityType.GetNavigations()
+                    .Concat<INavigationBase>(entry.EntityType.GetSkipNavigations()))
                 {
                     builder.AppendLine().Append(indentString);
 

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -507,6 +507,7 @@ namespace System
         private static readonly MethodInfo _generateDefaultValueConstantMethod =
             typeof(SharedTypeExtensions).GetTypeInfo().GetDeclaredMethod(nameof(GenerateDefaultValueConstant));
 
-        private static ConstantExpression GenerateDefaultValueConstant<TDefault>() => Expression.Constant(default(TDefault));
+        private static ConstantExpression GenerateDefaultValueConstant<TDefault>()
+            => Expression.Constant(default(TDefault), typeof(TDefault));
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
@@ -1,0 +1,577 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    public class SkipCollectionEntryTest
+    {
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_back_reference(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            var entityEntry = context.Entry(entity);
+            Assert.Same(entityEntry.Entity, entityEntry.Collection("Chunkies").EntityEntry.Entity);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_back_reference_generic(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            var entityEntry = context.Entry(entity);
+            Assert.Same(entityEntry.Entity, entityEntry.Collection(e => e.Chunkies).EntityEntry.Entity);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_metadata(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            Assert.Equal("Chunkies", context.Entry(entity).Collection("Chunkies").Metadata.Name);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_metadata_generic(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            Assert.Equal("Chunkies", context.Entry(entity).Collection(e => e.Chunkies).Metadata.Name);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.AddRange(chunky, cherry);
+
+            var collection = context.Entry(cherry).Collection("Chunkies");
+            var inverseCollection = context.Entry(chunky).Collection("Cherries");
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+            Assert.Same(cherry, inverseCollection.CurrentValue.Cast<Cherry>().Single());
+            Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Empty(inverseCollection.CurrentValue);
+            Assert.Null(collection.FindEntry(chunky));
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value_generic(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.AddRange(chunky, cherry);
+
+            var collection = context.Entry(cherry).Collection(e => e.Chunkies);
+            var inverseCollection = context.Entry(chunky).Collection(e => e.Cherries);
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, collection.CurrentValue.Single());
+            Assert.Same(cherry, inverseCollection.CurrentValue.Single());
+            Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Empty(inverseCollection.CurrentValue);
+            Assert.Null(collection.FindEntry(chunky));
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value_not_tracked(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+
+            var collection = context.Entry(cherry).Collection("Chunkies");
+            var inverseCollection = context.Entry(chunky).Collection("Cherries");
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Null(chunky.Cherries);
+            Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+            Assert.Null(inverseCollection.CurrentValue);
+
+            collection.CurrentValue = null;
+
+            Assert.Null(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Null(inverseCollection.CurrentValue);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value_generic_not_tracked(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+
+            var collection = context.Entry(cherry).Collection(e => e.Chunkies);
+            var inverseCollection = context.Entry(chunky).Collection(e => e.Cherries);
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Null(chunky.Cherries);
+            Assert.Same(chunky, collection.CurrentValue.Single());
+            Assert.Null(inverseCollection.CurrentValue);
+
+            collection.CurrentValue = null;
+
+            Assert.Null(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Null(inverseCollection.CurrentValue);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value_start_tracking(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.Add(cherry);
+
+            var collection = context.Entry(cherry).Collection("Chunkies");
+            var inverseCollection = context.Entry(chunky).Collection("Cherries");
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
+            Assert.Same(cherry, inverseCollection.CurrentValue.Cast<Cherry>().Single());
+
+            Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+            Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Empty(inverseCollection.CurrentValue);
+
+            Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+            Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Can_get_and_set_current_value_start_tracking_generic(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.Add(cherry);
+
+            var collection = context.Entry(cherry).Collection(e => e.Chunkies);
+            var inverseCollection = context.Entry(chunky).Collection(e => e.Cherries);
+
+            Assert.Null(collection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, collection.CurrentValue.Single());
+            Assert.Same(cherry, inverseCollection.CurrentValue.Single());
+
+            Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+            Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Null(collection.CurrentValue);
+            Assert.Empty(inverseCollection.CurrentValue);
+
+            Assert.Equal(EntityState.Added, context.Entry(cherry).State);
+            Assert.Equal(EntityState.Added, context.Entry(chunky).State);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsModified_tracks_detects_deletion_of_related_entity(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+
+            context.Entry(chunky1).State = EntityState.Deleted;
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.True(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsModified_tracks_adding_new_related_entity(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            var chunky3 = new Chunky { Id = 3 };
+            cherry1.Chunkies.Add(chunky3);
+            context.ChangeTracker.DetectChanges();
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+
+            context.Entry(chunky3).State = EntityState.Detached;
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsModified_tracks_removing_items_from_the_join_table(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            cherry1.Chunkies.Remove(chunky2);
+            context.ChangeTracker.DetectChanges();
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+
+            cherry1.Chunkies.Add(chunky2);
+            context.ChangeTracker.DetectChanges();
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsModified_tracks_adding_items_to_the_join_table(bool useExplicitPk)
+        {
+            using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            cherry2.Chunkies.Add(chunky1);
+            context.ChangeTracker.DetectChanges();
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.True(relatedToCherry2.IsModified);
+            Assert.True(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+        }
+
+        [ConditionalFact]
+        public void IsModified_tracks_mutation_of_join_fks()
+        {
+            using var context = new ExplicitFreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            var joinEntity = context.ChangeTracker.Entries<Dictionary<string, object>>()
+                .Single(e => e.Property<int?>("CherryId").CurrentValue == 1 && e.Property<int?>("ChunkyId").CurrentValue == 2)
+                .Entity;
+
+            joinEntity["CherryId"] = 2;
+            context.ChangeTracker.DetectChanges();
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.True(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+
+            joinEntity["CherryId"] = 1;
+            context.ChangeTracker.DetectChanges();
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+        }
+
+        [ConditionalFact]
+        public void Setting_IsModified_true_marks_all_join_table_FK_modified()
+        {
+            using var context = new ExplicitFreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+
+            foreach (var joinEntry in context.ChangeTracker.Entries<Dictionary<string, object>>())
+            {
+                Assert.Equal(EntityState.Unchanged, joinEntry.State);
+            }
+
+            relatedToCherry1.IsModified = true;
+
+            Assert.True(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.True(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+
+            foreach (var joinEntry in context.ChangeTracker.Entries<Dictionary<string, object>>())
+            {
+                Assert.Equal(EntityState.Modified, joinEntry.State);
+            }
+        }
+
+        [ConditionalFact]
+        public void Setting_IsModified_false_reverts_changes_to_join_table_FKs()
+        {
+            using var context = new ExplicitFreezerContext();
+
+            var cherry1 = new Cherry { Id = 1 };
+            var cherry2 = new Cherry { Id = 2 };
+            var chunky1 = new Chunky { Id = 1 };
+            var chunky2 = new Chunky { Id = 2 };
+
+            AttachGraph(context, cherry1, cherry2, chunky1, chunky2);
+
+            var relatedToCherry1 = context.Entry(cherry1).Collection(e => e.Chunkies);
+            var relatedToCherry2 = context.Entry(cherry2).Collection(e => e.Chunkies);
+            var relatedToChunky1 = context.Entry(chunky1).Collection(e => e.Cherries);
+            var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
+
+            var joinEntity = context.ChangeTracker.Entries<Dictionary<string, object>>()
+                .Single(e => e.Property<int?>("CherryId").CurrentValue == 1 && e.Property<int?>("ChunkyId").CurrentValue == 2)
+                .Entity;
+
+            joinEntity["CherryId"] = 2;
+            context.ChangeTracker.DetectChanges();
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.True(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.True(relatedToChunky2.IsModified);
+
+            relatedToCherry2.IsModified = false;
+
+            Assert.False(relatedToCherry1.IsModified);
+            Assert.False(relatedToCherry2.IsModified);
+            Assert.False(relatedToChunky1.IsModified);
+            Assert.False(relatedToChunky2.IsModified);
+
+            foreach (var joinEntry in context.ChangeTracker.Entries<Dictionary<string, object>>())
+            {
+                Assert.Equal(EntityState.Unchanged, joinEntry.State);
+            }
+        }
+
+        private static void AttachGraph(FreezerContext context, Cherry cherry1, Cherry cherry2, Chunky chunky1, Chunky chunky2)
+        {
+            cherry1.Chunkies = new List<Chunky> { chunky1, chunky2 };
+            cherry2.Chunkies = new List<Chunky>();
+
+            if (context is ExplicitFreezerContext)
+            {
+                context.AddRange(cherry1, cherry2, chunky1, chunky2); // So that PKs get generated values
+                context.ChangeTracker.Entries().ToList().ForEach(e => e.State = EntityState.Unchanged);
+            }
+            else
+            {
+                context.AttachRange(cherry1, cherry2, chunky1, chunky2);
+            }
+        }
+
+        private class Chunky
+        {
+            public int Id { get; set; }
+            public ICollection<Cherry> Cherries { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Id { get; set; }
+            public ICollection<Chunky> Chunkies { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+
+        private class ExplicitFreezerContext : FreezerContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(ExplicitFreezerContext));
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder
+                    .Entity<Cherry>().HasMany(e => e.Chunkies).WithMany(e => e.Cherries)
+                    .UsingEntity<Dictionary<string, object>>(
+                        "CherryChunky",
+                        b => b.HasOne<Chunky>().WithMany().HasForeignKey("ChunkyId"),
+                        b => b.HasOne<Cherry>().WithMany().HasForeignKey("CherryId"))
+                    .IndexerProperty<int>("Id");
+            }
+        }
+    }
+}

--- a/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
@@ -266,11 +266,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void IsModified_tracks_detects_deletion_of_related_entity(bool useExplicitPk)
+        [InlineData(false, CascadeTiming.Immediate)]
+        [InlineData(true, CascadeTiming.Immediate)]
+        [InlineData(false, CascadeTiming.OnSaveChanges)]
+        [InlineData(true, CascadeTiming.OnSaveChanges)]
+        [InlineData(false, CascadeTiming.Never)]
+        [InlineData(true, CascadeTiming.Never)]
+        public void IsModified_tracks_detects_deletion_of_related_entity(bool useExplicitPk, CascadeTiming cascadeTiming)
         {
             using var context = useExplicitPk ? new ExplicitFreezerContext() : new FreezerContext();
+
+            context.ChangeTracker.CascadeDeleteTiming = cascadeTiming;
 
             var cherry1 = new Cherry { Id = 1 };
             var cherry2 = new Cherry { Id = 2 };

--- a/test/EFCore.Tests/ChangeTracking/SkipMemberEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipMemberEntryTest.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    public class SkipMemberEntryTest
+    {
+        [ConditionalFact]
+        public void Can_get_back_reference_collection()
+        {
+            using var context = new FreezerContext();
+            var entity = new Cherry();
+            context.Add(entity);
+
+            var entityEntry = context.Entry(entity);
+            Assert.Same(entityEntry.Entity, entityEntry.Member("Chunkies").EntityEntry.Entity);
+        }
+
+        [ConditionalFact]
+        public void Can_get_metadata_collection()
+        {
+            using var context = new FreezerContext();
+            var entity = new Cherry();
+            context.Add(entity);
+
+            Assert.Equal("Chunkies", context.Entry(entity).Member("Chunkies").Metadata.Name);
+        }
+
+        [ConditionalFact]
+        public void Can_get_and_set_current_value_collection()
+        {
+            using var context = new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.AddRange(chunky, cherry);
+
+            var collection = context.Entry(cherry).Member("Chunkies");
+            var inverseCollection = context.Entry(chunky).Member("Cherries");
+
+            Assert.Null(collection.CurrentValue);
+            Assert.Null(inverseCollection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue).Single());
+            Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Empty((IEnumerable)inverseCollection.CurrentValue);
+            Assert.Null(collection.CurrentValue);
+        }
+
+        private class Chunky
+        {
+            public int Id { get; set; }
+            public ICollection<Cherry> Cherries { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Id { get; set; }
+            public ICollection<Chunky> Chunkies { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Tests/ChangeTracking/SkipNavigationEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipNavigationEntryTest.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    public class SkipNavigationEntryTest
+    {
+        [ConditionalFact]
+        public void Can_get_back_reference_collection()
+        {
+            using var context = new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            var entityEntry = context.Entry(entity);
+            Assert.Same(entityEntry.Entity, entityEntry.Navigation("Chunkies").EntityEntry.Entity);
+        }
+
+        [ConditionalFact]
+        public void Can_get_metadata_collection()
+        {
+            using var context = new FreezerContext();
+
+            var entity = new Cherry();
+            context.Add(entity);
+
+            Assert.Equal("Chunkies", context.Entry(entity).Navigation("Chunkies").Metadata.Name);
+        }
+
+        [ConditionalFact]
+        public void Can_get_and_set_current_value_collection()
+        {
+            using var context = new FreezerContext();
+
+            var cherry = new Cherry();
+            var chunky = new Chunky();
+            context.AddRange(chunky, cherry);
+
+            var collection = context.Entry(cherry).Navigation("Chunkies");
+            var inverseCollection = context.Entry(chunky).Navigation("Cherries");
+
+            Assert.Null(collection.CurrentValue);
+            Assert.Null(inverseCollection.CurrentValue);
+
+            collection.CurrentValue = new List<Chunky> { chunky };
+
+            Assert.Same(cherry, chunky.Cherries.Single());
+            Assert.Same(chunky, cherry.Chunkies.Single());
+            Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue).Single());
+            Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
+
+            collection.CurrentValue = null;
+
+            Assert.Empty(chunky.Cherries);
+            Assert.Null(cherry.Chunkies);
+            Assert.Empty((IEnumerable)inverseCollection.CurrentValue);
+            Assert.Null(collection.CurrentValue);
+        }
+
+        private class Chunky
+        {
+            public int Id { get; set; }
+            public ICollection<Cherry> Cherries { get; set; }
+        }
+
+        private class Cherry
+        {
+            public int Id { get; set; }
+            public ICollection<Chunky> Chunkies { get; set; }
+        }
+
+        private class FreezerContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase(nameof(FreezerContext));
+
+            public DbSet<Chunky> Icecream { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Part of #19003

New version of this that reads/manipulates the join table for IsModified.

Also:
* Fixed an issue with `HasDefaultValue` where we were comparing 0 to null for indexer properties
* When _attaching_ a many-to-many graph, existing join entities are created as Unchanged.
