### PR TITLE
Add the column type to the migration when deleting a data using a removed column

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -2020,6 +2020,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                 builder.AppendLine(",");
 
+                if (operation.KeyColumnTypes != null)
+                {
+                    if (operation.KeyColumnTypes.Length == 1)
+                    {
+                        builder
+                            .Append("keyColumnType: ")
+                            .Append(Code.Literal(operation.KeyColumnTypes[0]));
+                    }
+                    else
+                    {
+                        builder
+                            .Append("keyColumnTypes: ")
+                            .Append(Code.Literal(operation.KeyColumnTypes));
+                    }
+
+                    builder.AppendLine(",");
+                }
+
                 if (operation.KeyValues.GetLength(0) == 1
                     && operation.KeyValues.GetLength(1) == 1)
                 {

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1181,6 +1181,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => InsertData(table, new[] { Check.NotEmpty(column, nameof(column)) }, new[] { value }, schema);
 
         /// <summary>
+        ///     Builds an <see cref="InsertDataOperation" /> to insert a single seed data value for a single column.
+        /// </summary>
+        /// <param name="table"> The table into which the data will be inserted. </param>
+        /// <param name="column"> The name of the column into which the data will be inserted. </param>
+        /// <param name="columnType"> The store type for the column into which data will be inserted. </param>
+        /// <param name="value"> The value to insert. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<InsertDataOperation> InsertData(
+            [NotNull] string table,
+            [NotNull] string column,
+            [NotNull] string columnType,
+            [CanBeNull] object value,
+            [CanBeNull] string schema = null)
+            => InsertData(
+                table,
+                new[] { Check.NotEmpty(column, nameof(column)) },
+                new[] { Check.NotEmpty(columnType, nameof(columnType)) },
+                new[] { value }, schema);
+
+        /// <summary>
         ///     Builds an <see cref="InsertDataOperation" /> to insert a single row of seed data values.
         /// </summary>
         /// <param name="table"> The table into which the data will be inserted. </param>
@@ -1196,6 +1217,23 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => InsertData(table, columns, ToMultidimensionalArray(Check.NotNull(values, nameof(values))), schema);
 
         /// <summary>
+        ///     Builds an <see cref="InsertDataOperation" /> to insert a single row of seed data values.
+        /// </summary>
+        /// <param name="table"> The table into which the data will be inserted. </param>
+        /// <param name="columns"> The names of the columns into which the data will be inserted. </param>
+        /// <param name="columnTypes"> A list of store types for the columns into which data will be inserted. </param>
+        /// <param name="values"> The values to insert, one value for each column in 'columns'. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<InsertDataOperation> InsertData(
+            [NotNull] string table,
+            [NotNull] string[] columns,
+            [NotNull] string[] columnTypes,
+            [NotNull] object[] values,
+            [CanBeNull] string schema = null)
+            => InsertData(table, columns, columnTypes, ToMultidimensionalArray(Check.NotNull(values, nameof(values))), schema);
+
+        /// <summary>
         ///     Builds an <see cref="InsertDataOperation" /> to insert multiple rows of seed data values for a single column.
         /// </summary>
         /// <param name="table"> The table into which the data will be inserted. </param>
@@ -1208,9 +1246,32 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] string column,
             [NotNull] object[] values,
             [CanBeNull] string schema = null)
-            => InsertData(
+            => InsertDataInternal(
                 table,
                 new[] { Check.NotEmpty(column, nameof(column)) },
+                null,
+                ToMultidimensionalArray(Check.NotNull(values, nameof(values)), firstDimension: true),
+                schema);
+
+        /// <summary>
+        ///     Builds an <see cref="InsertDataOperation" /> to insert multiple rows of seed data values for a single column.
+        /// </summary>
+        /// <param name="table"> The table into which the data will be inserted. </param>
+        /// <param name="column"> The name of the column into which the data will be inserted. </param>
+        /// <param name="columnType"> The store type for the column into which data will be inserted. </param>
+        /// <param name="values"> The values to insert, one value for each row. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<InsertDataOperation> InsertData(
+            [NotNull] string table,
+            [NotNull] string column,
+            [NotNull] string columnType,
+            [NotNull] object[] values,
+            [CanBeNull] string schema = null)
+            => InsertDataInternal(
+                table,
+                new[] { Check.NotEmpty(column, nameof(column)) },
+                new[] { Check.NotEmpty(columnType, nameof(columnType)) },
                 ToMultidimensionalArray(Check.NotNull(values, nameof(values)), firstDimension: true),
                 schema);
 
