### PR TITLE
Create and initialize the TestStore inside InitializeAsync

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsInfrastructureSqlServerTest.cs
@@ -1399,9 +1399,10 @@ GO
             protected override ITestStoreFactory TestStoreFactory
                 => SqlServerTestStoreFactory.Instance;
 
-            public MigrationsInfrastructureSqlServerFixture()
+            public override async Task InitializeAsync()
             {
-                ((SqlServerTestStore)TestStore).ExecuteNonQuery(
+                await base.InitializeAsync();
+                await ((SqlServerTestStore)TestStore).ExecuteNonQueryAsync(
                     @"USE master
 IF EXISTS(select * from sys.databases where name='TransactionSuppressed')
 DROP DATABASE TransactionSuppressed");

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -634,10 +635,10 @@ CREATE TABLE [dbo].[Blogs] (
 );
 EXECUTE sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Blog table comment.
 On multiple lines.',
-    @level0type = N'SCHEMA', @level0name = 'dbo', 
+    @level0type = N'SCHEMA', @level0name = 'dbo',
     @level1type = N'TABLE', @level1name = 'Blogs';
 EXECUTE sys.sp_addextendedproperty @name = N'MS_Description', @value = N'Blog.Id column comment.',
-    @level0type = N'SCHEMA', @level0name = 'dbo', 
+    @level0type = N'SCHEMA', @level0name = 'dbo',
     @level1type = N'TABLE', @level1name = 'Blogs',
     @level2type = N'COLUMN', @level2name = 'Id';
 ",
@@ -2303,10 +2304,11 @@ DROP TABLE PrincipalTable;");
             public new SqlServerTestStore TestStore
                 => (SqlServerTestStore)base.TestStore;
 
-            public SqlServerDatabaseModelFixture()
+            public override async Task InitializeAsync()
             {
-                TestStore.ExecuteNonQuery("CREATE SCHEMA db2");
-                TestStore.ExecuteNonQuery("CREATE SCHEMA [db.2]");
+                await base.InitializeAsync();
+                await TestStore.ExecuteNonQueryAsync("CREATE SCHEMA db2");
+                await TestStore.ExecuteNonQueryAsync("CREATE SCHEMA [db.2]");
             }
 
             protected override bool ShouldLogCategory(string logCategory)


### PR DESCRIPTION
Before this commit, it was impossible to create a concrete implementation of SharedStoreFixtureBase that requires a `TestStoreFactory` which is initialized asynchronously (the purpose of `IAsyncLifetime`).

After this commit, it becomes possible because the `TestStoreFactory` and the `StoreName` properties are not accessed in the constructor anymore:

```csharp
public class MySharedStoreFixture<TContext> : SharedStoreFixtureBase<TContext> where TContext : DbContext
{
    private string? _storeName;
    private ITestStoreFactory? _testStoreFactory;

    protected override string StoreName => _storeName ?? throw new InvalidOperationException($"The {nameof(StoreName)} property is only available after {nameof(InitializeAsync)} has executed.");
    protected override ITestStoreFactory TestStoreFactory => _testStoreFactory ?? throw new InvalidOperationException($"The {nameof(TestStoreFactory)} property is only available after {nameof(InitializeAsync)} has executed.");

    public override async Task InitializeAsync()
    {
        var someInfo = await GetSomeInfoAsync();

        _storeName = someInfo.Name;
        _testStoreFactory = new MyTestStoreFactory(someInfo);

        await base.InitializeAsync();
    }
}
```