### PR TITLE
Fix to #15873 - Query: Identifying columns in the case of distinct

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -592,6 +592,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 valuesCount, columnsCount, table);
 
         /// <summary>
+        ///     Not enough information to uniquely identify outer element in correlated collection scenario. This can happen when trying to correlate on keyless entity or when using 'Distinct' or 'GroupBy' operations without projecting all of the key columns.
+        /// </summary>
+        public static string InsufficientInformationToIdentifyOuterElementOfCollectionJoin
+            => GetString("InsufficientInformationToIdentifyOuterElementOfCollectionJoin");
+
+        /// <summary>
         ///     The specified CommandTimeout value is not valid. It must be a positive number.
         /// </summary>
         public static string InvalidCommandTimeout
@@ -686,6 +692,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("MissingConcurrencyColumn", nameof(entityType), nameof(missingColumn), nameof(table)),
                 entityType, missingColumn, table);
+
+        /// <summary>
+        ///     Collection subquery that uses 'Distinct' or 'Group By' operations must project key columns of all of it's tables. Missing column: {column}. Either add column(s) to the projection or rewrite query to not use 'GroupBy'/'Distinct' operation.
+        /// </summary>
+        public static string MissingIdentifyingProjectionInDistinctGroupBySubquery([CanBeNull] object column)
+            => string.Format(GetString("MissingIdentifyingProjectionInDistinctGroupBySubquery", nameof(column)), column);
 
         /// <summary>
         ///     Reverse could not be translated to the server because there is no ordering on the server side.
@@ -816,12 +828,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string PendingAmbientTransaction
             => GetString("PendingAmbientTransaction");
-
-        /// <summary>
-        ///     Projecting collection correlated with keyless entity is not supported.
-        /// </summary>
-        public static string ProjectingCollectionOnKeylessEntityNotSupported
-            => GetString("ProjectingCollectionOnKeylessEntityNotSupported");
 
         /// <summary>
         ///     Different projection mapping count in set operation.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -337,6 +337,9 @@
   <data name="InsertDataOperationValuesCountMismatch" xml:space="preserve">
     <value>The number of values ({valuesCount}) doesn't match the number of columns ({columnsCount}) for the data insertion operation on '{table}'. Provide the same number of values and columns.</value>
   </data>
+  <data name="InsufficientInformationToIdentifyOuterElementOfCollectionJoin" xml:space="preserve">
+    <value>Not enough information to uniquely identify outer element in correlated collection scenario. This can happen when trying to correlate on keyless entity or when using 'Distinct' or 'GroupBy' operations without projecting all of the key columns.</value>
+  </data>
   <data name="InvalidCommandTimeout" xml:space="preserve">
     <value>The specified CommandTimeout value is not valid. It must be a positive number.</value>
   </data>
@@ -592,6 +595,9 @@
   <data name="MissingConcurrencyColumn" xml:space="preserve">
     <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' that is used by another entity type sharing the table '{table}'. Add a store-generated property mapped to the same column to '{entityType}'. It can be in shadow state.</value>
   </data>
+  <data name="MissingIdentifyingProjectionInDistinctGroupBySubquery" xml:space="preserve">
+    <value>Collection subquery that uses 'Distinct' or 'Group By' operations must project key columns of all of it's tables. Missing column: {column}. Either add column(s) to the projection or rewrite query to not use 'GroupBy'/'Distinct' operation.</value>
+  </data>
   <data name="MissingOrderingInSqlExpression" xml:space="preserve">
     <value>Reverse could not be translated to the server because there is no ordering on the server side.</value>
   </data>
@@ -648,9 +654,6 @@
   </data>
   <data name="PendingAmbientTransaction" xml:space="preserve">
     <value>This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.</value>
-  </data>
-  <data name="ProjectingCollectionOnKeylessEntityNotSupported" xml:space="preserve">
-    <value>Projecting collection correlated with keyless entity is not supported.</value>
   </data>
   <data name="ProjectionMappingCountMismatch" xml:space="preserve">
     <value>Different projection mapping count in set operation.</value>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1143,9 +1143,11 @@ ORDER BY c[""CustomerID""]");
         }
 
         [ConditionalTheory(Skip = "Issue#17246")]
-        public override Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        public override async Task Projecting_after_navigation_and_distinct_throws(bool isAsync)
         {
-            return base.Projecting_after_navigation_and_distinct_works_correctly(async);
+            await base.Projecting_after_navigation_and_distinct_throws(isAsync);
+
+            AssertSql(" ");
         }
 
         public override Task Reverse_without_explicit_ordering_throws(bool async)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -482,6 +482,14 @@ WHERE c[""Discriminator""] IN (""OwnedPerson"", ""Branch"", ""LeafB"", ""LeafA""
             AssertSql(" ");
         }
 
