### PR TITLE
Propagate original values for shared columns to added dependents in table splitting

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
@@ -24,7 +24,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public object GetValue(InternalEntityEntry entry, IProperty property)
             {
                 var index = property.GetOriginalValueIndex();
-
                 if (index == -1)
                 {
                     throw new InvalidOperationException(

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -496,10 +496,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
             }
 
-            return new OwnedNavigationBuilder(
-                Builder.Metadata,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder(relationship.Metadata);
         }
 
         /// <summary>
@@ -712,10 +709,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship.IsUnique(false, ConfigurationSource.Explicit);
             }
 
-            return new OwnedNavigationBuilder(
-                Builder.Metadata,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder(relationship.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -698,10 +698,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship = (InternalForeignKeyBuilder)batch.Run(relationship.Metadata).Builder;
             }
 
-            return new OwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                Builder.Metadata,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder<TEntity, TRelatedEntity>(relationship.Metadata);
         }
 
         /// <summary>
@@ -1080,10 +1077,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship = (InternalForeignKeyBuilder)batch.Run(relationship.Metadata).Builder;
             }
 
-            return new OwnedNavigationBuilder<TEntity, TRelatedEntity>(
-                Builder.Metadata,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder<TEntity, TRelatedEntity>(relationship.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -26,24 +26,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        public OwnedNavigationBuilder(
-            [NotNull] EntityType principalEntityType,
-            [NotNull] EntityType dependentEntityType,
-            [NotNull] InternalForeignKeyBuilder builder)
+        public OwnedNavigationBuilder([NotNull] IMutableForeignKey ownership)
         {
-            PrincipalEntityType = principalEntityType;
-            DependentEntityType = dependentEntityType;
-            _builder = builder;
+            PrincipalEntityType = (EntityType)ownership.PrincipalEntityType;
+            DependentEntityType = (EntityType)ownership.DeclaringEntityType;
+            _builder = ((ForeignKey)ownership).Builder;
         }
 
         /// <summary>
         ///     Gets the principal entity type used to configure this relationship.
         /// </summary>
+        [EntityFrameworkInternal]
         protected virtual EntityType PrincipalEntityType { get; }
 
         /// <summary>
         ///     Gets the dependent entity type used to configure this relationship.
         /// </summary>
+        [EntityFrameworkInternal]
         protected virtual EntityType DependentEntityType { get; }
 
         /// <summary>
@@ -527,10 +526,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
             }
 
-            return new OwnedNavigationBuilder(
-                DependentEntityType,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder(relationship.Metadata);
         }
 
         /// <summary>
@@ -752,10 +748,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship.IsUnique(false, ConfigurationSource.Explicit);
             }
 
-            return new OwnedNavigationBuilder(
-                DependentEntityType,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder(relationship.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -27,11 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
-        public OwnedNavigationBuilder(
-            [NotNull] EntityType principalEntityType,
-            [NotNull] EntityType dependentEntityType,
-            [NotNull] InternalForeignKeyBuilder builder)
-            : base(principalEntityType, dependentEntityType, builder)
+        public OwnedNavigationBuilder([NotNull] IMutableForeignKey ownership)
+            : base(ownership)
         {
         }
 
@@ -638,10 +635,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship = (InternalForeignKeyBuilder)batch.Run(relationship.Metadata).Builder;
             }
 
-            return new OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>(
-                relationship.Metadata.PrincipalEntityType,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder<TDependentEntity, TNewDependentEntity>(relationship.Metadata);
         }
 
         /// <summary>
@@ -1033,10 +1027,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 relationship = (InternalForeignKeyBuilder)batch.Run(relationship.Metadata).Builder;
             }
 
-            return new OwnedNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
-                DependentEntityType,
-                relationship.Metadata.DeclaringEntityType,
-                relationship);
+            return new OwnedNavigationBuilder<TDependentEntity, TNewRelatedEntity>(relationship.Metadata);
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TPTTableSplittingTestBase.cs
@@ -14,6 +14,11 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        public override void Can_use_optional_dependents_with_shared_concurrency_tokens()
+        {
+            // TODO: Issue #22060
+        }
+
         protected override string DatabaseName { get; } = "TPTTableSplittingTest";
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryFixtureBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 level2Fk = (ForeignKey)batch.Run(level2Fk);
             }
 
-            Configure(new OwnedNavigationBuilder<Level1, Level2>((EntityType)level1, level2Fk.DeclaringEntityType, level2Fk.Builder));
+            Configure(new OwnedNavigationBuilder<Level1, Level2>(level2Fk));
 
             modelBuilder.Entity<InheritanceBase1>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<InheritanceBase2>().Property(e => e.Id).ValueGeneratedNever();
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 level3Fk = (ForeignKey)batch.Run(level3Fk);
             }
 
-            Configure(new OwnedNavigationBuilder<Level2, Level3>((EntityType)level2, level3Fk.DeclaringEntityType, level3Fk.Builder));
+            Configure(new OwnedNavigationBuilder<Level2, Level3>(level3Fk));
         }
 
         protected virtual void Configure(OwnedNavigationBuilder<Level2, Level3> l3)
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 level4Fk = (ForeignKey)batch.Run(level4Fk);
             }
 
-            Configure(new OwnedNavigationBuilder<Level3, Level4>((EntityType)level3, level4Fk.DeclaringEntityType, level4Fk.Builder));
+            Configure(new OwnedNavigationBuilder<Level3, Level4>(level4Fk));
         }
 
         protected virtual void Configure(OwnedNavigationBuilder<Level3, Level4> l4)


### PR DESCRIPTION
Use public types in OwnedNavigationBuilder constructor

Fixes #21465

