### PR TITLE
Be consistent about OnModelCreating as the terminology for fluent API

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -163,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 resourceId, partitionKey);
 
         /// <summary>
-        ///     Null TypeMapping in Sql Tree.
+        ///     Null TypeMapping in SQL tree.
         /// </summary>
         public static string NullTypeMappingInSqlTree
             => GetString("NullTypeMappingInSqlTree");

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -175,7 +175,7 @@
     <value>There is no string-based representation of this query as it's executed using 'ReadItemQueryAsync({resourceId}, {partitionKey})'.</value>
   </data>
   <data name="NullTypeMappingInSqlTree" xml:space="preserve">
-    <value>Null TypeMapping in Sql Tree.</value>
+    <value>Null TypeMapping in SQL tree.</value>
   </data>
   <data name="OffsetRequiresLimit" xml:space="preserve">
     <value>Offset is not supported without Limit.</value>

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -213,12 +213,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 foreignKeyName);
 
         /// <summary>
-        ///     Could not scaffold the foreign key '{foreignKeyName}'. The referenced table '{principaltableName}' could not be scaffolded.
+        ///     Could not scaffold the foreign key '{foreignKeyName}'. The referenced table '{principalTableName}' could not be scaffolded.
         /// </summary>
-        public static string ForeignKeyScaffoldErrorPrincipalTableScaffoldingError([CanBeNull] object foreignKeyName, [CanBeNull] object principaltableName)
+        public static string ForeignKeyScaffoldErrorPrincipalTableScaffoldingError([CanBeNull] object foreignKeyName, [CanBeNull] object principalTableName)
             => string.Format(
-                GetString("ForeignKeyScaffoldErrorPrincipalTableScaffoldingError", nameof(foreignKeyName), nameof(principaltableName)),
-                foreignKeyName, principaltableName);
+                GetString("ForeignKeyScaffoldErrorPrincipalTableScaffoldingError", nameof(foreignKeyName), nameof(principalTableName)),
+                foreignKeyName, principalTableName);
 
         /// <summary>
         ///     Could not scaffold the foreign key '{foreignKeyName}'.  The following columns in the foreign key could not be scaffolded: {columnNames}.

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -196,7 +196,7 @@
     <value>Could not scaffold the foreign key '{foreignKeyName}'. The referenced table could not be found. This most likely occurred because the referenced table was excluded from scaffolding.</value>
   </data>
   <data name="ForeignKeyScaffoldErrorPrincipalTableScaffoldingError" xml:space="preserve">
-    <value>Could not scaffold the foreign key '{foreignKeyName}'. The referenced table '{principaltableName}' could not be scaffolded.</value>
+    <value>Could not scaffold the foreign key '{foreignKeyName}'. The referenced table '{principalTableName}' could not be scaffolded.</value>
   </data>
   <data name="ForeignKeyScaffoldErrorPropertyNotFound" xml:space="preserve">
     <value>Could not scaffold the foreign key '{foreignKeyName}'.  The following columns in the foreign key could not be scaffolded: {columnNames}.</value>

--- a/src/EFCore.Relational/Extensions/Internal/TupleExtensions.cs
+++ b/src/EFCore.Relational/Extensions/Internal/TupleExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static string FormatTables([NotNull] this IEnumerable<(string Table, string Schema)> tables)
             => "{"
-                + string.Join(", ", tables.Select(FormatTable))
+                + string.Join(", ", tables.Select(t => "'" + FormatTable(t) + "'"))
                 + "}";
 
         /// <summary>
@@ -34,8 +34,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static string FormatTable(this (string Table, string Schema) table)
-            => "'"
-                + (table.Schema == null ? table.Table : table.Schema + "." + table.Table)
-                + "'";
+            => table.Schema == null ? table.Table : table.Schema + "." + table.Table;
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2577,7 +2577,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 = new Dictionary<ITable, DropTableOperation>();
 
             private readonly IDictionary<IColumn, DropColumnOperation> _dropColumnOperations
-                = new Dictionary<IColumn, DropColumnOperation>();            
+                = new Dictionary<IColumn, DropColumnOperation>();
 
             private readonly IDictionary<DropTableOperation, ITable> _removedTables
                 = new Dictionary<DropTableOperation, ITable>();

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("ClientGroupByNotSupported");
 
         /// <summary>
-        ///     The column '{column}' on table {table} has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.
+        ///     The column '{column}' on table '{table}' has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.
         /// </summary>
         public static string ComputedColumnSqlUnspecified([CanBeNull] object column, [CanBeNull] object table)
             => string.Format(
@@ -77,20 +77,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("ConflictingEnlistedTransaction");
 
         /// <summary>
-        ///     An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different original property values for the properties {firstProperties} and {secondProperties} mapped to {columns}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.
+        ///     An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different original property values for the properties {firstProperty} and {secondProperty} mapped to '{column}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.
         /// </summary>
-        public static string ConflictingOriginalRowValues([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object firstProperties, [CanBeNull] object secondProperties, [CanBeNull] object columns)
+        public static string ConflictingOriginalRowValues([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object firstProperty, [CanBeNull] object secondProperty, [CanBeNull] object column)
             => string.Format(
-                GetString("ConflictingOriginalRowValues", nameof(firstEntityType), nameof(secondEntityType), nameof(firstProperties), nameof(secondProperties), nameof(columns)),
-                firstEntityType, secondEntityType, firstProperties, secondProperties, columns);
+                GetString("ConflictingOriginalRowValues", nameof(firstEntityType), nameof(secondEntityType), nameof(firstProperty), nameof(secondProperty), nameof(column)),
+                firstEntityType, secondEntityType, firstProperty, secondProperty, column);
 
         /// <summary>
-        ///     The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values '{firstConflictingValues}' and '{secondConflictingValues}' for the column {columns}.
+        ///     The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values {firstConflictingValues} and {secondConflictingValues} for the column '{column}'.
         /// </summary>
-        public static string ConflictingOriginalRowValuesSensitive([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object keyValue, [CanBeNull] object firstConflictingValues, [CanBeNull] object secondConflictingValues, [CanBeNull] object columns)
+        public static string ConflictingOriginalRowValuesSensitive([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object keyValue, [CanBeNull] object firstConflictingValues, [CanBeNull] object secondConflictingValues, [CanBeNull] object column)
             => string.Format(
-                GetString("ConflictingOriginalRowValuesSensitive", nameof(firstEntityType), nameof(secondEntityType), nameof(keyValue), nameof(firstConflictingValues), nameof(secondConflictingValues), nameof(columns)),
-                firstEntityType, secondEntityType, keyValue, firstConflictingValues, secondConflictingValues, columns);
+                GetString("ConflictingOriginalRowValuesSensitive", nameof(firstEntityType), nameof(secondEntityType), nameof(keyValue), nameof(firstConflictingValues), nameof(secondConflictingValues), nameof(column)),
+                firstEntityType, secondEntityType, keyValue, firstConflictingValues, secondConflictingValues, column);
 
         /// <summary>
         ///     An instance of entity type '{firstEntityType}' is marked as '{firstState}', but an instance of entity type '{secondEntityType}' is marked as '{secondState}' and both are mapped to the same row. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 firstEntityType, firstKeyValue, firstState, secondEntityType, secondKeyValue, secondState);
 
         /// <summary>
-        ///     An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different property values for the properties {firstProperty} and {secondProperty} mapped to {column}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.
+        ///     An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different property values for the properties {firstProperty} and {secondProperty} mapped to '{column}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.
         /// </summary>
         public static string ConflictingRowValues([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object firstProperty, [CanBeNull] object secondProperty, [CanBeNull] object column)
             => string.Format(
@@ -117,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 firstEntityType, secondEntityType, firstProperty, secondProperty, column);
 
         /// <summary>
-        ///     The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different property values '{firstConflictingValue}' and '{secondConflictingValue}' for the column {column}.
+        ///     The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different property values '{firstConflictingValue}' and '{secondConflictingValue}' for the column '{column}'.
         /// </summary>
         public static string ConflictingRowValuesSensitive([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType, [CanBeNull] object keyValue, [CanBeNull] object firstConflictingValue, [CanBeNull] object secondConflictingValue, [CanBeNull] object column)
             => string.Format(
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 function);
 
         /// <summary>
-        ///     The column '{column}' on table {table} has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.
+        ///     The column '{column}' on table '{table}' has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.
         /// </summary>
         public static string DefaultValueSqlUnspecified([CanBeNull] object column, [CanBeNull] object table)
             => string.Format(
@@ -243,7 +243,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 column, table);
 
         /// <summary>
-        ///     The column '{column}' on table {table} has an unspecified default value. Specify a value before using EF Core to create the database schema.
+        ///     The column '{column}' on table '{table}' has an unspecified default value. Specify a value before using EF Core to create the database schema.
         /// </summary>
         public static string DefaultValueUnspecified([CanBeNull] object column, [CanBeNull] object table)
             => string.Format(
@@ -460,7 +460,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 keyProperties1, entityType1, keyProperties2, entityType2, table, keyName, columnNames1, columnNames2);
 
         /// <summary>
-        ///     The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{keyName}' but with different columns ('{table1}' and '{table2}').
+        ///     The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{keyName}' but on different tables ('{table1}' and '{table2}').
         /// </summary>
         public static string DuplicateKeyTableMismatch([CanBeNull] object keyProperties1, [CanBeNull] object entityType1, [CanBeNull] object keyProperties2, [CanBeNull] object entityType2, [CanBeNull] object keyName, [CanBeNull] object table1, [CanBeNull] object table2)
             => string.Format(
@@ -498,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 propertySpecification, function);
 
         /// <summary>
-        ///     Data is Null. This method or property cannot be called on Null values.
+        ///     Data is null. This method or property cannot be called on null values.
         /// </summary>
         public static string GetXMethodOnNullData
             => GetString("GetXMethodOnNullData");
@@ -604,7 +604,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("InvalidCommandTimeout");
 
         /// <summary>
-        ///     'UpdateEntityType' called with '{derivedType}' which is not derived type of '{entityType}'.
+        ///     The specified entity type '{derivedType}' is not derived from '{entityType}'.
         /// </summary>
         public static string InvalidDerivedTypeInEntityProjection([CanBeNull] object derivedType, [CanBeNull] object entityType)
             => string.Format(
@@ -612,7 +612,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 derivedType, entityType);
 
         /// <summary>
-        ///     Invalid keySelector for Group By.
+        ///     Invalid keySelector for GroupBy.
         /// </summary>
         public static string InvalidKeySelectorForGroupBy
             => GetString("InvalidKeySelectorForGroupBy");
@@ -790,7 +790,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, otherEntityType, view);
 
         /// <summary>
-        ///     No relational database providers are configured. Configure a database provider using OnConfiguring or by creating an ImmutableDbContextOptions with a database provider configured and passing it to the context.
+        ///     No relational database providers are configured. Configure a database provider using 'OnConfiguring' or by creating an ImmutableDbContextOptions with a database provider configured and passing it to the context.
         /// </summary>
         public static string NoProviderConfigured
             => GetString("NoProviderConfigured");
@@ -810,7 +810,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NullabilityInfoOnlyAllowedOnScalarFunctions");
 
         /// <summary>
-        ///     Null TypeMapping in Sql Tree.
+        ///     Null TypeMapping in SQL tree.
         /// </summary>
         public static string NullTypeMappingInSqlTree
             => GetString("NullTypeMappingInSqlTree");
@@ -850,7 +850,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("QueryUnableToIdentifyConcreteTypeInTPT");
 
         /// <summary>
-        ///     The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Use ToTable to map it.
+        ///     The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Use 'ToTable' in 'OnModelCreating' to map it.
         /// </summary>
         public static string ReadonlyEntitySaved([CanBeNull] object entityType)
             => string.Format(
@@ -878,7 +878,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("SequenceContainsNoElements");
 
         /// <summary>
-        ///     Can't process set operations after client evaluation, consider moving the operation before the last Select() call (see issue #16243).
+        ///     Can't process set operations after client evaluation, consider moving the operation before the last 'Select' call (see issue #16243).
         /// </summary>
         public static string SetOperationsNotAllowedAfterClientEvaluation
             => GetString("SetOperationsNotAllowedAfterClientEvaluation");
@@ -1925,7 +1925,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Compiling a query which loads related collections for more than one collection navigation property either via 'Include' or through projection but no 'QuerySplittingBehavior' has been configured. By default EF Core will use 'QuerySplittingBehavior.SingleQuery' which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call .ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))
+        ///     Compiling a query which loads related collections for more than one collection navigation either via 'Include' or through projection but no 'QuerySplittingBehavior' has been configured. By default EF Core will use 'QuerySplittingBehavior.SingleQuery' which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'
         /// </summary>
         public static EventDefinition LogMultipleCollectionIncludeWarning([NotNull] IDiagnosticsLogger logger)
         {
@@ -1949,7 +1949,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. None of these properties are mapped to a column in any table. This index will not be created in the database.
+        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. None of these properties are mapped to a column in any table. This index will not be created in the database.
         /// </summary>
         public static EventDefinition<string, string, string> LogNamedIndexAllPropertiesNotToMappedToAnyTable([NotNull] IDiagnosticsLogger logger)
         {
@@ -1973,7 +1973,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.
+        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogNamedIndexPropertiesBothMappedAndNotMappedToTable([NotNull] IDiagnosticsLogger logger)
         {
@@ -1997,7 +1997,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.
+        ///     The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. The property '{propertyName1}' is mapped to table(s) {tables1}, whereas the property '{propertyName2}' is mapped to table(s) {tables2}. All index properties must map to at least one common table.
         /// </summary>
         public static FallbackEventDefinition LogNamedIndexPropertiesMappedToNonOverlappingTables([NotNull] IDiagnosticsLogger logger)
         {
@@ -2283,7 +2283,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Rolling back to transaction savepoint..
+        ///     Rolling back to transaction savepoint.
         /// </summary>
         public static EventDefinition LogRollingBackToTransactionSavepoint([NotNull] IDiagnosticsLogger logger)
         {
@@ -2355,7 +2355,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. None of these properties are mapped to a column in any table. This index will not be created in the database.
+        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. None of these properties are mapped to a column in any table. This index will not be created in the database.
         /// </summary>
         public static EventDefinition<string, string> LogUnnamedIndexAllPropertiesNotToMappedToAnyTable([NotNull] IDiagnosticsLogger logger)
         {
@@ -2379,7 +2379,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.
+        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.
         /// </summary>
         public static EventDefinition<string, string, string> LogUnnamedIndexPropertiesBothMappedAndNotMappedToTable([NotNull] IDiagnosticsLogger logger)
         {
@@ -2403,7 +2403,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.
+        ///     The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.
         /// </summary>
         public static EventDefinition<string, string, string, string, string, string> LogUnnamedIndexPropertiesMappedToNonOverlappingTables([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -130,7 +130,7 @@
     <value>The given GroupBy pattern is not translatable. Call AsEnumerable before GroupBy to evaluate it locally.</value>
   </data>
   <data name="ComputedColumnSqlUnspecified" xml:space="preserve">
-    <value>The column '{column}' on table {table} has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.</value>
+    <value>The column '{column}' on table '{table}' has unspecified computed column SQL. Specify the SQL before using EF Core to create the database schema.</value>
   </data>
   <data name="ConflictingAmbientTransaction" xml:space="preserve">
     <value>An ambient transaction has been detected. The ambient transaction needs to be completed before beginning a transaction on this connection.</value>
@@ -142,10 +142,10 @@
     <value>The connection is currently enlisted in a transaction. The enlisted transaction needs to be completed before starting a transaction.</value>
   </data>
   <data name="ConflictingOriginalRowValues" xml:space="preserve">
-    <value>An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different original property values for the properties {firstProperties} and {secondProperties} mapped to {columns}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.</value>
+    <value>An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different original property values for the properties {firstProperty} and {secondProperty} mapped to '{column}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.</value>
   </data>
   <data name="ConflictingOriginalRowValuesSensitive" xml:space="preserve">
-    <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values '{firstConflictingValues}' and '{secondConflictingValues}' for the column {columns}.</value>
+    <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values {firstConflictingValues} and {secondConflictingValues} for the column '{column}'.</value>
   </data>
   <data name="ConflictingRowUpdateTypes" xml:space="preserve">
     <value>An instance of entity type '{firstEntityType}' is marked as '{firstState}', but an instance of entity type '{secondEntityType}' is marked as '{secondState}' and both are mapped to the same row. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
@@ -154,10 +154,10 @@
     <value>The instance of entity type '{firstEntityType}' with the key value '{firstKeyValue}' is marked as '{firstState}', but the instance of entity type '{secondEntityType}' with the key value '{secondKeyValue}' is marked as '{secondState}' and both are mapped to the same row.</value>
   </data>
   <data name="ConflictingRowValues" xml:space="preserve">
-    <value>An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different property values for the properties {firstProperty} and {secondProperty} mapped to {column}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.</value>
+    <value>An instance of entity type '{firstEntityType}' and an instance of entity type '{secondEntityType}' are mapped to the same row, but have different property values for the properties {firstProperty} and {secondProperty} mapped to '{column}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting values.</value>
   </data>
   <data name="ConflictingRowValuesSensitive" xml:space="preserve">
-    <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different property values '{firstConflictingValue}' and '{secondConflictingValue}' for the column {column}.</value>
+    <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different property values '{firstConflictingValue}' and '{secondConflictingValue}' for the column '{column}'.</value>
   </data>
   <data name="DatabaseModelMissing" xml:space="preserve">
     <value>The database model hasn't been initialized. The model needs to be finalized before the database model can be accessed.</value>
@@ -202,10 +202,10 @@
     <value>Cannot set custom translation on the DbFunction '{function}' since it is a table valued function.</value>
   </data>
   <data name="DefaultValueSqlUnspecified" xml:space="preserve">
-    <value>The column '{column}' on table {table} has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.</value>
+    <value>The column '{column}' on table '{table}' has unspecified default value SQL. Specify the SQL before using EF Core to create the database schema.</value>
   </data>
   <data name="DefaultValueUnspecified" xml:space="preserve">
-    <value>The column '{column}' on table {table} has an unspecified default value. Specify a value before using EF Core to create the database schema.</value>
+    <value>The column '{column}' on table '{table}' has an unspecified default value. Specify a value before using EF Core to create the database schema.</value>
   </data>
   <data name="DeleteDataOperationNoModel" xml:space="preserve">
     <value>The data deletion operation on '{table}' is not associated with a model. Either add a model to the migration or specify the column types in all data operations.</value>
@@ -287,7 +287,7 @@
     <value>The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{table}.{keyName}' but with different columns ({columnNames1} and {columnNames2}).</value>
   </data>
   <data name="DuplicateKeyTableMismatch" xml:space="preserve">
-    <value>The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{keyName}' but with different columns ('{table1}' and '{table2}').</value>
+    <value>The keys {keyProperties1} on '{entityType1}' and {keyProperties2} on '{entityType2}' are both mapped to '{keyName}' but on different tables ('{table1}' and '{table2}').</value>
   </data>
   <data name="EitherOfTwoValuesMustBeNull" xml:space="preserve">
     <value>Either {param1} or {param2} must be null.</value>
@@ -302,7 +302,7 @@
     <value>The property '{propertySpecification}' has specific configuration for the function '{function}', however it isn't mapped to a column on that function return. Remove the specific configuration or map an entity type that contains this property to '{function}'.</value>
   </data>
   <data name="GetXMethodOnNullData" xml:space="preserve">
-    <value>Data is Null. This method or property cannot be called on Null values.</value>
+    <value>Data is null. This method or property cannot be called on null values.</value>
   </data>
   <data name="IncompatibleTableCommentMismatch" xml:space="preserve">
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and the comment '{comment}' does not match the comment '{otherComment}'.</value>
@@ -344,10 +344,10 @@
     <value>The specified CommandTimeout value is not valid. It must be a positive number.</value>
   </data>
   <data name="InvalidDerivedTypeInEntityProjection" xml:space="preserve">
-    <value>'UpdateEntityType' called with '{derivedType}' which is not derived type of '{entityType}'.</value>
+    <value>The specified entity type '{derivedType}' is not derived from '{entityType}'.</value>
   </data>
   <data name="InvalidKeySelectorForGroupBy" xml:space="preserve">
-    <value>Invalid keySelector for Group By.</value>
+    <value>Invalid keySelector for GroupBy.</value>
   </data>
   <data name="InvalidMappedFunctionDerivedType" xml:space="preserve">
     <value>The entity type '{entityType}' is mapped to the DbFunction named '{functionName}' and it's derived from '{baseEntityType}'. Derived entity types cannot be mapped to a function.</value>
@@ -499,19 +499,19 @@
     <comment>Warning RelationalEventId.MigrationAttributeMissingWarning string</comment>
   </data>
   <data name="LogMultipleCollectionIncludeWarning" xml:space="preserve">
-    <value>Compiling a query which loads related collections for more than one collection navigation property either via 'Include' or through projection but no 'QuerySplittingBehavior' has been configured. By default EF Core will use 'QuerySplittingBehavior.SingleQuery' which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call .ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))</value>
+    <value>Compiling a query which loads related collections for more than one collection navigation either via 'Include' or through projection but no 'QuerySplittingBehavior' has been configured. By default EF Core will use 'QuerySplittingBehavior.SingleQuery' which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'</value>
     <comment>Warning RelationalEventId.MultipleCollectionIncludeWarning</comment>
   </data>
   <data name="LogNamedIndexAllPropertiesNotToMappedToAnyTable" xml:space="preserve">
-    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. None of these properties are mapped to a column in any table. This index will not be created in the database.</value>
+    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. None of these properties are mapped to a column in any table. This index will not be created in the database.</value>
     <comment>Information RelationalEventId.AllIndexPropertiesNotToMappedToAnyTable string string string</comment>
   </data>
   <data name="LogNamedIndexPropertiesBothMappedAndNotMappedToTable" xml:space="preserve">
-    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.</value>
+    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.</value>
     <comment>Error RelationalEventId.IndexPropertiesBothMappedAndNotMappedToTable string string string string</comment>
   </data>
   <data name="LogNamedIndexPropertiesMappedToNonOverlappingTables" xml:space="preserve">
-    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexPropertiesList}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.</value>
+    <value>The index named '{indexName}' on the entity type '{entityType}' specifies properties {indexProperties}. The property '{propertyName1}' is mapped to table(s) {tables1}, whereas the property '{propertyName2}' is mapped to table(s) {tables2}. All index properties must map to at least one common table.</value>
     <comment>Error RelationalEventId.IndexPropertiesMappedToNonOverlappingTables string string string string string string string</comment>
   </data>
   <data name="LogNoMigrationsApplied" xml:space="preserve">
@@ -559,7 +559,7 @@
     <comment>Debug RelationalEventId.TransactionRolledBack</comment>
   </data>
   <data name="LogRollingBackToTransactionSavepoint" xml:space="preserve">
-    <value>Rolling back to transaction savepoint..</value>
+    <value>Rolling back to transaction savepoint.</value>
     <comment>Debug RelationalEventId.RollingBackToTransactionSavepoint</comment>
   </data>
   <data name="LogRollingBackTransaction" xml:space="preserve">
@@ -571,15 +571,15 @@
     <comment>Error RelationalEventId.TransactionError</comment>
   </data>
   <data name="LogUnnamedIndexAllPropertiesNotToMappedToAnyTable" xml:space="preserve">
-    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. None of these properties are mapped to a column in any table. This index will not be created in the database.</value>
+    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. None of these properties are mapped to a column in any table. This index will not be created in the database.</value>
     <comment>Information RelationalEventId.AllIndexPropertiesNotToMappedToAnyTable string string</comment>
   </data>
   <data name="LogUnnamedIndexPropertiesBothMappedAndNotMappedToTable" xml:space="preserve">
-    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.</value>
+    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. Some properties are mapped to a column in a table, but the property '{propertyName}' is not. All of the properties should be mapped for the index to be created in the database.</value>
     <comment>Error RelationalEventId.IndexPropertiesBothMappedAndNotMappedToTable string string string</comment>
   </data>
   <data name="LogUnnamedIndexPropertiesMappedToNonOverlappingTables" xml:space="preserve">
-    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexPropertiesList}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.</value>
+    <value>The unnamed index on the entity type '{entityType}' specifies properties {indexProperties}. The property '{propertyName1}' is mapped to table(s) {tableList1}, whereas the property '{propertyName2}' is mapped to table(s) {tableList2}. All index properties must map to at least one common table.</value>
     <comment>Error RelationalEventId.IndexPropertiesMappedToNonOverlappingTables string string string string string string</comment>
   </data>
   <data name="LogUsingTransaction" xml:space="preserve">
@@ -638,7 +638,7 @@
     <value>Both '{entityType}' and '{otherEntityType}' are mapped to the view '{view}'. All the entity types in a hierarchy that don't have a discriminator must be mapped to different views. See https://go.microsoft.com/fwlink/?linkid=2130430 for more information.</value>
   </data>
   <data name="NoProviderConfigured" xml:space="preserve">
-    <value>No relational database providers are configured. Configure a database provider using OnConfiguring or by creating an ImmutableDbContextOptions with a database provider configured and passing it to the context.</value>
+    <value>No relational database providers are configured. Configure a database provider using 'OnConfiguring' or by creating an ImmutableDbContextOptions with a database provider configured and passing it to the context.</value>
   </data>
   <data name="NoTypeMappingFoundForSubquery" xml:space="preserve">
     <value>The subquery '{subquery}' references type '{type}' for which no type mapping could be found.</value>
@@ -647,7 +647,7 @@
     <value>Nullability information should only be specified for scalar database functions.</value>
   </data>
   <data name="NullTypeMappingInSqlTree" xml:space="preserve">
-    <value>Null TypeMapping in Sql Tree.</value>
+    <value>Null TypeMapping in SQL tree.</value>
   </data>
   <data name="ParameterNotObjectArray" xml:space="preserve">
     <value>Cannot use the value provided for parameter '{parameter}' because it isn't assignable to type object[].</value>
@@ -665,7 +665,7 @@
     <value>Unable to identify the concrete entity type to materialize in TPT hierarchy.</value>
   </data>
   <data name="ReadonlyEntitySaved" xml:space="preserve">
-    <value>The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Use ToTable to map it.</value>
+    <value>The entity type '{entityType}' is not mapped to a table, therefore the entities cannot be persisted to the database. Use 'ToTable' in 'OnModelCreating' to map it.</value>
   </data>
   <data name="RelationalNotInUse" xml:space="preserve">
     <value>Relational-specific methods can only be used when the context is using a relational database provider.</value>
@@ -677,7 +677,7 @@
     <value>Sequence contains no elements.</value>
   </data>
   <data name="SetOperationsNotAllowedAfterClientEvaluation" xml:space="preserve">
-    <value>Can't process set operations after client evaluation, consider moving the operation before the last Select() call (see issue #16243).</value>
+    <value>Can't process set operations after client evaluation, consider moving the operation before the last 'Select' call (see issue #16243).</value>
   </data>
   <data name="SetOperationsOnDifferentStoreTypes" xml:space="preserve">
     <value>Set operations over different store types are currently unsupported.</value>

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -384,7 +384,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             Entry.BuildCurrentValuesString(Entry.EntityType.FindPrimaryKey().Properties),
                             Entry.BuildCurrentValuesString(new[] { Property }),
                             modification.Entry.BuildCurrentValuesString(new[] { modification.Property }),
-                            "{'" + ColumnName + "'}"));
+                            ColumnName));
                 }
 
                 throw new InvalidOperationException(
@@ -393,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                         modification.Entry.EntityType.DisplayName(),
                         new[] { Property }.Format(),
                         new[] { modification.Property }.Format(),
-                        "{'" + ColumnName + "'}"));
+                        ColumnName));
             }
 
             if (UseOriginalValueParameter
@@ -416,7 +416,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                                 Entry.BuildCurrentValuesString(Entry.EntityType.FindPrimaryKey().Properties),
                                 Entry.BuildOriginalValuesString(new[] { Property }),
                                 modification.Entry.BuildOriginalValuesString(new[] { modification.Property }),
-                                "{'" + ColumnName + "'}"));
+                                ColumnName));
                     }
 
                     throw new InvalidOperationException(
@@ -425,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                             modification.Entry.EntityType.DisplayName(),
                             new[] { Property }.Format(),
                             new[] { modification.Property }.Format(),
-                            "{'" + ColumnName + "'}"));
+                            ColumnName));
                 }
             }
 

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -316,6 +316,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                 }
             }
 
