### PR TITLE
Don't check for temporary values on non-key properties when deleting an entity

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 // ReSharper disable once LoopCanBeConvertedToQuery
                 foreach (var property in entityType.GetProperties())
                 {
-                    if (!property.IsForeignKey() && HasTemporaryValue(property))
+                    if (property.IsKey() && HasTemporaryValue(property))
                     {
                         throw new InvalidOperationException(
                             CoreStrings.TempValuePersists(

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -195,6 +195,8 @@ namespace Microsoft.EntityFrameworkCore
                         b.Property(e => e.NullableBackedIntZeroDefault).HasDefaultValue(0);
                     });
 
+                modelBuilder.Entity<NonStoreGenDependent>().Property(e => e.HasTemp).HasDefaultValue(777);
+
                 base.OnModelCreating(modelBuilder, context);
             }
         }

--- a/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -130,6 +130,8 @@ namespace Microsoft.EntityFrameworkCore
                     .ValueGeneratedOnAdd()
                     .HasDefaultValueSql("randomblob(16)");
 
+                modelBuilder.Entity<NonStoreGenDependent>().Property(e => e.HasTemp).HasDefaultValue(777);
+
                 base.OnModelCreating(modelBuilder, context);
             }
         }


### PR DESCRIPTION
Fixes #14192