+        [ConditionalTheory(Skip = "issue #17246")]
+        public override async Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool isAsync)
+        {
+            await base.Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(isAsync);
+
+            AssertSql(" ");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -12,6 +14,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalTheory(Skip = "issue #19742")]
+        public override Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool async)
+        {
+            return base.Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(async);
         }
 
         public class OwnedQueryInMemoryFixture : OwnedQueryFixtureBase

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -1,7 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -11,6 +17,41 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected GearsOfWarQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Correlated_collection_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .OrderBy(g => g.Nickname)
+                    .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.BornGears)
+                    .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList())))).Message;
+
+            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("w.Id"), message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Correlated_collection_with_GroupBy_missing_indentifying_columns_in_projection(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<Mission>()
+                    .Select(m => new
+                    {
+                        m.Id,
+                        grouping = m.ParticipatingSquads
+                            .Select(ps => ps.SquadId)
+                            .GroupBy(s => s)
+                            .Select(g => new { g.Key, Count = g.Count() })
+                    })))).Message;
+
+            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("s.MissionId"), message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
@@ -1,7 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -11,6 +17,81 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected NorthwindGroupByQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(c => c.CustomerID.StartsWith("A"))
+                    .Select(c => c.Customer.City)
+                    .Distinct()
+                    .Select(c => new
+                    {
+                        c1 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Key).ToArray(),
+                        c2 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Count()).ToArray()
+                    }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e.c1, a.c1);
+                    AssertCollection(e.c2, a.c2);
+                }))).Message;
+
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Complex_query_with_groupBy_in_subquery4(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(
+                        c => new
+                        {
+                            Key = c.CustomerID,
+                            Subquery = c.Orders
+                                .Select(o => new { First = o.OrderID, Second = o.Customer.City + o.CustomerID })
+                                .GroupBy(x => x.Second)
+                                .Select(g => new { Sum = g.Sum(x => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(e.Subquery, a.Subquery);
+                }))).Message;
+
+            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("o.OrderID"), message);
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Select_nested_collection_with_distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .OrderBy(c => c.CustomerID)
+                    .Where(c => c.CustomerID.StartsWith("A"))
+                    .Select(
+                        c => c.Orders.Any()
+                            ? c.Orders.Select(o => o.CustomerID).Distinct().ToArray()
+                            : Array.Empty<string>()),
+                assertOrder: true,
+                elementAsserter: (e, a) => AssertCollection(e, a)))).Message;
+
+            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("o.OrderID"), message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindKeylessEntitiesQueryRelationalTestBase.cs
@@ -37,7 +37,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                             OrderDetailIds = ss.Set<Customer>().Where(c => c.City == cq.City).ToList()
                         }).OrderBy(x => x.City).Take(2)))).Message;
 
-            Assert.Equal(RelationalStrings.ProjectingCollectionOnKeylessEntityNotSupported, message);
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Collection_of_entities_projecting_correlated_collection_of_keyless_entities(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => AssertQuery(
+                    async,
+                    ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(c => new
+                    {
+                        c.City,
+                        Collection = ss.Set<CustomerQuery>().Where(cq => cq.City == c.City).ToList(),
+                    })))).Message;
+
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
         protected override QueryAsserter CreateQueryAsserter(TFixture fixture)

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1795,7 +1795,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        public virtual Task Projecting_after_navigation_and_distinct_throws(bool async)
         {
             var filteredOrderIds = new[] { 10248, 10249, 10250 };
 

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -858,6 +858,25 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Fink>().OrderBy(f => f.Id).Select(f => f.Barton.Throned.Value).Select(t => new
+                {
+                    t,
+                    Planets = ss.Set<Planet>().Where(p => p.Id != t).ToList()
+                }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.t, a.t);
+                    AssertCollection(e.Planets, a.Planets);
+                });
+        }
+
         protected virtual DbContext CreateContext()
             => Fixture.CreateContext();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -161,6 +164,14 @@ LEFT JOIN (
     WHERE [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL AND [l2].[Level2_Required_Id] IS NOT NULL
 ) AS [t1] ON [t].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
 ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
+        }
+
+        public override async Task SelectMany_with_navigation_and_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_with_navigation_and_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1511,6 +1511,43 @@ WHERE @_outer_CustomerID = [o1].[CustomerID]
 ORDER BY [o1].[OrderID]");
         }
 
