### PR TITLE
[release/3.1] Add dependencies for CPD strict in aspnetcore

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,6 +49,11 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>a74155578bf2f1e27bc06b363a7225981fcce52f</Sha>
     </Dependency>
+    <!-- !!! Pin this again & remove CPD once 3.1.8 is released. -->
+    <Dependency Name="Microsoft.Internal.Extensions.Refs" Version="3.1.8-servicing.20418.2">
+      <Uri>https://github.com/dotnet/Extensions</Uri>
+      <Sha>a74155578bf2f1e27bc06b363a7225981fcce52f</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.1.6" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-core-setup</Uri>
       <Sha>3acd9b0cd16596bad450c82be08780875a73c05c</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,13 +17,13 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Pinned="true">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8a3ffed558ddf943c1efa87d693227722d6af094</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Pipelines" Version="4.7.1" Pinned="true">
+    <Dependency Name="System.IO.Pipelines" Version="4.7.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8a3ffed558ddf943c1efa87d693227722d6af094</Sha>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" CoherentParentDependency="Microsoft.Extensions.Logging">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-core-setup</Uri>
@@ -79,6 +79,18 @@
     </Dependency>
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
+    </Dependency>
+    <Dependency Name="System.Net.Http.WinHttpHandler" Version="4.7.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>620cea9ccf0359993e803c900059932966399584</Sha>
+    </Dependency>
+    <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878 </Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.Channels" Version="4.7.1" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <!-- Keep this dependency at the bottom of ProductDependencies, else it will be picked as the parent for CoherentParentDependencies -->


### PR DESCRIPTION
- aligns with dotnet/core-setup#9066 and dotnet/extensions#3417
- unpin System.IO.Pipelines and System.Runtime.CompilerServices.Unsafe Versions
  - see dotnet/aspnetcore#24937
- move System.IO.Pipelines version to latest