### PR TITLE
Redo pubternalyzer with Roslyn Operations

### DIFF
--- a/benchmark/EFCore.Benchmarks/EFCore.Benchmarks.csproj
+++ b/benchmark/EFCore.Benchmarks/EFCore.Benchmarks.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Debug' ">
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Release22' Or '$(Configuration)' == 'Debug22' ">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,4 +28,7 @@
     <MicrosoftExtensionsHostFactoryResolverSourcesVersion>5.0.0-rc.1.20402.3</MicrosoftExtensionsHostFactoryResolverSourcesVersion>
     <MicrosoftExtensionsLoggingVersion>5.0.0-rc.1.20402.3</MicrosoftExtensionsLoggingVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Other dependencies">
+    <MicrosoftCodeAnalysisVersion>3.7.0</MicrosoftCodeAnalysisVersion>
+  </PropertyGroup>
 </Project>

--- a/src/EFCore.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/EFCore.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,18 @@
+## Release 2.1.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+EF1000  | Usage    | Warning  | RawSqlStringInjectionDiagnosticAnalyzer, [Documentation](https://docs.microsoft.com/ef/core/querying/raw-sql)
+
+## Release 3.0.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+EF1001  | Usage    | Warning  | InternalUsageDiagnosticAnalyzer
+
+### Removed Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+EF1000  | Security | Disabled | RawSqlStringInjectionDiagnosticAnalyzer, [Documentation](https://docs.microsoft.com/ef/core/querying/raw-sql)

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <!-- NB: Version affects the minimum required Visual Studio version -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -32,4 +32,9 @@
     </ItemGroup>
   </Target>
 
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
 </Project>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <!-- NB: Version affects the minimum required Visual Studio version -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore
 
         private static void AnalyzeMember(OperationAnalysisContext context, ISymbol symbol)
         {
-            if (Equals(symbol.ContainingAssembly, context.Compilation.Assembly))
+            if ((object)symbol.ContainingAssembly == context.Compilation.Assembly)
             {
                 // Skip all methods inside the same assembly - internal access is fine
                 return;
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore
         private static void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context, INamedTypeSymbol symbol)
         {
             if (symbol.BaseType is ISymbol baseSymbol
-                && !Equals(baseSymbol.ContainingAssembly, context.Compilation.Assembly)
+                && (object)baseSymbol.ContainingAssembly != context.Compilation.Assembly
                 && (IsInInternalNamespace(baseSymbol) || HasInternalAttribute(baseSymbol)))
             {
                 foreach (var declaringSyntax in symbol.DeclaringSyntaxReferences)
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static bool IsTypeInternal(OperationAnalysisContext context, ISymbol symbol)
-            => !Equals(symbol.ContainingAssembly, context.Compilation.Assembly)
+            => (object)symbol.ContainingAssembly != context.Compilation.Assembly
                 && (IsInInternalNamespace(symbol) || HasInternalAttribute(symbol));
 
         private static bool HasInternalAttribute(ISymbol symbol)

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -76,19 +76,15 @@ namespace Microsoft.EntityFrameworkCore
                 case OperationKind.ObjectCreation:
                     AnalyzeMember(context, ((IObjectCreationOperation)context.Operation).Constructor);
                     break;
-
                 case OperationKind.Invocation:
                     AnalyzeInvocation(context, (IInvocationOperation)context.Operation);
                     break;
-
                 case OperationKind.VariableDeclaration:
                     AnalyzeVariableDeclaration(context, ((IVariableDeclarationOperation)context.Operation));
                     break;
-
                 case OperationKind.TypeOf:
                     AnalyzeTypeof(context, ((ITypeOfOperation)context.Operation));
                     break;
-
                 default:
                     throw new ArgumentException($"Unexpected {nameof(OperationKind)}: {context.Operation.Kind}");
             }
@@ -149,7 +145,6 @@ namespace Microsoft.EntityFrameworkCore
                     var syntax = context.Operation.Syntax switch
                     {
                         CSharpSyntax.VariableDeclarationSyntax s => s.Type,
-                        // TODO: VB
                         _ => context.Operation.Syntax
                     };
                     context.ReportDiagnostic(Diagnostic.Create(_descriptor, syntax.GetLocation(), declarator.Symbol.Type));
@@ -202,7 +197,6 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         CSharpSyntax.ClassDeclarationSyntax s when s.BaseList?.Types.Count > 0
                             => s.BaseList.Types[0].GetLocation(),
-                        // TODO: VB
                         { } otherSyntax => otherSyntax.GetLocation()
                     };
 
@@ -216,9 +210,7 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     var location = declaringSyntax.GetSyntax() switch
                     {
-                        // TODO: Report the location of the internal interface
                         CSharpSyntax.ClassDeclarationSyntax s => s.Identifier.GetLocation(),
-                        // TODO: VB
                         { } otherSyntax => otherSyntax.GetLocation()
                     };
 
@@ -272,8 +264,6 @@ namespace Microsoft.EntityFrameworkCore
                 VBSyntax.MemberAccessExpressionSyntax s => s.Name,
                 VBSyntax.ObjectCreationExpressionSyntax s => s.Type,
                 VBSyntax.TypeOfExpressionSyntax s => s.Type,
-
-                // TODO: Complete VB syntax handling corresponding to the C# ones above
 
                 _ => syntax
             };

