### PR TITLE
[5.0.0-rc2] Add null checks to account for owned types in TPT

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -103,13 +103,18 @@ namespace Microsoft.EntityFrameworkCore
                     .SelectMany(fk => fk.PrincipalEntityType.GetForeignKeys()))
                 {
                     if (principalStoreObject.Name == otherForeignKey.PrincipalEntityType.GetTableName()
-                        && principalStoreObject.Schema == otherForeignKey.PrincipalEntityType.GetSchema()
-                        && propertyNames.SequenceEqual(otherForeignKey.Properties.GetColumnNames(storeObject))
-                        && principalPropertyNames.SequenceEqual(
-                            otherForeignKey.PrincipalKey.Properties.GetColumnNames(principalStoreObject)))
+                        && principalStoreObject.Schema == otherForeignKey.PrincipalEntityType.GetSchema())
                     {
-                        linkedForeignKey = otherForeignKey;
-                        break;
+                        var otherColumnNames = otherForeignKey.Properties.GetColumnNames(storeObject);
+                        var otherPrincipalColumnNames = otherForeignKey.PrincipalKey.Properties.GetColumnNames(principalStoreObject);
+                        if (otherColumnNames != null
+                            && otherPrincipalColumnNames != null
+                            && propertyNames.SequenceEqual(otherColumnNames)
+                            && principalPropertyNames.SequenceEqual(otherPrincipalColumnNames))
+                        {
+                            linkedForeignKey = otherForeignKey;
+                            break;
+                        }
                     }
                 }
 

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -808,7 +808,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             foreach (var relatedEntityType in relatedEntityTypes)
             {
                 var relatedEntityTypeBuilder = relatedEntityType.Builder;
-                DiscoverRelationships(relatedEntityTypeBuilder, context);
+                if (relatedEntityTypeBuilder != null)
+                {
+                    DiscoverRelationships(relatedEntityTypeBuilder, context);
+                }
             }
         }
 

