### PR TITLE
PMC Tools: Throw a better exception when ActiveConfiguration returns null

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -1019,8 +1019,16 @@ function EF($project, $startupProject, $params, $applicationArgs, [switch] $skip
         Write-Host 'Build succeeded.'
     }
 
+    $activeConfiguration = $startupProject.ConfigurationManager.ActiveConfiguration
+    if ($activeConfiguration -eq $null)
+    {
+        throw "Unable to read project configuration settings of project '$($startupProject.ProjectName)' for the " +
+            'active solution configuration. Try closing Package Manager Console and restarting Visual Studio. If the ' +
+            'problem persists, use Help > Send Feedback > Report a Problem.'
+    }
+
     $startupProjectDir = GetProperty $startupProject.Properties 'FullPath'
-    $outputPath = GetProperty $startupProject.ConfigurationManager.ActiveConfiguration.Properties 'OutputPath'
+    $outputPath = GetProperty $activeConfiguration.Properties 'OutputPath'
     $targetDir = [IO.Path]::GetFullPath([IO.Path]::Combine($startupProjectDir, $outputPath))
     $startupTargetFileName = GetProperty $startupProject.Properties 'OutputFileName'
     $startupTargetPath = Join-Path $targetDir $startupTargetFileName


### PR DESCRIPTION
More users seem to be hitting this lately. Making the exception more obvious so we don't spend so much time investigating.

Part of #16386

/cc @Pilchie

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


