### PR TITLE
Query: Materialize Required dependents always

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/TableBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableBase.cs
@@ -103,9 +103,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc/>
         public virtual bool IsOptional(IEntityType entityType)
-            => OptionalEntityTypes == null
-                || !OptionalEntityTypes.TryGetValue(entityType, out var optional)
-                || optional;
+            => OptionalEntityTypes != null
+                && OptionalEntityTypes.TryGetValue(entityType, out var optional)
+                && optional;
 
         /// <inheritdoc/>
         IRelationalModel ITableBase.Model => Model;

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -103,9 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             if (entityType.FindPrimaryKey() != null)
             {
-                var linkingFks = entityType.GetViewOrTableMappings().FirstOrDefault()?.Table.GetRowInternalForeignKeys(entityType);
-                if (linkingFks != null
-                    && linkingFks.Any())
+                if (entityType.GetViewOrTableMappings().FirstOrDefault()?.Table.IsOptional(entityType) == true)
                 {
                     // Optional dependent
                     var body = baseCondition.Body;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1241,9 +1241,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var nonNullEntityReference = IsNullSqlConstantExpression(left) ? rightEntityReference : leftEntityReference;
                 var entityType1 = nonNullEntityReference.EntityType;
 
-                var linkingFks = entityType1.GetViewOrTableMappings().FirstOrDefault()?.Table.GetRowInternalForeignKeys(entityType1);
-                if (linkingFks != null
-                    && linkingFks.Any())
+                if (entityType1.GetViewOrTableMappings().FirstOrDefault()?.Table.IsOptional(entityType1) == true)
                 {
                     // Optional dependent sharing table
                     var requiredNonPkProperties = entityType1.GetProperties().Where(p => !p.IsNullable && !p.IsPrimaryKey()).ToList();

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -805,7 +805,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             // Add conditions if dependent sharing table with principal
             table ??= entityType.GetViewOrTableMappings().FirstOrDefault()?.Table;
             if (table != null
-                && table.GetRowInternalForeignKeys(entityType).Any()
+                && table.IsOptional(entityType)
                 && !discriminatorAdded)
             {
                 AddOptionalDependentConditions(selectExpression, entityType, table);
@@ -948,7 +948,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         var otherSelectExpression = new SelectExpression(entityType, this);
 
-                        var sameTable = table.GetRowInternalForeignKeys(referencingFk.DeclaringEntityType).Any();
+                        var sameTable = table.IsOptional(referencingFk.DeclaringEntityType);
                         AddInnerJoin(
                             otherSelectExpression, referencingFk,
                             sameTable ? table : null);

--- a/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
@@ -21,8 +21,7 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<Vehicle>().ToTable("Vehicles");
             modelBuilder.Entity<PoweredVehicle>().ToTable("PoweredVehicles");
 
-            modelBuilder.Entity<Operator>().ToTable("Vehicles")
-                .Property<int>("RequiredInt").HasDefaultValue(0);
+            modelBuilder.Entity<Operator>().ToTable("Vehicles");
             modelBuilder.Entity<LicensedOperator>().ToTable("LicensedOperators");
 
             modelBuilder.Entity<OperatorDetails>().ToTable("Vehicles");

--- a/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
@@ -22,11 +22,11 @@ namespace Microsoft.EntityFrameworkCore
             AssertSql(
                 @"SELECT [v].[Name], [v].[SeatingCapacity], CASE
     WHEN [p].[Name] IS NOT NULL THEN N'PoweredVehicle'
-END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[RequiredInt], [t0].[LicenseType], [t0].[Discriminator], [t3].[Name], [t3].[Type], [t5].[Name], [t5].[Computed], [t5].[Description], [t5].[Discriminator], [t7].[VehicleName], [t7].[Capacity], [t7].[FuelType], [t7].[GrainGeometry], [t7].[Discriminator]
+END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[LicenseType], [t0].[Discriminator], [t3].[Name], [t3].[Type], [t5].[Name], [t5].[Computed], [t5].[Description], [t5].[Discriminator], [t7].[VehicleName], [t7].[Capacity], [t7].[FuelType], [t7].[GrainGeometry], [t7].[Discriminator]
 FROM [Vehicles] AS [v]
 LEFT JOIN [PoweredVehicles] AS [p] ON [v].[Name] = [p].[Name]
 LEFT JOIN (
-    SELECT [v0].[Name], [v0].[Operator_Name], [v0].[RequiredInt], [l].[LicenseType], CASE
+    SELECT [v0].[Name], [v0].[Operator_Name], [l].[LicenseType], CASE
         WHEN [l].[VehicleName] IS NOT NULL THEN N'LicensedOperator'
     END AS [Discriminator]
     FROM [Vehicles] AS [v0]
@@ -87,7 +87,7 @@ ORDER BY [v].[Name]");
             base.Can_query_shared();
 
             AssertSql(
-                @"SELECT [v].[Name], [v].[Operator_Name], [v].[RequiredInt], [l].[LicenseType], CASE
+                @"SELECT [v].[Name], [v].[Operator_Name], [l].[LicenseType], CASE
     WHEN [l].[VehicleName] IS NOT NULL THEN N'LicensedOperator'
 END AS [Discriminator]
 FROM [Vehicles] AS [v]
@@ -103,7 +103,7 @@ INNER JOIN (
             base.Can_query_shared_nonhierarchy();
 
             AssertSql(
-                @"SELECT [v].[Name], [v].[Operator_Name], [v].[RequiredInt]
+                @"SELECT [v].[Name], [v].[Operator_Name]
 FROM [Vehicles] AS [v]
 INNER JOIN (
     SELECT [v0].[Name]
@@ -116,7 +116,7 @@ INNER JOIN (
             base.Can_query_shared_nonhierarchy_with_nonshared_dependent();
 
             AssertSql(
-                @"SELECT [v].[Name], [v].[Operator_Name], [v].[RequiredInt]
+                @"SELECT [v].[Name], [v].[Operator_Name]
 FROM [Vehicles] AS [v]
 INNER JOIN (
     SELECT [v0].[Name]
@@ -183,9 +183,7 @@ WHERE [c].[FuelType] IS NOT NULL AND [c].[Capacity] IS NOT NULL");
 SET NOCOUNT ON;
 UPDATE [Vehicles] SET [Operator_Name] = @p0
 WHERE [Name] = @p1;
-SELECT [RequiredInt]
-FROM [Vehicles]
-WHERE @@ROWCOUNT = 1 AND [Name] = @p1;",
+SELECT @@ROWCOUNT;",
                 //
                 @"@p2='Trek Pro Fit Madone 6 Series' (Nullable = false) (Size = 450)
 @p3='Repair' (Size = 4000)
@@ -196,11 +194,11 @@ VALUES (@p2, @p3);",
                 //
                 @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], CASE
     WHEN [p].[Name] IS NOT NULL THEN N'PoweredVehicle'
-END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[RequiredInt], [t0].[LicenseType], [t0].[Discriminator]
+END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[LicenseType], [t0].[Discriminator]
 FROM [Vehicles] AS [v]
 LEFT JOIN [PoweredVehicles] AS [p] ON [v].[Name] = [p].[Name]
 LEFT JOIN (
-    SELECT [v0].[Name], [v0].[Operator_Name], [v0].[RequiredInt], [l].[LicenseType], CASE
+    SELECT [v0].[Name], [v0].[Operator_Name], [l].[LicenseType], CASE
         WHEN [l].[VehicleName] IS NOT NULL THEN N'LicensedOperator'
     END AS [Discriminator]
     FROM [Vehicles] AS [v0]
@@ -228,11 +226,11 @@ SELECT @@ROWCOUNT;",
                 //
                 @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], CASE
     WHEN [p].[Name] IS NOT NULL THEN N'PoweredVehicle'
-END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[RequiredInt], [t0].[LicenseType], [t0].[Discriminator]
+END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[LicenseType], [t0].[Discriminator]
 FROM [Vehicles] AS [v]
 LEFT JOIN [PoweredVehicles] AS [p] ON [v].[Name] = [p].[Name]
 LEFT JOIN (
-    SELECT [v0].[Name], [v0].[Operator_Name], [v0].[RequiredInt], [l].[LicenseType], CASE
+    SELECT [v0].[Name], [v0].[Operator_Name], [l].[LicenseType], CASE
         WHEN [l].[VehicleName] IS NOT NULL THEN N'LicensedOperator'
     END AS [Discriminator]
     FROM [Vehicles] AS [v0]

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -91,21 +91,9 @@ INNER JOIN [Vehicles] AS [v0] ON [v].[Name] = [v0].[Name]");
             base.Can_query_shared_nonhierarchy();
 
             AssertSql(
-                @"SELECT [t0].[Name], [t0].[Operator_Name]
-FROM (
-    SELECT [v].[Name], [v].[Operator_Name]
-    FROM [Vehicles] AS [v]
-    WHERE [v].[Operator_Name] IS NOT NULL
-    UNION
-    SELECT [v0].[Name], [v0].[Operator_Name]
-    FROM [Vehicles] AS [v0]
-    INNER JOIN (
-        SELECT [v1].[Name], [v1].[Type]
-        FROM [Vehicles] AS [v1]
-        WHERE [v1].[Type] IS NOT NULL
-    ) AS [t] ON [v0].[Name] = [t].[Name]
-) AS [t0]
-INNER JOIN [Vehicles] AS [v2] ON [t0].[Name] = [v2].[Name]");
+                @"SELECT [v].[Name], [v].[Operator_Name]
+FROM [Vehicles] AS [v]
+INNER JOIN [Vehicles] AS [v0] ON [v].[Name] = [v0].[Name]");
         }
 
         public override void Can_query_shared_nonhierarchy_with_nonshared_dependent()
@@ -113,17 +101,9 @@ INNER JOIN [Vehicles] AS [v2] ON [t0].[Name] = [v2].[Name]");
             base.Can_query_shared_nonhierarchy_with_nonshared_dependent();
 
             AssertSql(
-                @"SELECT [t].[Name], [t].[Operator_Name]
-FROM (
-    SELECT [v].[Name], [v].[Operator_Name]
-    FROM [Vehicles] AS [v]
-    WHERE [v].[Operator_Name] IS NOT NULL
-    UNION
-    SELECT [v0].[Name], [v0].[Operator_Name]
-    FROM [Vehicles] AS [v0]
-    INNER JOIN [OperatorDetails] AS [o] ON [v0].[Name] = [o].[VehicleName]
-) AS [t]
-INNER JOIN [Vehicles] AS [v1] ON [t].[Name] = [v1].[Name]");
+                @"SELECT [v].[Name], [v].[Operator_Name]
+FROM [Vehicles] AS [v]
+INNER JOIN [Vehicles] AS [v0] ON [v].[Name] = [v0].[Name]");
         }
 
         public override void Can_query_shared_derived_hierarchy()


### PR DESCRIPTION
- Also remove additional conditions in SelectExpression

Resolves #21807
Resolves #12100
