### PR TITLE
Query: Disallow return types of queryables in projection

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2137,14 +2137,15 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 }
                 else
                 {
-                    if (limit != null)
-                    {
-                        innerSelectExpression.ApplyLimit(limit);
-                    }
-
+                    // Order matters Apply Offset before Limit
                     if (offset != null)
                     {
                         innerSelectExpression.ApplyOffset(offset);
+                    }
+
+                    if (limit != null)
+                    {
+                        innerSelectExpression.ApplyLimit(limit);
                     }
                 }
             }

--- a/src/EFCore/Infrastructure/TypeExtensions.cs
+++ b/src/EFCore/Infrastructure/TypeExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2812,6 +2812,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 GetString("DbSetIncorrectGenericType", nameof(entityType), nameof(entityClrType), nameof(genericType)),
                 entityType, entityClrType, genericType);
 
+        /// <summary>
+        ///     The query contains a final projection '{projection}' to type '{queryableType}'. Collections in the final projection must be an 'IEnumerable&lt;T&gt;' type such as 'List&lt;T&gt;'. Consider using 'ToList()' or some other mechanism to convert the 'IQueryable&lt;T&gt;' or 'IOrderedEnumerable&lt;T&gt;' into an 'IEnumerable&lt;T&gt;'.
+        /// </summary>
+        public static string QueryInvalidMaterializationType([CanBeNull] object projection, [CanBeNull] object queryableType)
+            => string.Format(
+                GetString("QueryInvalidMaterializationType", nameof(projection), nameof(queryableType)),
+                projection, queryableType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1491,5 +1491,8 @@
   </data>
   <data name="DbSetIncorrectGenericType" xml:space="preserve">
     <value>Cannot create DbSet for entity type '{entityType}' since it is of type '{entityClrType}' but the generic type provided is of type '{genericType}'.</value>
+  </data>
+  <data name="QueryInvalidMaterializationType" xml:space="preserve">
+    <value>The query contains a final projection '{projection}' to type '{queryableType}'. Collections in the final projection must be an 'IEnumerable&lt;T&gt;' type such as 'List&lt;T&gt;'. Consider using 'ToList()' or some other mechanism to convert the 'IQueryable&lt;T&gt;' or 'IOrderedEnumerable&lt;T&gt;' into an 'IEnumerable&lt;T&gt;'.</value>
   </data>
 </root>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindAggregateOperatorsQueryCosmosTest.cs
@@ -1613,6 +1613,12 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             return base.Average_with_unmapped_property_access_throws_meaningful_exception(async);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
+        {
+            return base.Multiple_collection_navigation_with_FirstOrDefault_chained(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -455,6 +455,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Employee"")");
         }
 
+        [ConditionalFact(Skip = "Cross collection join Issue#17246")]
         public override void Select_Subquery_Single()
         {
             base.Select_Subquery_Single();
@@ -1930,16 +1931,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        public override async Task Select_correlated_subquery_projection(bool async)
-        {
-            await base.Select_correlated_subquery_projection(async);
-
-            AssertSql(
-                @"SELECT c
-FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
-        }
-
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
         public override async Task Select_correlated_subquery_filtered(bool async)
         {
             await base.Select_correlated_subquery_filtered(async);
@@ -1950,6 +1942,7 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
         public override async Task Select_correlated_subquery_ordered(bool async)
         {
             await base.Select_correlated_subquery_ordered(async);
@@ -1958,6 +1951,18 @@ WHERE (c[""Discriminator""] = ""Customer"")");
                 @"SELECT c
 FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Select_nested_collection_in_anonymous_type(bool async)
+        {
+            return base.Select_nested_collection_in_anonymous_type(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Select_subquery_recursive_trivial(bool async)
+        {
+            return base.Select_subquery_recursive_trivial(async);
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
@@ -3621,6 +3626,7 @@ ORDER BY c[""CustomerID""]
 OFFSET @__p_0 LIMIT @__p_1");
         }
 
+        [ConditionalFact(Skip = "Cross collection join Issue#17246")]
         public override void Streaming_chained_sync_query()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -321,6 +321,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
         public override async Task Select_nested_collection(bool async)
         {
             await base.Select_nested_collection(async);
@@ -1155,6 +1156,12 @@ ORDER BY c[""CustomerID""]");
         public override Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
         {
             return base.Custom_projection_reference_navigation_PK_to_FK_optimization(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Select_nested_collection_deep(bool async)
+        {
+            return base.Select_nested_collection_deep(async);
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -1332,7 +1332,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Issue#16314")]
+        [ConditionalFact]
         public virtual void QF_Anonymous_Collection_No_IQueryable_In_Projection_Throws()
         {
             using (var context = CreateContext())

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -928,18 +928,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 1);
         }
 
-        [ConditionalTheory(Skip = "Issue#16314")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()),
-                ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Select(
                     c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
                         .Maybe(x => x.OrderDetails)
-                        .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault())));
+                        .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault())),
+                entryCount: 7);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select c.City);
         }
 
-        [ConditionalTheory(Skip = "Issue#16314")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection(bool async)
         {
@@ -471,7 +471,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                             o => o.CustomerID == c.CustomerID
                                 && o.OrderDate.Value.Year == 1997)
                         .Select(o => o.OrderID)
-                        .OrderBy(o => o),
+                        .OrderBy(o => o)
+                        .ToList(),
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
         }
@@ -621,7 +622,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Count);
         }
 
-        [ConditionalTheory(Skip = "Issue#16314")]
+        [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_nested_collection_deep(bool async)
         {
@@ -638,7 +639,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             select (from o2 in ss.Set<Order>()
                                     where o1.CustomerID == c.CustomerID
                                     orderby o2.OrderID
-                                    select o1.OrderID)),
+                                    select o1.OrderID).ToList()).ToList(),
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(
                     e,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2299,43 +2299,10 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
             await base.Select_correlated_filtered_collection_works_with_caching(async);
 
             AssertSql(
-                @"SELECT [t].[GearNickName]
+                @"SELECT [t].[Id], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Tags] AS [t]
-ORDER BY [t].[Note]",
-                //
-                @"@_outer_GearNickName='Baird' (Size = 450)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
-                //
-                @"@_outer_GearNickName='Cole Train' (Size = 450)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
-                //
-                @"@_outer_GearNickName='Dom' (Size = 450)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
-                //
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND [g].[Nickname] IS NULL",
-                //
-                @"@_outer_GearNickName='Marcus' (Size = 450)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)",
-                //
-                @"@_outer_GearNickName='Paduk' (Size = 450)
-
-SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = @_outer_GearNickName)");
+LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname]
+ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Join_predicate_value_equals_condition(bool async)
@@ -4667,17 +4634,18 @@ LEFT JOIN (
             await base.Streaming_correlated_collection_issue_11403(async);
 
             AssertSql(
-                @"SELECT TOP(1) [g].[FullName]
-FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [g].[Nickname]",
-                //
-                @"@_outer_FullName='Damon Baird' (Size = 450)
-
-SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
-FROM [Weapons] AS [w]
-WHERE (@_outer_FullName = [w].[OwnerFullName]) AND ([w].[IsAutomatic] = CAST(0 AS bit))
-ORDER BY [w].[Id]");
+                @"SELECT [t].[Nickname], [t].[SquadId], [t0].[Id], [t0].[AmmunitionType], [t0].[IsAutomatic], [t0].[Name], [t0].[OwnerFullName], [t0].[SynergyWithId]
+FROM (
+    SELECT TOP(1) [g].[Nickname], [g].[SquadId], [g].[FullName]
+    FROM [Gears] AS [g]
+    ORDER BY [g].[Nickname]
+) AS [t]
+LEFT JOIN (
+    SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+    FROM [Weapons] AS [w]
+    WHERE [w].[IsAutomatic] <> CAST(1 AS bit)
+) AS [t0] ON [t].[FullName] = [t0].[OwnerFullName]
+ORDER BY [t].[Nickname], [t].[SquadId], [t0].[Id]");
         }
 
         public override async Task Project_one_value_type_from_empty_collection(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAsyncSimpleQuerySqlServerTest.cs
@@ -26,13 +26,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected override bool CanExecuteQueryString => true;
 
-        [ConditionalFact(Skip = "Issue#16314")]
+        [ConditionalFact]
         public override Task Throws_on_concurrent_query_list()
         {
-            return Task.CompletedTask;
+            return base.Throws_on_concurrent_query_list();
         }
 
-        [ConditionalFact(Skip = "Issue#16314")]
+        [ConditionalFact]
         public Task Query_compiler_concurrency()
         {
             const int threadCount = 50;
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                         select (from o2 in context.Orders
                                                 where o1.CustomerID == c.CustomerID
                                                 orderby o2.OrderID
-                                                select o1.OrderID)))
+                                                select o1.OrderID).ToList()).ToList())
                             .GetEnumerator())
                         {
                         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -275,52 +275,15 @@ WHERE [c].[City] = N'London'");
             await base.Select_nested_collection(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID]
+                @"SELECT [c].[CustomerID], [t].[OrderID]
 FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT [o].[OrderID], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE DATEPART(year, [o].[OrderDate]) = 1997
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[City] = N'London'
-ORDER BY [c].[CustomerID]",
-                //
-                @"@_outer_CustomerID='AROUT' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]",
-                //
-                @"@_outer_CustomerID='BSBEV' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]",
-                //
-                @"@_outer_CustomerID='CONSH' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]",
-                //
-                @"@_outer_CustomerID='EASTC' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]",
-                //
-                @"@_outer_CustomerID='NORTS' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]",
-                //
-                @"@_outer_CustomerID='SEVES' (Size = 5)
-
-SELECT [o].[OrderID]
-FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = @_outer_CustomerID) AND (DATEPART(year, [o].[OrderDate]) = 1997)
-ORDER BY [o].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override void Select_nested_collection_multi_level()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqliteTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -29,5 +30,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override Task Average_with_division_on_decimal_no_significant_digits(bool async)
             => Assert.ThrowsAsync<NotSupportedException>(() => base.Average_with_division_on_decimal_no_significant_digits(async));
+
+        public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
+        {
+            Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async))).Message);
+        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -285,6 +285,20 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.DefaultIfEmpty_in_subquery_nested_filter_order_comparison(async))).Message);
 
+
+        public override async Task Select_subquery_recursive_trivial(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_subquery_recursive_trivial(async))).Message);
+
+
+        public override async Task Select_correlated_subquery_ordered(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_correlated_subquery_ordered(async))).Message);
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -192,6 +192,12 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Projecting_after_navigation_and_distinct_works_correctly(async))).Message);
 
+        public override async Task Select_nested_collection_deep(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_nested_collection_deep(async))).Message);
+
         [ConditionalTheory(Skip = "Issue#17324")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool async)
         {


### PR DESCRIPTION
Blocks collections in the projection which are of type
- IQueryable<T>
- IOrderedQueryable<T>
- IOrderedEnumerable<T>
- DbSet<T>

Resolves #16314