@@ -1230,6 +1291,38 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] string[] columns,
             [NotNull] object[,] values,
             [CanBeNull] string schema = null)
+            => InsertDataInternal(table, columns, null, values, schema);
+
+        /// <summary>
+        ///     Builds an <see cref="InsertDataOperation" /> to insert multiple rows of seed data values for multiple columns.
+        /// </summary>
+        /// <param name="table"> The table into which the data will be inserted. </param>
+        /// <param name="columns"> The names of the columns into which the data will be inserted. </param>
+        /// <param name="columnTypes"> A list of store types for the columns into which data will be inserted. </param>
+        /// <param name="values">
+        ///     The values to insert where each element of the outer array represents a row, and each inner array contains values for each of the
+        ///     columns in 'columns'.
+        /// </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<InsertDataOperation> InsertData(
+            [NotNull] string table,
+            [NotNull] string[] columns,
+            [NotNull] string[] columnTypes,
+            [NotNull] object[,] values,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(columnTypes, nameof(columnTypes));
+
+            return InsertDataInternal(table, columns, columnTypes, values, schema);
+        }
+
+        private OperationBuilder<InsertDataOperation> InsertDataInternal(
+            string table,
+            string[] columns,
+            string[] columnTypes,
+            object[,] values,
+            string schema)
         {
             Check.NotEmpty(table, nameof(table));
             Check.NotNull(columns, nameof(columns));
@@ -1263,6 +1356,30 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => DeleteData(table, new[] { Check.NotNull(keyColumn, nameof(keyValue)) }, new[] { keyValue }, schema);
 
         /// <summary>
+        ///     Builds an <see cref="DeleteDataOperation" /> to delete a single row of seed data.
+        /// </summary>
+        /// <param name="table"> The table from which the data will be deleted. </param>
+        /// <param name="keyColumn"> The name of the key column used to select the row to delete. </param>
+        /// <param name="keyColumnType">
+        ///     The store type for the column that will be used to identify the rows that should be deleted.
+        ///  </param>
+        /// <param name="keyValue"> The key value of the row to delete. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<DeleteDataOperation> DeleteData(
+            [NotNull] string table,
+            [NotNull] string keyColumn,
+            [NotNull] string keyColumnType,
+            [CanBeNull] object keyValue,
+            [CanBeNull] string schema = null)
+            => DeleteData(
+                table,
+                new[] { Check.NotNull(keyColumn, nameof(keyValue)) },
+                new[] { Check.NotNull(keyColumnType, nameof(keyColumnType)) },
+                new[] { keyValue },
+                schema);
+
+        /// <summary>
         ///     Builds an <see cref="DeleteDataOperation" /> to delete a single row of seed data from
         ///     a table with a composite (multi-column) key.
         /// </summary>
@@ -1279,6 +1396,31 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => DeleteData(
                 table,
                 keyColumns,
+                ToMultidimensionalArray(Check.NotNull(keyValues, nameof(keyValues))),
+                schema);
+
+        /// <summary>
+        ///     Builds an <see cref="DeleteDataOperation" /> to delete a single row of seed data from
+        ///     a table with a composite (multi-column) key.
+        /// </summary>
+        /// <param name="table"> The table from which the data will be deleted. </param>
+        /// <param name="keyColumns"> The names of the key columns used to select the row to delete. </param>
+        /// <param name="keyColumnTypes">
+        ///     The store types for the columns that will be used to identify the rows that should be deleted.
+        ///  </param>
+        /// <param name="keyValues"> The key values of the row to delete, one value for each column in 'keyColumns'. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<DeleteDataOperation> DeleteData(
+            [NotNull] string table,
+            [NotNull] string[] keyColumns,
+            [NotNull] string[] keyColumnTypes,
+            [NotNull] object[] keyValues,
+            [CanBeNull] string schema = null)
+            => DeleteDataInternal(
+                table,
+                keyColumns,
+                keyColumnTypes,
                 ToMultidimensionalArray(Check.NotNull(keyValues, nameof(keyValues))),
                 schema);
 
@@ -1302,6 +1444,30 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 schema);
 
         /// <summary>
