### PR TITLE
Fix return values from ResetAsync

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             ResetState();
 
-            return default;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTransactionManager.cs
@@ -166,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         {
             ResetState();
 
-            return default;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -395,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
             ((IResettableService)this).ResetState();
 
-            return default;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -697,7 +697,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             ResetState();
 
-            return default;
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -522,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             ((IResettableService)this).ResetState();
 
-            return default;
+            return Task.CompletedTask;
         }
 
         private EntityEntry<TEntity> EntryWithoutDetectChanges(TEntity entity)


### PR DESCRIPTION
Fixes #22255

This must have happened when we switched back from ValueTask to Task. We missed this because we had no coverage for async dispose with context pooling. Added this coverage and scanned code for other occurrences.


