### PR TITLE
Re-enable Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async for in-memory

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore
             await context.SaveChangesAsync();
         }
 
-        [ConditionalFact(Skip = "Issue #17672")]
+        [ConditionalFact]
         public async Task Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async()
         {
             var serviceProvider = new ServiceCollection()


### PR DESCRIPTION
I ran the test repeatedly:

* In the IDE for ~30 mins using run-until-fails
* 30 times in a full test run on the command line

and saw no failures.

Fixes #17672