+        ///     Builds an <see cref="DeleteDataOperation" /> to delete multiple rows of seed data.
+        /// </summary>
+        /// <param name="table"> The table from which the data will be deleted. </param>
+        /// <param name="keyColumn"> The name of the key column used to select the row to delete. </param>
+        /// <param name="keyColumnType">
+        ///     The store type for the column that will be used to identify the rows that should be deleted.
+        ///  </param>
+        /// <param name="keyValues"> The key values of the rows to delete, one value per row. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<DeleteDataOperation> DeleteData(
+            [NotNull] string table,
+            [NotNull] string keyColumn,
+            [NotNull] string keyColumnType,
+            [NotNull] object[] keyValues,
+            [CanBeNull] string schema = null)
+            => DeleteData(
+                table,
+                new[] { Check.NotEmpty(keyColumn, nameof(keyColumn)) },
+                new[] { Check.NotEmpty(keyColumnType, nameof(keyColumnType)) },
+                ToMultidimensionalArray(Check.NotNull(keyValues, nameof(keyValues)), firstDimension: true),
+                schema);
+
+        /// <summary>
         ///     Builds an <see cref="DeleteDataOperation" /> to delete multiple rows of seed data from
         ///     a table with a composite (multi-column) key.
         /// </summary>
@@ -1318,6 +1484,41 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] string[] keyColumns,
             [NotNull] object[,] keyValues,
             [CanBeNull] string schema = null)
+            => DeleteDataInternal(table, keyColumns, null, keyValues, schema);
+
+        /// <summary>
+        ///     Builds an <see cref="DeleteDataOperation" /> to delete multiple rows of seed data from
+        ///     a table with a composite (multi-column) key.
+        /// </summary>
+        /// <param name="table"> The table from which the data will be deleted. </param>
+        /// <param name="keyColumns"> The names of the key columns used to select the rows to delete. </param>
+        /// <param name="keyColumnTypes">
+        ///     The store types for the columns that will be used to identify the rows that should be deleted.
+        ///  </param>
+        /// <param name="keyValues">
+        ///     The key values of the rows to delete, where each element of the outer array represents a row, and each inner array contains values for
+        ///     each of the key columns in 'keyColumns'.
+        /// </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<DeleteDataOperation> DeleteData(
+            [NotNull] string table,
+            [NotNull] string[] keyColumns,
+            [NotNull] string[] keyColumnTypes,
+            [NotNull] object[,] keyValues,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(keyColumnTypes, nameof(keyColumnTypes));
+
+            return DeleteDataInternal(table, keyColumns, keyColumnTypes, keyValues, schema);
+        }
+
+        private OperationBuilder<DeleteDataOperation> DeleteDataInternal(
+            string table,
+            string[] keyColumns,
+            string[] keyColumnTypes,
+            object[,] keyValues,
+            string schema)
         {
             Check.NotEmpty(table, nameof(table));
             Check.NotNull(keyColumns, nameof(keyColumns));
@@ -1328,6 +1529,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Table = table,
                 Schema = schema,
                 KeyColumns = keyColumns,
+                KeyColumnTypes = keyColumnTypes,
                 KeyValues = keyValues
             };
             Operations.Add(operation);
@@ -1438,6 +1640,40 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 schema);
 
         /// <summary>
+        ///     Builds an <see cref="UpdateDataOperation" /> to update a single row of seed data for a table with
+        ///     a composite (multi-column) key.
+        /// </summary>
+        /// <param name="table"> The table containing the data to be updated. </param>
+        /// <param name="keyColumns"> The names of the key columns used to select the row to update. </param>
+        /// <param name="keyColumnTypes">
+        ///     A list of store types for the columns that will be used to identify the rows that should be updated.
+        /// </param>
+        /// <param name="keyValues"> The key values of the row to update, one value for each column in 'keyColumns'. </param>
+        /// <param name="columns"> The columns to update. </param>
+        /// <param name="columnTypes"> A list of store types for the columns in which data will be updated. </param>
+        /// <param name="values"> The new values, one for each column in 'columns', for the selected row. </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<UpdateDataOperation> UpdateData(
+            [NotNull] string table,
+            [NotNull] string[] keyColumns,
+            [NotNull] string[] keyColumnTypes,
+            [NotNull] object[] keyValues,
+            [NotNull] string[] columns,
+            [NotNull] string[] columnTypes,
+            [NotNull] object[] values,
+            [CanBeNull] string schema = null)
+            => UpdateData(
+                table,
+                keyColumns,
+                keyColumnTypes,
+                ToMultidimensionalArray(Check.NotNull(keyValues, nameof(keyValues))),
+                columns,
+                columnTypes,
+                ToMultidimensionalArray(Check.NotNull(values, nameof(values))),
+                schema);
+
+        /// <summary>
         ///     Builds an <see cref="UpdateDataOperation" /> to update multiple rows of seed data.
         /// </summary>
         /// <param name="table"> The table containing the data to be updated. </param>
