### PR TITLE
[5.0.0-rc2] Change ChangeTrackingStrategy from annotation to field

### DIFF
--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -606,8 +607,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IConventionEntityType entityType,
             ChangeTrackingStrategy? changeTrackingStrategy,
             bool fromDataAnnotation = false)
-            => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
-                .SetChangeTrackingStrategy(
+            => ((EntityType)entityType).SetChangeTrackingStrategy(
                     changeTrackingStrategy,
                     fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -616,8 +616,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The configuration source for <see cref="EntityTypeExtensions.GetChangeTrackingStrategy" />. </returns>
+        [DebuggerStepThrough]
         public static ConfigurationSource? GetChangeTrackingStrategyConfigurationSource([NotNull] this IConventionEntityType entityType)
-            => entityType.FindAnnotation(CoreAnnotationNames.ChangeTrackingStrategy)?.GetConfigurationSource();
+            => ((EntityType)entityType).GetChangeTrackingStrategyConfigurationSource();
 
         /// <summary>
         ///     Sets the LINQ expression filter automatically applied to queries for this entity type.

--- a/src/EFCore/Extensions/ConventionModelExtensions.cs
+++ b/src/EFCore/Extensions/ConventionModelExtensions.cs
@@ -192,8 +192,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IConventionModel model,
             ChangeTrackingStrategy? changeTrackingStrategy,
             bool fromDataAnnotation = false)
-            => Check.NotNull((Model)model, nameof(model))
-                .SetChangeTrackingStrategy(
+            => ((Model)model).SetChangeTrackingStrategy(
                     changeTrackingStrategy,
                     fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
@@ -202,8 +201,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model to find configuration source for. </param>
         /// <returns> The configuration source for <see cref="ModelExtensions.GetChangeTrackingStrategy" />. </returns>
+        [DebuggerStepThrough]
         public static ConfigurationSource? GetChangeTrackingStrategyConfigurationSource([NotNull] this IConventionModel model)
-            => model.FindAnnotation(CoreAnnotationNames.ChangeTrackingStrategy)?.GetConfigurationSource();
+            => ((Model)model).GetChangeTrackingStrategyConfigurationSource();
 
         /// <summary>
         ///     Returns a value indicating whether the entity types using the given type should be configured

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -698,13 +698,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The change tracking strategy. </returns>
+        [DebuggerStepThrough]
         public static ChangeTrackingStrategy GetChangeTrackingStrategy([NotNull] this IEntityType entityType)
-        {
-            Check.NotNull(entityType, nameof(entityType));
-
-            return (ChangeTrackingStrategy?)entityType[CoreAnnotationNames.ChangeTrackingStrategy]
-                ?? entityType.Model.GetChangeTrackingStrategy();
-        }
+            => ((EntityType)entityType).GetChangeTrackingStrategy();
 
         /// <summary>
         ///     Gets the data stored in the model for the given entity type.

--- a/src/EFCore/Extensions/ModelExtensions.cs
+++ b/src/EFCore/Extensions/ModelExtensions.cs
@@ -139,8 +139,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The change tracking strategy. </returns>
         [DebuggerStepThrough]
         public static ChangeTrackingStrategy GetChangeTrackingStrategy([NotNull] this IModel model)
-            => (ChangeTrackingStrategy?)Check.NotNull(model, nameof(model))[CoreAnnotationNames.ChangeTrackingStrategy]
-                ?? ChangeTrackingStrategy.Snapshot;
+            => ((Model)model).GetChangeTrackingStrategy();
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -549,8 +549,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetChangeTrackingStrategy(
             [NotNull] this IMutableEntityType entityType,
             ChangeTrackingStrategy? changeTrackingStrategy)
-            => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
-                .SetChangeTrackingStrategy(changeTrackingStrategy, ConfigurationSource.Explicit);
+            => ((EntityType)entityType).SetChangeTrackingStrategy(changeTrackingStrategy, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Sets the LINQ expression filter automatically applied to queries for this entity type.

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -196,8 +196,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetChangeTrackingStrategy(
             [NotNull] this IMutableModel model,
             ChangeTrackingStrategy? changeTrackingStrategy)
-            => Check.NotNull((Model)model, nameof(model))
-                .SetChangeTrackingStrategy(changeTrackingStrategy, ConfigurationSource.Explicit);
+            => ((Model)model).SetChangeTrackingStrategy(changeTrackingStrategy, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Marks the given entity type as ignored, preventing conventions from adding a matching entity type to the model.

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -84,14 +84,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string ChangeTrackingStrategy = "ChangeTrackingStrategy";
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public const string OwnedTypes = "OwnedTypes";
 
         /// <summary>
@@ -289,7 +281,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ValueGeneratorFactory,
             PropertyAccessMode,
             NavigationAccessMode,
-            ChangeTrackingStrategy,
             OwnedTypes,
             DiscriminatorProperty,
             DiscriminatorMappingComplete,

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -57,10 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private Key _primaryKey;
         private bool? _isKeyless;
         private EntityType _baseType;
+        private ChangeTrackingStrategy? _changeTrackingStrategy;
 
         private ConfigurationSource? _primaryKeyConfigurationSource;
         private ConfigurationSource? _isKeylessConfigurationSource;
         private ConfigurationSource? _baseTypeConfigurationSource;
+        private ConfigurationSource? _changeTrackingStrategyConfigurationSource;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private PropertyCounts _counts;
@@ -3064,7 +3066,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         #endregion
 
-        #region Annotations
+        #region Other
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [DebuggerStepThrough]
+        public virtual ChangeTrackingStrategy GetChangeTrackingStrategy()
+            => _changeTrackingStrategy ?? Model.GetChangeTrackingStrategy();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -3086,7 +3098,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            this.SetOrRemoveAnnotation(CoreAnnotationNames.ChangeTrackingStrategy, changeTrackingStrategy, configurationSource);
+            _changeTrackingStrategy = changeTrackingStrategy;
+
+            _changeTrackingStrategyConfigurationSource = _changeTrackingStrategy == null
+                ? (ConfigurationSource?)null
+                : configurationSource.Max(_changeTrackingStrategyConfigurationSource);
 
             return changeTrackingStrategy;
         }
@@ -3130,6 +3146,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             return null;
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource? GetChangeTrackingStrategyConfigurationSource()
+            => _changeTrackingStrategyConfigurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -62,6 +62,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             new Dictionary<Type, ConfigurationSource> { { DefaultPropertyBagType, ConfigurationSource.Convention } };
 
         private bool? _skipDetectChanges;
+        private ChangeTrackingStrategy? _changeTrackingStrategy;
+
+        private ConfigurationSource? _changeTrackingStrategyConfigurationSource;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -937,14 +940,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [DebuggerStepThrough]
+        public virtual ChangeTrackingStrategy GetChangeTrackingStrategy()
+            => _changeTrackingStrategy ?? ChangeTrackingStrategy.Snapshot;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual ChangeTrackingStrategy? SetChangeTrackingStrategy(
             ChangeTrackingStrategy? changeTrackingStrategy,
             ConfigurationSource configurationSource)
         {
-            this.SetOrRemoveAnnotation(CoreAnnotationNames.ChangeTrackingStrategy, changeTrackingStrategy, configurationSource);
+            _changeTrackingStrategy = changeTrackingStrategy;
+
+            _changeTrackingStrategyConfigurationSource = _changeTrackingStrategy == null
+                ? (ConfigurationSource?)null
+                : configurationSource.Max(_changeTrackingStrategyConfigurationSource);
 
             return changeTrackingStrategy;
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource? GetChangeTrackingStrategyConfigurationSource()
+            => _changeTrackingStrategyConfigurationSource;
 
         /// <summary>
         ///     Runs the conventions when an annotation was set or removed.


### PR DESCRIPTION
Fixes #22503

**Description**
Some issues fixed late in 5.0.0-rc2 caused a significant perf regression on the code path used frequently by applications. To mitigate this the implementation of how `ChangeTrackingStrategy` is stored in the model was changed.

**Customer Impact**
Customers would experience perf degradation if the affected code path is used extensively.

**How found**
Automated perf testing.

**Test coverage**
Already covered.

**Regression?**
Yes

**Risk**
Low. There is no functional impact.