+            if (!_sensitiveLoggingEnabled)
+            {
+                builder.Append(CoreStrings.SensitiveDataDisabled);
+            }
+
             return builder.ToString();
         }
 
@@ -359,10 +364,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             var reverseDependency = !source.Entries.Any(e => foreignKey.DeclaringEntityType.IsAssignableFrom(e.EntityType));
             if (reverseDependency)
             {
-                builder.Append(" <-");
+                builder.AppendLine(" <-");
+            }
+            else
+            {
+                builder.Append(" ");
             }
 
-            builder.Append(" ");
             if (foreignKey.DependentToPrincipal != null
                 || foreignKey.PrincipalToDependent != null)
             {
@@ -416,7 +424,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             if (!reverseDependency)
             {
-                builder.Append("<- ");
+                builder.AppendLine("<-");
             }
         }
 
@@ -425,10 +433,14 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             var reverseDependency = source.EntityState != EntityState.Deleted;
             if (reverseDependency)
             {
-                builder.Append(" <-");
+                builder.AppendLine(" <-");
+            }
+            else
+            {
+                builder.Append(" ");
             }
 
-            builder.Append(" Index ");
+            builder.Append("Index ");
 
             var dependentCommand = reverseDependency ? target : source;
             var dependentEntry = dependentCommand.Entries.First(e => index.DeclaringEntityType.IsAssignableFrom(e.EntityType));
@@ -455,7 +467,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
             if (!reverseDependency)
             {
-                builder.Append("<- ");
+                builder.AppendLine("<-");
             }
         }
 

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 table, entityType, otherEntityType, memoryOptimizedEntityType, nonMemoryOptimizedEntityType);
 
         /// <summary>
-        ///     SQL Server requires the table name to be specified for rename index operations. Specify table name in the call to MigrationBuilder.RenameIndex.
+        ///     SQL Server requires the table name to be specified for rename index operations. Specify table name in the call to 'MigrationBuilder.RenameIndex'.
         /// </summary>
         public static string IndexTableRequired
             => GetString("IndexTableRequired");
@@ -282,7 +282,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.
+        ///     Both the SqlServerValueGenerationStrategy '{generationStrategy}' and '{otherGenerationStrategy}' have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogConflictingValueGenerationStrategies([NotNull] IDiagnosticsLogger logger)
         {
@@ -330,7 +330,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     No type was specified for the decimal property '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()', specify precision and scale using 'HasPrecision()' or configure a value converter using 'HasConversion()'.
+        ///     No type was specified for the decimal property '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType()', specify precision and scale using 'HasPrecision()' or configure a value converter using 'HasConversion()'.
         /// </summary>
         public static EventDefinition<string, string> LogDefaultDecimalTypeColumn([NotNull] IDiagnosticsLogger logger)
         {
@@ -375,7 +375,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Found default schema {defaultSchema}.
+        ///     Found default schema '{defaultSchema}'.
         /// </summary>
         public static EventDefinition<string> LogFoundDefaultSchema([NotNull] IDiagnosticsLogger logger)
         {
@@ -564,7 +564,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Unable to find a schema in the database matching the selected schema {schema}.
+        ///     Unable to find a schema in the database matching the selected schema '{schema}'.
         /// </summary>
         public static EventDefinition<string> LogMissingSchema([NotNull] IDiagnosticsLogger logger)
         {
@@ -588,7 +588,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     Unable to find a table in the database matching the selected table {table}.
+        ///     Unable to find a table in the database matching the selected table '{table}'.
         /// </summary>
         public static EventDefinition<string> LogMissingTable([NotNull] IDiagnosticsLogger logger)
         {
@@ -612,7 +612,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     For foreign key {foreignKeyName} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.
+        ///     For foreign key '{foreignKeyName}' on table '{tableName}', unable to find the column called '{principalColumnName}' on the foreign key's principal table, '{principalTableName}'. Skipping foreign key.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogPrincipalColumnNotFound([NotNull] IDiagnosticsLogger logger)
         {
@@ -636,7 +636,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         }
 
         /// <summary>
-        ///     For foreign key {fkName} on table {tableName}, unable to model the end of the foreign key on principal table {principaltableName}. This is usually because the principal table was not included in the selection set.
+        ///     For foreign key '{foreignKeyName}' on table '{tableName}', unable to model the end of the foreign key on principal table '{principalTableName}'. This is usually because the principal table was not included in the selection set.
         /// </summary>
         public static EventDefinition<string, string, string> LogPrincipalTableNotInSelectionSet([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -169,7 +169,7 @@
     <value>Cannot use table '{table}' for entity type '{entityType}' since it is being used for entity type '{otherEntityType}' and entity type '{memoryOptimizedEntityType}' is marked as memory-optimized, but entity type '{nonMemoryOptimizedEntityType}' is not.</value>
   </data>
   <data name="IndexTableRequired" xml:space="preserve">
-    <value>SQL Server requires the table name to be specified for rename index operations. Specify table name in the call to MigrationBuilder.RenameIndex.</value>
+    <value>SQL Server requires the table name to be specified for rename index operations. Specify table name in the call to 'MigrationBuilder.RenameIndex'.</value>
   </data>
   <data name="InvalidColumnNameForFreeText" xml:space="preserve">
     <value>The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'</value>
@@ -182,7 +182,7 @@
     <comment>Warning SqlServerEventId.ByteIdentityColumnWarning string string</comment>
   </data>
   <data name="LogConflictingValueGenerationStrategies" xml:space="preserve">
-    <value>Both the SqlServerValueGenerationStrategy {generationStrategy} and {otherGenerationStrategy} have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.</value>
+    <value>Both the SqlServerValueGenerationStrategy '{generationStrategy}' and '{otherGenerationStrategy}' have been set on property '{propertyName}' on entity type '{entityName}'. Usually this is a mistake. Only use these at the same time if you are sure you understand the consequences.</value>
     <comment>Warning SqlServerEventId.ConflictingValueGenerationStrategiesWarning string string string string</comment>
   </data>
   <data name="LogDecimalTypeKey" xml:space="preserve">
@@ -190,7 +190,7 @@
     <comment>Warning SqlServerEventId.DecimalTypeKeyWarning string string</comment>
   </data>
   <data name="LogDefaultDecimalTypeColumn" xml:space="preserve">
-    <value>No type was specified for the decimal property '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()', specify precision and scale using 'HasPrecision()' or configure a value converter using 'HasConversion()'.</value>
+    <value>No type was specified for the decimal property '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values in 'OnModelCreating' using 'HasColumnType()', specify precision and scale using 'HasPrecision()' or configure a value converter using 'HasConversion()'.</value>
     <comment>Warning SqlServerEventId.DecimalTypeDefaultWarning string string</comment>
   </data>
   <data name="LogFoundColumn" xml:space="preserve">
@@ -198,7 +198,7 @@
     <comment>Debug SqlServerEventId.ColumnFound string string int string int int int bool bool string string bool?</comment>
   </data>
   <data name="LogFoundDefaultSchema" xml:space="preserve">
-    <value>Found default schema {defaultSchema}.</value>
+    <value>Found default schema '{defaultSchema}'.</value>
     <comment>Debug SqlServerEventId.DefaultSchemaFound string</comment>
   </data>
   <data name="LogFoundForeignKey" xml:space="preserve">
@@ -230,19 +230,19 @@
     <comment>Debug SqlServerEventId.UniqueConstraintFound string string</comment>
   </data>
   <data name="LogMissingSchema" xml:space="preserve">
-    <value>Unable to find a schema in the database matching the selected schema {schema}.</value>
+    <value>Unable to find a schema in the database matching the selected schema '{schema}'.</value>
     <comment>Warning SqlServerEventId.MissingSchemaWarning string</comment>
   </data>
   <data name="LogMissingTable" xml:space="preserve">
-    <value>Unable to find a table in the database matching the selected table {table}.</value>
+    <value>Unable to find a table in the database matching the selected table '{table}'.</value>
     <comment>Warning SqlServerEventId.MissingTableWarning string</comment>
   </data>
   <data name="LogPrincipalColumnNotFound" xml:space="preserve">
-    <value>For foreign key {foreignKeyName} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.</value>
+    <value>For foreign key '{foreignKeyName}' on table '{tableName}', unable to find the column called '{principalColumnName}' on the foreign key's principal table, '{principalTableName}'. Skipping foreign key.</value>
     <comment>Warning SqlServerEventId.ForeignKeyPrincipalColumnMissingWarning string string string string</comment>
   </data>
   <data name="LogPrincipalTableNotInSelectionSet" xml:space="preserve">
-    <value>For foreign key {fkName} on table {tableName}, unable to model the end of the foreign key on principal table {principaltableName}. This is usually because the principal table was not included in the selection set.</value>
+    <value>For foreign key '{foreignKeyName}' on table '{tableName}', unable to model the end of the foreign key on principal table '{principalTableName}'. This is usually because the principal table was not included in the selection set.</value>
     <comment>Warning SqlServerEventId.ForeignKeyReferencesMissingPrincipalTableWarning string string string</comment>
   </data>
   <data name="LogReflexiveConstraintIgnored" xml:space="preserve">

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
         }
 
         /// <summary>
-        ///     For foreign key with identity {id} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.
+        ///     For foreign key with identity '{id}' on table '{tableName}', unable to find the column called '{principalColumnName}' on the foreign key's principal table, '{principaltableName}'. Skipping foreign key.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogPrincipalColumnNotFound([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.resx
@@ -162,7 +162,7 @@
     <comment>Warning SqliteEventId.MissingTableWarning string</comment>
   </data>
   <data name="LogPrincipalColumnNotFound" xml:space="preserve">
-    <value>For foreign key with identity {id} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.</value>
+    <value>For foreign key with identity '{id}' on table '{tableName}', unable to find the column called '{principalColumnName}' on the foreign key's principal table, '{principaltableName}'. Skipping foreign key.</value>
     <comment>Warning SqliteEventId.ForeignKeyPrincipalColumnMissingWarning string string string string</comment>
   </data>
   <data name="LogSchemaConfigured" xml:space="preserve">

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -331,7 +331,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The display name. </returns>
         [DebuggerStepThrough]
         public static string DisplayName([NotNull] this ITypeBase type)
-            => type.FullName();
+            => type.FullName() + (type is IEntityType entityType && entityType.HasSharedClrType
+            ? " (" + entityType.ClrType.ShortDisplayName() + ")"
+            : "");
 
         /// <summary>
         ///     Gets the unique name for the given <see cref="ITypeBase" />.

--- a/src/EFCore/Infrastructure/AnnotatableExtensions.cs
+++ b/src/EFCore/Infrastructure/AnnotatableExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var annotation = annotatable.FindAnnotation(annotationName);
             if (annotation == null)
             {
-                throw new InvalidOperationException(CoreStrings.AnnotationNotFound(annotationName));
+                throw new InvalidOperationException(CoreStrings.AnnotationNotFound(annotationName, annotatable.ToString()));
             }
 
             return annotation;

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -994,7 +994,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     if (entityType.BaseType != null)
                     {
                         throw new InvalidOperationException(
-                            CoreStrings.BadFilterDerivedType(entityType.GetQueryFilter(), entityType.DisplayName()));
+                            CoreStrings.BadFilterDerivedType(
+                                entityType.GetQueryFilter(),
+                                entityType.DisplayName(),
+                                entityType.GetRootType().DisplayName()));
                     }
 
                     if (entityType.IsOwned())

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2401,13 +2401,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (memberInfo.DeclaringType?.IsAssignableFrom(ClrType) != true)
                 {
-                    throw new InvalidOperationException(
-                        HasSharedClrType
-                            ? CoreStrings.PropertyWrongEntitySharedClrType(
-                                memberInfo.Name, this.DisplayName(), ClrType.ShortDisplayName(),
-                                memberInfo.DeclaringType?.ShortDisplayName())
-                            : CoreStrings.PropertyWrongEntityClrType(
-                                memberInfo.Name, this.DisplayName(), memberInfo.DeclaringType?.ShortDisplayName()));
+                    throw new InvalidOperationException(CoreStrings.PropertyWrongEntityClrType(
+                        memberInfo.Name, this.DisplayName(), memberInfo.DeclaringType?.ShortDisplayName()));
                 }
             }
             else if (IsPropertyBag)

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -49,31 +49,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, targetEntryCall);
 
         /// <summary>
-        ///     The foreign key {foreignKey} on entity type '{entityType}' cannot be configured as having a required dependent since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
+        ///     The foreign key {foreignKeyProperties} on entity type '{entityType}' cannot be configured as having a required dependent since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
         /// </summary>
-        public static string AmbiguousEndRequiredDependent([CanBeNull] object foreignKey, [CanBeNull] object entityType)
+        public static string AmbiguousEndRequiredDependent([CanBeNull] object foreignKeyProperties, [CanBeNull] object entityType)
             => string.Format(
-                GetString("AmbiguousEndRequiredDependent", nameof(foreignKey), nameof(entityType)),
-                foreignKey, entityType);
+                GetString("AmbiguousEndRequiredDependent", nameof(foreignKeyProperties), nameof(entityType)),
+                foreignKeyProperties, entityType);
 
         /// <summary>
-        ///     The navigation '{entityType}.{navigation}' cannot be configured as required since the dependent side of the underlying foreign key {foreignKey} cannot be determined. To identify the dependent side of the relationship, configure the foreign key property. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
+        ///     The navigation '{entityType}.{navigation}' cannot be configured as required since the dependent side of the underlying foreign key {foreignKeyProperties} cannot be determined. To identify the dependent side of the relationship, configure the foreign key property in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
         /// </summary>
-        public static string AmbiguousEndRequiredDependentNavigation([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object foreignKey)
+        public static string AmbiguousEndRequiredDependentNavigation([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object foreignKeyProperties)
             => string.Format(
-                GetString("AmbiguousEndRequiredDependentNavigation", nameof(entityType), nameof(navigation), nameof(foreignKey)),
-                entityType, navigation, foreignKey);
+                GetString("AmbiguousEndRequiredDependentNavigation", nameof(entityType), nameof(navigation), nameof(foreignKeyProperties)),
+                entityType, navigation, foreignKeyProperties);
 
         /// <summary>
-        ///     The foreign key {foreignKey} on entity type '{entityType}' cannot be flipped to entity type '{principalEntityType}' since it was configured as required before the dependent side was configured. Configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
+        ///     The foreign key {foreignKeyProperties} on entity type '{entityType}' cannot be flipped to entity type '{principalEntityType}' since it was configured as required before the dependent side was configured. Configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
         /// </summary>
-        public static string AmbiguousEndRequiredInverted([CanBeNull] object foreignKey, [CanBeNull] object entityType, [CanBeNull] object principalEntityType)
+        public static string AmbiguousEndRequiredInverted([CanBeNull] object foreignKeyProperties, [CanBeNull] object entityType, [CanBeNull] object principalEntityType)
             => string.Format(
-                GetString("AmbiguousEndRequiredInverted", nameof(foreignKey), nameof(entityType), nameof(principalEntityType)),
-                foreignKey, entityType, principalEntityType);
+                GetString("AmbiguousEndRequiredInverted", nameof(foreignKeyProperties), nameof(entityType), nameof(principalEntityType)),
+                foreignKeyProperties, entityType, principalEntityType);
 
         /// <summary>
-        ///     Both relationships between '{firstDependentToPrincipalNavigationSpecification}' and '{firstPrincipalToDependentNavigationSpecification}' and between '{secondDependentToPrincipalNavigationSpecification}' and '{secondPrincipalToDependentNavigationSpecification}' could use {foreignKeyProperties} as the foreign key. To resolve this configure the foreign key properties explicitly on at least one of the relationships.
+        ///     Both relationships between '{firstDependentToPrincipalNavigationSpecification}' and '{firstPrincipalToDependentNavigationSpecification}' and between '{secondDependentToPrincipalNavigationSpecification}' and '{secondPrincipalToDependentNavigationSpecification}' could use {foreignKeyProperties} as the foreign key. To resolve this configure the foreign key properties explicitly in 'OnModelCreating' on at least one of the relationships.
         /// </summary>
         public static string AmbiguousForeignKeyPropertyCandidates([CanBeNull] object firstDependentToPrincipalNavigationSpecification, [CanBeNull] object firstPrincipalToDependentNavigationSpecification, [CanBeNull] object secondDependentToPrincipalNavigationSpecification, [CanBeNull] object secondPrincipalToDependentNavigationSpecification, [CanBeNull] object foreignKeyProperties)
             => string.Format(
@@ -105,12 +105,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, serviceType, entityType);
 
         /// <summary>
-        ///     The annotation '{annotation}' was not found. Ensure that the annotation has been added.
+        ///     The annotation '{annotation}' was not found. Ensure that the annotation has been added to the object {annotatable}
         /// </summary>
-        public static string AnnotationNotFound([CanBeNull] object annotation)
+        public static string AnnotationNotFound([CanBeNull] object annotation, [CanBeNull] object annotatable)
             => string.Format(
-                GetString("AnnotationNotFound", nameof(annotation)),
-                annotation);
+                GetString("AnnotationNotFound", nameof(annotation), nameof(annotatable)),
+                annotation, annotatable);
 
         /// <summary>
         ///     The property '{property}' of the argument '{argument}' cannot be null.
@@ -145,12 +145,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 dependenciesType);
 
         /// <summary>