@@ -1543,6 +1779,54 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] string[] columns,
             [NotNull] object[,] values,
             [CanBeNull] string schema = null)
+            => UpdateDataInternal(table, keyColumns, null, keyValues, columns, null, values, schema);
+
+        /// <summary>
+        ///     Builds an <see cref="UpdateDataOperation" /> to update multiple rows of seed data for a table with
+        ///     a composite (multi-column) key.
+        /// </summary>
+        /// <param name="table"> The table containing the data to be updated. </param>
+        /// <param name="keyColumns"> The names of the key columns used to select the rows to update. </param>
+        /// <param name="keyColumnTypes">
+        ///     A list of store types for the columns that will be used to identify the rows that should be updated.
+        /// </param>
+        /// <param name="keyValues">
+        ///     The key values of the rows to update, where each element of the outer array represents a row, and each inner array contains values for
+        ///     each of the key columns in 'keyColumns'.
+        /// </param>
+        /// <param name="columns"> The columns to update. </param>
+        /// <param name="columnTypes"> A list of store types for the columns in which data will be updated. </param>
+        /// <param name="values">
+        ///     The values for each update, where each element of the outer array represents a row specified in
+        ///     'keyValues', and each inner array contains values for each of the columns in 'columns'.
+        /// </param>
+        /// <param name="schema"> The schema that contains the table, or <see langword="null" /> to use the default schema. </param>
+        /// <returns> A builder to allow annotations to be added to the operation. </returns>
+        public virtual OperationBuilder<UpdateDataOperation> UpdateData(
+            [NotNull] string table,
+            [NotNull] string[] keyColumns,
+            [NotNull] string[] keyColumnTypes,
+            [NotNull] object[,] keyValues,
+            [NotNull] string[] columns,
+            [NotNull] string[] columnTypes,
+            [NotNull] object[,] values,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotEmpty(keyColumnTypes, nameof(keyColumnTypes));
+            Check.NotEmpty(columnTypes, nameof(columnTypes));
+
+            return UpdateDataInternal(table, keyColumns, keyColumnTypes, keyValues, columns, columnTypes, values, schema);
+        }
+
+        private OperationBuilder<UpdateDataOperation> UpdateDataInternal(
+            string table,
+            string[] keyColumns,
+            string[] keyColumnTypes,
+            object[,] keyValues,
+            string[] columns,
+            string[] columnTypes,
+            object[,] values,
+            string schema)
         {
             Check.NotEmpty(table, nameof(table));
             Check.NotNull(keyColumns, nameof(keyColumns));
@@ -1555,8 +1839,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Table = table,
                 Schema = schema,
                 KeyColumns = keyColumns,
+                KeyColumnTypes = keyColumnTypes,
                 KeyValues = keyValues,
                 Columns = columns,
+                ColumnTypes = columnTypes,
                 Values = values
             };
             Operations.Add(operation);

