### PR TITLE
Add CreateContextFactory public method on SharedStoreFixtureBase

### DIFF
--- a/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
@@ -68,6 +68,9 @@ namespace Microsoft.EntityFrameworkCore
                 ? (TContext)new DbContextLease(ContextPool, standalone: true).Context
                 : (TContext)ServiceProvider.GetRequiredService(ContextType);
 
+        public virtual IDbContextFactory<TContext> CreateContextFactory()
+            => new DbContextFactory(CreateContext);
+
         public DbContextOptions CreateOptions()
             => ConfigureOptions(ServiceProvider, new DbContextOptionsBuilder()).Options;
 
@@ -125,5 +128,16 @@ namespace Microsoft.EntityFrameworkCore
 
         public virtual Task DisposeAsync()
             => TestStore.DisposeAsync();
+
+        private class DbContextFactory : IDbContextFactory<TContext>
+        {
+            private readonly Func<TContext> _createDbContext;
+
+            public DbContextFactory(Func<TContext> createDbContext)
+                => _createDbContext = createDbContext ?? throw new ArgumentNullException(nameof(createDbContext));
+
+            public TContext CreateDbContext()
+                => _createDbContext();
+        }
     }
 }


### PR DESCRIPTION
The [IDbContextFactory<TContext> interface][1] was introduced in EF Core 5.0 preview 7. It makes sense to have it on `SharedStoreFixtureBase` where the consumers of the fixture can get a ready-to-use context factory.

[1]: https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-5.0/whatsnew#dbcontextfactory

Ping @AndriySvyryd