-        ///     The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.
+        ///     The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type '{rootType}'.
         /// </summary>
-        public static string BadFilterDerivedType([CanBeNull] object filter, [CanBeNull] object entityType)
+        public static string BadFilterDerivedType([CanBeNull] object filter, [CanBeNull] object entityType, [CanBeNull] object rootType)
             => string.Format(
-                GetString("BadFilterDerivedType", nameof(filter), nameof(entityType)),
-                filter, entityType);
+                GetString("BadFilterDerivedType", nameof(filter), nameof(entityType), nameof(rootType)),
+                filter, entityType, rootType);
 
         /// <summary>
         ///     The filter expression '{filter}' specified for entity type '{entityType}' is invalid. The expression must accept a single parameter of type '{clrType}' and return bool.
@@ -277,7 +277,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, otherClrType);
 
         /// <summary>
-        ///     There is already an entity type named '{ownedTypeName}'. Use a different name when configuring the ownership '{ownerEntityType}.{navigation}'.
+        ///     There is already an entity type named '{ownedTypeName}'. Use a different name when configuring the ownership '{ownerEntityType}.{navigation}' in 'OnModelCreating'.
         /// </summary>
         public static string ClashingNamedOwnedType([CanBeNull] object ownedTypeName, [CanBeNull] object ownerEntityType, [CanBeNull] object navigation)
             => string.Format(
@@ -301,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The shared type entity type '{entityType}' with clr type '{type}' cannot be added to the model because a non shared entity type with the same clr type already exists.
+        ///     The shared type entity type '{entityType}' with clr type '{type}' cannot be added to the model because a non shared entity type with the same CLR type already exists.
         /// </summary>
         public static string ClashingNonSharedType([CanBeNull] object entityType, [CanBeNull] object type)
             => string.Format(
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation property. Use the '{ReferenceMethod}' method to access reference navigation properties.
+        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation. Use the '{ReferenceMethod}' method to access reference navigation properties.
         /// </summary>
         public static string CollectionIsReference([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object CollectionMethod, [CanBeNull] object ReferenceMethod)
             => string.Format(
@@ -397,7 +397,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
-        ///     Entity type '{entityType}' has composite primary key defined with data annotations. To set composite primary key, use fluent API.
+        ///     Entity type '{entityType}' has composite primary key defined with data annotations. Composite primary keys can only be set in 'OnModelCreating'.
         /// </summary>
         public static string CompositePKWithDataAnnotation([CanBeNull] object entityType)
             => string.Format(
@@ -411,7 +411,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("ConcurrentMethodInvocation");
 
         /// <summary>
-        ///     Property '{1_entityType}.{0_property}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating()'.
+        ///     Property '{1_entityType}.{0_property}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating'.
         /// </summary>
         public static string ConflictingBackingFields([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object field1, [CanBeNull] object field2)
             => string.Format(
@@ -435,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 member, entityType, conflictingEntityType);
 
         /// <summary>
-        ///     Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation '{newDependentNavigationSpecification}' first.
+        ///     Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation '{newDependentNavigationSpecification}' first in 'OnModelCreating'.
         /// </summary>
         public static string ConflictingRelationshipNavigation([CanBeNull] object newPrincipalNavigationSpecification, [CanBeNull] object newDependentNavigationSpecification, [CanBeNull] object existingPrincipalNavigationSpecification, [CanBeNull] object existingDependentNavigationSpecification)
             => string.Format(
@@ -555,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Unable to set a base type for entity type '{entityType}' because it has one or more keys defined.
+        ///     Unable to set a base type for entity type '{entityType}' because it has one or more keys defined. Only root types can have keys.
         /// </summary>
         public static string DerivedEntityCannotHaveKeys([CanBeNull] object entityType)
             => string.Format(
@@ -563,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     A '{derivedType}' cannot be configured as keyless because it is a derived type. The root type '{rootType}' must be configured as keyless. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.
+        ///     A '{derivedType}' cannot be configured as keyless because it is a derived type. The root type '{rootType}' must be configured as keyless. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder in 'OnModelCreating', or referenced from a navigation on a type that is included in the model.
         /// </summary>
         public static string DerivedEntityTypeHasNoKey([CanBeNull] object derivedType, [CanBeNull] object rootType)
             => string.Format(
@@ -571,7 +571,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 derivedType, rootType);
 
         /// <summary>
-        ///     A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.
+        ///     A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation on a type that is included in the model.
         /// </summary>
         public static string DerivedEntityTypeKey([CanBeNull] object derivedType, [CanBeNull] object rootType)
             => string.Format(
@@ -643,12 +643,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}' and also targets the key {key} on '{principalType}'.
+        ///     The foreign key {foreignKeyProperties} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}' and also targets the key {keyProperties} on '{principalType}'.
         /// </summary>
-        public static string DuplicateForeignKey([CanBeNull] object foreignKey, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType, [CanBeNull] object key, [CanBeNull] object principalType)
+        public static string DuplicateForeignKey([CanBeNull] object foreignKeyProperties, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType, [CanBeNull] object keyProperties, [CanBeNull] object principalType)
             => string.Format(
-                GetString("DuplicateForeignKey", nameof(foreignKey), nameof(entityType), nameof(duplicateEntityType), nameof(key), nameof(principalType)),
-                foreignKey, entityType, duplicateEntityType, key, principalType);
+                GetString("DuplicateForeignKey", nameof(foreignKeyProperties), nameof(entityType), nameof(duplicateEntityType), nameof(keyProperties), nameof(principalType)),
+                foreignKeyProperties, entityType, duplicateEntityType, keyProperties, principalType);
 
         /// <summary>
         ///     The index {indexProperties} cannot be added to the entity type '{entityType}' because an index on the same properties already exists on entity type '{duplicateEntityType}'.
@@ -659,12 +659,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 indexProperties, entityType, duplicateEntityType);
 
         /// <summary>
-        ///     The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.
+        ///     The key {keyProperties} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateKey([CanBeNull] object key, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
+        public static string DuplicateKey([CanBeNull] object keyProperties, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
             => string.Format(
-                GetString("DuplicateKey", nameof(key), nameof(entityType), nameof(duplicateEntityType)),
-                key, entityType, duplicateEntityType);
+                GetString("DuplicateKey", nameof(keyProperties), nameof(entityType), nameof(duplicateEntityType)),
+                keyProperties, entityType, duplicateEntityType);
 
         /// <summary>
         ///     The index named '{indexName}' defined on properties {indexProperties} cannot be added to the entity type '{entityType}' because an index with the same name already exists on entity type '{duplicateEntityType}'.
@@ -723,7 +723,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' requires a primary key to be defined. If you intended to use a keyless entity type call 'HasNoKey()'.
+        ///     The entity type '{entityType}' requires a primary key to be defined. If you intended to use a keyless entity type call 'HasNoKey()' in 'OnModelCreating'.
         /// </summary>
         public static string EntityRequiresKey([CanBeNull] object entityType)
             => string.Format(
@@ -739,12 +739,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, derivedEntityType);
 
         /// <summary>
-        ///     The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKey} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.
+        ///     The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKeyProperties} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.
         /// </summary>
-        public static string EntityTypeInUseByReferencingForeignKey([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object referencingEntityType)
+        public static string EntityTypeInUseByReferencingForeignKey([CanBeNull] object entityType, [CanBeNull] object foreignKeyProperties, [CanBeNull] object referencingEntityType)
             => string.Format(
-                GetString("EntityTypeInUseByReferencingForeignKey", nameof(entityType), nameof(foreignKey), nameof(referencingEntityType)),
-                entityType, foreignKey, referencingEntityType);
+                GetString("EntityTypeInUseByReferencingForeignKey", nameof(entityType), nameof(foreignKeyProperties), nameof(referencingEntityType)),
+                entityType, foreignKeyProperties, referencingEntityType);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot be removed because it is being referenced by the skip navigation '{skipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before the entity type can be removed.
@@ -855,7 +855,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 strategy, getExecutionStrategyMethod);
 
         /// <summary>
-        ///     An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.
+        ///     An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call 'DbContextOptionsBuilder.EnableSensitiveDataLogging'.
         /// </summary>
         public static string ExpressionParameterizationException
             => GetString("ExpressionParameterizationException");
@@ -917,12 +917,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, navigation, entityType);
 
         /// <summary>
-        ///     The number of properties specified for the foreign key {foreignKey} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.
+        ///     The number of properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.
         /// </summary>
-        public static string ForeignKeyCountMismatch([CanBeNull] object foreignKey, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)
+        public static string ForeignKeyCountMismatch([CanBeNull] object foreignKeyProperties, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)
             => string.Format(
-                GetString("ForeignKeyCountMismatch", nameof(foreignKey), nameof(dependentType), nameof(principalKey), nameof(principalType)),
-                foreignKey, dependentType, principalKey, principalType);
+                GetString("ForeignKeyCountMismatch", nameof(foreignKeyProperties), nameof(dependentType), nameof(principalKey), nameof(principalType)),
+                foreignKeyProperties, dependentType, principalKey, principalType);
 
         /// <summary>
         ///     Cannot remove foreign key {foreigKey} from entity type '{entityType}' because it is referenced by a skip navigation '{navigation}' on entity type '{navigationEntityType}'. All referencing skip navigation must be removed before the referenced foreign key can be removed.
@@ -933,20 +933,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 foreigKey, entityType, navigation, navigationEntityType);
 
         /// <summary>
-        ///     The specified foreign key properties {foreignKey} are not declared on the entity type '{entityType}'. Ensure foreign key properties are declared on the target entity type.
+        ///     The specified foreign key properties {foreignKeyProperties} are not declared on the entity type '{entityType}'. Ensure foreign key properties are declared on the target entity type.
         /// </summary>
-        public static string ForeignKeyPropertiesWrongEntity([CanBeNull] object foreignKey, [CanBeNull] object entityType)
+        public static string ForeignKeyPropertiesWrongEntity([CanBeNull] object foreignKeyProperties, [CanBeNull] object entityType)
             => string.Format(
-                GetString("ForeignKeyPropertiesWrongEntity", nameof(foreignKey), nameof(entityType)),
-                foreignKey, entityType);
+                GetString("ForeignKeyPropertiesWrongEntity", nameof(foreignKeyProperties), nameof(entityType)),
+                foreignKeyProperties, entityType);
 
         /// <summary>
-        ///     The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {key} defined on a base entity type '{baseEntityType}'.
+        ///     The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {keyProperties} defined on a base entity type '{baseEntityType}'.
         /// </summary>
-        public static string ForeignKeyPropertyInKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key, [CanBeNull] object baseEntityType)
+        public static string ForeignKeyPropertyInKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object keyProperties, [CanBeNull] object baseEntityType)
             => string.Format(
-                GetString("ForeignKeyPropertyInKey", nameof(property), nameof(entityType), nameof(key), nameof(baseEntityType)),
-                property, entityType, key, baseEntityType);
+                GetString("ForeignKeyPropertyInKey", nameof(property), nameof(entityType), nameof(keyProperties), nameof(baseEntityType)),
+                property, entityType, keyProperties, baseEntityType);
 
         /// <summary>
         ///     The provided principal entity key '{principalKey}' is not a key on the entity type '{principalEntityType}'.
@@ -965,20 +965,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 dependentType);
 
         /// <summary>
-        ///     The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.
+        ///     The types of the properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.
         /// </summary>
-        public static string ForeignKeyTypeMismatch([CanBeNull] object foreignKey, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)
+        public static string ForeignKeyTypeMismatch([CanBeNull] object foreignKeyProperties, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)
             => string.Format(
-                GetString("ForeignKeyTypeMismatch", nameof(foreignKey), nameof(dependentType), nameof(principalKey), nameof(principalType)),
-                foreignKey, dependentType, principalKey, principalType);
+                GetString("ForeignKeyTypeMismatch", nameof(foreignKeyProperties), nameof(dependentType), nameof(principalKey), nameof(principalType)),
+                foreignKeyProperties, dependentType, principalKey, principalType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} targeting the key {key} on '{principalType}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
+        ///     The foreign key {foreignKeyProperties} targeting the key {keyProperties} on '{principalType}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
         /// </summary>
-        public static string ForeignKeyWrongType([CanBeNull] object foreignKey, [CanBeNull] object key, [CanBeNull] object principalType, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
+        public static string ForeignKeyWrongType([CanBeNull] object foreignKeyProperties, [CanBeNull] object keyProperties, [CanBeNull] object principalType, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
             => string.Format(
-                GetString("ForeignKeyWrongType", nameof(foreignKey), nameof(key), nameof(principalType), nameof(entityType), nameof(otherEntityType)),
-                foreignKey, key, principalType, entityType, otherEntityType);
+                GetString("ForeignKeyWrongType", nameof(foreignKeyProperties), nameof(keyProperties), nameof(principalType), nameof(entityType), nameof(otherEntityType)),
+                foreignKeyProperties, keyProperties, principalType, entityType, otherEntityType);
 
         /// <summary>
         ///     The entity type '{entityType}' is configured to use the '{changeTrackingStrategy}' change tracking strategy when full change tracking notifications are required. Use 'ModelBuilder.HasChangeTrackingStrategy' in 'OnModelCreating' to configure all entity types in the model to use the '{fullStrategy}' or '{fullPlusStrategy}' strategy.
@@ -1096,7 +1096,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, baseEntityType);
 
         /// <summary>
-        ///     The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not. All entity types sharing a CLR type must be configured as owned.
+        ///     The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not. All entity types sharing a CLR type must be configured as owned in 'OnModelCreating'.
         /// </summary>
         public static string InconsistentOwnership([CanBeNull] object ownedEntityType, [CanBeNull] object nonOwnedEntityType)
             => string.Format(
@@ -1120,7 +1120,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 indexProperties, entityType, otherEntityType);
 
         /// <summary>
-        ///     The property '{property}' cannot be ignored on entity type '{entityType}', because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use [NotMapped] attribute or Ignore method on the base type.
+        ///     The property '{property}' cannot be ignored on entity type '{entityType}', because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use [NotMapped] attribute or 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.
         /// </summary>
         public static string InheritedPropertyCannotBeIgnored([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object baseEntityType)
             => string.Format(
@@ -1128,7 +1128,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, baseEntityType);
 
         /// <summary>
-        ///     The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation property manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
+        ///     The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
         /// </summary>
         public static string InterfacePropertyNotAdded([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object propertyType)
             => string.Format(
@@ -1136,12 +1136,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, navigation, propertyType);
 
         /// <summary>
-        ///     The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.
+        ///     The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKeyProperties} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.
         /// </summary>
-        public static string IntraHierarchicalAmbiguousTargetEntityType([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object principalEntityType, [CanBeNull] object dependentEntityType)
+        public static string IntraHierarchicalAmbiguousTargetEntityType([CanBeNull] object entityType, [CanBeNull] object foreignKeyProperties, [CanBeNull] object principalEntityType, [CanBeNull] object dependentEntityType)
             => string.Format(
-                GetString("IntraHierarchicalAmbiguousTargetEntityType", nameof(entityType), nameof(foreignKey), nameof(principalEntityType), nameof(dependentEntityType)),
-                entityType, foreignKey, principalEntityType, dependentEntityType);
+                GetString("IntraHierarchicalAmbiguousTargetEntityType", nameof(entityType), nameof(foreignKeyProperties), nameof(principalEntityType), nameof(dependentEntityType)),
+                entityType, foreignKeyProperties, principalEntityType, dependentEntityType);
 
         /// <summary>
         ///     Unable to track an entity of type '{entityType}' because alternate key property '{keyProperty}' is null. If the alternate key is not used in a relationship, then consider using a unique index instead. Unique indexes may contain nulls, while alternate keys must not.
@@ -1152,7 +1152,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, keyProperty);
 
         /// <summary>
-        ///     The specified type '{type}'must be a non-interface reference type to be used as an entity type.
+        ///     The specified type '{type}' must be a non-interface reference type to be used as an entity type.
         /// </summary>
         public static string InvalidEntityType([CanBeNull] object type)
             => string.Format(
@@ -1184,7 +1184,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, keyProperty);
 
         /// <summary>
-        ///     Lambda expression used inside Include is not valid.
+        ///     Lambda expression used inside 'Include' is not valid.
         /// </summary>
         public static string InvalidLambdaExpressionInsideInclude
             => GetString("InvalidLambdaExpressionInsideInclude");
@@ -1212,7 +1212,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 expression);
 
         /// <summary>
-        ///     The [InverseProperty] attribute on property '{1_entityType}.{0_property}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.
+        ///     The [InverseProperty] attribute on property '{1_entityType}.{0_property}' is not valid. The property '{referencedProperty}' is not a valid navigation on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation.
         /// </summary>
         public static string InvalidNavigationWithInverseProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referencedProperty, [CanBeNull] object referencedEntityType)
             => string.Format(
@@ -1324,7 +1324,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, valueType, propertyType);
 
         /// <summary>
-        ///     Invalid type conversion when specifying include.
+        ///     Invalid type conversion specified in 'Include' call.
         /// </summary>
         public static string InvalidTypeConversationWithInclude
             => GetString("InvalidTypeConversationWithInclude");
@@ -1384,12 +1384,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 derivedType, property);
 
         /// <summary>
-        ///     Cannot remove key {key} from entity type '{entityType}' because it is referenced by a foreign key {foreignKey} in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.
+        ///     Cannot remove key {keyProperties} from entity type '{entityType}' because it is referenced by a foreign key {foreignKeyProperties} in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.
         /// </summary>