--- a/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/InternalUsageDiagnosticAnalyzer.cs
@@ -106,18 +106,10 @@ namespace Microsoft.EntityFrameworkCore
 
             var containingType = symbol.ContainingType;
 
-            switch (symbol)
+            if (HasInternalAttribute(symbol))
             {
-                case IMethodSymbol _:
-                case IFieldSymbol _:
-                case IPropertySymbol _:
-                case IEventSymbol _:
-                    if (HasInternalAttribute(symbol))
-                    {
-                        ReportDiagnostic(context, symbol.Name == ".ctor" ? (object)containingType : $"{containingType}.{symbol.Name}");
-                        return;
-                    }
-                    break;
+                ReportDiagnostic(context, symbol.Name == ".ctor" ? (object)containingType : $"{containingType}.{symbol.Name}");
+                return;
             }
 
             if (IsInternal(context, containingType))

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -397,7 +397,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     .GetDeclaredMethod(nameof(IncludeReference));
 
             private static void IncludeReference<TIncludingEntity, TIncludedEntity>(
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 InternalEntityEntry entry,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 object entity,
                 IEntityType entityType,
                 TIncludedEntity relatedEntity,
@@ -440,7 +442,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     .GetDeclaredMethod(nameof(IncludeCollection));
 
             private static void IncludeCollection<TIncludingEntity, TIncludedEntity>(
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 InternalEntityEntry entry,
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 object entity,
                 IEntityType entityType,
                 IEnumerable<TIncludedEntity> relatedEntities,

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -365,9 +365,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 var includeMethod = navigation.IsCollection ? _includeCollectionMethodInfo : _includeReferenceMethodInfo;
                 var includingClrType = navigation.DeclaringEntityType.ClrType;
                 var relatedEntityClrType = navigation.TargetEntityType.ClrType;
+#pragma warning disable EF1001 // Internal EF Core API usage.
                 var entityEntryVariable = _trackQueryResults
                     ? shaperBlock.Variables.Single(v => v.Type == typeof(InternalEntityEntry))
                     : (Expression)Expression.Constant(null, typeof(InternalEntityEntry));
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
                 var concreteEntityTypeVariable = shaperBlock.Variables.Single(v => v.Type == typeof(IEntityType));
                 var inverseNavigation = navigation.Inverse;
                 var fixup = GenerateFixup(

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -254,10 +254,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 {
                     var entityEntry = Activator.CreateInstance(_readItemExpression.EntityType.ClrType);
 
-#pragma warning disable EF1001
+#pragma warning disable EF1001 // Internal EF Core API usage.
                     var internalEntityEntry = new InternalEntityEntryFactory().Create(
                         _cosmosQueryContext.Context.GetDependencies().StateManager, _readItemExpression.EntityType, entityEntry);
-#pragma warning restore EF1001
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                     foreach (var keyProperty in _readItemExpression.EntityType.FindPrimaryKey().Properties)
                     {
@@ -265,17 +265,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
                         if (TryGetParameterValue(property, out var parameterValue))
                         {
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             internalEntityEntry[property] = parameterValue;
+#pragma warning restore EF1001 // Internal EF Core API usage.
                         }
                     }
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
                     internalEntityEntry.SetEntityState(EntityState.Added);
-#pragma warning restore EF1001 // Internal EF Core API usage.
 
                     value = internalEntityEntry[idProperty];
 
-#pragma warning disable EF1001 // Internal EF Core API usage.
                     internalEntityEntry.SetEntityState(EntityState.Detached);
 #pragma warning restore EF1001 // Internal EF Core API usage.
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -139,7 +139,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         protected virtual IChangeDetector ChangeDetector { get; }
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -88,7 +88,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         {
             Check.NotNull(typeMappingSource, nameof(typeMappingSource));
             Check.NotNull(migrationsAnnotations, nameof(migrationsAnnotations));
+#pragma warning disable EF1001 // Internal EF Core API usage.
             Check.NotNull(changeDetector, nameof(changeDetector));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             Check.NotNull(updateAdapterFactory, nameof(updateAdapterFactory));
             Check.NotNull(commandBatchPreparerDependencies, nameof(commandBatchPreparerDependencies));
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -82,7 +82,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         public MigrationsModelDiffer(
             [NotNull] IRelationalTypeMappingSource typeMappingSource,
             [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
+#pragma warning disable EF1001 // Internal EF Core API usage.
             [NotNull] IChangeDetector changeDetector,
+#pragma warning restore EF1001 // Internal EF Core API usage.
             [NotNull] IUpdateAdapterFactory updateAdapterFactory,
             [NotNull] CommandBatchPreparerDependencies commandBatchPreparerDependencies)
         {

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -31,7 +31,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
         ///     Initializes a new instance of this class.
         /// </summary>
         /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public SqlServerAnnotationProvider([NotNull] RelationalAnnotationProviderDependencies dependencies)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             : base(dependencies)
         {
         }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -31,7 +31,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
         ///     Initializes a new instance of this class.
         /// </summary>
         /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public SqlServerMigrationsAnnotationProvider([NotNull] MigrationsAnnotationProviderDependencies dependencies)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             : base(dependencies)
         {
         }

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
@@ -33,7 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+#pragma warning disable EF1001 // Internal EF Core API usage.
         public SqliteAnnotationProvider([NotNull] RelationalAnnotationProviderDependencies dependencies)
+#pragma warning restore EF1001 // Internal EF Core API usage.
             : base(dependencies)
         {
         }

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\src\EFCore.Analyzers\EFCore.Analyzers.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 

--- a/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTest.cs
+++ b/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTest.cs
@@ -71,16 +71,15 @@ class MyClass : Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalPara
         public Task Implemented_interface()
             => TestFullSource(
                 @"
-using System.Threading;
-using System.Threading.Tasks;
+using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
 
-class MyClass : IDbContextPool {
-    public IDbContextPoolable Rent() => default;
-    public void Return(IDbContextPoolable context) {}
-    public ValueTask ReturnAsync(IDbContextPoolable context, CancellationToken cancellationToken = default) => default;
+class MyClass : IDbSetSource {
+    public object Create(DbContext context, Type type) => null;
+    public object Create(DbContext context, string name, Type type) => null;
 }",
-                "Microsoft.EntityFrameworkCore.Internal.IDbContextPool",
+                "Microsoft.EntityFrameworkCore.Internal.IDbSetSource",
                 "MyClass");
 
         [ConditionalFact]
@@ -137,6 +136,26 @@ class MyClass {
                 @"
 class MyClass {
     private Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager StateManager { get; set; }
+}",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager");
+
+        [ConditionalFact]
+        public Task Method_declaration_return_type()
+            => TestFullSource(
+                @"
+class MyClass {
+    private Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager Foo() => null;
+}",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager");
+
+        [ConditionalFact]
+        public Task Method_declaration_parameter()
+            => TestFullSource(
+                @"
+class MyClass {
+    private void Foo(Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager stateManager) {}
 }",
                 "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
                 "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager");

--- a/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTest.cs
+++ b/test/EFCore.Analyzers.Tests/InternalUsageDiagnosticAnalyzerTest.cs
@@ -15,74 +15,106 @@ namespace Microsoft.EntityFrameworkCore
         protected override DiagnosticAnalyzer CreateDiagnosticAnalyzer() => new InternalUsageDiagnosticAnalyzer();
 
         [ConditionalFact]
-        public async Task No_warning_on_ef_non_internal()
+        public Task Invocation_on_type_in_internal_namespace()
+            => Test(
+                "var x = typeof(object).GetMethod(nameof(object.ToString), Type.EmptyTypes).DisplayName();",
+                "Microsoft.EntityFrameworkCore.Internal.MethodInfoExtensions",
+                "DisplayName");
+
+        [ConditionalFact]
+        public Task Instantiation_on_type_in_internal_namespace()
+            => Test(
+                "new CoreSingletonOptions();",
+                "Microsoft.EntityFrameworkCore.Internal.CoreSingletonOptions",
+                "CoreSingletonOptions");
+
+        [ConditionalFact]
+        public async Task Subclassing_type_in_internal_namespace()
+        {
+            var source = @"
+class MyClass : Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter {
+    MyClass() : base(null, null) {}
+}";
+
+            var diagnostics = await GetDiagnosticsFullSourceAsync(source);
+
+            Assert.Collection(diagnostics,
+                diagnostic =>
+                {
+                    Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
+                    Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+                    Assert.Equal(
+                        string.Format(
+                            InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter"),
+                        diagnostic.GetMessage());
+
+                    var span = diagnostic.Location.SourceSpan;
+                    Assert.Equal(
+                        "Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter",
+                        source[span.Start..span.End]);
+                },
+                diagnostic =>
+                {
+                    Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
+                    Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+                    Assert.Equal(
+                        string.Format(
+                            InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter"),
+                        diagnostic.GetMessage());
+
+                    var span = diagnostic.Location.SourceSpan;
+                    Assert.Equal(": base(null, null)", source[span.Start..span.End]);
+                });
+        }
+
+        [ConditionalFact]
+        public Task Access_property_with_internal_attribute()
+            => Test(
+                "var x = Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkRelationalServicesBuilder.RelationalServices.Count;",
+                "Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkRelationalServicesBuilder.RelationalServices",
+                "RelationalServices");
+
+        [ConditionalFact]
+        public Task Instantiation_with_ctor_with_internal_attribute()
+            => Test(
+                "new Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies(null, null);",
+                "Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies",
+                "Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies");
+
+        [ConditionalFact]
+        public Task Variable_declaration()
+            => Test(
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager state = null;",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager");
+
+        [ConditionalFact]
+        public Task Generic_type_parameter_in_method_call()
+            => Test(
+                @"
+void SomeGenericMethod<T>() {}
+
+SomeGenericMethod<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager>();",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
+                "SomeGenericMethod<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager>()");
+
+        [ConditionalFact]
+        public Task Typeof()
+            => Test(
+                "var t = typeof(Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager);",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager",
+                "Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager");
+
+        [ConditionalFact]
+        public async Task No_warning_on_non_internal()
             => await AssertNoDiagnostics(
                 @"
 var a = new Microsoft.EntityFrameworkCore.Infrastructure.Annotatable();
 var x = a.GetAnnotations();
 ");
 
-        #region Namespace
-
         [ConditionalFact]
-        public async Task Warning_on_ef_internal_namespace_invocation()
-        {
-            var (diagnostics, source) = await GetDiagnosticsAsync(
-                @"var x = typeof(object).GetMethod(nameof(object.ToString), Type.EmptyTypes).DisplayName();");
-            var diagnostic = diagnostics.Single();
-
-            Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
-            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
-            Assert.Equal(
-                string.Format(InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Internal.MethodInfoExtensions"),
-                diagnostic.GetMessage());
-
-            var span = diagnostic.Location.SourceSpan;
-            Assert.Equal("DisplayName", source[span.Start..span.End]);
-        }
-
-        [ConditionalFact]
-        public async Task Warning_on_ef_internal_namespace_instantiation()
-        {
-            var (diagnostics, source) = await GetDiagnosticsAsync(@"new CoreSingletonOptions();");
-            var diagnostic = diagnostics.Single();
-
-            Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
-            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
-            Assert.Equal(
-                string.Format(InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Internal.CoreSingletonOptions"),
-                diagnostic.GetMessage());
-
-            var span = diagnostic.Location.SourceSpan;
-            Assert.Equal("CoreSingletonOptions", source[span.Start..span.End]);
-        }
-
-        [ConditionalFact]
-        public async Task Warning_on_ef_internal_namespace_subclass()
-        {
-            var source = @"
-class MyClass : Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter {
-    MyClass() : base (null, null) {}
-}";
-
-            var diagnostics = await GetDiagnosticsFullSourceAsync(source);
-            var diagnostic = diagnostics.Single();
-
-            Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
-            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
-            Assert.Equal(
-                string.Format(
-                    InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter"),
-                diagnostic.GetMessage());
-
-            var span = diagnostic.Location.SourceSpan;
-            Assert.Equal(
-                "Microsoft.EntityFrameworkCore.Storage.Internal.RawRelationalParameter",
-                source[span.Start..span.End]);
-        }
-
-        [ConditionalFact]
-        public async Task No_warning_on_ef_internal_namespace_in_same_assembly()
+        public async Task No_warning_in_same_assembly()
         {
             var diagnostics = await GetDiagnosticsFullSourceAsync(
                 @"
@@ -107,50 +139,23 @@ namespace Bar
             Assert.Empty(diagnostics);
         }
 
-        #endregion Namespace
-
-        #region Attribute
-
-        [ConditionalFact]
-        public async Task Warning_on_ef_internal_attribute_property_access()
+        private async Task Test(
+            string source,
+            string expectedInternalApi,
+            string expectedDiagnosticSpan)
         {
-            var (diagnostics, source) = await GetDiagnosticsAsync(
-                @"var x = Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkRelationalServicesBuilder.RelationalServices.Count;");
-            //throw new Exception("FOO: " + string.Join(", ", diagnostics.Select(d => d.ToString())));
-            var diagnostic = diagnostics.Single();
+            var (diagnostics, fullSource) = await GetDiagnosticsAsync(source);
+            var diagnostic = Assert.Single(diagnostics);
 
             Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
             Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
             Assert.Equal(
-                string.Format(
-                    InternalUsageDiagnosticAnalyzer.MessageFormat,
-                    "Microsoft.EntityFrameworkCore.Infrastructure.EntityFrameworkRelationalServicesBuilder.RelationalServices"),
+                string.Format(InternalUsageDiagnosticAnalyzer.MessageFormat, expectedInternalApi),
                 diagnostic.GetMessage());
 
             var span = diagnostic.Location.SourceSpan;
-            Assert.Equal("RelationalServices", source[span.Start..span.End]);
+            Assert.Equal(expectedDiagnosticSpan, fullSource[span.Start..span.End]);
         }
-
-        [ConditionalFact]
-        public async Task Warning_on_ef_internal_name_instantiation()
-        {
-            var (diagnostics, source) =
-                await GetDiagnosticsAsync(@"new Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies(null, null);");
-            var diagnostic = diagnostics.Single();
-
-            Assert.Equal(InternalUsageDiagnosticAnalyzer.Id, diagnostic.Id);
-            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
-            Assert.Equal(
-                string.Format(
-                    InternalUsageDiagnosticAnalyzer.MessageFormat, "Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies"),
-                diagnostic.GetMessage());
-
-            var span = diagnostic.Location.SourceSpan;
-            Assert.Equal(
-                "new Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies(null, null)", source[span.Start..span.End]);
-        }
-
-        #endregion Attribute
 
         protected override Task<(Diagnostic[], string)> GetDiagnosticsAsync(string source, params string[] extraUsings)
             => base.GetDiagnosticsAsync(source, extraUsings.Concat(new[] { "Microsoft.EntityFrameworkCore.Internal" }).ToArray());

--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 

--- a/test/ef.Tests/ef.Tests.csproj
+++ b/test/ef.Tests/ef.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
* Rewrite most of the analyzer using Operations, for much better perf and VB.NET support.
* Support some extra language scenarios which weren't being detected.

Fixes #19648
Fixes #20206
