### PR TITLE
[5.0.0-rc2] Throw for ForeignKeyAttribute on skip navigation

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -302,7 +302,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                         && Attribute.IsDefined(p, typeof(ForeignKeyAttribute), inherit: true))
                 ?.GetCustomAttribute<ForeignKeyAttribute>(inherit: true);
 
-        private static ForeignKeyAttribute GetForeignKeyAttribute(IConventionNavigation navigation)
+        private static ForeignKeyAttribute GetForeignKeyAttribute(IConventionNavigationBase navigation)
             => GetAttribute<ForeignKeyAttribute>(navigation.GetIdentifyingMemberInfo());
 
         private static InversePropertyAttribute GetInversePropertyAttribute(IConventionNavigation navigation)
@@ -449,6 +449,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                                     foreignKey.PrincipalEntityType.DisplayName(),
                                     foreignKey.DeclaringEntityType.DisplayName()));
                         }
+                    }
+                }
+
+                foreach (var declaredSkipNavigation in entityType.GetDeclaredSkipNavigations())
+                {
+                    var fkAttribute = GetForeignKeyAttribute(declaredSkipNavigation);
+                    if (fkAttribute != null
+                        && declaredSkipNavigation.ForeignKey?.GetPropertiesConfigurationSource() != ConfigurationSource.Explicit)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.FkAttributeOnSkipNavigation(entityType.DisplayName(), declaredSkipNavigation.Name));
                     }
                 }
             }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -887,6 +887,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, navigation, entityType);
 
         /// <summary>
+        ///     The [ForeignKey] attribute cannot be specified on the skip navigation '{entityType}'.'{navigation}'. Configure the foreign key properties in 'OnModelCreating' instead.
+        /// </summary>
+        public static string FkAttributeOnSkipNavigation([CanBeNull] object entityType, [CanBeNull] object navigation)
+            => string.Format(
+                GetString("FkAttributeOnSkipNavigation", nameof(entityType), nameof(navigation)),
+                entityType, navigation);
+
+        /// <summary>
         ///     The number of properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.
         /// </summary>
         public static string ForeignKeyCountMismatch([CanBeNull] object foreignKeyProperties, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -447,6 +447,9 @@
   <data name="FkAttributeOnPropertyNavigationMismatch" xml:space="preserve">
     <value>The [ForeignKey] attributes on property '{property}' and navigation '{navigation}' in entity type '{entityType}' do not point at each other. The value of the [ForeignKey] attribute on the property should be navigation name, and the value of the [ForeignKey] attribute on the navigation should be the foreign key property name.</value>
   </data>
+  <data name="FkAttributeOnSkipNavigation" xml:space="preserve">
+    <value>The [ForeignKey] attribute cannot be specified on the skip navigation '{entityType}'.'{navigation}'. Configure the foreign key properties in 'OnModelCreating' instead.</value>
+  </data>
   <data name="ForeignKeyCountMismatch" xml:space="preserve">
     <value>The number of properties specified for the foreign key {foreignKeyProperties} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>


### PR DESCRIPTION
Part of #22530

**Description**
Skip navigations were introduced in 5.0.0, but `ForeignKeyAttribute` support wasn't implemented.

**Customer Impact**
Customers using `ForeignKeyAttribute` on skip navigation would see no effect without this fix. Now an exception will be thrown allowing us to add support later without it being a breaking change.

**How found**
Customer reported.

**Test coverage**
New tests included in PR.

**Regression?**
No.

**Risk**
Low. Corner case in a new feature.