--- a/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/DeleteDataOperation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string[] KeyColumns { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     A list of column store types for the columns that will be used to identify
+        ///     A list of store types for the columns that will be used to identify
         ///     the rows that should be deleted.
         /// </summary>
         public virtual string[] KeyColumnTypes { get; [param: NotNull] set; }

--- a/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/InsertDataOperation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string[] Columns { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     A list of column store types for the columns into which data will be inserted.
+        ///     A list of store types for the columns into which data will be inserted.
         /// </summary>
         public virtual string[] ColumnTypes { get; [param: NotNull] set; }
 

--- a/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/UpdateDataOperation.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string[] KeyColumns { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     A list of column store types for the columns that will be used to identify
+        ///     A list of store types for the columns that will be used to identify
         ///     the rows that should be updated.
         /// </summary>
         public virtual string[] KeyColumnTypes { get; [param: NotNull] set; }
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string[] Columns { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     A list of column store types for the columns in which data will be updated.
+        ///     A list of store types for the columns in which data will be updated.
         /// </summary>
         public virtual string[] ColumnTypes { get; [param: NotNull] set; }
 

--- a/src/EFCore.Relational/Update/ColumnModification.cs
+++ b/src/EFCore.Relational/Update/ColumnModification.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 originalValue: null,
                 value: null,
                 property: property,
-                null,
+                column.StoreType,
                 typeMapping,
                 isRead: isRead,
                 isWrite: isWrite,

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -2836,6 +2836,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     Schema = "dbo",
                     Table = "People",
                     KeyColumns = new[] { "First Name" },
+                    KeyColumnTypes = new[] { "string" },
                     KeyValues = new object[,] { { "Hodor" }, { "Daenerys" }, { "John" }, { "Arya" }, { "Harry" } }
                 },
                 "mb.DeleteData("
@@ -2845,6 +2846,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + "    table: \"People\","
                 + _eol
                 + "    keyColumn: \"First Name\","
+                + _eol
+                + "    keyColumnType: \"string\","
                 + _eol
                 + "    keyValues: new object[]"
                 + _eol
@@ -2880,6 +2883,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 {
                     Table = "People",
                     KeyColumns = new[] { "First Name", "Last Name" },
+                    KeyColumnTypes = new[] { "string", "string" },
                     KeyValues = new object[,]
                     {
                         { "Hodor", null }, { "Daenerys", "Targaryen" }, { "John", "Snow" }, { "Arya", "Stark" }, { "Harry", "Strickland" }
@@ -2890,6 +2894,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + "    table: \"People\","
                 + _eol
                 + "    keyColumns: new[] { \"First Name\", \"Last Name\" },"
+                + _eol
+                + "    keyColumnTypes: new[] { \"string\", \"string\" },"
                 + _eol
                 + "    keyValues: new object[,]"
                 + _eol

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -1416,6 +1416,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(43, v));
@@ -1487,6 +1488,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(42, v));
@@ -1494,6 +1496,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(43, v));
@@ -1501,6 +1504,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(44, v));
@@ -1508,6 +1512,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(45, v));
@@ -2139,6 +2144,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(42, v));
@@ -2146,6 +2152,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(43, v));
@@ -5232,6 +5239,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(43, v));
@@ -5684,6 +5692,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(21, v));
@@ -5694,6 +5703,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(22, v));
@@ -5704,6 +5714,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(23, v));
@@ -5724,6 +5735,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Animal", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(33, v));
@@ -6321,6 +6333,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(21, v));
@@ -6331,6 +6344,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(22, v));
@@ -6341,6 +6355,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Dogs", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(23, v));
@@ -6411,6 +6426,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Equal("Animal", operation.Table);
 
                         Assert.Equal(new[] { "Id" }, operation.KeyColumns);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(33, v));
@@ -6909,6 +6925,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var operation = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("Animal", operation.Table);
+                        Assert.Null(operation.KeyColumnTypes);
                         Assert.Collection(
                             operation.KeyColumns,
                             v => Assert.Equal("Id", v));
@@ -6940,6 +6957,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Collection(
                             operation.KeyColumns,
                             v => Assert.Equal("Id", v));
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(43, v));
@@ -7238,6 +7256,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         Assert.Collection(
                             operation.KeyColumns,
                             v => Assert.Equal("ReferencedTableId", v));
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(42, v));
@@ -7972,6 +7991,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var operation = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("Table", operation.Table);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(42, v));
@@ -8021,6 +8041,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var operation = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("ReferencedTable", operation.Table);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(42, v));
@@ -8040,6 +8061,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var operation = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("ReferencedTable", operation.Table);
+                        Assert.Null(operation.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             operation.KeyValues,
                             v => Assert.Equal(42, v));
@@ -8048,6 +8070,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var operation = Assert.IsType<InsertDataOperation>(o);
                         Assert.Equal("ReferencedTable", operation.Table);
