### PR TITLE
Re-run fk discovery convention when skip navigation changes

### DIFF
--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -446,6 +446,11 @@ namespace Microsoft.EntityFrameworkCore
                 builder.Append(" Shadow");
             }
 
+            if (property.IsIndexerProperty())
+            {
+                builder.Append(" Indexer");
+            }
+
             if (!property.IsNullable)
             {
                 builder.Append(" Required");

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -187,9 +187,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.SkipNavigationRemovedConventions.Add(manyToManyJoinEntityTypeConvention);
 
             conventionSet.SkipNavigationInverseChangedConventions.Add(manyToManyJoinEntityTypeConvention);
+            conventionSet.SkipNavigationInverseChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.SkipNavigationForeignKeyChangedConventions.Add(manyToManyJoinEntityTypeConvention);
             conventionSet.SkipNavigationForeignKeyChangedConventions.Add(keyDiscoveryConvention);
+            conventionSet.SkipNavigationForeignKeyChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
 

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (keyProperties == null)
             {
                 var candidateProperties = entityType.GetProperties().Where(
-                    p => !p.IsShadowProperty()
+                    p => !p.IsImplicitlyCreated()
                         || !ConfigurationSource.Convention.Overrides(p.GetConfigurationSource()));
                 keyProperties = DiscoverKeyProperties(entityType, candidateProperties).ToList();
                 if (keyProperties.Count > 1)

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -90,5 +90,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The configuration source for <see cref="IProperty.IsConcurrencyToken" />. </returns>
         ConfigurationSource? GetIsConcurrencyTokenConfigurationSource();
+
+        /// <summary>
+        ///     Returns a value indicating whether the property was created implicitly and isn't based on the CLR model.
+        /// </summary>
+        /// <returns> A value indicating whether the property was created implicitly and isn't based on the CLR model. </returns>
+        bool IsImplicitlyCreated()
+            => (this.IsShadowProperty() || (DeclaringEntityType.IsPropertyBag && this.IsIndexerProperty()))
+                && GetConfigurationSource() == ConfigurationSource.Convention;
     }
 }

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -1624,7 +1624,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalForeignKeyBuilder ReuniquifyTemporaryProperties(bool force)
+        public virtual InternalForeignKeyBuilder ReuniquifyImplicitProperties(bool force)
         {
             if (!force
                 && (Metadata.GetPropertiesConfigurationSource() != null
@@ -2091,7 +2091,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (Metadata.GetPropertiesConfigurationSource().Overrides(ConfigurationSource.DataAnnotation)
                     && Metadata.Properties.All(
                         p => ConfigurationSource.Convention.Overrides(p.GetTypeConfigurationSource())
-                            && p.IsShadowProperty()))
+                            && (p.IsShadowProperty() || p.IsIndexerProperty())))
                 {
                     oldNameDependentProperties = Metadata.Properties;
                 }
@@ -2843,7 +2843,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             // Issue #15898
             var temporaryProperties = dependentProperties?.Where(
                 p => p.GetConfigurationSource() == ConfigurationSource.Convention
-                    && p.IsShadowProperty()).ToList();
+                    && ((IConventionProperty)p).IsImplicitlyCreated()).ToList();
             var tempIndex = temporaryProperties?.Count > 0
                 && dependentEntityType.FindIndex(temporaryProperties) == null
                     ? dependentEntityType.Builder.HasIndex(temporaryProperties, ConfigurationSource.Convention).Metadata
@@ -2851,7 +2851,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var temporaryKeyProperties = principalProperties?.Where(
                 p => p.GetConfigurationSource() == ConfigurationSource.Convention
-                    && p.IsShadowProperty()).ToList();
+                    && ((IConventionProperty)p).IsImplicitlyCreated()).ToList();
             var keyTempIndex = temporaryKeyProperties?.Count > 0
                 && principalEntityType.FindIndex(temporaryKeyProperties) == null
                     ? principalEntityType.Builder.HasIndex(temporaryKeyProperties, ConfigurationSource.Convention).Metadata
@@ -2963,7 +2963,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                 shouldThrow: false)
                             && dependentProperties.All(
                                 p => ConfigurationSource.Convention.Overrides(p.GetTypeConfigurationSource())
-                                    && p.IsShadowProperty())))
+                                    && (p.IsShadowProperty() || p.IsIndexerProperty()))))
                     {
                         dependentProperties = oldNameDependentProperties ?? dependentProperties;
                         if (principalKey.Properties.Count == dependentProperties.Count)

--- a/test/EFCore.Cosmos.FunctionalTests/Internal/CosmosDatabaseCreatorTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Internal/CosmosDatabaseCreatorTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             Assert.False(async ? await creator.EnsureDeletedAsync() : creator.EnsureDeleted());
         }
 
