### PR TITLE
Sqlite: Make AUTOINCREMENT accurate

### DIFF
--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
@@ -63,7 +63,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
         {
             // Model validation ensures that these facets are the same on all mapped properties
             var property = column.PropertyMappings.First().Property;
-            if (property.ValueGenerated == ValueGenerated.OnAdd
+            // Only return auto increment for integer single column primary key
+            var primaryKey = property.DeclaringEntityType.FindPrimaryKey();
+            if (primaryKey != null
+                && primaryKey.Properties.Count == 1
+                && primaryKey.Properties[0] == property
+                && property.ValueGenerated == ValueGenerated.OnAdd
                 && property.ClrType.UnwrapNullableType().IsInteger()
                 && !HasConverter(property))
             {

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
@@ -25,9 +25,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [ConditionalFact]
-        public void Adds_Autoincrement_for_OnAdd_integer_property()
+        public void Does_not_add_Autoincrement_for_OnAdd_integer_property_non_key()
         {
             var property = _modelBuilder.Entity<Entity>().Property(e => e.IntProp).ValueGeneratedOnAdd().Metadata;
+            _modelBuilder.FinalizeModel();
+
+            Assert.DoesNotContain(
+                _provider.For(property.GetTableColumnMappings().Single().Column),
+                a => a.Name == _autoincrement.Name && (bool)a.Value);
+        }
+
+        [ConditionalFact]
+        public void Adds_Autoincrement_for_OnAdd_integer_property_primary_key()
+        {
+            var property = _modelBuilder.Entity<Entity>().Property(e => e.IntProp).ValueGeneratedOnAdd().Metadata;
+            _modelBuilder.Entity<Entity>().HasKey(e => e.IntProp);
             _modelBuilder.FinalizeModel();
 
             Assert.Contains(


### PR DESCRIPTION
Turns out SqlServer:Identity is also not first class. It is computed based on ValueGenerationStrategy and ValueGenerated flag.
Aligned Sqlite to do the same to compute AutoIncrement only when applicable

Resolves #10228