-        public static string KeyInUse([CanBeNull] object key, [CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object dependentType)
+        public static string KeyInUse([CanBeNull] object keyProperties, [CanBeNull] object entityType, [CanBeNull] object foreignKeyProperties, [CanBeNull] object dependentType)
             => string.Format(
-                GetString("KeyInUse", nameof(key), nameof(entityType), nameof(foreignKey), nameof(dependentType)),
-                key, entityType, foreignKey, dependentType);
+                GetString("KeyInUse", nameof(keyProperties), nameof(entityType), nameof(foreignKeyProperties), nameof(dependentType)),
+                keyProperties, entityType, foreignKeyProperties, dependentType);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot be marked as keyless because it contains a key.
@@ -1408,28 +1408,28 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
-        ///     The key {key} cannot be added to keyless type '{entityType}'.
+        ///     The key {keyProperties} cannot be added to keyless type '{entityType}'.
         /// </summary>
-        public static string KeylessTypeWithKey([CanBeNull] object key, [CanBeNull] object entityType)
+        public static string KeylessTypeWithKey([CanBeNull] object keyProperties, [CanBeNull] object entityType)
             => string.Format(
-                GetString("KeylessTypeWithKey", nameof(key), nameof(entityType)),
-                key, entityType);
+                GetString("KeylessTypeWithKey", nameof(keyProperties), nameof(entityType)),
+                keyProperties, entityType);
 
         /// <summary>
-        ///     The specified key properties {key} are not declared on the entity type '{entityType}'. Ensure key properties are declared on the target entity type.
+        ///     The specified key properties {keyProperties} are not declared on the entity type '{entityType}'. Ensure key properties are declared on the target entity type.
         /// </summary>
-        public static string KeyPropertiesWrongEntity([CanBeNull] object key, [CanBeNull] object entityType)
+        public static string KeyPropertiesWrongEntity([CanBeNull] object keyProperties, [CanBeNull] object entityType)
             => string.Format(
-                GetString("KeyPropertiesWrongEntity", nameof(key), nameof(entityType)),
-                key, entityType);
+                GetString("KeyPropertiesWrongEntity", nameof(keyProperties), nameof(entityType)),
+                keyProperties, entityType);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' cannot be marked as nullable/optional because it has been included in a key {key}.
+        ///     The property '{1_entityType}.{0_property}' cannot be marked as nullable/optional because it has been included in a key {keyProperties}.
         /// </summary>
-        public static string KeyPropertyCannotBeNullable([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key)
+        public static string KeyPropertyCannotBeNullable([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object keyProperties)
             => string.Format(
-                GetString("KeyPropertyCannotBeNullable", "0_property", "1_entityType", nameof(key)),
-                property, entityType, key);
+                GetString("KeyPropertyCannotBeNullable", "0_property", "1_entityType", nameof(keyProperties)),
+                property, entityType, keyProperties);
 
         /// <summary>
         ///     The property '{1_entityType}.{0_property}' cannot be part of a key because it has value generation enabled and is contained in a foreign key defined on a derived entity type.
@@ -1456,12 +1456,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType);
 
         /// <summary>
-        ///     The key {key} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
+        ///     The key {keyProperties} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
         /// </summary>
-        public static string KeyWrongType([CanBeNull] object key, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
+        public static string KeyWrongType([CanBeNull] object keyProperties, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
             => string.Format(
-                GetString("KeyWrongType", nameof(key), nameof(entityType), nameof(otherEntityType)),
-                key, entityType, otherEntityType);
+                GetString("KeyWrongType", nameof(keyProperties), nameof(entityType), nameof(otherEntityType)),
+                keyProperties, entityType, otherEntityType);
 
         /// <summary>
         ///     The type mapping for '{type}' has not implemented code literal generation.
@@ -1480,7 +1480,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 field, property, entityType);
 
         /// <summary>
-        ///     Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation property in the HasMany() call.
+        ///     Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation in the 'HasMany()' call in 'OnModelCreating'.
         /// </summary>
         public static string MissingInverseManyToManyNavigation([CanBeNull] object principalEntityType, [CanBeNull] object declaringEntityType)
             => string.Format(
@@ -1568,7 +1568,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 indexName, entityType);
 
         /// <summary>
-        ///     The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.
+        ///     The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.
         /// </summary>
         public static string NavigationArray([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType)
             => string.Format(
@@ -1576,7 +1576,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, foundType);
 
         /// <summary>
-        ///     The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
+        ///     The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
         /// </summary>
         public static string NavigationBadType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType, [CanBeNull] object targetType)
             => string.Format(
@@ -1584,7 +1584,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, foundType, targetType);
 
         /// <summary>
-        ///     The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
+        ///     The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
         /// </summary>
         public static string NavigationCannotCreateType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType)
             => string.Format(
@@ -1592,7 +1592,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, foundType);
 
         /// <summary>
-        ///     The collection navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.
+        ///     The collection navigation '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.
         /// </summary>
         public static string NavigationCollectionWrongClrType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object targetType)
             => string.Format(
@@ -1600,7 +1600,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, clrType, targetType);
 
         /// <summary>
-        ///     The navigation property '{1_entityType}.{0_navigation}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.
+        ///     The navigation '{1_entityType}.{0_navigation}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.
         /// </summary>
         public static string NavigationForWrongForeignKey([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetFk, [CanBeNull] object actualFk)
             => string.Format(
@@ -1608,15 +1608,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, targetFk, actualFk);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{ReferenceMethod}' or '{CollectionMethod}' method, but is defined in the model as a non-navigation property. Use the '{PropertyMethod}' method to access non-navigation properties.
+        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' or '{collectionMethod}' method, but is defined in the model as a non-navigation. Use the '{propertyMethod}' method to access non-navigation properties.
         /// </summary>
-        public static string NavigationIsProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object ReferenceMethod, [CanBeNull] object CollectionMethod, [CanBeNull] object PropertyMethod)
+        public static string NavigationIsProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referenceMethod, [CanBeNull] object collectionMethod, [CanBeNull] object propertyMethod)
             => string.Format(
-                GetString("NavigationIsProperty", "0_property", "1_entityType", nameof(ReferenceMethod), nameof(CollectionMethod), nameof(PropertyMethod)),
-                property, entityType, ReferenceMethod, CollectionMethod, PropertyMethod);
+                GetString("NavigationIsProperty", "0_property", "1_entityType", nameof(referenceMethod), nameof(collectionMethod), nameof(propertyMethod)),
+                property, entityType, referenceMethod, collectionMethod, propertyMethod);
 
         /// <summary>
-        ///     The navigation property '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigation properties must be initialized before use.
+        ///     The navigation '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigation properties must be initialized before use.
         /// </summary>
         public static string NavigationNoSetter([CanBeNull] object navigation, [CanBeNull] object entityType)
             => string.Format(
@@ -1624,7 +1624,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
-        ///     Unable to determine the relationship represented by navigation property '{entityType}.{navigation}' of type '{propertyType}'. Either manually configure the relationship, or ignore this property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
+        ///     Unable to determine the relationship represented by navigation '{entityType}.{navigation}' of type '{propertyType}'. Either manually configure the relationship, or ignore this property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
         /// </summary>
         public static string NavigationNotAdded([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object propertyType)
             => string.Format(
@@ -1632,7 +1632,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, navigation, propertyType);
 
         /// <summary>
-        ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.
+        ///     The navigation '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.
         /// </summary>
         public static string NavigationSingleWrongClrType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object targetType)
             => string.Format(
@@ -1648,7 +1648,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
-        ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.
+        ///     The navigation '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.
         /// </summary>
         public static string NavigationToShadowEntity([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetType)
             => string.Format(
@@ -1656,12 +1656,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType, targetType);
 
         /// <summary>
-        ///     No field was found backing property '{1_entityType}.{0_property}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{pam}'.
+        ///     No field was found backing property '{1_entityType}.{0_property}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{propertyAccessMode}'.
         /// </summary>
-        public static string NoBackingField([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object pam)
+        public static string NoBackingField([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyAccessMode)
             => string.Format(
-                GetString("NoBackingField", "0_property", "1_entityType", nameof(pam)),
-                property, entityType, pam);
+                GetString("NoBackingField", "0_property", "1_entityType", nameof(propertyAccessMode)),
+                property, entityType, propertyAccessMode);
 
         /// <summary>
         ///     No field was found backing property '{1_entityType}.{0_property}'. Lazy-loaded navigation properties must have backing fields. Either name the backing field so that it is picked up by convention or configure the backing field to use.
@@ -1672,7 +1672,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType);
 
         /// <summary>
-        ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added in shadow state.
+        ///     The navigation '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added in shadow state.
         /// </summary>
         public static string NoClrNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
             => string.Format(
@@ -1720,7 +1720,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Entity Framework services have not been added to the internal service provider. Either remove the call to UseInternalServiceProvider so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. AddEntityFrameworkSqlServer).
+        ///     Entity Framework services have not been added to the internal service provider. Either remove the call to 'UseInternalServiceProvider' so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. 'AddEntityFrameworkSqlServer').
         /// </summary>
         public static string NoEfServices
             => GetString("NoEfServices");
@@ -1742,12 +1742,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' does not have a getter. Either make the property readable or use a different '{pam}'.
+        ///     The property '{1_entityType}.{0_property}' does not have a getter. Either make the property readable or use a different '{propertyAccessMode}'.
         /// </summary>
-        public static string NoGetter([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object pam)
+        public static string NoGetter([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyAccessMode)
             => string.Format(
-                GetString("NoGetter", "0_property", "1_entityType", nameof(pam)),
-                property, entityType, pam);
+                GetString("NoGetter", "0_property", "1_entityType", nameof(propertyAccessMode)),
+                property, entityType, propertyAccessMode);
 
         /// <summary>
         ///     'InterceptionResult.Result' was called when 'InterceptionResult.HasResult' is false.
@@ -1756,12 +1756,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NoInterceptionResult");
 
         /// <summary>
-        ///     There is no navigation on entity type '{entityType}' associated with the foreign key {foreignKey}.
+        ///     There is no navigation on entity type '{entityType}' associated with the foreign key {foreignKeyProperties}.
         /// </summary>
-        public static string NoNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKey)
+        public static string NoNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKeyProperties)
             => string.Format(
-                GetString("NoNavigation", nameof(entityType), nameof(foreignKey)),
-                entityType, foreignKey);
+                GetString("NoNavigation", nameof(entityType), nameof(foreignKeyProperties)),
+                entityType, foreignKeyProperties);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{baseEntityType}' is a shadow state entity type while '{entityType}' is not.
@@ -1772,7 +1772,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, baseEntityType);
 
         /// <summary>
-        ///     Property '{entityType}.{property}' cannot be used as a key because it has type '{providerType}' which does not implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Use 'HasConversion()' in 'OnModelCreating()' to wrap '{providerType}' with a type that can be compared.
+        ///     Property '{entityType}.{property}' cannot be used as a key because it has type '{providerType}' which does not implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Use 'HasConversion()' in 'OnModelCreating' to wrap '{providerType}' with a type that can be compared.
         /// </summary>
         public static string NonComparableKeyType([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object providerType)
             => string.Format(
@@ -1788,7 +1788,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property, modelType, providerType);
 
         /// <summary>
-        ///     The navigation '{1_entityType}.{0_navigation}' must be configured using Fluent API with an explicit name for the target shared type entity type or excluded by calling 'EntityTypeBuilder.Ignore'.
+        ///     The navigation '{1_entityType}.{0_navigation}' must be configured in 'OnModelCreating' with an explicit name for the target shared type entity type or excluded by calling 'EntityTypeBuilder.Ignore'.
         /// </summary>
         public static string NonConfiguredNavigationToSharedType([CanBeNull] object navigation, [CanBeNull] object entityType)
             => string.Format(
@@ -1820,7 +1820,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, type);
 
         /// <summary>
-        ///     The collection type being used for navigation property '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.
+        ///     The collection type being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.
         /// </summary>
         public static string NonNotifyingCollection([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object changeTrackingStrategy)
             => string.Format(
@@ -1836,12 +1836,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, baseEntityType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.
+        ///     The foreign key {foreignKeyProperties} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.
         /// </summary>
-        public static string NonUniqueRequiredDependentForeignKey([CanBeNull] object foreignKey, [CanBeNull] object declaringEntityType)
+        public static string NonUniqueRequiredDependentForeignKey([CanBeNull] object foreignKeyProperties, [CanBeNull] object declaringEntityType)
             => string.Format(
-                GetString("NonUniqueRequiredDependentForeignKey", nameof(foreignKey), nameof(declaringEntityType)),
-                foreignKey, declaringEntityType);
+                GetString("NonUniqueRequiredDependentForeignKey", nameof(foreignKeyProperties), nameof(declaringEntityType)),
+                foreignKeyProperties, declaringEntityType);
 
         /// <summary>
         ///     '{principalEntityType}.{principalNavigation}' cannot be configured as required since it contains a collection.
@@ -1860,12 +1860,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{pam}'.
+        ///     No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{propertyAccessMode}'.
         /// </summary>
-        public static string NoProperty([CanBeNull] object field, [CanBeNull] object entity, [CanBeNull] object pam)
+        public static string NoProperty([CanBeNull] object field, [CanBeNull] object entity, [CanBeNull] object propertyAccessMode)
             => string.Format(
-                GetString("NoProperty", nameof(field), nameof(entity), nameof(pam)),
-                field, entity, pam);
+                GetString("NoProperty", nameof(field), nameof(entity), nameof(propertyAccessMode)),
+                field, entity, propertyAccessMode);
 
         /// <summary>
         ///     The property '{property}' cannot be added to the type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type must be specified.
@@ -1890,12 +1890,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 service);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{pam}'.
+        ///     The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{propertyAccessMode}'.
         /// </summary>
-        public static string NoSetter([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object pam)
+        public static string NoSetter([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyAccessMode)
             => string.Format(
-                GetString("NoSetter", "0_property", "1_entityType", nameof(pam)),
-                property, entityType, pam);
+                GetString("NoSetter", "0_property", "1_entityType", nameof(propertyAccessMode)),
+                property, entityType, propertyAccessMode);
 
         /// <summary>
         ///     The database provider attempted to register an implementation of the '{service}' service. This is not a service defined by EF and as such must be registered as a provider-specific service using the 'TryAddProviderSpecificServices' method.
@@ -1920,7 +1920,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("NotQueryingEnumerable");
 
         /// <summary>
-        ///     The '{1_entityType}.{0_property}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.
+        ///     The '{1_entityType}.{0_property}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}' in 'OnModelCreating'.
         /// </summary>
         public static string NoValueGenerator([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)
             => string.Format(
@@ -1960,7 +1960,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     A tracking query projects owned entity without corresponding owner in result. Owned entities cannot be tracked without their owner. Either include the owner entity in the result or make query non-tracking using AsNoTracking().
+        ///     A tracking query projects owned entity without corresponding owner in result. Owned entities cannot be tracked without their owner. Either include the owner entity in the result or make query non-tracking using 'AsNoTracking()'.
         /// </summary>
         public static string OwnedEntitiesCannotBeTrackedWithoutTheirOwner
             => GetString("OwnedEntitiesCannotBeTrackedWithoutTheirOwner");
@@ -2052,12 +2052,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, expectedType);
 
         /// <summary>
-        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKey} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.
+        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKeyProperties} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.
         /// </summary>
-        public static string PropertyInUseForeignKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object foreignKeyType)
+        public static string PropertyInUseForeignKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object foreignKeyProperties, [CanBeNull] object foreignKeyType)
             => string.Format(
-                GetString("PropertyInUseForeignKey", nameof(property), nameof(entityType), nameof(foreignKey), nameof(foreignKeyType)),
-                property, entityType, foreignKey, foreignKeyType);
+                GetString("PropertyInUseForeignKey", nameof(property), nameof(entityType), nameof(foreignKeyProperties), nameof(foreignKeyType)),
+                property, entityType, foreignKeyProperties, foreignKeyType);
 
         /// <summary>
         ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.
@@ -2068,15 +2068,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, index, indexType);
 
         /// <summary>
-        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {key}. All containing keys must be removed or redefined before the property can be removed.
+        ///     The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {keyProperties}. All containing keys must be removed or redefined before the property can be removed.
         /// </summary>
-        public static string PropertyInUseKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object key)
+        public static string PropertyInUseKey([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object keyProperties)
             => string.Format(
-                GetString("PropertyInUseKey", nameof(property), nameof(entityType), nameof(key)),
-                property, entityType, key);
+                GetString("PropertyInUseKey", nameof(property), nameof(entityType), nameof(keyProperties)),
+                property, entityType, keyProperties);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{propertyMethod}' method, but is defined in the model as a navigation property. Use either the '{referenceMethod}' or '{collectionMethod}' method to access navigation properties.
+        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{propertyMethod}' method, but is defined in the model as a navigation. Use either the '{referenceMethod}' or '{collectionMethod}' method to access navigation properties.
         /// </summary>
         public static string PropertyIsNavigation([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyMethod, [CanBeNull] object referenceMethod, [CanBeNull] object collectionMethod)
             => string.Format(
@@ -2144,14 +2144,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("PropertyWrongEntityClrType", nameof(property), nameof(entityType), nameof(clrType)),
                 property, entityType, clrType);
-
-        /// <summary>
-        ///     The CLR property '{property}' cannot be added to entity type '{entityType}'({sharedType}) because it is declared on the CLR type '{clrType}'.
-        /// </summary>
-        public static string PropertyWrongEntitySharedClrType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object sharedType, [CanBeNull] object clrType)
-            => string.Format(
-                GetString("PropertyWrongEntitySharedClrType", nameof(property), nameof(entityType), nameof(sharedType), nameof(clrType)),
-                property, entityType, sharedType, clrType);
 
         /// <summary>
         ///     The property '{property}' cannot be added to type '{entityType}' because the name of the given CLR property or field '{clrName}' is different.
@@ -2230,13 +2222,13 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("QueryUnableToTranslateStringEqualsWithStringComparison");
 
         /// <summary>
-        ///     An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point. This can happen if a second operation is started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.
+        ///     An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.
         /// </summary>
         public static string RecursiveOnConfiguring
             => GetString("RecursiveOnConfiguring");
 
         /// <summary>
-        ///     An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.
+        ///     An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside 'OnModelCreating' in any way that makes use of the model that is being created.
         /// </summary>
         public static string RecursiveOnModelCreating
             => GetString("RecursiveOnModelCreating");
@@ -2250,15 +2242,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 referencingEntityTypeOrNavigation, referencedEntityTypeOrNavigation, foreignKeyPropertiesWithTypes, primaryKeyPropertiesWithTypes);
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{ReferenceMethod}' method, but is defined in the model as a collection navigation property. Use the '{CollectionMethod}' method to access collection navigation properties.
+        ///     The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' method, but is defined in the model as a collection navigation. Use the '{collectionMethod}' method to access collection navigation properties.
         /// </summary>
-        public static string ReferenceIsCollection([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object ReferenceMethod, [CanBeNull] object CollectionMethod)
+        public static string ReferenceIsCollection([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referenceMethod, [CanBeNull] object collectionMethod)
             => string.Format(
-                GetString("ReferenceIsCollection", "0_property", "1_entityType", nameof(ReferenceMethod), nameof(CollectionMethod)),
-                property, entityType, ReferenceMethod, CollectionMethod);
+                GetString("ReferenceIsCollection", "0_property", "1_entityType", nameof(referenceMethod), nameof(collectionMethod)),
+                property, entityType, referenceMethod, collectionMethod);
 
         /// <summary>
-        ///     Navigation property '{1_entityType}.{0_navigation}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.
+        ///     The navigation '{1_entityType}.{0_navigation}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.
         /// </summary>
         public static string ReferenceMustBeLoaded([CanBeNull] object navigation, [CanBeNull] object entityType)
             => string.Format(
@@ -2396,12 +2388,18 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property);
 
         /// <summary>
-        ///     A relationship cannot be established from property '{1_entityType}.{0_property}' to property '{3_referencedEntityType}.{2_referencedProperty}'. Check the values in the [InverseProperty] attribute to ensure relationship definitions are unique and reference from one navigation property to its corresponding inverse navigation property.
+        ///     A relationship cannot be established from property '{1_entityType}.{0_property}' to property '{3_referencedEntityType}.{2_referencedProperty}'. Check the values in the [InverseProperty] attribute to ensure relationship definitions are unique and reference from one navigation to its corresponding inverse navigation.
         /// </summary>
         public static string SelfReferencingNavigationWithInverseProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referencedProperty, [CanBeNull] object referencedEntityType)
             => string.Format(
                 GetString("SelfReferencingNavigationWithInverseProperty", "0_property", "1_entityType", "2_referencedProperty", "3_referencedEntityType"),
                 property, entityType, referencedProperty, referencedEntityType);
+
+        /// <summary>
+        ///     To show additional information call 'DbContextOptionsBuilder.EnableSensitiveDataLogging'.
+        /// </summary>
+        public static string SensitiveDataDisabled
+            => GetString("SensitiveDataDisabled");
 
         /// <summary>
         ///     Sequence contains more than one element.
@@ -2440,7 +2438,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 key);
 
         /// <summary>
-        ///     When performing a set operation, both operands must have the same Include operations.
+        ///     When performing a set operation, both operands must have the same 'Include' operations.
         /// </summary>
         public static string SetOperationWithDifferentIncludesInOperands
             => GetString("SetOperationWithDifferentIncludesInOperands");
