### PR TITLE
[Cosmos] Translate JObject Property

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/EntityProjectionExpression.cs
@@ -128,6 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             }
 
             if (!clientEval
+                && property.Name != EntityFrameworkCore.Metadata.Conventions.StoreKeyConvention.JObjectPropertyName
                 && expression.Name.Length == 0)
             {
                 // Non-persisted property can't be translated

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTypeMappingSource.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Newtonsoft.Json.Linq;
 
@@ -33,7 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             _clrTypeMappings
                 = new Dictionary<Type, CosmosTypeMapping>
                 {
-                    { typeof(byte[]), new CosmosTypeMapping(typeof(byte[]), keyComparer: new ArrayStructuralComparer<byte>()) }
+                    { typeof(byte[]), new CosmosTypeMapping(typeof(byte[]), keyComparer: new ArrayStructuralComparer<byte>()) },
+                    { typeof(JObject), new CosmosTypeMapping(typeof(JObject)) }
                 };
         }
 


### PR DESCRIPTION
This PR makes it so that the EFCore CosmosDB provider translated the `__jObject` property even though it is non-persisted, in order to allow `await context.ReloadAsync()` to work. This is discussed in #18710.

Fixes #18710