-        public class BloggingContext : DbContext
+        private class BloggingContext : DbContext
         {
             private readonly string _connectionUri;
             private readonly string _authToken;
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             public DbSet<Blog> Blogs { get; set; }
         }
 
-        public class Blog
+        private class Blog
         {
             public int Id { get; set; }
         }

--- a/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
@@ -420,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
 
             var joinEntity = context.ChangeTracker.Entries<Dictionary<string, object>>()
-                .Single(e => e.Property<int?>("CherryId").CurrentValue == 1 && e.Property<int?>("ChunkyId").CurrentValue == 2)
+                .Single(e => e.Property<int>("CherryId").CurrentValue == 1 && e.Property<int>("ChunkyId").CurrentValue == 2)
                 .Entity;
 
             joinEntity["CherryId"] = 2;
@@ -498,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             var relatedToChunky2 = context.Entry(chunky2).Collection(e => e.Cherries);
 
             var joinEntity = context.ChangeTracker.Entries<Dictionary<string, object>>()
-                .Single(e => e.Property<int?>("CherryId").CurrentValue == 1 && e.Property<int?>("ChunkyId").CurrentValue == 2)
+                .Single(e => e.Property<int>("CherryId").CurrentValue == 1 && e.Property<int>("ChunkyId").CurrentValue == 2)
                 .Entity;
 
             joinEntity["CherryId"] = 2;

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -206,8 +206,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             SetPrimaryKey(entityType);
             AddProperties(entityType);
 
-            var keyProperty = entityType.AddProperty("Key", typeof(int));
-            entityType.AddKey(keyProperty);
+            var keyProperty = ((IConventionEntityType)entityType).AddProperty("Key", typeof(int));
+            ((IConventionEntityType)entityType).AddKey(keyProperty);
 
             VerifyWarning(
                 CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Key", "A"), model,

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1624,8 +1624,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.NotNull(replacedPropertyBuilder);
             Assert.NotSame(propertyBuilder, replacedPropertyBuilder);
-            Assert.False(replacedPropertyBuilder.Metadata.IsIndexerProperty());
-            Assert.True(replacedPropertyBuilder.Metadata.IsShadowProperty());
+            Assert.True(replacedPropertyBuilder.Metadata.IsIndexerProperty());
+            Assert.False(replacedPropertyBuilder.Metadata.IsShadowProperty());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -408,15 +408,27 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var shared1 = model.FindEntityType("Shared1");
                 Assert.NotNull(shared1);
                 Assert.Equal(2, shared1.GetForeignKeys().Count());
+                Assert.Equal(new[]
+                    {
+                        nameof(ManyToManyNavPrincipal.Dependents) + nameof(NavDependent.Id),
+                        nameof(NavDependent.ManyToManyPrincipals) + nameof(ManyToManyNavPrincipal.Id)
+                    },
+                    shared1.GetProperties().Select(p => p.Name));
                 Assert.True(shared1.HasSharedClrType);
                 Assert.Equal(typeof(Dictionary<string, object>), shared1.ClrType);
 
                 var shared2 = model.FindEntityType("Shared2");
                 Assert.NotNull(shared2);
                 Assert.Equal(2, shared2.GetForeignKeys().Count());
+                Assert.Equal(new[]
+                    {
+                        nameof(ManyToManyPrincipalWithField.Dependents) + nameof(DependentWithField.DependentWithFieldId),
+                        nameof(DependentWithField.ManyToManyPrincipals) + nameof(ManyToManyPrincipalWithField.Id),
+                        "Payload"
+                    },
+                    shared2.GetProperties().Select(p => p.Name));
                 Assert.True(shared2.HasSharedClrType);
                 Assert.Equal(typeof(Dictionary<string, object>), shared2.ClrType);
-                Assert.NotNull(shared2.FindProperty("Payload"));
 
                 Assert.Equal(
                     CoreStrings.ClashingSharedType(typeof(Dictionary<string, object>).DisplayName()),


### PR DESCRIPTION
Unify base FK property name logic
Unify implicit property logic

Fixes #22128