### PR TITLE
Type mapping fixes from API reviews

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 scale: mapping.Scale);
 
             if (defaultTypeMapping != null
-                && string.Equals(defaultTypeMapping.StoreType, storeType, StringComparison.OrdinalIgnoreCase))
+                && string.Equals(defaultTypeMapping.StoreType, storeType, StringComparison.Ordinal))
             {
                 canInfer = true;
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -414,7 +414,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 var openParen = storeTypeName.IndexOf("(", StringComparison.Ordinal);
                 if (openParen > 0)
                 {
-                    string storeTypeNameBase = storeTypeName.Substring(0, openParen).Trim();
+                    var storeTypeNameBase = storeTypeName.Substring(0, openParen).Trim();
                     var closeParen = storeTypeName.IndexOf(")", openParen + 1, StringComparison.Ordinal);
                     if (closeParen > openParen)
                     {
@@ -435,15 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         else if (int.TryParse(
                             storeTypeName.Substring(openParen + 1, closeParen - openParen - 1).Trim(), out var parsedSize))
                         {
-                            if (StoreTypeNameBaseUsesPrecision(storeTypeNameBase))
-                            {
-                                precision = parsedSize;
-                                scale = 0;
-                            }
-                            else
-                            {
-                                size = parsedSize;
-                            }
+                            size = parsedSize;
                         }
 
                         return storeTypeNameBase;
@@ -453,17 +445,5 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             return storeTypeName;
         }
-
-        /// <summary>
-        /// Returns whether the store type name base interprets
-        /// nameBase(n) as a precision rather than a length
-        /// </summary>
-        /// <param name="storeTypeNameBase"> The name base of the store type </param>
-        /// <returns>
-        /// <see langword="true" /> if the store type name base interprets nameBase(n)
-        /// as a precision rather than a length, <see langword="false" /> otherwise.
-        /// </returns>
-        protected virtual bool StoreTypeNameBaseUsesPrecision([NotNull] string storeTypeNameBase)
-            => false;
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSourceExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSourceExtensions.cs
@@ -106,52 +106,5 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             throw new InvalidOperationException(RelationalStrings.UnsupportedStoreType(typeName));
         }
-
-        /// <summary>
-        ///     <para>
-        ///         Finds the type mapping for a given <see cref="Type" /> and additional facets, throwing if no mapping is found.
-        ///     </para>
-        ///     <para>
-        ///         Note: Only call this method if there is no <see cref="IProperty" /> available, otherwise
-        ///         call <see cref="GetMapping(IRelationalTypeMappingSource, IProperty)" />
-        ///     </para>
-        /// </summary>
-        /// <param name="typeMappingSource"> The type mapping source. </param>
-        /// <param name="type"> The CLR type. </param>
-        /// <param name="storeTypeName"> The database type name. </param>
-        /// <param name="keyOrIndex"> If <see langword="true" />, then a special mapping for a key or index may be returned. </param>
-        /// <param name="unicode">
-        ///     Specify <see langword="true" /> for Unicode mapping, <see langword="false" /> for Ansi mapping or <see langword="null" /> for the default.
-        /// </param>
-        /// <param name="size"> Specifies a size for the mapping, or <see langword="null" /> for default. </param>
-        /// <param name="rowVersion"> Specifies a row-version, or <see langword="null" /> for default. </param>
-        /// <param name="fixedLength"> Specifies a fixed length mapping, or <see langword="null" /> for default. </param>
-        /// <param name="precision"> Specifies a precision for the mapping, or <see langword="null" /> for default. </param>
-        /// <param name="scale"> Specifies a scale for the mapping, or <see langword="null" /> for default. </param>
-        /// <returns> The type mapping, or <see langword="null" /> if none was found. </returns>
-        public static RelationalTypeMapping GetMapping(
-            [NotNull] this IRelationalTypeMappingSource typeMappingSource,
-            [NotNull] Type type,
-            [CanBeNull] string storeTypeName,
-            bool keyOrIndex = false,
-            bool? unicode = null,
-            int? size = null,
-            bool? rowVersion = null,
-            bool? fixedLength = null,
-            int? precision = null,
-            int? scale = null)
-        {
-            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
-            Check.NotNull(type, nameof(type));
-
-            var mapping = typeMappingSource.FindMapping(
-                type, storeTypeName, keyOrIndex, unicode, size, rowVersion, fixedLength, precision, scale);
-            if (mapping != null)
-            {
-                return mapping;
-            }
-
-            throw new InvalidOperationException(RelationalStrings.UnsupportedType(type));
-        }
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -303,9 +303,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         [InlineData("nvarchar(450)", null)]
         [InlineData("datetime2(4)", null)]
         [InlineData("DateTime2(4)", "DateTime2(4)")]
-        public void Column_type_annotation(string StoreType, string expectedColumnType)
+        public void Column_type_annotation(string storeType, string expectedColumnType)
         {
-            var column = new DatabaseColumn { Table = Table, Name = "Col", StoreType = StoreType };
+            var column = new DatabaseColumn { Table = Table, Name = "Col", StoreType = storeType };
 
             var info = new DatabaseModel
             {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqliteTest.cs
@@ -18,9 +18,57 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
-        public void Maps_text_column(bool keyOrIndex, bool rowVersion)
+        public void Maps_text_column_with_abnormal_casing(bool keyOrIndex, bool rowVersion)
         {
             var mapping = CreateMapper().FindMapping("text", keyOrIndex, rowVersion);
+
+            AssertMapping<string>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_integer_column_with_abnormal_casing(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("integer", keyOrIndex, rowVersion);
+
+            AssertMapping<long>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_blob_column_with_abnormal_casing(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("blob", keyOrIndex, rowVersion);
+
+            AssertMapping<byte[]>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_real_column_with_abnormal_casing(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("real", keyOrIndex, rowVersion);
+
+            AssertMapping<double>(mapping, inferred: false, maxLength: null, unicode: null, fixedLength: null);
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Maps_text_column(bool keyOrIndex, bool rowVersion)
+        {
+            var mapping = CreateMapper().FindMapping("TEXT", keyOrIndex, rowVersion);
 
             AssertMapping<string>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
         }
@@ -32,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public void Maps_integer_column(bool keyOrIndex, bool rowVersion)
         {
-            var mapping = CreateMapper().FindMapping("integer", keyOrIndex, rowVersion);
+            var mapping = CreateMapper().FindMapping("INTEGER", keyOrIndex, rowVersion);
 
             AssertMapping<long>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
         }
@@ -44,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public void Maps_blob_column(bool keyOrIndex, bool rowVersion)
         {
-            var mapping = CreateMapper().FindMapping("blob", keyOrIndex, rowVersion);
+            var mapping = CreateMapper().FindMapping("BLOB", keyOrIndex, rowVersion);
 
             AssertMapping<byte[]>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
         }
@@ -56,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(true, true)]
         public void Maps_real_column(bool keyOrIndex, bool rowVersion)
         {
-            var mapping = CreateMapper().FindMapping("real", keyOrIndex, rowVersion);
+            var mapping = CreateMapper().FindMapping("REAL", keyOrIndex, rowVersion);
 
             AssertMapping<double>(mapping, inferred: true, maxLength: null, unicode: null, fixedLength: null);
         }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
@@ -236,7 +236,24 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     : null;
         }
 
-        protected override bool StoreTypeNameBaseUsesPrecision(string storeTypeNameBase)
-            => "default_decimal_mapping" == storeTypeNameBase;
+        protected override string ParseStoreTypeName(
+            string storeTypeName,
+            out bool? unicode,
+            out int? size,
+            out int? precision,
+            out int? scale)
+        {
+            var parsedName = base.ParseStoreTypeName(storeTypeName, out unicode, out size, out precision, out scale);
+
+            if (size.HasValue
+                && storeTypeName?.StartsWith("default_decimal_mapping", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                precision = size;
+                size = null;
+                scale = 0;
+            }
+
+            return parsedName;
+        }
     }
 }


### PR DESCRIPTION
* Removed `StoreTypeNameBaseUsesPrecision`
* Removed large GetMapping overload that was added in 5.0 but is never called
* Fixed issue when reverse engineering where different casing for type name was being ignored

Part of #20409