@@ -2478,12 +2476,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 scope, service);
 
         /// <summary>
-        ///     The foreign key '{foreignKey}' cannot be set for the skip navigation '{navigation}' as it uses the join entity type '{joinType}' while the inverse skip navigation '{inverse}' is using the join entity type '{inverseJoinType}'. The inverse should use the same join entity type.
+        ///     The foreign key {foreignKeyProperties} cannot be set for the skip navigation '{navigation}' as it uses the join entity type '{joinType}' while the inverse skip navigation '{inverse}' is using the join entity type '{inverseJoinType}'. The inverse should use the same join entity type.
         /// </summary>
-        public static string SkipInverseMismatchedForeignKey([CanBeNull] object foreignKey, [CanBeNull] object navigation, [CanBeNull] object joinType, [CanBeNull] object inverse, [CanBeNull] object inverseJoinType)
+        public static string SkipInverseMismatchedForeignKey([CanBeNull] object foreignKeyProperties, [CanBeNull] object navigation, [CanBeNull] object joinType, [CanBeNull] object inverse, [CanBeNull] object inverseJoinType)
             => string.Format(
-                GetString("SkipInverseMismatchedForeignKey", nameof(foreignKey), nameof(navigation), nameof(joinType), nameof(inverse), nameof(inverseJoinType)),
-                foreignKey, navigation, joinType, inverse, inverseJoinType);
+                GetString("SkipInverseMismatchedForeignKey", nameof(foreignKeyProperties), nameof(navigation), nameof(joinType), nameof(inverse), nameof(inverseJoinType)),
+                foreignKeyProperties, navigation, joinType, inverse, inverseJoinType);
 
         /// <summary>
         ///     The skip navigation '{inverse}' using the join entity type '{inverseJoinType}' cannot be set as the inverse of '{navigation}' that uses the join entity type '{joinType}'. The inverse should use the same join entity type.
@@ -2494,20 +2492,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 inverse, inverseJoinType, navigation, joinType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} cannot be used for the skip navigation property '{2_entityType}.{1_navigation}' because it is expected to be on the dependent entity type '{dependentEntityType}'.
+        ///     The foreign key {foreignKeyProperties} cannot be used for the skip navigation '{2_entityType}.{1_navigation}' because it is expected to be on the dependent entity type '{dependentEntityType}'.
         /// </summary>