+        public override async Task Select_uncorrelated_collection_with_groupby_works(bool async)
+        {
+            await base.Select_uncorrelated_collection_with_groupby_works(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t].[OrderID]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[OrderID]
+) AS [t]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY [c].[CustomerID], [t].[OrderID]");
+        }
+
+        public override async Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
+        {
+            await base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [t].[ProductID], [t0].[c], [t0].[ProductID]
+FROM [Orders] AS [o]
+OUTER APPLY (
+    SELECT [p].[ProductID]
+    FROM [Products] AS [p]
+    GROUP BY [p].[ProductID]
+) AS [t]
+OUTER APPLY (
+    SELECT COUNT(*) AS [c], [p0].[ProductID]
+    FROM [Products] AS [p0]
+    GROUP BY [p0].[ProductID]
+) AS [t0]
+WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
+ORDER BY [o].[OrderID], [t].[ProductID], [t0].[ProductID]");
+        }
+
         public override async Task Select_GroupBy_All(bool async)
         {
             await base.Select_GroupBy_All(async);
@@ -2397,14 +2434,6 @@ ORDER BY [o].[CustomerID]");
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[OrderID]");
-        }
-
-        public override async Task Complex_query_with_groupBy_in_subquery4(bool async)
-        {
-            await base.Complex_query_with_groupBy_in_subquery4(async);
-
-            AssertSql(
-                @"");
         }
 
         public override async Task Group_by_with_arithmetic_operation_inside_aggregate(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5273,6 +5273,33 @@ WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY [c].[CustomerID]");
         }
 
