### PR TITLE
Cache derived types used in DerivedTypeDiscoveryConvention.

### DIFF
--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The derived types. </returns>
         public static IEnumerable<IEntityType> GetDirectlyDerivedTypes([NotNull] this IEntityType entityType)
-            => Check.NotNull(entityType, nameof(entityType)).AsEntityType().GetDirectlyDerivedTypes();
+            => ((EntityType)entityType).GetDirectlyDerivedTypes();
 
         /// <summary>
         ///     Determines if this entity type derives from (or is the same as) a given entity type.

--- a/src/EFCore/Metadata/Conventions/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/BaseTypeDiscoveryConvention.cs
@@ -1,18 +1,27 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     /// <summary>
-    ///     A convention that finds a base entity type that's already part of the model based on the associated
+    ///     A convention that finds base and derived entity types that are already part of the model based on the associated
     ///     CLR type hierarchy.
     /// </summary>
-    public class BaseTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
+    public class BaseTypeDiscoveryConvention :
+#pragma warning disable CS0612 // Type or member is obsolete
+        InheritanceDiscoveryConventionBase,
+#pragma warning restore CS0612 // Type or member is obsolete
+        IEntityTypeAddedConvention,
+        IForeignKeyOwnershipChangedConvention
     {
         /// <summary>
         ///     Creates a new instance of <see cref="BaseTypeDiscoveryConvention" />.
@@ -23,11 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
         }
 
-        /// <summary>
-        ///     Called after an entity type is added to the model.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
-        /// <param name="context"> Additional information associated with convention execution. </param>
+        /// <inheritdoc />
         public virtual void ProcessEntityTypeAdded(
             IConventionEntityTypeBuilder entityTypeBuilder,
             IConventionContext<IConventionEntityTypeBuilder> context)
@@ -37,19 +42,90 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (clrType == null
                 || entityType.HasSharedClrType
                 || entityType.HasDefiningNavigation()
-                || entityType.FindDeclaredOwnership() != null
-                || entityType.Model.FindIsOwnedConfigurationSource(clrType) != null)
+                || entityType.Model.FindIsOwnedConfigurationSource(clrType) != null
+                || entityType.FindDeclaredOwnership() != null)
             {
                 return;
             }
 
-            var baseEntityType = FindClosestBaseType(entityType);
-            if (baseEntityType?.HasDefiningNavigation() == false)
+            var model = entityType.Model;
+            var derivedTypesMap = (Dictionary<Type, List<IConventionEntityType>>)model[CoreAnnotationNames.DerivedTypes];
+            if (derivedTypesMap == null)
+            {
+                derivedTypesMap = new Dictionary<Type, List<IConventionEntityType>>();
+                model.SetAnnotation(CoreAnnotationNames.DerivedTypes, derivedTypesMap);
+            }
+
+            var baseType = clrType.BaseType;
+            if (derivedTypesMap.TryGetValue(clrType, out var derivedTypes))
+            {
+                foreach (var derivedType in derivedTypes)
+                {
+                    derivedType.Builder.HasBaseType(entityType);
+
+                    var otherBaseType = baseType;
+                    while (otherBaseType != typeof(object))
+                    {
+                        if (derivedTypesMap.TryGetValue(otherBaseType, out var otherDerivedTypes))
+                        {
+                            otherDerivedTypes.Remove(derivedType);
+                        }
+
+                        otherBaseType = otherBaseType.BaseType;
+                    }
+                }
+
+                derivedTypesMap.Remove(clrType);
+            }
+
+            if (baseType == typeof(object))
+            {
+                return;
+            }
+
+            IConventionEntityType baseEntityType = null;
+            while (baseEntityType == null
+                && baseType != typeof(object)
+                && baseType != null)
+            {
+                baseEntityType = model.FindEntityType(baseType);
+                if (baseEntityType == null)
+                {
+                    derivedTypesMap.GetOrAddNew(baseType).Add(entityType);
+                }
+
+                baseType = baseType.BaseType;
+            }
+
+            if (baseEntityType == null)
+            {
+                return;
+            }
+
+            if (!baseEntityType.HasSharedClrType
+                && !baseEntityType.HasDefiningNavigation()
+                && baseEntityType.FindOwnership() == null)
             {
                 entityTypeBuilder = entityTypeBuilder.HasBaseType(baseEntityType);
                 if (entityTypeBuilder != null)
                 {
                     context.StopProcessingIfChanged(entityTypeBuilder);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void ProcessForeignKeyOwnershipChanged(
+            IConventionForeignKeyBuilder relationshipBuilder,
+            IConventionContext<bool?> context)
+        {
+            var foreignKey = relationshipBuilder.Metadata;
+            if (foreignKey.IsOwnership
+                && foreignKey.DeclaringEntityType.GetDirectlyDerivedTypes().Any())
+            {
+                foreach (var derivedType in foreignKey.DeclaringEntityType.GetDirectlyDerivedTypes().ToList())
+                {
+                    derivedType.Builder.HasBaseType(null);
                 }
             }
         }

--- a/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     ///     A convention that finds derived entity types that are already part of the model based on the associated
     ///     CLR type hierarchy.
     /// </summary>
+    [Obsolete]
     public class DerivedTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeAddedConvention
     {
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -63,24 +63,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var servicePropertyDiscoveryConvention = new ServicePropertyDiscoveryConvention(Dependencies);
             var indexAttributeConvention = new IndexAttributeConvention(Dependencies);
 
+            var baseTypeDiscoveryConvention = new BaseTypeDiscoveryConvention(Dependencies);
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new KeylessEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention(Dependencies));
-            conventionSet.EntityTypeAddedConventions.Add(new BaseTypeDiscoveryConvention(Dependencies));
+            conventionSet.EntityTypeAddedConventions.Add(baseTypeDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(indexAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
-            conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention(Dependencies));
 
-            conventionSet.EntityTypeIgnoredConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeIgnoredConventions.Add(relationshipDiscoveryConvention);
 
             var discriminatorConvention = new DiscriminatorConvention(Dependencies);
             conventionSet.EntityTypeRemovedConventions.Add(new OwnedTypesConvention(Dependencies));
+            conventionSet.EntityTypeRemovedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeRemovedConventions.Add(discriminatorConvention);
 
             var foreignKeyIndexConvention = new ForeignKeyIndexConvention(Dependencies);
@@ -164,6 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ForeignKeyRequirednessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention(Dependencies));
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(baseTypeDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(valueGeneratorConvention);

--- a/src/EFCore/Metadata/Conventions/InheritanceDiscoveryConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/InheritanceDiscoveryConventionBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 
@@ -9,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     /// <summary>
     ///     Base type for inheritance discovery conventions
     /// </summary>
+    [Obsolete]
     public abstract class InheritanceDiscoveryConventionBase
     {
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -89,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         private void RemoveModelBuildingAnnotations(IConventionModelBuilder modelBuilder)
         {
+            modelBuilder.Metadata.RemoveAnnotation(CoreAnnotationNames.DerivedTypes);
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
                 entityType.RemoveAnnotation(CoreAnnotationNames.AmbiguousNavigations);

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -867,6 +867,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Type type,
             IConventionContext<string> context)
         {
+            if (type == null)
+            {
+                return;
+            }
+
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
                 var ambiguityRemoved = RemoveAmbiguous(entityType, type);

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -239,6 +239,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public const string DerivedTypes = "BaseTypeDiscoveryConvention:DerivedTypes";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public const string AmbiguousNavigations = "RelationshipDiscoveryConvention:AmbiguousNavigations";
 
         /// <summary>
@@ -247,7 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string DuplicateServiceProperties = "ServicePropertyDiscoveryConvention:DuplicateServiceProperties";
+        public const string AmbiguousField = "BackingFieldConvention:AmbiguousField";
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -255,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string AmbiguousField = "BackingFieldConvention:AmbiguousField";
+        public const string DuplicateServiceProperties = "ServicePropertyDiscoveryConvention:DuplicateServiceProperties";
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -303,10 +311,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             EagerLoaded,
             ProviderClrType,
             InverseNavigations,
+            DerivedTypes,
             NavigationCandidates,
             AmbiguousNavigations,
-            DuplicateServiceProperties,
             AmbiguousField,
+            DuplicateServiceProperties,
             FullChangeTrackingNotificationsRequiredAnnotation
         };
     }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1484,7 +1484,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                     return baseNavigation != null
                                         && n.TargetEntityType == baseNavigation.TargetEntityType;
                                 },
-                                n => n.ForeignKey.DeclaringEntityType.RemoveForeignKey(n.ForeignKey))
+                                n => n.ForeignKey.DeclaringEntityType.Builder.HasNoRelationship(n.ForeignKey, ConfigurationSource.Explicit))
                             ?.Select(n => n.ForeignKey).ToHashSet();
 
                     foreach (var key in Metadata.GetDeclaredKeys().ToList())
