### PR TITLE
Don't identify dictionary indexer as NRT

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -69,11 +69,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             conventionSet.KeyAddedConventions.Add(sqlServerInMemoryTablesConvention);
 
+            var sqlServerOnDeleteConvention = new SqlServerOnDeleteConvention(Dependencies, RelationalDependencies);
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, valueGenerationConvention);
+            ReplaceConvention(conventionSet.ForeignKeyAddedConventions, (CascadeDeleteConvention)sqlServerOnDeleteConvention);
 
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGenerationConvention);
 
-            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(new SqlServerOnDeleteConvention(Dependencies, RelationalDependencies));
+            ReplaceConvention(conventionSet.ForeignKeyRequirednessChangedConventions, (CascadeDeleteConvention)sqlServerOnDeleteConvention);
+
+            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(sqlServerOnDeleteConvention);
 
             conventionSet.IndexAddedConventions.Add(sqlServerInMemoryTablesConvention);
             conventionSet.IndexAddedConventions.Add(sqlServerIndexConvention);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2367,7 +2367,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 field, entityType, property);
 
         /// <summary>
-        ///     The entity type '{entityType}' cannot be added to the model because a shared entity type with the same clr type already exists.
+        ///     The entity type '{entityType}' cannot be added to the model because a shared entity type with the same CLR type already exists.
         /// </summary>
         public static string ClashingSharedType([CanBeNull] object entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1281,7 +1281,7 @@
     <value>Cannot set backing field '{field}' for the indexer property '{entityType}.{property}'. Indexer properties are not allowed to use a backing field.</value>
   </data>
   <data name="ClashingSharedType" xml:space="preserve">
-    <value>The entity type '{entityType}' cannot be added to the model because a shared entity type with the same clr type already exists.</value>
+    <value>The entity type '{entityType}' cannot be added to the model because a shared entity type with the same CLR type already exists.</value>
   </data>
   <data name="SkipNavigationInUseBySkipNavigation" xml:space="preserve">
     <value>The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.</value>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindKeylessEntitiesQueryCosmosTest.cs
@@ -136,9 +136,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
-        public override async Task KeylesEntity_groupby(bool async)
+        public override async Task KeylessEntity_groupby(bool async)
         {
-            await base.KeylesEntity_groupby(async);
+            await base.KeylessEntity_groupby(async);
 
             AssertSql(@"");
         }

--- a/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task KeylesEntity_groupby(bool async)
+        public virtual Task KeylessEntity_groupby(bool async)
         {
             return AssertQuery(
                 async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindKeylessEntitiesQuerySqlServerTest.cs
@@ -147,9 +147,9 @@ WHERE EXISTS (
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region] FROM [Customers] AS [c]");
         }
 
-        public override async Task KeylesEntity_groupby(bool async)
+        public override async Task KeylessEntity_groupby(bool async)
         {
-            await base.KeylesEntity_groupby(async);
+            await base.KeylessEntity_groupby(async);
 
             AssertSql(
                 @"SELECT [c].[City] AS [Key], COUNT(*) AS [Count], COALESCE(SUM(CAST(LEN([c].[Address]) AS int)), 0) AS [Sum]

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableReferencePropertyConventionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -80,6 +81,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var entityTypeBuilder = modelBuilder.Entity(type);
 
             Assert.Equal(expectedNullable, entityTypeBuilder.Property(propertyName).Metadata.IsNullable);
+        }
+
+        [ConditionalFact]
+        public void Non_nullability_ignores_context_on_generic_types()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityTypeBuilder = modelBuilder.SharedTypeEntity<Dictionary<string, object>>("SomeBag");
+            entityTypeBuilder.IndexerProperty(typeof(string), "b");
+            Assert.True(entityTypeBuilder.Property("b").Metadata.IsNullable);
         }
 
         private void RunConvention(InternalPropertyBuilder propertyBuilder)


### PR DESCRIPTION
We currently don't calculate nullability for generic properties, since that's a complex task (https://github.com/dotnet/runtime/issues/29723 is supposed to add this capability to the reflection API at some point). This interferes with the ability to use Dictionary for property bag, since it's a generic type and its indexer is incorrectly identified as non-nullable (the actual nullability of the generic type argument isn't taken into account).

The general inability to handle generic properties hasn't proved problematic - it's been this way since EF Core 3.0 and we've received no user complaints. This is a specific fix to recognize the indexer on Dictionary and not identify it as non-nullable. If this is OK to merge, I'll document the general limitation in our doc page on nullability, and open a separate issue for handling generic properties.

Fixes #20718