+        public override async Task SelectMany_correlated_subquery_hard(bool async)
+        {
+            await base.SelectMany_correlated_subquery_hard(async);
+
+            AssertSql(
+                @"@__p_0='91'
+
+SELECT [t0].[City] AS [c1], [t1].[City], [t1].[City0] AS [c1]
+FROM (
+    SELECT DISTINCT [t].[City]
+    FROM (
+        SELECT TOP(@__p_0) [c].[City]
+        FROM [Customers] AS [c]
+    ) AS [t]
+) AS [t0]
+CROSS APPLY (
+    SELECT TOP(9) [e].[City], [t0].[City] AS [City0]
+    FROM [Employees] AS [e]
+    WHERE ([t0].[City] = [e].[City]) OR ([t0].[City] IS NULL AND [e].[City] IS NULL)
+) AS [t1]
+CROSS APPLY (
+    SELECT TOP(9) [t0].[City], [e0].[EmployeeID]
+    FROM [Employees] AS [e0]
+    WHERE ([t1].[City] = [e0].[City]) OR ([t1].[City] IS NULL AND [e0].[City] IS NULL)
+) AS [t2]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -1424,23 +1426,12 @@ WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
-        public override async Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        public override async Task Projecting_after_navigation_and_distinct_throws(bool async)
         {
-            await base.Projecting_after_navigation_and_distinct_works_correctly(async);
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_after_navigation_and_distinct_throws(async))).Message;
 
-            AssertSql(
-                @"SELECT [t].[CustomerID], [t0].[CustomerID], [t0].[OrderID], [t0].[OrderDate]
-FROM (
-    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-    FROM [Orders] AS [o]
-    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-) AS [t]
-OUTER APPLY (
-    SELECT [t].[CustomerID], [o0].[OrderID], [o0].[OrderDate]
-    FROM [Orders] AS [o0]
-    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
-) AS [t0]
-ORDER BY [t].[CustomerID], [t0].[OrderID]");
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
         public override Task Reverse_without_explicit_ordering_throws(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -994,6 +994,18 @@ LEFT JOIN [Order] AS [o8] ON [o].[Id] = [o8].[ClientId]
 ORDER BY [o].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t3].[Id], [t3].[Id0], [t5].[Id], [t5].[Id0], [o8].[ClientId], [o8].[Id]");
         }
 
+        public override async Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool async)
+        {
+            await base.Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(async);
+
+            AssertSql(
+                @"SELECT [b].[Throned_Value], [f].[Id], [b].[Id], [p].[Id], [p].[StarId]
+FROM [Fink] AS [f]
+LEFT JOIN [Barton] AS [b] ON [f].[BartonId] = [b].[Id]
+LEFT JOIN [Planet] AS [p] ON ([b].[Throned_Value] <> [p].[Id]) OR [b].[Throned_Value] IS NULL
+ORDER BY [f].[Id], [b].[Id], [p].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -533,17 +533,6 @@ CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [g]
 ORDER BY [g].[Year]");
         }
 
-        public override void QF_Select_Direct_In_Anonymous()
-        {
-            base.QF_Select_Direct_In_Anonymous();
-
-            AssertSql(
-                @"SELECT [t].[AmountSold], [t].[ProductId]
-FROM [dbo].[GetTopTwoSellingProducts]() AS [t]",
-                @"SELECT [c].[Id]
-FROM [Customers] AS [c]");
-        }
-
         public override void QF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous()
         {
             base.QF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous();
@@ -583,76 +572,6 @@ INNER JOIN (
     FROM [Customers] AS [c]
     CROSS APPLY [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [g]
 ) AS [t] ON [o].[Id] = [t].[OrderId]");
-        }
-
-        public override void QF_Select_Correlated_Subquery_In_Anonymous_Nested()
-        {
-            base.QF_Select_Correlated_Subquery_In_Anonymous_Nested();
-
-            AssertSql(
-                @"SELECT [t].[AmountSold], [t].[ProductId]
-FROM [dbo].[GetTopTwoSellingProducts]() AS [t]",
-                @"SELECT [c].[Id], [t].[OrderId], [t].[OrderId0], [t].[CustomerId], [t].[OrderDate]
-FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT [m].[OrderId], [m0].[OrderId] AS [OrderId0], [m0].[CustomerId], [m0].[OrderDate]
-    FROM [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [m]
-    OUTER APPLY [dbo].[GetOrdersWithMultipleProducts]([m].[CustomerId]) AS [m0]
-    WHERE DATEPART(day, [m].[OrderDate]) = 21
-) AS [t]
-ORDER BY [c].[Id], [t].[OrderId], [t].[OrderId0]");
-        }
-
-        public override void QF_Select_Correlated_Subquery_In_Anonymous_MultipleCollections()
-        {
-            base.QF_Select_Correlated_Subquery_In_Anonymous_MultipleCollections();
-
-            AssertSql(
-                @"SELECT [c].[Id], [t].[ProductId], [t0].[Id], [t0].[City], [t0].[CustomerId], [t0].[State], [t0].[Street]
-FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT [g].[ProductId]
-    FROM [dbo].[GetTopTwoSellingProducts]() AS [g]
-    WHERE [g].[AmountSold] = 249
-) AS [t]
-LEFT JOIN (
-    SELECT [a].[Id], [a].[City], [a].[CustomerId], [a].[State], [a].[Street]
-    FROM [Addresses] AS [a]
-    WHERE [a].[State] = N'NY'
-) AS [t0] ON [c].[Id] = [t0].[CustomerId]
-ORDER BY [c].[Id], [t0].[Id]");
-        }
-
-        public override void QF_Select_NonCorrelated_Subquery_In_Anonymous()
-        {
-            base.QF_Select_NonCorrelated_Subquery_In_Anonymous();
-
-            AssertSql(
-                @"SELECT [c].[Id], [t].[ProductId]
-FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT [g].[ProductId]
-    FROM [dbo].[GetTopTwoSellingProducts]() AS [g]
-    WHERE [g].[AmountSold] = 249
-) AS [t]
-ORDER BY [c].[Id]");
-        }
-
-        public override void QF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter()
-        {
-            base.QF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter();
-
-            AssertSql(
-                @"@__amount_1='27' (Nullable = true)
-
-SELECT [c].[Id], [t].[ProductId]
-FROM [Customers] AS [c]
-OUTER APPLY (
-    SELECT [g].[ProductId]
-    FROM [dbo].[GetTopTwoSellingProducts]() AS [g]
-    WHERE [g].[AmountSold] = @__amount_1
-) AS [t]
-ORDER BY [c].[Id]");
         }
 
         public override void QF_Correlated_Select_In_Anonymous()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsWeakQuerySqliteTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,6 +16,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         public ComplexNavigationsWeakQuerySqliteTest(ComplexNavigationsWeakQuerySqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+        }
+
+        public override async Task SelectMany_with_navigation_and_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.SelectMany_with_navigation_and_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
         public override async Task Filtered_include_after_different_filtered_include_different_level(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -15,5 +19,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
+
+        public override async Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_uncorrelated_collection_with_groupby_multiple_collections_work(async))).Message);
+
+        public override async Task Select_uncorrelated_collection_with_groupby_works(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_uncorrelated_collection_with_groupby_works(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -186,11 +186,11 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.SelectMany_whose_selector_references_outer_source(async))).Message);
 
-        public override async Task Projecting_after_navigation_and_distinct_works_correctly(bool async)
+        public override async Task Projecting_after_navigation_and_distinct_throws(bool async)
             => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
+                RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Projecting_after_navigation_and_distinct_works_correctly(async))).Message);
+                    () => base.Projecting_after_navigation_and_distinct_throws(async))).Message);
 
         public override async Task Select_nested_collection_deep(bool async)
             => Assert.Equal(


### PR DESCRIPTION
Added validation step for AddCollectionJoin which checks that if subquery contains Distinct or GroupBy, the projection contains all identifying columns needed to correctly bucket the results during materialization.
Also making sure that identifying columns can be correctly propagated during pushdown and joining - if they are not we mark them as such (by removing identifying columns altogether), so that we can throw exception when these columns are actually needed.

Fixes #15873
Fixes #20184