--- a/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class DataAnnotationRelationalTestBase<TFixture> : DataAnnotationTestBase<TFixture>
+        where TFixture : DataAnnotationRelationalTestBase<TFixture>.DataAnnotationRelationalFixtureBase, new()
+    {
+        protected DataAnnotationRelationalTestBase(TFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalFact]
+        public virtual void Table_can_configure_TPT_with_Owned()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var model = context.Model;
+
+                    var animalType = model.FindEntityType(typeof(Animal));
+                    Assert.Equal("Animals", animalType.GetTableMappings().Single().Table.Name);
+
+                    var petType = model.FindEntityType(typeof(Pet));
+                    Assert.Equal("Pets", petType.GetTableMappings().Last().Table.Name);
+
+                    var tagNavigation = petType.FindNavigation(nameof(Pet.Tag));
+                    var ownership = tagNavigation.ForeignKey;
+                    Assert.True(ownership.IsRequiredDependent);
+
+                    var petTagType = ownership.DeclaringEntityType;
+                    Assert.Equal("Pets", petTagType.GetTableMappings().Single().Table.Name);
+
+                    var tagIdProperty = petTagType.FindProperty(nameof(PetTag.TagId));
+                    Assert.False(tagIdProperty.IsNullable);
+                    Assert.All(tagIdProperty.GetTableColumnMappings(), m => Assert.False(m.Column.IsNullable));
+
+                    var catType = model.FindEntityType(typeof(Cat));
+                    Assert.Equal("Cats", catType.GetTableMappings().Last().Table.Name);
+
+                    var dogType = model.FindEntityType(typeof(Dog));
+                    Assert.Equal("Dogs", dogType.GetTableMappings().Last().Table.Name);
+
+                    context.Set<Cat>().Add(
+                        new Cat { Key = 1, Species = "Felis catus", Tag = new PetTag { TagId = 2 } });
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var cat = context.Set<Cat>().Single();
+                    Assert.Equal("Felis catus", cat.Species);
+                    Assert.Equal(2u, cat.Tag.TagId);
+                });
+        }
+
+        public abstract class DataAnnotationRelationalFixtureBase : DataAnnotationFixtureBase
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+
+                modelBuilder.Entity<Animal>().ToTable("Animals").Property(x => x.Key).ValueGeneratedNever();
+                modelBuilder.Entity<Pet>().ToTable("Pets").HasOne(x => x.CatFriend);
+                modelBuilder.Entity<Cat>().ToTable("Cats");
+                modelBuilder.Entity<Dog>().ToTable("Dogs");
+            }
+        }
+
+        [Table("Animals")]
+        protected class Animal
+        {
+            [Key]
+            public int Key { get; set; }
+            public string Species { get; set; }
+        }
+
+        [Table("Pets")]
+        protected class Pet : Animal
+        {
+            public string Name { get; set; }
+
+            [Column("CatFriend_Id")]
+            [ForeignKey(nameof(CatFriend))]
+            public int? CatFriendId { get; set; }
+            public Cat CatFriend { get; set; }
+
+            [Required]
+            public PetTag Tag { get; set; }
+        }
+
+        [Table("Cats")]
+        protected sealed class Cat : Pet
+        {
+            public string EducationLevel { get; set; }
+        }
+
+        [Table("Dogs")]
+        protected sealed class Dog : Pet
+        {
+            public string FavoriteToy { get; set; }
+        }
+
+        [Owned]
+        protected sealed class PetTag
+        {
+            [Required]
+            public uint? TagId { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -39,6 +39,9 @@ namespace Microsoft.EntityFrameworkCore
         protected virtual void ExecuteWithStrategyInTransaction(Action<DbContext> testOperation)
             => TestHelpers.ExecuteWithStrategyInTransaction(CreateContext, UseTransaction, testOperation);
 
+        protected virtual void ExecuteWithStrategyInTransaction(Action<DbContext> testOperation1, Action<DbContext> testOperation2)
+            => TestHelpers.ExecuteWithStrategyInTransaction(CreateContext, UseTransaction, testOperation1, testOperation2);
+
         protected virtual void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         {
         }

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    public class DataAnnotationSqlServerTest : DataAnnotationTestBase<DataAnnotationSqlServerTest.DataAnnotationSqlServerFixture>
+    public class DataAnnotationSqlServerTest : DataAnnotationRelationalTestBase<DataAnnotationSqlServerTest.DataAnnotationSqlServerFixture>
     {
         // ReSharper disable once UnusedParameter.Local
         public DataAnnotationSqlServerTest(DataAnnotationSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
@@ -276,7 +276,7 @@ WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();");
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        public class DataAnnotationSqlServerFixture : DataAnnotationFixtureBase
+        public class DataAnnotationSqlServerFixture : DataAnnotationRelationalFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory
                 => SqlServerTestStoreFactory.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -10,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
 {
-    public class DataAnnotationSqliteTest : DataAnnotationTestBase<DataAnnotationSqliteTest.DataAnnotationSqliteFixture>
+    public class DataAnnotationSqliteTest : DataAnnotationRelationalTestBase<DataAnnotationSqliteTest.DataAnnotationSqliteFixture>
     {
         // ReSharper disable once UnusedParameter.Local
         public DataAnnotationSqliteTest(DataAnnotationSqliteFixture fixture, ITestOutputHelper testOutputHelper)
@@ -165,12 +164,10 @@ WHERE changes() = 1 AND ""rowid"" = last_insert_rowid();");
             Assert.True(context.Model.FindEntityType(typeof(Two)).FindProperty("Timestamp").IsConcurrencyToken);
         }
 
-        private static readonly string _eol = Environment.NewLine;
-
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        public class DataAnnotationSqliteFixture : DataAnnotationFixtureBase
+        public class DataAnnotationSqliteFixture : DataAnnotationRelationalFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory
                 => SqliteTestStoreFactory.Instance;


### PR DESCRIPTION
Fixes #22576

### Description

This is a bug in a new feature. In scenarios with more than 2 levels of TPT with an owned type defined on a derived type some methods will return `null` that we haven't accounted for.

### Customer Impact

It's hard to estimate how many customers will be impacted, but given the location in the code path it's likely to affect other TPT scenarios apart from the one described above.

### How found

Customer reported on RC1.

### Test coverage

We were lacking test coverage for complex TPT models. This PR adds a test for the affected scenario. 

### Regression?

No, new feature in 5.0.

### Risk

Low. Code changes just add `null` checks.

