### PR TITLE
Generate values for PK properties that are also self-referencing FK properties

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -55,7 +55,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             var principalEntry = TryPropagateValue(entry, property);
             if (principalEntry == null
-                && property.IsKey())
+                && property.IsKey()
+                && !property.IsForeignKeyToSelf())
             {
                 var valueGenerator = TryGetValueGenerator(property);
 
@@ -153,19 +154,23 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         if (principalEntry != null)
                         {
                             var principalProperty = foreignKey.PrincipalKey.Properties[propertyIndex];
-                            var principalValue = principalEntry[principalProperty];
-                            if (!principalProperty.ClrType.IsDefaultValue(principalValue))
-                            {
-                                if (principalEntry.HasTemporaryValue(principalProperty))
-                                {
-                                    entry.SetTemporaryValue(property, principalValue);
-                                }
-                                else
-                                {
-                                    entry[property] = principalValue;
-                                }
 
-                                return principalEntry;
+                            if (principalProperty != property)
+                            {
+                                var principalValue = principalEntry[principalProperty];
+                                if (!principalProperty.ClrType.IsDefaultValue(principalValue))
+                                {
+                                    if (principalEntry.HasTemporaryValue(principalProperty))
+                                    {
+                                        entry.SetTemporaryValue(property, principalValue);
+                                    }
+                                    else
+                                    {
+                                        entry[property] = principalValue;
+                                    }
+
+                                    return principalEntry;
+                                }
                             }
                         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -69,6 +70,97 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         foreignKey.DeleteBehavior = DeleteBehavior.ClientNoAction;
                     }
+                }
+            }
+        }
+
+        public class TptIdentity : GraphUpdatesSqlServerTestBase<TptIdentity.SqlServerFixture>
+        {
+            public TptIdentity(SqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            [ConditionalFact(Skip = "Issue #22582")]
+            public override void Can_add_multiple_dependents_when_multiple_possible_principal_sides()
+            {
+            }
+
+            [ConditionalFact(Skip = "Issue #22582")]
+            public override void Can_add_valid_first_dependent_when_multiple_possible_principal_sides()
+            {
+            }
+
+            [ConditionalFact(Skip = "Issue #22582")]
+            public override void Can_add_valid_second_dependent_when_multiple_possible_principal_sides()
+            {
+            }
+
+            protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+                => facade.UseTransaction(transaction.GetDbTransaction());
+
+            public class SqlServerFixture : GraphUpdatesSqlServerFixtureBase
+            {
+                protected override string StoreName { get; } = "GraphTptIdentityUpdatesTest";
+
+                protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+                {
+                    modelBuilder.UseIdentityColumns();
+
+                    base.OnModelCreating(modelBuilder, context);
+
+                    modelBuilder.Entity<Root>().ToTable(nameof(Root));
+                    modelBuilder.Entity<Required1>().ToTable(nameof(Required1));
+                    modelBuilder.Entity<Required1Derived>().ToTable(nameof(Required1Derived));
+                    modelBuilder.Entity<Required1MoreDerived>().ToTable(nameof(Required1MoreDerived));
+                    modelBuilder.Entity<Required2Derived>().ToTable(nameof(Required2Derived));
+                    modelBuilder.Entity<Required2MoreDerived>().ToTable(nameof(Required2MoreDerived));
+                    modelBuilder.Entity<Optional1>().ToTable(nameof(Optional1));
+                    modelBuilder.Entity<Optional1Derived>().ToTable(nameof(Optional1Derived));
+                    modelBuilder.Entity<Optional1MoreDerived>().ToTable(nameof(Optional1MoreDerived));
+                    modelBuilder.Entity<Optional2Derived>().ToTable(nameof(Optional2Derived));
+                    modelBuilder.Entity<Optional2MoreDerived>().ToTable(nameof(Optional2MoreDerived));
+                    modelBuilder.Entity<RequiredSingle1>().ToTable(nameof(RequiredSingle1));
+                    modelBuilder.Entity<OptionalSingle1>().ToTable(nameof(OptionalSingle1));
+                    modelBuilder.Entity<OptionalSingle2>().ToTable(nameof(OptionalSingle2));
+                    modelBuilder.Entity<RequiredNonPkSingle1>().ToTable(nameof(RequiredNonPkSingle1));
+                    modelBuilder.Entity<RequiredNonPkSingle2Derived>().ToTable(nameof(RequiredNonPkSingle2Derived));
+                    modelBuilder.Entity<RequiredNonPkSingle2MoreDerived>().ToTable(nameof(RequiredNonPkSingle2MoreDerived));
+                    modelBuilder.Entity<RequiredAk1>().ToTable(nameof(RequiredAk1));
+                    modelBuilder.Entity<RequiredAk1Derived>().ToTable(nameof(RequiredAk1Derived));
+                    modelBuilder.Entity<RequiredAk1MoreDerived>().ToTable(nameof(RequiredAk1MoreDerived));
+                    modelBuilder.Entity<OptionalAk1>().ToTable(nameof(OptionalAk1));
+                    modelBuilder.Entity<OptionalAk1Derived>().ToTable(nameof(OptionalAk1Derived));
+                    modelBuilder.Entity<OptionalAk1MoreDerived>().ToTable(nameof(OptionalAk1MoreDerived));
+                    modelBuilder.Entity<RequiredSingleAk1>().ToTable(nameof(RequiredSingleAk1));
+                    modelBuilder.Entity<OptionalSingleAk1>().ToTable(nameof(OptionalSingleAk1));
+                    modelBuilder.Entity<OptionalSingleAk2Derived>().ToTable(nameof(OptionalSingleAk2Derived));
+                    modelBuilder.Entity<OptionalSingleAk2MoreDerived>().ToTable(nameof(OptionalSingleAk2MoreDerived));
+                    modelBuilder.Entity<RequiredNonPkSingleAk1>().ToTable(nameof(RequiredNonPkSingleAk1));
+                    modelBuilder.Entity<RequiredAk2>().ToTable(nameof(RequiredAk2));
+                    modelBuilder.Entity<RequiredAk2Derived>().ToTable(nameof(RequiredAk2Derived));
+                    modelBuilder.Entity<RequiredAk2MoreDerived>().ToTable(nameof(RequiredAk2MoreDerived));
+                    modelBuilder.Entity<OptionalAk2>().ToTable(nameof(OptionalAk2));
+                    modelBuilder.Entity<OptionalAk2Derived>().ToTable(nameof(OptionalAk2Derived));
+                    modelBuilder.Entity<OptionalAk2MoreDerived>().ToTable(nameof(OptionalAk2MoreDerived));
+                    modelBuilder.Entity<RequiredSingleAk2>().ToTable(nameof(RequiredSingleAk2));
+                    modelBuilder.Entity<RequiredNonPkSingleAk2>().ToTable(nameof(RequiredNonPkSingleAk2));
+                    modelBuilder.Entity<RequiredNonPkSingleAk2Derived>().ToTable(nameof(RequiredNonPkSingleAk2Derived));
+                    modelBuilder.Entity<RequiredNonPkSingleAk2MoreDerived>().ToTable(nameof(RequiredNonPkSingleAk2MoreDerived));
+                    modelBuilder.Entity<OptionalSingleAk2>().ToTable(nameof(OptionalSingleAk2));
+                    modelBuilder.Entity<RequiredComposite1>().ToTable(nameof(RequiredComposite1));
+                    modelBuilder.Entity<OptionalOverlapping2>().ToTable(nameof(OptionalOverlapping2));
+                    modelBuilder.Entity<BadCustomer>().ToTable(nameof(BadCustomer));
+                    modelBuilder.Entity<BadOrder>().ToTable(nameof(BadOrder));
+                    modelBuilder.Entity<QuestTask>().ToTable(nameof(QuestTask));
+                    modelBuilder.Entity<QuizTask>().ToTable(nameof(QuizTask));
+                    modelBuilder.Entity<HiddenAreaTask>().ToTable(nameof(HiddenAreaTask));
+                    modelBuilder.Entity<TaskChoice>().ToTable(nameof(TaskChoice));
+                    modelBuilder.Entity<ParentAsAChild>().ToTable(nameof(ParentAsAChild));
+                    modelBuilder.Entity<ChildAsAParent>().ToTable(nameof(ChildAsAParent));
+                    modelBuilder.Entity<Poost>().ToTable(nameof(Poost));
+                    modelBuilder.Entity<Bloog>().ToTable(nameof(Bloog));
+                    modelBuilder.Entity<Produce>().ToTable(nameof(Produce));
                 }
             }
         }


### PR DESCRIPTION
Fixes #22573

### Description

This is a regression from preview 8 on a very common case for a major new feature. We added FK constraints to the TPT model in RC1, but this broke value generation for the PK property of any TPT mapping.

### Customer Impact

Very common scenario on a major new feature.

### How found

Customer reported moving from preview 8 to RC1.

### Test coverage

We were lacking test coverage for change tracking in TPT models. This PR adds a TPT variation to our main change tracking tests (1622 tests). This revealed one additional bug which we will triage separately. 

### Regression?

New feature in 5.0, but regression from preview 8.

### Risk

Low. Issue is well understood and fix is small.