-        public static string SkipNavigationForeignKeyWrongDependentType([CanBeNull] object foreignKey, [CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object dependentEntityType)
+        public static string SkipNavigationForeignKeyWrongDependentType([CanBeNull] object foreignKeyProperties, [CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object dependentEntityType)
             => string.Format(
-                GetString("SkipNavigationForeignKeyWrongDependentType", nameof(foreignKey), "1_navigation", "2_entityType", nameof(dependentEntityType)),
-                foreignKey, navigation, entityType, dependentEntityType);
+                GetString("SkipNavigationForeignKeyWrongDependentType", nameof(foreignKeyProperties), "1_navigation", "2_entityType", nameof(dependentEntityType)),
+                foreignKeyProperties, navigation, entityType, dependentEntityType);
 
         /// <summary>
-        ///     The foreign key {foreignKey} cannot be used for the skip navigation property '{2_entityType}.{1_navigation}' because it is expected to be on the principal entity type '{principalEntityType}'.
+        ///     The foreign key {foreignKeyProperties} cannot be used for the skip navigation '{2_entityType}.{1_navigation}' because it is expected to be on the principal entity type '{principalEntityType}'.
         /// </summary>
-        public static string SkipNavigationForeignKeyWrongPrincipalType([CanBeNull] object foreignKey, [CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object principalEntityType)
+        public static string SkipNavigationForeignKeyWrongPrincipalType([CanBeNull] object foreignKeyProperties, [CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object principalEntityType)
             => string.Format(
-                GetString("SkipNavigationForeignKeyWrongPrincipalType", nameof(foreignKey), "1_navigation", "2_entityType", nameof(principalEntityType)),
-                foreignKey, navigation, entityType, principalEntityType);
+                GetString("SkipNavigationForeignKeyWrongPrincipalType", nameof(foreignKeyProperties), "1_navigation", "2_entityType", nameof(principalEntityType)),
+                foreignKeyProperties, navigation, entityType, principalEntityType);
 
         /// <summary>
         ///     The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.
@@ -2550,7 +2548,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 inverse, inverseEntityType, navigation, targetEntityType);
 
         /// <summary>
-        ///     The skip navigation property '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
+        ///     The skip navigation '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.
         /// </summary>
         public static string SkipNavigationWrongType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object otherEntityType)
             => string.Format(
@@ -2596,7 +2594,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => GetString("TransactionsNotSupported");
 
         /// <summary>
-        ///     The LINQ expression '{expression}' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
+        ///     The LINQ expression '{expression}' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either 'AsEnumerable()', 'AsAsyncEnumerable()', 'ToList()', or 'ToListAsync()'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
         /// </summary>
         public static string TranslationFailed([CanBeNull] object expression)
             => string.Format(
@@ -2604,7 +2602,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 expression);
 
         /// <summary>
-        ///     The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
+        ///     The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either 'AsEnumerable()', 'AsAsyncEnumerable()', 'ToList()', or 'ToListAsync()'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
         /// </summary>
         public static string TranslationFailedWithDetails([CanBeNull] object expression, [CanBeNull] object details)
             => string.Format(
@@ -2628,7 +2626,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, discriminator);
 
         /// <summary>
-        ///     Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{2_entityType}.{1_navigationName}' because the navigation property has the opposite multiplicity.
+        ///     Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation '{2_entityType}.{1_navigationName}' because the navigation has the opposite multiplicity.
         /// </summary>
         public static string UnableToSetIsUnique([CanBeNull] object isUnique, [CanBeNull] object navigationName, [CanBeNull] object entityType)
             => string.Format(
@@ -2676,7 +2674,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property);
 
         /// <summary>
-        ///     The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.
+        ///     The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' was ignored by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. An index cannot use such properties.
         /// </summary>
         public static string UnnamedIndexDefinedOnIgnoredProperty([CanBeNull] object entityType, [CanBeNull] object indexPropertyList, [CanBeNull] object propertyName)
             => string.Format(
@@ -2756,7 +2754,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, actualType, genericType);
 
         /// <summary>
-        ///     Cannot start tracking InternalEntityEntry for entity type '{entityType}' because it was created by a different StateManager instance.
+        ///     Cannot start tracking the entry for entity type '{entityType}' because it was created by a different StateManager instance.
         /// </summary>
         public static string WrongStateManager([CanBeNull] object entityType)
             => string.Format(
@@ -2790,7 +2788,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.Properties.CoreStrings", typeof(CoreResources).Assembly);
 
         /// <summary>
-        ///     The foreign key {foreignKey} on entity type '{entityType}' should not be configured as required since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
+        ///     The foreign key {foreignKeyProperties} on entity type '{entityType}' should not be configured as required since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property or the principal key before configuring the foreign key as required in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.
         /// </summary>
         public static EventDefinition<string, string> LogAmbiguousEndRequired([NotNull] IDiagnosticsLogger logger)
         {
@@ -2910,7 +2908,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Detected {addedCount} entities added and {removedCount} entities removed from navigation property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+        ///     Detected {addedCount} entities added and {removedCount} entities removed from navigation '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<int, int, string, string> LogCollectionChangeDetected([NotNull] IDiagnosticsLogger logger)
         {
@@ -2934,7 +2932,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Detected {addedCount} entities added and {removedCount} entities removed from navigation property '{entityType}.{property}' on entity with key '{keyValues}'.
+        ///     Detected {addedCount} entities added and {removedCount} entities removed from navigation '{entityType}.{property}' on entity with key '{keyValues}'.
         /// </summary>
         public static EventDefinition<int, int, string, string, string> LogCollectionChangeDetectedSensitive([NotNull] IDiagnosticsLogger logger)
         {
@@ -3006,7 +3004,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Conflicting attributes have been applied: the 'Key' attribute on property '{property}' and the 'Keyless' attribute on its entity '{entity}'. Note that the entity will have no key unless you use fluent API to override this.
+        ///     Conflicting attributes have been applied: the 'Key' attribute on property '{property}' and the 'Keyless' attribute on its entity '{entity}'. Note that the entity will have no key unless you configure one in 'OnModelCreating'.
         /// </summary>
         public static EventDefinition<string, string> LogConflictingKeylessAndKeyAttributes([NotNull] IDiagnosticsLogger logger)
         {
@@ -3102,7 +3100,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     An attempt was made to lazy-load navigation property '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.
+        ///     An attempt was made to lazy-load navigation '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.
         /// </summary>
         public static EventDefinition<string, string> LogDetachedLazyLoading([NotNull] IDiagnosticsLogger logger)
         {
@@ -3390,7 +3388,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     For the relationship between dependent '{dependentToPrincipalNavigationSpecification}' and principal '{principalToDependentNavigationSpecification}', the foreign key properties haven't been configured by convention because the best match {foreignKey} are incompatible with the current principal key {principalKey}. This message can be disregarded if explicit configuration has been specified.
+        ///     For the relationship between dependent '{dependentToPrincipalNavigationSpecification}' and principal '{principalToDependentNavigationSpecification}', the foreign key properties haven't been configured by convention because the best match {foreignKeyProperties} are incompatible with the current principal key {principalKey}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogIncompatibleMatchingForeignKeyProperties([NotNull] IDiagnosticsLogger logger)
         {
@@ -3438,7 +3436,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     An attempt was made to lazy-load navigation property '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.
+        ///     An attempt was made to lazy-load navigation '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.
         /// </summary>
         public static EventDefinition<string, string> LogLazyLoadOnDisposedContext([NotNull] IDiagnosticsLogger logger)
         {
@@ -3510,7 +3508,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     No relationship from '{firstEntityType}' to '{secondEntityType}' has been configured by convention because there are multiple properties on one entity type {navigationProperties} that could be matched with the properties on the other entity type {inverseNavigations}. This message can be disregarded if explicit configuration has been specified.
+        ///     No relationship from '{firstEntityType}' to '{secondEntityType}' has been configured by convention because there are multiple properties on one entity type {navigationProperties} that could be matched with the properties on the other entity type {inverseNavigations}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
         /// </summary>
         public static EventDefinition<string, string, string, string> LogMultipleNavigationProperties([NotNull] IDiagnosticsLogger logger)
         {
@@ -3534,7 +3532,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Primary key hasn't been configured by convention as both properties '{firstProperty}' and '{secondProperty}' could be used as the primary key for the entity type '{entityType}'. This message can be disregarded if explicit configuration has been specified.
+        ///     Primary key hasn't been configured by convention as both properties '{firstProperty}' and '{secondProperty}' could be used as the primary key for the entity type '{entityType}'. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.
         /// </summary>
         public static EventDefinition<string, string, string> LogMultiplePrimaryKeyCandidates([NotNull] IDiagnosticsLogger logger)
         {
@@ -3582,7 +3580,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Navigation property '{1_entityType}.{0_navigation}' is being lazy-loaded.
+        ///     The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.
         /// </summary>
         public static EventDefinition<string, string> LogNavigationLazyLoading([NotNull] IDiagnosticsLogger logger)
         {
@@ -3630,7 +3628,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The navigation property '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.
+        ///     The navigation '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.
         /// </summary>
         [Obsolete]
         public static EventDefinition<string, string> LogNonNullableInverted([NotNull] IDiagnosticsLogger logger)
@@ -3993,7 +3991,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Navigation property '{entityType}.{property}' detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+        ///     The navigation '{entityType}.{property}' detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<string, string> LogReferenceChangeDetected([NotNull] IDiagnosticsLogger logger)
         {
@@ -4017,7 +4015,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Navigation property '{entityType}.{property}' for entity with key '{keyValues}' detected as changed.
+        ///     The navigation '{entityType}.{property}' for entity with key '{keyValues}' detected as changed.
         /// </summary>
         public static EventDefinition<string, string, string> LogReferenceChangeDetectedSensitive([NotNull] IDiagnosticsLogger logger)
         {
@@ -4041,7 +4039,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The navigation property '{navigation}' has a [Required] attribute causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.
+        ///     The navigation '{navigation}' has a [Required] attribute causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.
         /// </summary>
         [Obsolete]
         public static EventDefinition<string, string> LogRequiredAttributeInverted([NotNull] IDiagnosticsLogger logger)
@@ -4115,7 +4113,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The [Required] attribute on '{principalEntityType}.{principalNavigation}' is invalid. [Required] attribute should only be specified on the navigation pointing to the principal side of the relationship. To change the dependent side configure the foreign key properties.
+        ///     The [Required] attribute on '{principalEntityType}.{principalNavigation}' is invalid. [Required] attribute should only be specified on the navigation pointing to the principal side of the relationship. To change the dependent side configure the foreign key properties using [ForeignKey] attribute or in 'OnModelCreating'.
         /// </summary>
         [Obsolete]
         public static EventDefinition<string, string> LogRequiredAttributeOnDependent([NotNull] IDiagnosticsLogger logger)
@@ -4140,7 +4138,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The [Required] attribute on '{principalEntityType}.{principalNavigation}' was ignored because it is a skip navigation. Instead configure the underlying foreign keys.
+        ///     The [Required] attribute on '{principalEntityType}.{principalNavigation}' was ignored because it is a skip navigation. Instead configure the underlying foreign keys in 'OnModelCreating'.
         /// </summary>
         public static EventDefinition<string, string> LogRequiredAttributeOnSkipNavigation([NotNull] IDiagnosticsLogger logger)
         {
@@ -4332,7 +4330,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Detected {addedCount} entities added and {removedCount} entities removed from skip navigation property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
+        ///     Detected {addedCount} entities added and {removedCount} entities removed from skip navigation '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.
         /// </summary>
         public static EventDefinition<int, int, string, string> LogSkipCollectionChangeDetected([NotNull] IDiagnosticsLogger logger)
         {
@@ -4356,7 +4354,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Detected {addedCount} entities added and {removedCount} entities removed from skip navigation property '{entityType}.{property}' on entity with key '{keyValues}'.
+        ///     Detected {addedCount} entities added and {removedCount} entities removed from skip navigation '{entityType}.{property}' on entity with key '{keyValues}'.
         /// </summary>
         public static EventDefinition<int, int, string, string, string> LogSkipCollectionChangeDetectedSensitive([NotNull] IDiagnosticsLogger logger)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -127,16 +127,16 @@
     <value>The entity type '{entityType}' has a defining navigation and the supplied entity is currently referenced from several owner entities. To access the entry for a particular reference call '{targetEntryCall}' on the owner entry.</value>
   </data>
   <data name="AmbiguousEndRequiredDependent" xml:space="preserve">
-    <value>The foreign key {foreignKey} on entity type '{entityType}' cannot be configured as having a required dependent since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
+    <value>The foreign key {foreignKeyProperties} on entity type '{entityType}' cannot be configured as having a required dependent since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
   </data>
   <data name="AmbiguousEndRequiredDependentNavigation" xml:space="preserve">
-    <value>The navigation '{entityType}.{navigation}' cannot be configured as required since the dependent side of the underlying foreign key {foreignKey} cannot be determined. To identify the dependent side of the relationship, configure the foreign key property. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
+    <value>The navigation '{entityType}.{navigation}' cannot be configured as required since the dependent side of the underlying foreign key {foreignKeyProperties} cannot be determined. To identify the dependent side of the relationship, configure the foreign key property in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
   </data>
   <data name="AmbiguousEndRequiredInverted" xml:space="preserve">
-    <value>The foreign key {foreignKey} on entity type '{entityType}' cannot be flipped to entity type '{principalEntityType}' since it was configured as required before the dependent side was configured. Configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
+    <value>The foreign key {foreignKeyProperties} on entity type '{entityType}' cannot be flipped to entity type '{principalEntityType}' since it was configured as required before the dependent side was configured. Configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
   </data>
   <data name="AmbiguousForeignKeyPropertyCandidates" xml:space="preserve">
-    <value>Both relationships between '{firstDependentToPrincipalNavigationSpecification}' and '{firstPrincipalToDependentNavigationSpecification}' and between '{secondDependentToPrincipalNavigationSpecification}' and '{secondPrincipalToDependentNavigationSpecification}' could use {foreignKeyProperties} as the foreign key. To resolve this configure the foreign key properties explicitly on at least one of the relationships.</value>
+    <value>Both relationships between '{firstDependentToPrincipalNavigationSpecification}' and '{firstPrincipalToDependentNavigationSpecification}' and between '{secondDependentToPrincipalNavigationSpecification}' and '{secondPrincipalToDependentNavigationSpecification}' could use {foreignKeyProperties} as the foreign key. To resolve this configure the foreign key properties explicitly in 'OnModelCreating' on at least one of the relationships.</value>
   </data>
   <data name="AmbiguousOneToOneRelationship" xml:space="preserve">
     <value>The dependent side could not be determined for the one-to-one relationship between '{dependentToPrincipalNavigationSpecification}' and '{principalToDependentNavigationSpecification}'. To identify the dependent side of the relationship, configure the foreign key property. If these navigations should not be part of the same relationship configure them independently via separate method chains in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
@@ -148,7 +148,7 @@
     <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
   <data name="AnnotationNotFound" xml:space="preserve">
-    <value>The annotation '{annotation}' was not found. Ensure that the annotation has been added.</value>
+    <value>The annotation '{annotation}' was not found. Ensure that the annotation has been added to the object {annotatable}</value>
   </data>
   <data name="ArgumentPropertyNull" xml:space="preserve">
     <value>The property '{property}' of the argument '{argument}' cannot be null.</value>
@@ -163,7 +163,7 @@
     <value>The service dependencies type '{dependenciesType}' has been registered incorrectly in the service collection. Service dependencies types must only be registered by Entity Framework or database providers.</value>
   </data>
   <data name="BadFilterDerivedType" xml:space="preserve">
-    <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type in a hierarchy.</value>
+    <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type '{rootType}'.</value>
   </data>
   <data name="BadFilterExpression" xml:space="preserve">
     <value>The filter expression '{filter}' specified for entity type '{entityType}' is invalid. The expression must accept a single parameter of type '{clrType}' and return bool.</value>
@@ -214,7 +214,7 @@
     <value>The shared-type entity type '{entityType}' cannot be added because the model already contains an entity type with the same name but a different CLR type '{otherClrType}'. Ensure all entity type names are unique.</value>
   </data>
   <data name="ClashingNamedOwnedType" xml:space="preserve">
-    <value>There is already an entity type named '{ownedTypeName}'. Use a different name when configuring the ownership '{ownerEntityType}.{navigation}'.</value>
+    <value>There is already an entity type named '{ownedTypeName}'. Use a different name when configuring the ownership '{ownerEntityType}.{navigation}' in 'OnModelCreating'.</value>
   </data>
   <data name="ClashingNonOwnedDerivedEntityType" xml:space="preserve">
     <value>The type '{entityType}' cannot be marked as owned because the derived entity type - '{derivedType}' has been configured as non-owned.</value>
@@ -223,7 +223,7 @@
     <value>The type '{entityType}' cannot be marked as owned because a non-owned entity type with the same name already exists.</value>
   </data>
   <data name="ClashingNonSharedType" xml:space="preserve">
-    <value>The shared type entity type '{entityType}' with clr type '{type}' cannot be added to the model because a non shared entity type with the same clr type already exists.</value>
+    <value>The shared type entity type '{entityType}' with clr type '{type}' cannot be added to the model because a non shared entity type with the same CLR type already exists.</value>
   </data>
   <data name="ClashingNonWeakEntityType" xml:space="preserve">
     <value>The weak entity type '{entityType}' cannot be added to the model because an entity type with the same name already exists.</value>
@@ -250,7 +250,7 @@
     <value>The property '{property}' cannot exist on type '{entityType}' because the type is marked as shadow state while the property is not. Shadow state types can only contain shadow state properties.</value>
   </data>
   <data name="CollectionIsReference" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation property. Use the '{ReferenceMethod}' method to access reference navigation properties.</value>
+    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{CollectionMethod}' method, but is defined in the model as a non-collection, reference navigation. Use the '{ReferenceMethod}' method to access reference navigation properties.</value>
   </data>
   <data name="ComparerPropertyMismatch" xml:space="preserve">
     <value>Comparer for type '{type}' cannot be used for '{entityType}.{propertyName}' because its type is '{propertyType}'.</value>
@@ -259,13 +259,13 @@
     <value>There are multiple properties pointing to navigation '{1_entityType}.{0_navigation}'. To define composite foreign key using data annotations, use [ForeignKey] attribute on navigation.</value>
   </data>
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
-    <value>Entity type '{entityType}' has composite primary key defined with data annotations. To set composite primary key, use fluent API.</value>
+    <value>Entity type '{entityType}' has composite primary key defined with data annotations. Composite primary keys can only be set in 'OnModelCreating'.</value>
   </data>
   <data name="ConcurrentMethodInvocation" xml:space="preserve">
     <value>A second operation started on this context before a previous operation completed. This is usually caused by different threads using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.</value>
   </data>
   <data name="ConflictingBackingFields" xml:space="preserve">
-    <value>Property '{1_entityType}.{0_property}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating()'.</value>
+    <value>Property '{1_entityType}.{0_property}' matches both '{field1}' and '{field2}' by convention. Explicitly specify the backing field to use with '.HasField()' in 'OnModelCreating'.</value>
   </data>
   <data name="ConflictingForeignKeyAttributes" xml:space="preserve">
     <value>There are multiple [ForeignKey] attributes which are pointing to same set of properties - '{propertyList}' on entity type '{entityType}'.</value>
@@ -274,7 +274,7 @@
     <value>The property or navigation '{member}' cannot be added to the entity type '{entityType}' because a property or navigation with the same name already exists on entity type '{conflictingEntityType}'.</value>
   </data>
   <data name="ConflictingRelationshipNavigation" xml:space="preserve">
-    <value>Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation '{newDependentNavigationSpecification}' first.</value>
+    <value>Cannot create a relationship between '{newPrincipalNavigationSpecification}' and '{newDependentNavigationSpecification}', because there already is a relationship between '{existingPrincipalNavigationSpecification}' and '{existingDependentNavigationSpecification}'. Navigation properties can only participate in a single relationship. If you want to override an existing relationship call Ignore on the navigation '{newDependentNavigationSpecification}' first in 'OnModelCreating'.</value>
   </data>
   <data name="ConstructorBindingFailed" xml:space="preserve">
     <value>cannot bind '{failedBinds}' in '{parameters}'</value>
@@ -322,13 +322,13 @@
     <value>Unable to set a base type for entity type '{entityType}' because it has been configured as having no keys.</value>
   </data>
   <data name="DerivedEntityCannotHaveKeys" xml:space="preserve">
-    <value>Unable to set a base type for entity type '{entityType}' because it has one or more keys defined.</value>
+    <value>Unable to set a base type for entity type '{entityType}' because it has one or more keys defined. Only root types can have keys.</value>
   </data>
   <data name="DerivedEntityTypeHasNoKey" xml:space="preserve">
-    <value>A '{derivedType}' cannot be configured as keyless because it is a derived type. The root type '{rootType}' must be configured as keyless. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.</value>
+    <value>A '{derivedType}' cannot be configured as keyless because it is a derived type. The root type '{rootType}' must be configured as keyless. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder in 'OnModelCreating', or referenced from a navigation on a type that is included in the model.</value>
   </data>
   <data name="DerivedEntityTypeKey" xml:space="preserve">
-    <value>A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.</value>
+    <value>A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation on a type that is included in the model.</value>
   </data>
   <data name="DerivedTypeDefiningQuery" xml:space="preserve">
     <value>The entity type '{entityType}' cannot have a defining query because it is derived from '{baseType}'. Only base entity types can have a defining query.</value>
@@ -355,13 +355,13 @@
     <value>The entity type '{entityType}' cannot be added to the model because an entity type with the same name already exists.</value>
   </data>
   <data name="DuplicateForeignKey" xml:space="preserve">
-    <value>The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}' and also targets the key {key} on '{principalType}'.</value>
+    <value>The foreign key {foreignKeyProperties} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}' and also targets the key {keyProperties} on '{principalType}'.</value>
   </data>
   <data name="DuplicateIndex" xml:space="preserve">
     <value>The index {indexProperties} cannot be added to the entity type '{entityType}' because an index on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
-    <value>The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.</value>
+    <value>The key {keyProperties} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="DuplicateNamedIndex" xml:space="preserve">
     <value>The index named '{indexName}' defined on properties {indexProperties} cannot be added to the entity type '{entityType}' because an index with the same name already exists on entity type '{duplicateEntityType}'.</value>
@@ -385,13 +385,13 @@
     <value>This query would cause multiple evaluation of a subquery because entity '{entityType}' has a composite key. Rewrite your query avoiding the subquery.</value>
   </data>
   <data name="EntityRequiresKey" xml:space="preserve">
-    <value>The entity type '{entityType}' requires a primary key to be defined. If you intended to use a keyless entity type call 'HasNoKey()'.</value>
+    <value>The entity type '{entityType}' requires a primary key to be defined. If you intended to use a keyless entity type call 'HasNoKey()' in 'OnModelCreating'.</value>
   </data>
   <data name="EntityTypeInUseByDerived" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.</value>
   </data>
   <data name="EntityTypeInUseByReferencingForeignKey" xml:space="preserve">
-    <value>The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKey} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.</value>
+    <value>The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKeyProperties} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.</value>
   </data>
   <data name="EntityTypeInUseByReferencingSkipNavigation" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be removed because it is being referenced by the skip navigation '{skipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before the entity type can be removed.</value>
@@ -436,7 +436,7 @@
     <value>The configured execution strategy '{strategy}' does not support user initiated transactions. Use the execution strategy returned by '{getExecutionStrategyMethod}' to execute all the operations in the transaction as a retriable unit.</value>
   </data>
   <data name="ExpressionParameterizationException" xml:space="preserve">
-    <value>An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.</value>
+    <value>An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call 'DbContextOptionsBuilder.EnableSensitiveDataLogging'.</value>
   </data>
   <data name="ExpressionParameterizationExceptionSensitive" xml:space="preserve">
     <value>An exception was thrown while attempting to evaluate the LINQ query parameter expression '{expression}'.</value>
@@ -460,16 +460,16 @@
     <value>The [ForeignKey] attributes on property '{property}' and navigation '{navigation}' in entity type '{entityType}' do not point at each other. The value of [ForeignKey] attribute on property should be navigation name and the value of [ForeignKey] attribute on navigation should be the foreign key property name.</value>
   </data>
   <data name="ForeignKeyCountMismatch" xml:space="preserve">
-    <value>The number of properties specified for the foreign key {foreignKey} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.</value>
+    <value>The number of properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>
   <data name="ForeignKeyInUseSkipNavigation" xml:space="preserve">
     <value>Cannot remove foreign key {foreigKey} from entity type '{entityType}' because it is referenced by a skip navigation '{navigation}' on entity type '{navigationEntityType}'. All referencing skip navigation must be removed before the referenced foreign key can be removed.</value>
   </data>
   <data name="ForeignKeyPropertiesWrongEntity" xml:space="preserve">
-    <value>The specified foreign key properties {foreignKey} are not declared on the entity type '{entityType}'. Ensure foreign key properties are declared on the target entity type.</value>
+    <value>The specified foreign key properties {foreignKeyProperties} are not declared on the entity type '{entityType}'. Ensure foreign key properties are declared on the target entity type.</value>
   </data>
   <data name="ForeignKeyPropertyInKey" xml:space="preserve">
-    <value>The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {key} defined on a base entity type '{baseEntityType}'.</value>
+    <value>The property '{property}' cannot be part of a foreign key on '{entityType}' because it has value generation enabled and is contained in the key {keyProperties} defined on a base entity type '{baseEntityType}'.</value>
   </data>
   <data name="ForeignKeyReferencedEntityKeyMismatch" xml:space="preserve">
     <value>The provided principal entity key '{principalKey}' is not a key on the entity type '{principalEntityType}'.</value>
@@ -478,10 +478,10 @@
     <value>The foreign keys on entity type '{dependentType}' cannot target the same entity type because it is a weak entity type.</value>
   </data>
   <data name="ForeignKeyTypeMismatch" xml:space="preserve">
-    <value>The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.</value>
+    <value>The types of the properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>
   <data name="ForeignKeyWrongType" xml:space="preserve">
-    <value>The foreign key {foreignKey} targeting the key {key} on '{principalType}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
+    <value>The foreign key {foreignKeyProperties} targeting the key {keyProperties} on '{principalType}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="FullChangeTrackingRequired" xml:space="preserve">
     <value>The entity type '{entityType}' is configured to use the '{changeTrackingStrategy}' change tracking strategy when full change tracking notifications are required. Use 'ModelBuilder.HasChangeTrackingStrategy' in 'OnModelCreating' to configure all entity types in the model to use the '{fullStrategy}' or '{fullPlusStrategy}' strategy.</value>
@@ -530,7 +530,7 @@
     <value>The entity type '{entityType}' should derive from '{baseEntityType}' to reflect the hierarchy of the corresponding CLR types.</value>
   </data>
   <data name="InconsistentOwnership" xml:space="preserve">
-    <value>The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not. All entity types sharing a CLR type must be configured as owned.</value>
+    <value>The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not. All entity types sharing a CLR type must be configured as owned in 'OnModelCreating'.</value>
   </data>
   <data name="IndexPropertiesWrongEntity" xml:space="preserve">
     <value>The specified index properties {index} are not declared on the entity type '{entityType}'. Ensure index properties are declared on the target entity type.</value>
@@ -539,19 +539,19 @@
     <value>The index {indexProperties} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="InheritedPropertyCannotBeIgnored" xml:space="preserve">
-    <value>The property '{property}' cannot be ignored on entity type '{entityType}', because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use [NotMapped] attribute or Ignore method on the base type.</value>
+    <value>The property '{property}' cannot be ignored on entity type '{entityType}', because it's declared on the base entity type '{baseEntityType}'. To exclude this property from your model, use [NotMapped] attribute or 'EntityTypeBuilder.Ignore' on the base type in 'OnModelCreating'.</value>
   </data>
   <data name="InterfacePropertyNotAdded" xml:space="preserve">
-    <value>The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation property manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
+    <value>The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
   <data name="IntraHierarchicalAmbiguousTargetEntityType" xml:space="preserve">
-    <value>The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.</value>
+    <value>The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKeyProperties} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.</value>
   </data>
   <data name="InvalidAlternateKeyValue" xml:space="preserve">
     <value>Unable to track an entity of type '{entityType}' because alternate key property '{keyProperty}' is null. If the alternate key is not used in a relationship, then consider using a unique index instead. Unique indexes may contain nulls, while alternate keys must not.</value>
   </data>
   <data name="InvalidEntityType" xml:space="preserve">
-    <value>The specified type '{type}'must be a non-interface reference type to be used as an entity type.</value>
+    <value>The specified type '{type}' must be a non-interface reference type to be used as an entity type.</value>
   </data>
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
@@ -563,7 +563,7 @@
     <value>Unable to track an entity of type '{entityType}' because primary key property '{keyProperty}' is null.</value>
   </data>
   <data name="InvalidLambdaExpressionInsideInclude" xml:space="preserve">
-    <value>Lambda expression used inside Include is not valid.</value>
+    <value>Lambda expression used inside 'Include' is not valid.</value>
   </data>
   <data name="InvalidMemberExpression" xml:space="preserve">
     <value>The expression '{expression}' is not a valid member access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'.</value>
@@ -575,7 +575,7 @@
     <value>The expression '{expression}' is not a valid members access expression. The expression should represent a simple property or field access: 't =&gt; t.MyProperty'. When specifying multiple properties or fields use an anonymous type: 't =&gt; new {{ t.MyProperty, t.MyField }}'.</value>
   </data>
   <data name="InvalidNavigationWithInverseProperty" xml:space="preserve">
-    <value>The [InverseProperty] attribute on property '{1_entityType}.{0_property}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.</value>
+    <value>The [InverseProperty] attribute on property '{1_entityType}.{0_property}' is not valid. The property '{referencedProperty}' is not a valid navigation on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation.</value>
   </data>
   <data name="InvalidPoolSize" xml:space="preserve">
     <value>The specified poolSize must be greater than 0.</value>
@@ -619,7 +619,7 @@
     <value>The value for property '{1_entityType}.{0_property}' cannot be set to a value of type '{valueType}' because its type is '{propertyType}'.</value>
   </data>
   <data name="InvalidTypeConversationWithInclude" xml:space="preserve">
-    <value>Invalid type conversion when specifying include.</value>
+    <value>Invalid type conversion specified in 'Include' call.</value>
   </data>
   <data name="InvalidUseService" xml:space="preserve">
     <value>A call was made to '{useService}', but Entity Framework is not building its own internal service provider. Either allow EF to build the service provider by removing the call to '{useInternalServiceProvider}', or build the '{service}' services to use into the service provider before passing it to '{useInternalServiceProvider}'.</value>
@@ -643,7 +643,7 @@
     <value>The derived type '{derivedType}' cannot have [Key] attribute on property '{property}' since primary key can only be declared on the root type.</value>
   </data>
   <data name="KeyInUse" xml:space="preserve">
-    <value>Cannot remove key {key} from entity type '{entityType}' because it is referenced by a foreign key {foreignKey} in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
+    <value>Cannot remove key {keyProperties} from entity type '{entityType}' because it is referenced by a foreign key {foreignKeyProperties} in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
   </data>
   <data name="KeylessTypeExistingKey" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be marked as keyless because it contains a key.</value>
@@ -652,13 +652,13 @@
     <value>Unable to track an instance of type '{type}' because it does not have a primary key. Only entity types with primary keys may be tracked.</value>
   </data>
   <data name="KeylessTypeWithKey" xml:space="preserve">
-    <value>The key {key} cannot be added to keyless type '{entityType}'.</value>
+    <value>The key {keyProperties} cannot be added to keyless type '{entityType}'.</value>
   </data>
   <data name="KeyPropertiesWrongEntity" xml:space="preserve">
-    <value>The specified key properties {key} are not declared on the entity type '{entityType}'. Ensure key properties are declared on the target entity type.</value>
+    <value>The specified key properties {keyProperties} are not declared on the entity type '{entityType}'. Ensure key properties are declared on the target entity type.</value>
   </data>
   <data name="KeyPropertyCannotBeNullable" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' cannot be marked as nullable/optional because it has been included in a key {key}.</value>
+    <value>The property '{1_entityType}.{0_property}' cannot be marked as nullable/optional because it has been included in a key {keyProperties}.</value>
   </data>
   <data name="KeyPropertyInForeignKey" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' cannot be part of a key because it has value generation enabled and is contained in a foreign key defined on a derived entity type.</value>
@@ -670,13 +670,13 @@
     <value>The property '{1_entityType}.{0_property}' is part of a key and so cannot be modified or marked as modified. To change the principal of an existing entity with an identifying foreign key first delete the dependent and invoke 'SaveChanges' then associate the dependent with the new principal.</value>
   </data>
   <data name="KeyWrongType" xml:space="preserve">
-    <value>The key {key} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
+    <value>The key {keyProperties} cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="LiteralGenerationNotSupported" xml:space="preserve">
     <value>The type mapping for '{type}' has not implemented code literal generation.</value>
   </data>
   <data name="LogAmbiguousEndRequired" xml:space="preserve">
-    <value>The foreign key {foreignKey} on entity type '{entityType}' should not be configured as required since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property or the principal key before configuring the foreign key as required. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
+    <value>The foreign key {foreignKeyProperties} on entity type '{entityType}' should not be configured as required since the dependent side cannot be determined. To identify the dependent side of the relationship, configure the foreign key property or the principal key before configuring the foreign key as required in 'OnModelCreating'. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
     <comment>Warning CoreEventId.AmbiguousEndRequiredWarning string string</comment>
   </data>
   <data name="LogCascadeDelete" xml:space="preserve">
@@ -696,11 +696,11 @@
     <comment>Debug CoreEventId.CascadeDelete string string EntityState string string</comment>
   </data>
   <data name="LogCollectionChangeDetected" xml:space="preserve">
-    <value>Detected {addedCount} entities added and {removedCount} entities removed from navigation property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
+    <value>Detected {addedCount} entities added and {removedCount} entities removed from navigation '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.CollectionChangeDetected int int string string</comment>
   </data>
   <data name="LogCollectionChangeDetectedSensitive" xml:space="preserve">
-    <value>Detected {addedCount} entities added and {removedCount} entities removed from navigation property '{entityType}.{property}' on entity with key '{keyValues}'.</value>
+    <value>Detected {addedCount} entities added and {removedCount} entities removed from navigation '{entityType}.{property}' on entity with key '{keyValues}'.</value>
     <comment>Debug CoreEventId.CollectionChangeDetected int int string string string</comment>
   </data>
   <data name="LogCollectionWithoutComparer" xml:space="preserve">
@@ -712,7 +712,7 @@
     <comment>Warning CoreEventId.ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning string string string string</comment>
   </data>
   <data name="LogConflictingKeylessAndKeyAttributes" xml:space="preserve">
-    <value>Conflicting attributes have been applied: the 'Key' attribute on property '{property}' and the 'Keyless' attribute on its entity '{entity}'. Note that the entity will have no key unless you use fluent API to override this.</value>
+    <value>Conflicting attributes have been applied: the 'Key' attribute on property '{property}' and the 'Keyless' attribute on its entity '{entity}'. Note that the entity will have no key unless you configure one in 'OnModelCreating'.</value>
     <comment>Warning CoreEventId.ConflictingKeylessAndKeyAttributesWarning string string</comment>
   </data>
   <data name="LogConflictingShadowForeignKeys" xml:space="preserve">
@@ -728,7 +728,7 @@
     <comment>Information CoreEventId.ContextInitialized string string string string</comment>
   </data>
   <data name="LogDetachedLazyLoading" xml:space="preserve">
-    <value>An attempt was made to lazy-load navigation property '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.</value>
+    <value>An attempt was made to lazy-load navigation '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.</value>
     <comment>Warning CoreEventId.DetachedLazyLoadingWarning string string</comment>
   </data>
   <data name="LogDetectChangesCompleted" xml:space="preserve">
@@ -776,7 +776,7 @@
     <comment>Debug CoreEventId.ForeignKeyChangeDetected string string object object string</comment>
   </data>
   <data name="LogIncompatibleMatchingForeignKeyProperties" xml:space="preserve">
-    <value>For the relationship between dependent '{dependentToPrincipalNavigationSpecification}' and principal '{principalToDependentNavigationSpecification}', the foreign key properties haven't been configured by convention because the best match {foreignKey} are incompatible with the current principal key {principalKey}. This message can be disregarded if explicit configuration has been specified.</value>
+    <value>For the relationship between dependent '{dependentToPrincipalNavigationSpecification}' and principal '{principalToDependentNavigationSpecification}', the foreign key properties haven't been configured by convention because the best match {foreignKeyProperties} are incompatible with the current principal key {principalKey}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.</value>
     <comment>Debug CoreEventId.IncompatibleMatchingForeignKeyProperties string string string string</comment>
   </data>
   <data name="LogInvalidIncludePath" xml:space="preserve">
@@ -784,7 +784,7 @@
     <comment>Error CoreEventId.InvalidIncludePathError object object</comment>
   </data>
   <data name="LogLazyLoadOnDisposedContext" xml:space="preserve">
-    <value>An attempt was made to lazy-load navigation property '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.</value>
+    <value>An attempt was made to lazy-load navigation '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.</value>
     <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning string string</comment>
   </data>
   <data name="LogManyServiceProvidersCreated" xml:space="preserve">
@@ -796,11 +796,11 @@
     <comment>Warning CoreEventId.MultipleInversePropertiesSameTargetWarning string string</comment>
   </data>
   <data name="LogMultipleNavigationProperties" xml:space="preserve">
-    <value>No relationship from '{firstEntityType}' to '{secondEntityType}' has been configured by convention because there are multiple properties on one entity type {navigationProperties} that could be matched with the properties on the other entity type {inverseNavigations}. This message can be disregarded if explicit configuration has been specified.</value>
+    <value>No relationship from '{firstEntityType}' to '{secondEntityType}' has been configured by convention because there are multiple properties on one entity type {navigationProperties} that could be matched with the properties on the other entity type {inverseNavigations}. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.</value>
     <comment>Debug CoreEventId.MultipleNavigationProperties string string string string</comment>
   </data>
   <data name="LogMultiplePrimaryKeyCandidates" xml:space="preserve">
-    <value>Primary key hasn't been configured by convention as both properties '{firstProperty}' and '{secondProperty}' could be used as the primary key for the entity type '{entityType}'. This message can be disregarded if explicit configuration has been specified.</value>
+    <value>Primary key hasn't been configured by convention as both properties '{firstProperty}' and '{secondProperty}' could be used as the primary key for the entity type '{entityType}'. This message can be disregarded if explicit configuration has been specified in 'OnModelCreating'.</value>
     <comment>Debug CoreEventId.MultiplePrimaryKeyCandidates string string string</comment>
   </data>
   <data name="LogNavigationBaseIncluded" xml:space="preserve">
@@ -808,7 +808,7 @@
     <comment>Debug CoreEventId.NavigationBaseIncluded string</comment>
   </data>
   <data name="LogNavigationLazyLoading" xml:space="preserve">
-    <value>Navigation property '{1_entityType}.{0_navigation}' is being lazy-loaded.</value>
+    <value>The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.</value>
     <comment>Debug CoreEventId.NavigationLazyLoading string string</comment>
   </data>
   <data name="LogNonDefiningInverseNavigation" xml:space="preserve">
@@ -816,7 +816,7 @@
     <comment>Warning CoreEventId.NonDefiningInverseNavigationWarning string string string string string</comment>
   </data>
   <data name="LogNonNullableInverted" xml:space="preserve">
-    <value>The navigation property '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
+    <value>The navigation '{navigation}' is non-nullable, causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
     <comment>Obsolete Debug CoreEventId.NonNullableInverted string string</comment>
   </data>
   <data name="LogNonNullableReferenceOnBothNavigations" xml:space="preserve">
@@ -876,15 +876,15 @@
     <comment>Debug CoreEventId.RedundantIndexRemoved string string string</comment>
   </data>
   <data name="LogReferenceChangeDetected" xml:space="preserve">
-    <value>Navigation property '{entityType}.{property}' detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
+    <value>The navigation '{entityType}.{property}' detected as changed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.ReferenceChangeDetected string string</comment>
   </data>
   <data name="LogReferenceChangeDetectedSensitive" xml:space="preserve">
-    <value>Navigation property '{entityType}.{property}' for entity with key '{keyValues}' detected as changed.</value>
+    <value>The navigation '{entityType}.{property}' for entity with key '{keyValues}' detected as changed.</value>
     <comment>Debug CoreEventId.ReferenceChangeDetected string string string</comment>
   </data>
   <data name="LogRequiredAttributeInverted" xml:space="preserve">
-    <value>The navigation property '{navigation}' has a [Required] attribute causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
+    <value>The navigation '{navigation}' has a [Required] attribute causing the entity type '{entityType}' to be configured as the dependent side in the corresponding relationship.</value>
     <comment>Obsolete Debug CoreEventId.RequiredAttributeInverted string string</comment>
   </data>
   <data name="LogRequiredAttributeOnBothNavigations" xml:space="preserve">
@@ -896,11 +896,11 @@
     <comment>Debug CoreEventId.RequiredAttributeOnCollection string string</comment>
   </data>
   <data name="LogRequiredAttributeOnDependent" xml:space="preserve">
-    <value>The [Required] attribute on '{principalEntityType}.{principalNavigation}' is invalid. [Required] attribute should only be specified on the navigation pointing to the principal side of the relationship. To change the dependent side configure the foreign key properties.</value>
+    <value>The [Required] attribute on '{principalEntityType}.{principalNavigation}' is invalid. [Required] attribute should only be specified on the navigation pointing to the principal side of the relationship. To change the dependent side configure the foreign key properties using [ForeignKey] attribute or in 'OnModelCreating'.</value>
     <comment>Obsolete Error CoreEventId.RequiredAttributeOnDependent string string</comment>
   </data>
   <data name="LogRequiredAttributeOnSkipNavigation" xml:space="preserve">
-    <value>The [Required] attribute on '{principalEntityType}.{principalNavigation}' was ignored because it is a skip navigation. Instead configure the underlying foreign keys.</value>
+    <value>The [Required] attribute on '{principalEntityType}.{principalNavigation}' was ignored because it is a skip navigation. Instead configure the underlying foreign keys in 'OnModelCreating'.</value>
     <comment>Debug CoreEventId.RequiredAttributeOnSkipNavigation string string</comment>
   </data>
   <data name="LogRowLimitingOperationWithoutOrderBy" xml:space="preserve">
@@ -932,11 +932,11 @@
     <comment>Debug CoreEventId.ShadowPropertyCreated string string</comment>
   </data>
   <data name="LogSkipCollectionChangeDetected" xml:space="preserve">
-    <value>Detected {addedCount} entities added and {removedCount} entities removed from skip navigation property '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
+    <value>Detected {addedCount} entities added and {removedCount} entities removed from skip navigation '{entityType}.{property}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see key values.</value>
     <comment>Debug CoreEventId.SkipCollectionChangeDetected int int string string</comment>
   </data>
   <data name="LogSkipCollectionChangeDetectedSensitive" xml:space="preserve">
-    <value>Detected {addedCount} entities added and {removedCount} entities removed from skip navigation property '{entityType}.{property}' on entity with key '{keyValues}'.</value>
+    <value>Detected {addedCount} entities added and {removedCount} entities removed from skip navigation '{entityType}.{property}' on entity with key '{keyValues}'.</value>
     <comment>Debug CoreEventId.SkipCollectionChangeDetected int int string string string</comment>
   </data>
   <data name="LogStartedTracking" xml:space="preserve">
@@ -975,7 +975,7 @@
     <value>The specified field '{field}' could not be found for property '{2_entityType}.{1_property}'.</value>
   </data>
   <data name="MissingInverseManyToManyNavigation" xml:space="preserve">
-    <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation property in the HasMany() call.</value>
+    <value>Unable to set up a many-to-many relationship between the entity types '{principalEntityType}' and '{declaringEntityType}' because one of the navigations was not specified. Please provide a navigation in the 'HasMany()' call in 'OnModelCreating'.</value>
   </data>
   <data name="ModelNotFinalized" xml:space="preserve">
     <value>The model must be finalized before '{method}' can be used. Ensure that either 'OnModelCreating' has completed or, if using a stand-alone 'ModelBuilder', that 'FinalizeModel' has been called.</value>
@@ -1008,46 +1008,46 @@
     <value>The index with name {indexName} cannot be removed from the entity type '{entityType}' because no such index exists on that entity type.</value>
   </data>
   <data name="NavigationArray" xml:space="preserve">
-    <value>The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.</value>
+    <value>The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' which is an array type. Collection navigation properties cannot be arrays.</value>
   </data>
   <data name="NavigationBadType" xml:space="preserve">
-    <value>The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
+    <value>The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
   </data>
   <data name="NavigationCannotCreateType" xml:space="preserve">
-    <value>The type of navigation property '{1_entityType}.{0_navigation}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
+    <value>The type of navigation '{1_entityType}.{0_navigation}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
   </data>
   <data name="NavigationCollectionWrongClrType" xml:space="preserve">
-    <value>The collection navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.</value>
+    <value>The collection navigation '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.</value>
   </data>
   <data name="NavigationForWrongForeignKey" xml:space="preserve">
-    <value>The navigation property '{1_entityType}.{0_navigation}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>
+    <value>The navigation '{1_entityType}.{0_navigation}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>
   </data>
   <data name="NavigationIsProperty" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{ReferenceMethod}' or '{CollectionMethod}' method, but is defined in the model as a non-navigation property. Use the '{PropertyMethod}' method to access non-navigation properties.</value>
+    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' or '{collectionMethod}' method, but is defined in the model as a non-navigation. Use the '{propertyMethod}' method to access non-navigation properties.</value>
   </data>
   <data name="NavigationNoSetter" xml:space="preserve">
-    <value>The navigation property '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigation properties must be initialized before use.</value>
+    <value>The navigation '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigation properties must be initialized before use.</value>
   </data>
   <data name="NavigationNotAdded" xml:space="preserve">
-    <value>Unable to determine the relationship represented by navigation property '{entityType}.{navigation}' of type '{propertyType}'. Either manually configure the relationship, or ignore this property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
+    <value>Unable to determine the relationship represented by navigation '{entityType}.{navigation}' of type '{propertyType}'. Either manually configure the relationship, or ignore this property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
   <data name="NavigationSingleWrongClrType" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>
+    <value>The navigation '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>
   </data>
   <data name="NavigationToKeylessType" xml:space="preserve">
     <value>The navigation '{navigation}' cannot be added because it targets the keyless entity type '{entityType}'. Navigations can only target entity types with keys.</value>
   </data>
   <data name="NavigationToShadowEntity" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.</value>
+    <value>The navigation '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.</value>
   </data>
   <data name="NoBackingField" xml:space="preserve">
-    <value>No field was found backing property '{1_entityType}.{0_property}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{pam}'.</value>
+    <value>No field was found backing property '{1_entityType}.{0_property}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{propertyAccessMode}'.</value>
   </data>
   <data name="NoBackingFieldLazyLoading" xml:space="preserve">
     <value>No field was found backing property '{1_entityType}.{0_property}'. Lazy-loaded navigation properties must have backing fields. Either name the backing field so that it is picked up by convention or configure the backing field to use.</value>
   </data>
   <data name="NoClrNavigation" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added in shadow state.</value>
+    <value>The navigation '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added in shadow state.</value>
   </data>
   <data name="NoClrType" xml:space="preserve">
     <value>The CLR entity materializer cannot be used for entity type '{entityType}' because it is a shadow state entity type. Materialization to a CLR type is only possible for entity types that have a corresponding CLR type.</value>
@@ -1065,7 +1065,7 @@
     <value>The entity type '{entityType}' is part of a hierarchy, but does not have a discriminator value configured.</value>
   </data>
   <data name="NoEfServices" xml:space="preserve">
-    <value>Entity Framework services have not been added to the internal service provider. Either remove the call to UseInternalServiceProvider so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. AddEntityFrameworkSqlServer).</value>
+    <value>Entity Framework services have not been added to the internal service provider. Either remove the call to 'UseInternalServiceProvider' so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. 'AddEntityFrameworkSqlServer').</value>
   </data>
   <data name="NoFieldOrGetter" xml:space="preserve">
     <value>No backing field could be found for property '{1_entityType}.{0_property}' and the property does not have a getter.</value>
@@ -1074,25 +1074,25 @@
     <value>No backing field could be found for property '{1_entityType}.{0_property}' and the property does not have a setter.</value>
   </data>
   <data name="NoGetter" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' does not have a getter. Either make the property readable or use a different '{pam}'.</value>
+    <value>The property '{1_entityType}.{0_property}' does not have a getter. Either make the property readable or use a different '{propertyAccessMode}'.</value>
   </data>
   <data name="NoInterceptionResult" xml:space="preserve">
     <value>'InterceptionResult.Result' was called when 'InterceptionResult.HasResult' is false.</value>
   </data>
   <data name="NoNavigation" xml:space="preserve">
-    <value>There is no navigation on entity type '{entityType}' associated with the foreign key {foreignKey}.</value>
+    <value>There is no navigation on entity type '{entityType}' associated with the foreign key {foreignKeyProperties}.</value>
   </data>
   <data name="NonClrBaseType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{baseEntityType}' is a shadow state entity type while '{entityType}' is not.</value>
   </data>
   <data name="NonComparableKeyType" xml:space="preserve">
-    <value>Property '{entityType}.{property}' cannot be used as a key because it has type '{providerType}' which does not implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Use 'HasConversion()' in 'OnModelCreating()' to wrap '{providerType}' with a type that can be compared.</value>
+    <value>Property '{entityType}.{property}' cannot be used as a key because it has type '{providerType}' which does not implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Use 'HasConversion()' in 'OnModelCreating' to wrap '{providerType}' with a type that can be compared.</value>
   </data>
   <data name="NonComparableKeyTypes" xml:space="preserve">
     <value>Property '{entityType}.{property}' cannot be used as a key because it has type '{modelType}' and provider type '{providerType}' neither of which implement 'IComparable&lt;T&gt;', 'IComparable' or 'IStructuralComparable'. Make '{modelType}' implement one of these interfaces to use it as a key.</value>
   </data>
   <data name="NonConfiguredNavigationToSharedType" xml:space="preserve">
-    <value>The navigation '{1_entityType}.{0_navigation}' must be configured using Fluent API with an explicit name for the target shared type entity type or excluded by calling 'EntityTypeBuilder.Ignore'.</value>
+    <value>The navigation '{1_entityType}.{0_navigation}' must be configured in 'OnModelCreating' with an explicit name for the target shared type entity type or excluded by calling 'EntityTypeBuilder.Ignore'.</value>
   </data>
   <data name="NonDefiningOwnership" xml:space="preserve">
     <value>The ownership by '{ownershipNavigation}' should use defining navigation '{definingNavigation}' for the owned type '{entityType}'</value>
@@ -1104,13 +1104,13 @@
     <value>Cannot add property '{1_entityType}.{0_property}' since there is no indexer on '{1_entityType}' taking a single argument of type '{type}'.</value>
   </data>
   <data name="NonNotifyingCollection" xml:space="preserve">
-    <value>The collection type being used for navigation property '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
+    <value>The collection type being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
   </data>
   <data name="NonShadowBaseType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{entityType}' is a shadow state entity type while '{baseEntityType}' is not.</value>
   </data>
   <data name="NonUniqueRequiredDependentForeignKey" xml:space="preserve">
-    <value>The foreign key {foreignKey} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.</value>
+    <value>The foreign key {foreignKeyProperties} on the entity type '{declaringEntityType}' cannot have a required dependent end since it is not unique.</value>
   </data>
   <data name="NonUniqueRequiredDependentNavigation" xml:space="preserve">
     <value>'{principalEntityType}.{principalNavigation}' cannot be configured as required since it contains a collection.</value>
@@ -1119,7 +1119,7 @@
     <value>A parameterless constructor was not found on entity type '{entityType}'. In order to create an instance of '{entityType}' EF requires that a parameterless constructor be declared.</value>
   </data>
   <data name="NoProperty" xml:space="preserve">
-    <value>No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{pam}'.</value>
+    <value>No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{propertyAccessMode}'.</value>
   </data>
   <data name="NoPropertyType" xml:space="preserve">
     <value>The property '{property}' cannot be added to the type '{entityType}' because there was no property type specified and there is no corresponding CLR property or field. To add a shadow state property the property type must be specified.</value>
@@ -1131,7 +1131,7 @@
     <value>Unable to resolve service for type '{service}'. This is often because no database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions&lt;TContext&gt; object in its constructor and passes it to the base constructor for DbContext.</value>
   </data>
   <data name="NoSetter" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{pam}'.</value>
+    <value>The property '{1_entityType}.{0_property}' does not have a setter. Either make the property writable or use a different '{propertyAccessMode}'.</value>
   </data>
   <data name="NotAnEFService" xml:space="preserve">
     <value>The database provider attempted to register an implementation of the '{service}' service. This is not a service defined by EF and as such must be registered as a provider-specific service using the 'TryAddProviderSpecificServices' method.</value>
@@ -1143,7 +1143,7 @@
     <value>The given 'IQueryable' does not support generation of query strings.</value>
   </data>
   <data name="NoValueGenerator" xml:space="preserve">
-    <value>The '{1_entityType}.{0_property}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.</value>
+    <value>The '{1_entityType}.{0_property}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}' in 'OnModelCreating'.</value>
   </data>
   <data name="NullableKey" xml:space="preserve">
     <value>A key on entity type '{entityType}' cannot contain the property '{property}' because it is nullable/optional. All properties on which a key is declared must be marked as non-nullable/required.</value>
@@ -1158,7 +1158,7 @@
     <value>The owned entity type '{entityType}' cannot have a base type.</value>
   </data>
   <data name="OwnedEntitiesCannotBeTrackedWithoutTheirOwner" xml:space="preserve">
-    <value>A tracking query projects owned entity without corresponding owner in result. Owned entities cannot be tracked without their owner. Either include the owner entity in the result or make query non-tracking using AsNoTracking().</value>
+    <value>A tracking query projects owned entity without corresponding owner in result. Owned entities cannot be tracked without their owner. Either include the owner entity in the result or make query non-tracking using 'AsNoTracking()'.</value>
   </data>
   <data name="OwnerlessOwnedType" xml:space="preserve">
     <value>The owned entity type '{ownedType}' requires to be referenced from another entity type via a navigation. Add a navigation to an entity type that points at '{ownedType}'.</value>
@@ -1194,16 +1194,16 @@
     <value>The property '{property}' belongs to entity type '{entityType}' but is being used with an instance of entity type '{expectedType}'.</value>
   </data>
   <data name="PropertyInUseForeignKey" xml:space="preserve">
-    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKey} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.</value>
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the foreign key {foreignKeyProperties} on '{foreignKeyType}'. All containing foreign keys must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseIndex" xml:space="preserve">
     <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the index {index} on '{indexType}'. All containing indexes must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyInUseKey" xml:space="preserve">
-    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {key}. All containing keys must be removed or redefined before the property can be removed.</value>
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in the key {keyProperties}. All containing keys must be removed or redefined before the property can be removed.</value>
   </data>
   <data name="PropertyIsNavigation" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{propertyMethod}' method, but is defined in the model as a navigation property. Use either the '{referenceMethod}' or '{collectionMethod}' method to access navigation properties.</value>
+    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{propertyMethod}' method, but is defined in the model as a navigation. Use either the '{referenceMethod}' or '{collectionMethod}' method to access navigation properties.</value>
   </data>
   <data name="PropertyMethodInvoked" xml:space="preserve">
     <value>The EF.Property&lt;T&gt; method may only be used within LINQ queries.</value>
@@ -1228,9 +1228,6 @@
   </data>
   <data name="PropertyWrongEntityClrType" xml:space="preserve">
     <value>The CLR property '{property}' cannot be added to entity type '{entityType}' because it is declared on the CLR type '{clrType}'.</value>
-  </data>
-  <data name="PropertyWrongEntitySharedClrType" xml:space="preserve">
-    <value>The CLR property '{property}' cannot be added to entity type '{entityType}'({sharedType}) because it is declared on the CLR type '{clrType}'.</value>
   </data>
   <data name="PropertyWrongName" xml:space="preserve">
     <value>The property '{property}' cannot be added to type '{entityType}' because the name of the given CLR property or field '{clrName}' is different.</value>
@@ -1263,19 +1260,19 @@
     <value>Translation of 'string.Equals' method which takes 'StringComparison' argument is not supported. See https://go.microsoft.com/fwlink/?linkid=2129535 for more information.</value>
   </data>
   <data name="RecursiveOnConfiguring" xml:space="preserve">
-    <value>An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point. This can happen if a second operation is started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.</value>
+    <value>An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside 'OnConfiguring' since it is still being configured at this point. This can happen if a second operation is started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.</value>
   </data>
   <data name="RecursiveOnModelCreating" xml:space="preserve">
-    <value>An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.</value>
+    <value>An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside 'OnModelCreating' in any way that makes use of the model that is being created.</value>
   </data>
   <data name="ReferencedShadowKey" xml:space="preserve">
     <value>The relationship from '{referencingEntityTypeOrNavigation}' to '{referencedEntityTypeOrNavigation}' with foreign key properties {foreignKeyPropertiesWithTypes} cannot target the primary key {primaryKeyPropertiesWithTypes} because it is not compatible. Configure a principal key or a set of compatible foreign key properties for this relationship.</value>
   </data>
   <data name="ReferenceIsCollection" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{ReferenceMethod}' method, but is defined in the model as a collection navigation property. Use the '{CollectionMethod}' method to access collection navigation properties.</value>
+    <value>The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' method, but is defined in the model as a collection navigation. Use the '{collectionMethod}' method to access collection navigation properties.</value>
   </data>
   <data name="ReferenceMustBeLoaded" xml:space="preserve">
-    <value>Navigation property '{1_entityType}.{0_navigation}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.</value>
+    <value>The navigation '{1_entityType}.{0_navigation}' cannot have 'IsLoaded' set to false because the referenced entity is non-null and therefore is loaded.</value>
   </data>
   <data name="RelationshipCannotBeInverted" xml:space="preserve">
     <value>The principal and dependent ends of the relationship cannot be flipped once foreign key or principal key properties have been specified.</value>
@@ -1329,7 +1326,10 @@
     <value>The seed entity for entity type '{entityType}' cannot be added because a non-zero value is required for property '{property}'. Consider providing a negative value to avoid collisions with non-seed data.</value>
   </data>
   <data name="SelfReferencingNavigationWithInverseProperty" xml:space="preserve">
-    <value>A relationship cannot be established from property '{1_entityType}.{0_property}' to property '{3_referencedEntityType}.{2_referencedProperty}'. Check the values in the [InverseProperty] attribute to ensure relationship definitions are unique and reference from one navigation property to its corresponding inverse navigation property.</value>
+    <value>A relationship cannot be established from property '{1_entityType}.{0_property}' to property '{3_referencedEntityType}.{2_referencedProperty}'. Check the values in the [InverseProperty] attribute to ensure relationship definitions are unique and reference from one navigation to its corresponding inverse navigation.</value>
+  </data>
+  <data name="SensitiveDataDisabled" xml:space="preserve">
+    <value>To show additional information call 'DbContextOptionsBuilder.EnableSensitiveDataLogging'.</value>
   </data>
   <data name="SequenceContainsMoreThanOneElement" xml:space="preserve">
     <value>Sequence contains more than one element.</value>
@@ -1347,7 +1347,7 @@
     <value>configuration removed for '{key}'</value>
   </data>
   <data name="SetOperationWithDifferentIncludesInOperands" xml:space="preserve">
-    <value>When performing a set operation, both operands must have the same Include operations.</value>
+    <value>When performing a set operation, both operands must have the same 'Include' operations.</value>
   </data>
   <data name="ShadowEntity" xml:space="preserve">
     <value>Entity type '{entityType}' is in shadow-state. A valid model requires all entity types to have corresponding CLR type.</value>
@@ -1362,16 +1362,16 @@
     <value>An attempt was made to register an instance for the '{scope}' service '{service}'. Instances can only be registered for 'Singleton' services.</value>
   </data>
   <data name="SkipInverseMismatchedForeignKey" xml:space="preserve">
-    <value>The foreign key '{foreignKey}' cannot be set for the skip navigation '{navigation}' as it uses the join entity type '{joinType}' while the inverse skip navigation '{inverse}' is using the join entity type '{inverseJoinType}'. The inverse should use the same join entity type.</value>
+    <value>The foreign key {foreignKeyProperties} cannot be set for the skip navigation '{navigation}' as it uses the join entity type '{joinType}' while the inverse skip navigation '{inverse}' is using the join entity type '{inverseJoinType}'. The inverse should use the same join entity type.</value>
   </data>
   <data name="SkipInverseMismatchedJoinType" xml:space="preserve">
     <value>The skip navigation '{inverse}' using the join entity type '{inverseJoinType}' cannot be set as the inverse of '{navigation}' that uses the join entity type '{joinType}'. The inverse should use the same join entity type.</value>
   </data>
   <data name="SkipNavigationForeignKeyWrongDependentType" xml:space="preserve">
-    <value>The foreign key {foreignKey} cannot be used for the skip navigation property '{2_entityType}.{1_navigation}' because it is expected to be on the dependent entity type '{dependentEntityType}'.</value>
+    <value>The foreign key {foreignKeyProperties} cannot be used for the skip navigation '{2_entityType}.{1_navigation}' because it is expected to be on the dependent entity type '{dependentEntityType}'.</value>
   </data>
   <data name="SkipNavigationForeignKeyWrongPrincipalType" xml:space="preserve">
-    <value>The foreign key {foreignKey} cannot be used for the skip navigation property '{2_entityType}.{1_navigation}' because it is expected to be on the principal entity type '{principalEntityType}'.</value>
+    <value>The foreign key {foreignKeyProperties} cannot be used for the skip navigation '{2_entityType}.{1_navigation}' because it is expected to be on the principal entity type '{principalEntityType}'.</value>
   </data>
   <data name="SkipNavigationInUseBySkipNavigation" xml:space="preserve">
     <value>The skip navigation '{skipNavigation}' cannot be removed because it is set as the inverse of the skip navigation '{inverseSkipNavigation}' on '{referencingEntityType}'. All referencing skip navigations must be removed before this skip navigation can be removed.</value>
@@ -1389,7 +1389,7 @@
     <value>The skip navigation '{inverse}' declared on the entity type '{inverseEntityType}' cannot be set as the inverse of '{navigation}' that targets '{targetEntityType}'. The inverse should be declared on the target entity type.</value>
   </data>
   <data name="SkipNavigationWrongType" xml:space="preserve">
-    <value>The skip navigation property '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
+    <value>The skip navigation '{navigation}' cannot be removed from the entity type '{entityType}' because it is defined on the entity type '{otherEntityType}'.</value>
   </data>
   <data name="StoreGenValue" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' cannot be assigned a value generated by the database. Store-generated values can only be assigned to properties configured to use store-generated values.</value>
@@ -1407,10 +1407,10 @@
     <value>Current provider doesn't support System.Transaction.</value>
   </data>
   <data name="TranslationFailed" xml:space="preserve">
-    <value>The LINQ expression '{expression}' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
+    <value>The LINQ expression '{expression}' could not be translated. Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either 'AsEnumerable()', 'AsAsyncEnumerable()', 'ToList()', or 'ToListAsync()'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
   </data>
   <data name="TranslationFailedWithDetails" xml:space="preserve">
-    <value>The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
+    <value>The LINQ expression '{expression}' could not be translated. Additional information: {details} Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either 'AsEnumerable()', 'AsAsyncEnumerable()', 'ToList()', or 'ToListAsync()'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.</value>
   </data>
   <data name="TypeNotMarkedAsShared" xml:space="preserve">
     <value>Type '{type}' is not been configured as shared type in the model. Before calling 'UsingEntity', please mark the type as shared or add the entity type in the model as shared entity.</value>
@@ -1419,7 +1419,7 @@
     <value>Unable to materialize entity of type '{entityType}'. No discriminators matched '{discriminator}'.</value>
   </data>
   <data name="UnableToSetIsUnique" xml:space="preserve">
-    <value>Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation property '{2_entityType}.{1_navigationName}' because the navigation property has the opposite multiplicity.</value>
+    <value>Unable to set IsUnique to '{isUnique}' on the relationship underlying the navigation '{2_entityType}.{1_navigationName}' because the navigation has the opposite multiplicity.</value>
   </data>
   <data name="UnhandledExpressionNode" xml:space="preserve">
     <value>Unhandled expression node type '{nodeType}'.</value>
@@ -1437,7 +1437,7 @@
     <value>The value of '{entityType}.{property}' is unknown when attempting to save changes. This is because the property is also part of a foreign key for which the principal entity in the relationship is not known.</value>
   </data>
   <data name="UnnamedIndexDefinedOnIgnoredProperty" xml:space="preserve">
-    <value>The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' has been marked NotMapped or Ignore(). An index cannot use such properties.</value>
+    <value>The unnamed index on the entity type '{entityType}' with properties {indexPropertyList} is invalid. The property '{propertyName}' was ignored by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. An index cannot use such properties.</value>
   </data>
   <data name="UnnamedIndexDefinedOnNonExistentProperty" xml:space="preserve">
     <value>An unnamed index on the entity type '{entityType}' specifies properties {indexPropertyList}. But no property with name '{propertyName}' exists on that entity type or any of its base types.</value>
@@ -1467,6 +1467,6 @@
     <value>Property '{1_entityType}.{0_property}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.</value>
   </data>
   <data name="WrongStateManager" xml:space="preserve">
-    <value>Cannot start tracking InternalEntityEntry for entity type '{entityType}' because it was created by a different StateManager instance.</value>
+    <value>Cannot start tracking the entry for entity type '{entityType}' because it was created by a different StateManager instance.</value>
   </data>
 </root>

--- a/src/Shared/Multigraph.cs
+++ b/src/Shared/Multigraph.cs
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             string cycleString;
             if (formatCycle == null)
             {
-                cycleString = cycle.Select(ToString).Join(" -> ");
+                cycleString = cycle.Select(ToString).Join(" ->" + Environment.NewLine);
             }
             else
             {

--- a/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore
                 builder => { },
                 builder => builder.Entity("People").Property<int?>("Sum")
                     .HasDefaultValueSql());
-            Assert.Equal(RelationalStrings.DefaultValueSqlUnspecified("Sum", "'People'"), ex.Message);
+            Assert.Equal(RelationalStrings.DefaultValueSqlUnspecified("Sum", "People"), ex.Message);
         }
 
         [ConditionalFact]
@@ -426,7 +426,7 @@ namespace Microsoft.EntityFrameworkCore
                 builder => { },
                 builder => builder.Entity("People").Property<int?>("Sum")
                     .HasDefaultValue());
-            Assert.Equal(RelationalStrings.DefaultValueUnspecified("Sum", "'People'"), ex.Message);
+            Assert.Equal(RelationalStrings.DefaultValueUnspecified("Sum", "People"), ex.Message);
         }
 
         [ConditionalTheory]
@@ -466,7 +466,7 @@ namespace Microsoft.EntityFrameworkCore
                 builder => { },
                 builder => builder.Entity("People").Property<int?>("Sum")
                     .HasComputedColumnSql());
-            Assert.Equal(RelationalStrings.ComputedColumnSqlUnspecified("Sum", "'People'"), ex.Message);
+            Assert.Equal(RelationalStrings.ComputedColumnSqlUnspecified("Sum", "People"), ex.Message);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 {
                     foreach (var expectedFragment in expected)
                     {
-                        var normalizedExpectedFragment = expectedFragment.Replace("\r", string.Empty).Replace("\n", _eol);
+                        var normalizedExpectedFragment = NormalizeLineEndings(expectedFragment);
                         Assert.Contains(
                             normalizedExpectedFragment,
                             SqlStatements);

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -401,11 +401,15 @@ namespace Microsoft.EntityFrameworkCore.Update
             var modelData = new UpdateAdapter(stateManager);
 
             var expectedCycle = sensitiveLogging
-                ? "FakeEntity { 'Id': 42 } [Added] <- ForeignKey { 'RelatedId': 42 } RelatedFakeEntity { 'Id': 1 } [Added] <- ForeignKey { 'RelatedId': 1 } FakeEntity { 'Id': 42 } [Added]"
-                : "FakeEntity [Added] <- ForeignKey { 'RelatedId' } RelatedFakeEntity [Added] <- ForeignKey { 'RelatedId' } FakeEntity [Added]";
-
+                ? @"FakeEntity { 'Id': 42 } [Added] <-
+ForeignKey { 'RelatedId': 42 } RelatedFakeEntity { 'Id': 1 } [Added] <-
+ForeignKey { 'RelatedId': 1 } FakeEntity { 'Id': 42 } [Added]"
+                : @"FakeEntity [Added] <-
+ForeignKey { 'RelatedId' } RelatedFakeEntity [Added] <-
+ForeignKey { 'RelatedId' } FakeEntity [Added]" + CoreStrings.SensitiveDataDisabled;
+ 
             Assert.Equal(
-                CoreStrings.CircularDependency(expectedCycle),
+                CoreStrings.CircularDependency(ListLoggerFactory.NormalizeLineEndings(expectedCycle)),
                 Assert.Throws<InvalidOperationException>(
                     () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: sensitiveLogging)
                         .BatchCommands(new[] { fakeEntry, relatedFakeEntry }, modelData).ToArray()).Message);
@@ -441,11 +445,17 @@ namespace Microsoft.EntityFrameworkCore.Update
             var modelData = new UpdateAdapter(stateManager);
 
             var expectedCycle = sensitiveLogging
-                ? "FakeEntity { 'Id': 42 } [Added] <- ForeignKey { 'RelatedId': 42 } RelatedFakeEntity { 'Id': 1 } [Added] <- ForeignKey { 'RelatedId': 1 } FakeEntity { 'Id': 2 } [Modified] <- Index { 'UniqueValue': Test } FakeEntity { 'Id': 42 } [Added]"
-                : "FakeEntity [Added] <- ForeignKey { 'RelatedId' } RelatedFakeEntity [Added] <- ForeignKey { 'RelatedId' } FakeEntity [Modified] <- Index { 'UniqueValue' } FakeEntity [Added]";
+                ? @"FakeEntity { 'Id': 42 } [Added] <-
+ForeignKey { 'RelatedId': 42 } RelatedFakeEntity { 'Id': 1 } [Added] <-
+ForeignKey { 'RelatedId': 1 } FakeEntity { 'Id': 2 } [Modified] <-
+Index { 'UniqueValue': Test } FakeEntity { 'Id': 42 } [Added]"
+                : @"FakeEntity [Added] <-
+ForeignKey { 'RelatedId' } RelatedFakeEntity [Added] <-
+ForeignKey { 'RelatedId' } FakeEntity [Modified] <-
+Index { 'UniqueValue' } FakeEntity [Added]" + CoreStrings.SensitiveDataDisabled;
 
             Assert.Equal(
-                CoreStrings.CircularDependency(expectedCycle),
+                CoreStrings.CircularDependency(ListLoggerFactory.NormalizeLineEndings(expectedCycle)),
                 Assert.Throws<InvalidOperationException>(
                     () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: sensitiveLogging)
                         .BatchCommands(new[] { fakeEntry, relatedFakeEntry, fakeEntry2 }, modelData).ToArray()).Message);
@@ -475,11 +485,15 @@ namespace Microsoft.EntityFrameworkCore.Update
             var modelData = new UpdateAdapter(stateManager);
 
             var expectedCycle = sensitiveLogging
-                ? "FakeEntity { 'Id': 1 } [Deleted] ForeignKey { 'RelatedId': 2 } <- RelatedFakeEntity { 'Id': 2 } [Deleted] ForeignKey { 'RelatedId': 1 } <- FakeEntity { 'Id': 1 } [Deleted]"
-                : "FakeEntity [Deleted] ForeignKey { 'RelatedId' } <- RelatedFakeEntity [Deleted] ForeignKey { 'RelatedId' } <- FakeEntity [Deleted]";
+                ? @"FakeEntity { 'Id': 1 } [Deleted] ForeignKey { 'RelatedId': 2 } <-
+RelatedFakeEntity { 'Id': 2 } [Deleted] ForeignKey { 'RelatedId': 1 } <-
+FakeEntity { 'Id': 1 } [Deleted]"
+                : @"FakeEntity [Deleted] ForeignKey { 'RelatedId' } <-
+RelatedFakeEntity [Deleted] ForeignKey { 'RelatedId' } <-
+FakeEntity [Deleted]" + CoreStrings.SensitiveDataDisabled;
 
             Assert.Equal(
-                CoreStrings.CircularDependency(expectedCycle),
+                CoreStrings.CircularDependency(ListLoggerFactory.NormalizeLineEndings(expectedCycle)),
                 Assert.Throws<InvalidOperationException>(
                     () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: sensitiveLogging).BatchCommands(
                         // Order is important for this test. Entry which is not part of cycle but tail should come first.
@@ -744,7 +758,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     Assert.Equal(
                         RelationalStrings.ConflictingRowValuesSensitive(
                             nameof(FakeEntity), nameof(RelatedFakeEntity),
-                            "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "{'RelatedId'}"),
+                            "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "RelatedId"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: true)
                                 .BatchCommands(new[] { firstEntry, secondEntry }, modelData).ToArray()).Message);
@@ -754,7 +768,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     Assert.Equal(
                         RelationalStrings.ConflictingRowValues(
                             nameof(FakeEntity), nameof(RelatedFakeEntity),
-                            "{'RelatedId'}", "{'RelatedId'}", "{'RelatedId'}"),
+                            "{'RelatedId'}", "{'RelatedId'}", "RelatedId"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: false)
                                 .BatchCommands(new[] { firstEntry, secondEntry }, modelData).ToArray()).Message);
@@ -767,7 +781,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     Assert.Equal(
                         RelationalStrings.ConflictingOriginalRowValuesSensitive(
                             nameof(FakeEntity), nameof(RelatedFakeEntity),
-                            "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "{'RelatedId'}"),
+                            "{Id: 42}", "{RelatedId: 1}", "{RelatedId: 2}", "RelatedId"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: true)
                                 .BatchCommands(new[] { firstEntry, secondEntry }, modelData).ToArray()).Message);
@@ -777,7 +791,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     Assert.Equal(
                         RelationalStrings.ConflictingOriginalRowValues(
                             nameof(FakeEntity), nameof(RelatedFakeEntity),
-                            "{'RelatedId'}", "{'RelatedId'}", "{'RelatedId'}"),
+                            "{'RelatedId'}", "{'RelatedId'}", "RelatedId"),
                         Assert.Throws<InvalidOperationException>(
                             () => CreateCommandBatchPreparer(updateAdapter: modelData, sensitiveLogging: false)
                                 .BatchCommands(new[] { firstEntry, secondEntry }, modelData).ToArray()).Message);

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -623,7 +623,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             Assert.Contains(
-                @"Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                @"See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
                 Assert.Throws<InvalidOperationException>(
                         () => context.Set<CollectionScalar>().Where(e => e.Tags.Any()).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));
@@ -653,7 +653,7 @@ namespace Microsoft.EntityFrameworkCore
             using var context = CreateContext();
             var sameRole = Roles.Seller;
             Assert.Contains(
-                @"Either rewrite the query in a form that can be translated, or switch to client evaluation explicitly by inserting a call to either AsEnumerable(), AsAsyncEnumerable(), ToList(), or ToListAsync(). See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
+                @"See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.",
                 Assert.Throws<InvalidOperationException>(
                         () => context.Set<CollectionEnum>().Where(e => e.Roles.Contains(sameRole)).ToList())
                     .Message.Replace("\r", "").Replace("\n", ""));

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4937,7 +4937,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes)))).Message;
 
             Assert.Equal(
-                "When performing a set operation, both operands must have the same Include operations.",
+                CoreStrings.SetOperationWithDifferentIncludesInOperands,
                 message);
         }
 