+                        Assert.Null(operation.ColumnTypes);
                         AssertMultidimensionalArray(
                             operation.Values,
                             v => Assert.Equal(42, v),
@@ -8056,7 +8079,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [ConditionalFact]
-        public void SeedData_add_on_existing_table()
+        public void SeedData_and_PK_rename()
         {
             Execute(
                 _ => { },
@@ -8064,9 +8087,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     "EntityWithTwoProperties",
                     x =>
                     {
-                        x.Property<int>("Id");
+                        x.Property<int>("Key");
                         x.Property<int>("Value1");
                         x.Property<string>("Value2");
+                        x.HasKey("Key");
                     }),
                 target => target.Entity(
                     "EntityWithTwoProperties",
@@ -8080,6 +8104,95 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     }),
                 upOps => Assert.Collection(
                     upOps,
+                    o =>
+                    {
+                        var operation = Assert.IsType<RenameColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Key", operation.Name);
+                        Assert.Equal("Id", operation.NewName);
+                    },
+                    o =>
+                    {
+                        var m = Assert.IsType<InsertDataOperation>(o);
+                        Assert.Equal(new[] { "Id", "Value1", "Value2" }, m.Columns);
+                        Assert.Null(m.ColumnTypes);
+                        AssertMultidimensionalArray(
+                            m.Values,
+                            v => Assert.Equal(42, v),
+                            v => Assert.Equal(32, v),
+                            Assert.Null);
+                    }),
+                downOps => Assert.Collection(
+                    downOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Equal(new[] { "Id" }, m.KeyColumns);
+                        Assert.Null(m.KeyColumnTypes);
+                        AssertMultidimensionalArray(
+                            m.KeyValues,
+                            v => Assert.Equal(42, v));
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<RenameColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Id", operation.Name);
+                        Assert.Equal("Key", operation.NewName);
+                    }));
+        }
+
+        [ConditionalFact]
+        public void SeedData_and_change_PK_type()
+        {
+            Execute(
+                _ => { },
+                source => source.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<string>("Key");
+                        x.Property<int>("Value1");
+                        x.Property<string>("Value2");
+                        x.HasKey("Key");
+                    }),
+                target => target.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<int>("Value1");
+                        x.Property<string>("Value2");
+                        x.HasData(
+                            new { Id = 42, Value1 = 32 });
+                    }),
+                upOps => Assert.Collection(
+                    upOps,
+                    o =>
+                    {
+                        var operation = Assert.IsType<DropPrimaryKeyOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("PK_EntityWithTwoProperties", operation.Name);
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<DropColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Key", operation.Name);
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<AddColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Id", operation.Name);
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<AddPrimaryKeyOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("PK_EntityWithTwoProperties", operation.Name);
+                        Assert.Equal(new[] { "Id" }, operation.Columns);
+                    },
                     o =>
                     {
                         var m = Assert.IsType<InsertDataOperation>(o);
@@ -8093,55 +8206,37 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     downOps,
                     o =>
                     {
-                        var m = Assert.IsType<DeleteDataOperation>(o);
-                        AssertMultidimensionalArray(
-                            m.KeyValues,
-                            v => Assert.Equal(42, v));
-                    }));
-        }
-
-        [ConditionalFact]
-        public void SeedData_remove()
-        {
-            Execute(
-                _ => { },
-                source => source.Entity(
-                    "EntityWithTwoProperties",
-                    x =>
-                    {
-                        x.Property<int>("Id");
-                        x.Property<int>("Value1");
-                        x.Property<string>("Value2");
-                        x.HasData(
-                            new { Id = 42, Value1 = 32 });
-                    }),
-                target => target.Entity(
-                    "EntityWithTwoProperties",
-                    x =>
-                    {
-                        x.Property<int>("Id");
-                        x.Property<int>("Value1");
-                        x.Property<string>("Value2");
-                    }),
-                upOps => Assert.Collection(
-                    upOps,
+                        var operation = Assert.IsType<DropPrimaryKeyOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("PK_EntityWithTwoProperties", operation.Name);
+                    },
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Equal(new[] { "Id" }, m.KeyColumns);
+                        Assert.Equal(new[] { "default_int_mapping" }, m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(42, v));
-                    }),
-                downOps => Assert.Collection(
-                    downOps,
+                    },
                     o =>
                     {
-                        var m = Assert.IsType<InsertDataOperation>(o);
-                        AssertMultidimensionalArray(
-                            m.Values,
-                            v => Assert.Equal(42, v),
-                            v => Assert.Equal(32, v),
-                            v => Assert.Null(v));
+                        var operation = Assert.IsType<DropColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Id", operation.Name);
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<AddColumnOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("Key", operation.Name);
+                    },
+                    o =>
+                    {
+                        var operation = Assert.IsType<AddPrimaryKeyOperation>(o);
+                        Assert.Equal("EntityWithTwoProperties", operation.Table);
+                        Assert.Equal("PK_EntityWithTwoProperties", operation.Name);
+                        Assert.Equal(new[] { "Key" }, operation.Columns);
                     }));
         }
 
