### PR TITLE
Populate DbUpdateException.Entries for non-concurrency exceptions

### DIFF
--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -254,7 +254,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
             catch (Exception ex)
             {
-                throw new DbUpdateException(RelationalStrings.UpdateStoreException, ex);
+                throw new DbUpdateException(
+                    RelationalStrings.UpdateStoreException,
+                    ex,
+                    ModificationCommands.SelectMany(c => c.Entries).ToList());
             }
         }
 
@@ -291,7 +294,10 @@ namespace Microsoft.EntityFrameworkCore.Update
             }
             catch (Exception ex)
             {
-                throw new DbUpdateException(RelationalStrings.UpdateStoreException, ex);
+                throw new DbUpdateException(
+                    RelationalStrings.UpdateStoreException,
+                    ex,
+                    ModificationCommands.SelectMany(c => c.Entries).ToList());
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -708,7 +708,8 @@ END");
             Assert.Equal(default, blog.NotId);
 
             // No value set on a required column
-            Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            var updateException = Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            Assert.Single(updateException.Entries);
         }
 
         public class BlogContextClientGuidNonKey : ContextBase
@@ -794,8 +795,10 @@ END");
             // SqlException : Cannot insert explicit value for identity column in table
             // 'Blog' when IDENTITY_INSERT is set to OFF.
             context.Database.CreateExecutionStrategy().Execute(
-                context, c =>
-                    Assert.Throws<DbUpdateException>(() => c.SaveChanges()));
+                context, c => {
+                    var updateException = Assert.Throws<DbUpdateException>(() => c.SaveChanges());
+                    Assert.Single(updateException.Entries);
+                });
         }
 
         [ConditionalFact]
@@ -812,7 +815,8 @@ END");
             // inner exception for details.
             // SqlException : Cannot insert explicit value for identity column in table
             // 'Blog' when IDENTITY_INSERT is set to OFF.
-            Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            var updateException = Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+            Assert.Single(updateException.Entries);
         }
 
         public class BlogContext : ContextBase

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -66,7 +66,12 @@ namespace Microsoft.EntityFrameworkCore
                                     new object[] { context.Entry(entity).Property(p => p.Id).CurrentValue }).Entity);
                         }
 
-                        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+                        // DbUpdateException : An error occurred while updating the entries. See the
+                        // inner exception for details.
+                        // SqlException : Cannot insert explicit value for identity column in table
+                        // 'Blog' when IDENTITY_INSERT is set to OFF.
+                        var updateException = Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+                        Assert.Single(updateException.Entries);
 
                         foreach (var entity in entities.Take(100))
                         {


### PR DESCRIPTION
Fixes #7829

