### PR TITLE
Fix to #20839 - Calling ToString() on a string column no longer causes translation error

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
@@ -70,7 +70,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             Check.NotNull(arguments, nameof(arguments));
             Check.NotNull(logger, nameof(logger));
 
-            if (method.Name == nameof(ToString) && instance.Type.UnwrapNullableType() == typeof(string))
+            if (method.Name == nameof(ToString)
+                && instance != null
+                && instance.TypeMapping.ClrType == typeof(string))
             {
                 return instance;
             }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerObjectToStringTranslator.cs
@@ -70,6 +70,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             Check.NotNull(arguments, nameof(arguments));
             Check.NotNull(logger, nameof(logger));
 
+            if (method.Name == nameof(ToString) && instance.Type.UnwrapNullableType() == typeof(string))
+            {
+                return instance;
+            }
+
             return method.Name == nameof(ToString)
                 && arguments.Count == 0
                 && instance != null


### PR DESCRIPTION
Fixes #20839 