--- a/test/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ListLoggerFactory.cs
@@ -72,6 +72,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             _disposed = true;
         }
 
+        public static string NormalizeLineEndings(string expectedString)
+            => expectedString.Replace("\r", string.Empty).Replace("\n", Environment.NewLine);
+
         protected class ListLogger : ILogger
         {
             private readonly object _sync = new object();

--- a/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
+++ b/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             Assert.Empty(annotatable.GetAnnotations());
 
             Assert.Equal(
-                CoreStrings.AnnotationNotFound("Foo"),
+                CoreStrings.AnnotationNotFound("Foo", "Microsoft.EntityFrameworkCore.Infrastructure.Annotatable"),
                 Assert.Throws<InvalidOperationException>(() => annotatable.GetAnnotation("Foo")).Message);
         }
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -164,12 +164,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual void Detects_filter_on_derived_type()
         {
             var modelBuilder = CreateConventionalModelBuilder();
-            modelBuilder.Entity<A>();
+            var entityTypeA = modelBuilder.Entity<A>().Metadata;
             var entityTypeD = modelBuilder.Entity<D>().Metadata;
 
             entityTypeD.SetQueryFilter((Expression<Func<D, bool>>)(_ => true));
 
-            VerifyError(CoreStrings.BadFilterDerivedType(entityTypeD.GetQueryFilter(), entityTypeD.DisplayName()), modelBuilder.Model);
+            VerifyError(CoreStrings.BadFilterDerivedType(entityTypeD.GetQueryFilter(), entityTypeD.DisplayName(), entityTypeA.DisplayName()),
+                modelBuilder.Model);
         }
 
         [ConditionalFact]
