### PR TITLE
Fix22287

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -884,7 +884,6 @@ FROM
 AND[c].[is_hidden] = 1
 AND[i].[is_hypothetical] = 0
 ) AS TempIndexes([name])");
-            }
 
             commandTextBuilder.AppendLine().Append(
                 @"
@@ -892,6 +891,8 @@ AND CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarcha
 (
 	SELECT * FROM #TempIndexes ti
 )");
+            }
+
             commandTextBuilder.AppendLine(
                 @"
 ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]");

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -887,7 +887,8 @@ AND[i].[is_hypothetical] = 0
             }
 
             commandTextBuilder.AppendLine().Append(
-                @"AND CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12)) NOT IN
+                @"
+AND CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12)) NOT IN
 (
 	SELECT * FROM #TempIndexes ti
 )");


### PR DESCRIPTION
Fixes #22287 

This is a light retouching of the query execute by EF to retrieve a list of indexes.
I don't expect to be smarter than the query optimizer in MSSQL in any case, but for some reason it was unable to optimize the tight loop below, and this resulted in exponential rows read.
![image](https://user-images.githubusercontent.com/6847381/91588040-90c34700-e925-11ea-9c27-5ef42c4708a6.png)

In my work environment, I have the follow counts from the sys.* schema -
![image](https://user-images.githubusercontent.com/6847381/91586868-fe6e7380-e923-11ea-8916-fbccf461f15a.png)

Given this setup, the current query takes an excess of 30 seconds, which is past the timeout for a DbCommand, and thus I am unable to successfully reverse engineer data.

My proposed query takes about 2 seconds on my large database, and incurs no noticeable overhead for the smaller database. The tests under `Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDatabaseModelFactoryTest` all still pass, which I expect is a reasonable set of tests, but I am more than willing to add additional ones as necessary.

Below is the proposed query. **We may need to make the temp-table name more unique.** Thank you!
```sql

SELECT * INTO #TempIndexes
FROM
(
   SELECT CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12))
   FROM [sys].[indexes] i
   JOIN [sys].[tables] AS [t] ON [i].[object_id] = [t].[object_id]
   JOIN [sys].[index_columns] AS [ic] ON [i].[object_id] = [ic].[object_id] AND [i].[index_id] = [ic].[index_id]
   JOIN [sys].[columns] AS [c] ON [ic].[object_id] = [c].[object_id] AND [ic].[column_id] = [c].[column_id]
   WHERE [t].[is_ms_shipped] = 0
AND NOT EXISTS (SELECT *
    FROM [sys].[extended_properties] AS [ep]
    WHERE [ep].[major_id] = [t].[object_id]
        AND [ep].[minor_id] = 0
        AND [ep].[class] = 1
        AND [ep].[name] = N'microsoft_database_tools_support'
    )
AND [t].[name] <> '__EFMigrationsHistory'
AND [t].[temporal_type] <> 1
AND[c].[is_hidden] = 1
AND[i].[is_hypothetical] = 0
) AS TempIndexes([name])
SELECT
    SCHEMA_NAME([t].[schema_id]) AS [table_schema],
    [t].[name] AS [table_name],
    [i].[name] AS [index_name],
    [i].[type_desc],
    [i].[is_primary_key],
    [i].[is_unique_constraint],
    [i].[is_unique],
    [i].[has_filter],
    [i].[filter_definition],
    [i].[fill_factor],
    COL_NAME([ic].[object_id], [ic].[column_id]) AS [column_name],
    [ic].[is_included_column]
FROM [sys].[indexes] AS [i]
JOIN [sys].[tables] AS [t] ON [i].[object_id] = [t].[object_id]
JOIN [sys].[index_columns] AS [ic] ON [i].[object_id] = [ic].[object_id] AND [i].[index_id] = [ic].[index_id]
JOIN [sys].[columns] AS [c] ON [ic].[object_id] = [c].[object_id] AND [ic].[column_id] = [c].[column_id]
WHERE [i].[is_hypothetical] = 0
AND [t].[is_ms_shipped] = 0
AND NOT EXISTS (SELECT *
    FROM [sys].[extended_properties] AS [ep]
    WHERE [ep].[major_id] = [t].[object_id]
        AND [ep].[minor_id] = 0
        AND [ep].[class] = 1
        AND [ep].[name] = N'microsoft_database_tools_support'
    )
AND [t].[name] <> '__EFMigrationsHistory'
AND [t].[temporal_type] <> 1
AND CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12)) NOT IN
(
	SELECT * FROM #TempIndexes ti
)
ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]
DROP TABLE #TempIndexes
```