### PR TITLE
[5.0-rc2] RevEng: Remove ColumnType annotation from scaffolded code

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -582,15 +582,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 }
 
                 var columnType = property.GetConfiguredColumnType();
-
                 if (columnType != null)
                 {
                     lines.Add(
                         $".{nameof(RelationalPropertyBuilderExtensions.HasColumnType)}({_code.Literal(columnType)})");
+                    annotations.Remove(RelationalAnnotationNames.ColumnType);
                 }
 
                 var maxLength = property.GetMaxLength();
-
                 if (maxLength.HasValue)
                 {
                     lines.Add(


### PR DESCRIPTION
Fixes #22564

**Description**

This is a regression from 3.1 found by a customer using RC1. We scaffold the appropriate method call to set the column type, but then also explicitly add the underlying annotation.

**Customer Impact**

This will impact a large majority of migrations generated by customers. While it does not cause a functional break, we would like to avoid thousands of customers getting this redundant code in their apps.

**How found**

Found in customer repro

**Test coverage**

New tests included in PR. This is also an area where we recognize that we need more testing; this is planned for MQ.

**Regression?**

Yes. Regression from 3.1

**Risk**

Low. Just remove redundant annotation.
