### PR TITLE
Schrödinger's Cat

### DIFF
--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     var allNonSharedProperties = GetNonSharedProperties(table, entityType);
                     if (allNonSharedProperties.Count != 0
-                        && allNonSharedProperties.Count(p => !p.IsNullable) == 0)
+                        && allNonSharedProperties.All(p => p.IsNullable))
                     {
                         var allNonSharedNullableProperties = allNonSharedProperties.Where(p => p.IsNullable).ToList();
                         var atLeastOneNonNullValueInNullablePropertyCondition = allNonSharedNullableProperties
@@ -191,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var propertyMappings = table.FindColumn(property).PropertyMappings;
                 if (propertyMappings.Count() > 1
-                    && propertyMappings.Any(pm => principalEntityTypes.Any(et => !pm.Property.DeclaringEntityType.IsAssignableFrom(et))))
+                    && propertyMappings.Any(pm => principalEntityTypes.Contains(pm.TableMapping.EntityType)))
                 {
                     continue;
                 }


### PR DESCRIPTION
**Query: New set of conditions to materialize optional dependents**

Let A be the set of properties which are not sharing column with any principal.
B be the subset of A where property is required.
C be subset of A where property is optional. (hence A = B + C)

The necessary condition for materialization without anything else be C1 - all required properties (excluding PK) must have a value (with or without sharing).
- If A is empty, then C1 will be sufficient condition as it will be required dependent.
- If B is non-empty, then C1 will cover those properties and be sufficient condition.
- If B is empty and then C is non-empty, then materialize if there is at least 1 non-null value in C along with C1 being true.
- Otherwise null.

If there are no required properties other than PK (essentially C1 does not exist). B is by definition empty.
- If A is empty then always materialize.
- If A is non-empty implies C is non-empty, then materialize if there is at least 1 non-null value in C.

Resolves #22054
