### PR TITLE
DoubleValueComparer / FloatValueComparer cleaned up NaN-handling

### DIFF
--- a/src/EFCore/ChangeTracking/DoubleValueComparer.cs
+++ b/src/EFCore/ChangeTracking/DoubleValueComparer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     Initializes a new instance of the <see cref="DoubleValueComparer" /> class.
         /// </summary>
         public DoubleValueComparer() : base(
-            (x, y) => double.IsNaN(x) ? double.IsNaN(y) : x.Equals(y),
+            (x, y) => x.Equals(y),
             d => d.GetHashCode())
         {
         }

--- a/src/EFCore/ChangeTracking/FloatValueComparer.cs
+++ b/src/EFCore/ChangeTracking/FloatValueComparer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     Initializes a new instance of the <see cref="FloatValueComparer" /> class.
         /// </summary>
         public FloatValueComparer() : base(
-            (x, y) => float.IsNaN(x) ? float.IsNaN(y) : x.Equals(y),
+            (x, y) => x.Equals(y),
             d => d.GetHashCode())
         {
         }


### PR DESCRIPTION
[double.Equals](https://github.com/dotnet/runtime/blob/aa5fdab9654d74bc6274c0b5d820272c8e859621/src/libraries/System.Private.CoreLib/src/System/Double.cs#L233-L239) handles the `NaN`-case, as 

> `A NaN will never equal itself so this is an easy and efficient way to check for NaN.`

[Source](https://github.com/dotnet/runtime/blob/aa5fdab9654d74bc6274c0b5d820272c8e859621/src/libraries/System.Private.CoreLib/src/System/Double.cs#L93-L94)

So the test can be simplified. Cf. https://github.com/dotnet/efcore/pull/22168#discussion_r476260205