@@ -3219,8 +3219,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
 
                     if (existingNavigation.ForeignKey.DeclaringEntityType.Builder
-                            .HasNoRelationship(existingNavigation.ForeignKey, configurationSource)
-                        == null)
+                            .HasNoRelationship(existingNavigation.ForeignKey, configurationSource) == null)
                     {
                         return null;
                     }

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -434,28 +434,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             using (Metadata.ConventionDispatcher.DelayConventions())
             {
+                var removed = false;
                 foreach (var entityType in Metadata.GetEntityTypes(name).ToList())
                 {
-                    HasNoEntityType(entityType, configurationSource);
-
                     if (entityType.HasClrType())
                     {
-                        Metadata.AddIgnored(entityType.ClrType, configurationSource);
+                        if (entityType.HasSharedClrType)
+                        {
+                            Metadata.AddIgnored(entityType.Name, entityType.ClrType, configurationSource);
+                        }
+                        else
+                        {
+                            Metadata.AddIgnored(entityType.ClrType, configurationSource);
+                        }
                     }
                     else
                     {
                         Metadata.AddIgnored(entityType.Name, configurationSource);
                     }
+
+                    removed = true;
+                    HasNoEntityType(entityType, configurationSource);
                 }
 
-                if (type.Type == null)
+                if (!removed)
                 {
-                    Metadata.AddIgnored(name, configurationSource);
+                    if (type.Type == null)
+                    {
+                        Metadata.AddIgnored(name, configurationSource);
+                    }
+                    else
+                    {
+                        Metadata.AddIgnored(type.Type, configurationSource);
+                    }
                 }
-                else
+
+                if (type.Type != null)
                 {
                     Metadata.RemoveOwned(type.Type);
-                    Metadata.AddIgnored(type.Type, configurationSource);
                 }
 
                 return this;

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -709,7 +709,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource configurationSource)
             => AddIgnored(Check.NotNull(name, nameof(name)), null, configurationSource);
 
-        private string AddIgnored(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string AddIgnored(
             [NotNull] string name,
             [CanBeNull] Type type,
             ConfigurationSource configurationSource)


### PR DESCRIPTION
Merge BaseTypeDiscoveryConvention with DerivedTypeDiscoveryConvention.
Make sure that base type is reset when it becomes owned.
Remove entries from the ambiguous inverses as soon as the navigation or declaring type is ignored.