### PR TITLE
InMemory: No-op for AsSplitQuery operator (#22098)

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -77,6 +77,25 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.IsGenericMethod
+                && methodCallExpression.Arguments.Count == 1
+                && methodCallExpression.Arguments[0].Type.TryGetSequenceType() != null
+                && string.Equals(methodCallExpression.Method.Name, "AsSplitQuery", StringComparison.Ordinal))
+            {
+                return Visit(methodCallExpression.Arguments[0]);
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         [Obsolete("Use overload which takes IEntityType.")]
         protected override ShapedQueryExpression CreateShapedQueryExpression(Type elementType)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2469,14 +2469,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigationName, inverseNavigationName);
 
         /// <summary>
-        ///     Unhandled method '{methodName}'.
-        /// </summary>
-        public static string UnhandledMethod([CanBeNull] object methodName)
-            => string.Format(
-                GetString("UnhandledMethod", nameof(methodName)),
-                methodName);
-
-        /// <summary>
         ///     Runtime parameter extraction lambda must have one QueryContext parameter.
         /// </summary>
         public static string RuntimeParameterMissingParameter

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1322,9 +1322,6 @@
   <data name="IncludeWithCycle" xml:space="preserve">
     <value>The Include path '{navigationName}-&gt;{inverseNavigationName}' results in a cycle. Cycles are not allowed in no-tracking queries. Either use a tracking query or remove the cycle.</value>
   </data>
-  <data name="UnhandledMethod" xml:space="preserve">
-    <value>Unhandled method '{methodName}'.</value>
-  </data>
   <data name="RuntimeParameterMissingParameter" xml:space="preserve">
     <value>Runtime parameter extraction lambda must have one QueryContext parameter.</value>
   </data>

--- a/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore/Query/QueryableMethodTranslatingExpressionVisitor.cs
@@ -493,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return _subquery
                 ? (Expression)null
-                : throw new NotImplementedException(CoreStrings.UnhandledMethod(method.Name));
+                : throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
         }
 
         private sealed class EntityShaperNullableMarkingExpressionVisitor : ExpressionVisitor


### PR DESCRIPTION
Manually verified
- Works for Relational
- No-op for InMemory
- Throws translation failure for Cosmos

Resolves #22034

Cherry-pick because branching did not take my PR changes.