### PR TITLE
[release/3.1] Query: Unwind nested invocation expressions

### DIFF
--- a/src/EFCore/Query/Internal/InvocationExpressionRemovingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/InvocationExpressionRemovingExpressionVisitor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
@@ -14,8 +14,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             var invokedExpression = StripTrivialConversions(invocationExpression.Expression);
 
+
             return invokedExpression is LambdaExpression lambdaExpression
-                ? InlineLambdaExpression(lambdaExpression, invocationExpression.Arguments)
+                ? AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue19511", out var isEnabled) && isEnabled
+                    ? InlineLambdaExpression(lambdaExpression, invocationExpression.Arguments)
+                    : Visit(InlineLambdaExpression(lambdaExpression, invocationExpression.Arguments))
                 : base.VisitInvocation(invocationExpression);
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/SimpleQueryCosmosTest.Where.cs
@@ -1536,6 +1536,16 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
 
+        public override async Task Where_expression_invoke_3(bool async)
+        {
+            await base.Where_expression_invoke_3(async);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
         [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_concat_string_int_comparison1(bool isAsync)
         {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1521,6 +1521,26 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_expression_invoke_3(bool isAsync)
+        {
+            Expression<Func<Customer, bool>> lambda3 = c => c.CustomerID == "ALFKI";
+            var customerParameter2 = Expression.Parameter(typeof(Customer));
+            var lambda2 = Expression.Lambda<Func<Customer, bool>>(
+                Expression.Invoke(lambda3, customerParameter2),
+                customerParameter2);
+
+            var customerParameter = Expression.Parameter(typeof(Customer));
+            var lambda = Expression.Lambda<Func<Customer, bool>>(
+                Expression.Invoke(lambda2, customerParameter),
+                customerParameter);
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(lambda),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_concat_string_int_comparison1(bool isAsync)
         {
             var i = 10;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1282,6 +1282,16 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }
 
+        public override async Task Where_expression_invoke_3(bool isAsync)
+        {
+            await base.Where_expression_invoke_3(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'");
+        }
+
         public override async Task Where_concat_string_int_comparison1(bool isAsync)
         {
             await base.Where_concat_string_int_comparison1(isAsync);


### PR DESCRIPTION
Resolves #19511

Port of #19514

**Description**
In 2.x query pipeline when we used Remotion.Linq library to normalize expression tree into query model, it also inlined all invocation expressions. In 3.1 we added code in our pipeline to do inilining but it was not applying it recursively.

**Customer Impact**
Customers using nested invocations to build expression tree get an exception with translation error.

**How found**
Customers reported that they are facing issue with invocation expressions even after the fix we added in 3.1.

**Test coverage**
Regression test added to verify that we cover recursive case.

**Regression?**
Yes, from EF Core 2.x to 3.1 as 2.x pipeline normalized this through external library.

**Risk**
Very low. Visiting recursively should be no-op if not the case of invocation. Also this fix has been released in 5.0 preview1 and we haven't had any feedback of anything breaking.