@@ -1356,7 +1357,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.SharedTypeEntity<A>("Shared1");
             modelBuilder.SharedTypeEntity<C>("Shared2").HasBaseType("Shared1");
 
-            VerifyError(CoreStrings.SharedTypeDerivedType("Shared2"), modelBuilder.Model);
+            VerifyError(CoreStrings.SharedTypeDerivedType("Shared2 (C)"), modelBuilder.Model);
         }
 
         // INotify interfaces not really implemented; just marking the classes to test metadata construction

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         [ConditionalFact]
         public void Display_name_is_entity_type_name_when_shared_entity_type()
-            => Assert.Equal("PostTag", CreateModel().AddEntityType("PostTag", typeof(Dictionary<string, object>)).DisplayName());
+            => Assert.Equal("PostTag (Dictionary<string, object>)", CreateModel().AddEntityType("PostTag", typeof(Dictionary<string, object>)).DisplayName());
 
         [ConditionalFact]
         public void Name_is_prettified_CLR_full_name()

--- a/test/EFCore.Tests/Utilities/MultigraphTest.cs
+++ b/test/EFCore.Tests/Utilities/MultigraphTest.cs
@@ -350,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
             Assert.Equal(
                 CoreStrings.CircularDependency(
-                    string.Join(" -> ", new[] { vertexOne, vertexTwo, vertexThree, vertexOne }.Select(v => v.ToString()))),
+                    string.Join(" ->" + Environment.NewLine, new[] { vertexOne, vertexTwo, vertexThree, vertexOne }.Select(v => v.ToString()))),
                 Assert.Throws<InvalidOperationException>(() => graph.TopologicalSort()).Message);
         }
 
@@ -656,7 +656,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.Populate(entityTypeA);
 
             Assert.Equal(
-                CoreStrings.CircularDependency(nameof(A) + " -> " + nameof(A)),
+                CoreStrings.CircularDependency(nameof(A) + " ->" + Environment.NewLine + nameof(A)),
                 Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
         }
 
@@ -682,7 +682,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.Populate(entityTypeC, entityTypeA, entityTypeB);
 
             Assert.Equal(
-                CoreStrings.CircularDependency(nameof(A) + " -> " + nameof(B) + " -> " + nameof(A)),
+                CoreStrings.CircularDependency(nameof(A) + " ->" + Environment.NewLine + nameof(B) + " ->" + Environment.NewLine + nameof(A)),
                 Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
         }
 
@@ -709,7 +709,10 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
 
             Assert.Equal(
-                CoreStrings.CircularDependency(nameof(A) + " -> " + nameof(C) + " -> " + nameof(B) + " -> " + nameof(A)),
+                CoreStrings.CircularDependency(nameof(A) + " ->" + Environment.NewLine
+                + nameof(C) + " ->" + Environment.NewLine
+                + nameof(B) + " ->" + Environment.NewLine
+                + nameof(A)),
                 Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
         }
 
@@ -747,7 +750,10 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.Populate(entityTypeA, entityTypeB, entityTypeC, entityTypeD, entityTypeE);
 
             Assert.Equal(
-                CoreStrings.CircularDependency(nameof(A) + " -> " + nameof(C) + " -> " + nameof(B) + " -> " + nameof(A)),
+                CoreStrings.CircularDependency(nameof(A) + " ->" + Environment.NewLine
+                + nameof(C) + " ->" + Environment.NewLine
+                + nameof(B) + " ->" + Environment.NewLine
+                + nameof(A)),
                 Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
         }
 
@@ -774,7 +780,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
 
             Assert.Equal(
-                CoreStrings.CircularDependency(nameof(C) + " -> " + nameof(B) + " -> " + nameof(C)),
+                CoreStrings.CircularDependency(nameof(C) + " ->" + Environment.NewLine + nameof(B) + " ->" + Environment.NewLine + nameof(C)),
                 Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort()).Message);
         }
 


### PR DESCRIPTION
Use "navigation" rather than "navigation property"
Check usage of {foreignKey} and for correct quoting and use foreignKeyProperties where appropriate
Fix AnnotationNotFound, BadFilterDerivedType, CircularDependency
Update DisplayName for shared-type entity types to include the entity type name

Part of #7201
Fixes #22310