@@ -8677,6 +8772,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(99999, v));
@@ -8684,6 +8780,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(24, v));
@@ -8695,6 +8792,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(42, v));
@@ -8705,6 +8803,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<InsertDataOperation>(o);
+                        Assert.Null(m.ColumnTypes);
                         AssertMultidimensionalArray(
                             m.Values,
                             v => Assert.Equal(11111, v),
@@ -8714,6 +8813,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<InsertDataOperation>(o);
+                        Assert.Null(m.ColumnTypes);
                         AssertMultidimensionalArray(
                             m.Values,
                             v => Assert.Equal(11112, v),
@@ -8725,6 +8825,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(11111, v));
@@ -8732,6 +8833,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(11112, v));
@@ -8739,6 +8841,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(24, v));
@@ -8750,6 +8853,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(42, v));
@@ -8760,6 +8864,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     o =>
                     {
                         var m = Assert.IsType<InsertDataOperation>(o);
+                        Assert.Null(m.ColumnTypes);
                         AssertMultidimensionalArray(
                             m.Values,
                             v => Assert.Equal(99999, v),
@@ -8832,6 +8937,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<DeleteDataOperation>(o);
+                            Assert.Null(m.KeyColumnTypes);
                             AssertMultidimensionalArray(
                                 m.KeyValues,
                                 v => Assert.Equal(21, v));
@@ -8839,6 +8945,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<UpdateDataOperation>(o);
+                            Assert.Null(m.KeyColumnTypes);
                             AssertMultidimensionalArray(
                                 m.KeyValues,
                                 v => Assert.Equal(11, v));
@@ -8849,6 +8956,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<UpdateDataOperation>(o);
+                            Assert.Null(m.KeyColumnTypes);
                             AssertMultidimensionalArray(
                                 m.KeyValues,
                                 v => Assert.Equal(12, v));
@@ -8861,6 +8969,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<InsertDataOperation>(o);
+                            Assert.Null(m.ColumnTypes);
                             AssertMultidimensionalArray(
                                 m.Values,
                                 v => Assert.Equal(31, v),
@@ -8869,6 +8978,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<InsertDataOperation>(o);
+                            Assert.Null(m.ColumnTypes);
                             AssertMultidimensionalArray(
                                 m.Values,
                                 v => Assert.Equal(32, v),
@@ -8884,6 +8994,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<DeleteDataOperation>(o);
+                            Assert.Null(m.KeyColumnTypes);
                             AssertMultidimensionalArray(
                                 m.KeyValues,
                                 v => Assert.Equal(31, v));
@@ -8891,6 +9002,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                         o =>
                         {
                             var m = Assert.IsType<DeleteDataOperation>(o);
+                            Assert.Null(m.KeyColumnTypes);
                             AssertMultidimensionalArray(
                                 m.KeyValues,
                                 v => Assert.Equal(32, v));
@@ -9079,6 +9191,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("Post", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(390, v));
@@ -9087,6 +9200,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
                         Assert.Equal("Blog", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(32, v));
@@ -9140,6 +9254,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("Blog", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(38, v));
@@ -9156,6 +9271,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<DeleteDataOperation>(o);
                         Assert.Equal("Post", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(546, v));
@@ -9164,6 +9280,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
                         Assert.Equal("Blog", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(32, v));
@@ -9175,6 +9292,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<UpdateDataOperation>(o);
                         Assert.Equal("Post", m.Table);
+                        Assert.Null(m.KeyColumnTypes);
                         AssertMultidimensionalArray(
                             m.KeyValues,
                             v => Assert.Equal(545, v));
@@ -9187,6 +9305,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         var m = Assert.IsType<InsertDataOperation>(o);
                         Assert.Equal("Post", m.Table);
+                        Assert.Null(m.ColumnTypes);
                         AssertMultidimensionalArray(
                             m.Values,
                             v => Assert.Equal(390, v),

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -1012,9 +1012,8 @@ SELECT @@ROWCOUNT;
                     .DeleteData(
                         table: "Table1",
                         keyColumn: "Id",
-                        keyValue: 1)
-                    .GetInfrastructure()
-                    .KeyColumnTypes = new[] { "int" },
+                        keyColumnType: "int",
+                        keyValue: 1),
                 MigrationsSqlGenerationOptions.Idempotent);
 
             AssertSql(


### PR DESCRIPTION
Add fluent overloads to specify column types for Insert/Update/Delete operations

Fixes #21886
Fixes #22302
