### PR TITLE
[release/5.0-rc2] Make newline escaping logic more robust

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -108,9 +108,9 @@ EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSc
 DECLARE @defaultSchema AS sysname;
 SET @defaultSchema = SCHEMA_NAME();
 DECLARE @description AS sql_variant;
-SET @description = CONCAT(N'This is a multi-line', CHAR(13), CHAR(10), N'table comment.', CHAR(13), CHAR(10), N'More information can', CHAR(13), CHAR(10), N'be found in the docs.');
+SET @description = CONCAT(N'This is a multi-line', NCHAR(13), NCHAR(10), N'table comment.', NCHAR(13), NCHAR(10), N'More information can', NCHAR(13), NCHAR(10), N'be found in the docs.');
 EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSchema, 'TABLE', N'People';
-SET @description = CONCAT(N'This is a multi-line', CHAR(10), N'column comment.', CHAR(10), N'More information can', CHAR(10), N'be found in the docs.');
+SET @description = CONCAT(N'This is a multi-line', NCHAR(10), N'column comment.', NCHAR(10), N'More information can', NCHAR(10), N'be found in the docs.');
 EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSchema, 'TABLE', N'People', 'COLUMN', N'Name';");
         }
 

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
     public class SqlServerMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
     {
         protected static string SQL_EOL
-            => string.Join(", ", EOL.Select(c => "CHAR(" + (short)c + ")"));
+            => string.Join(", ", EOL.Select(c => "NCHAR(" + (short)c + ")"));
 
         [ConditionalFact]
         public virtual void AddColumnOperation_identity_legacy()
@@ -926,7 +926,7 @@ SELECT @@ROWCOUNT;
             var storeType = isUnicode ? "nvarchar(max)" : "varchar(max)";
             var unicodePrefix = isUnicode ? "N" : string.Empty;
             var expectedSql = @$"CREATE TABLE [dbo].[TestLineBreaks] (
-    [TestDefaultValue] {storeType} NOT NULL DEFAULT CONCAT(CHAR(13), CHAR(10), {unicodePrefix}'Various Line', CHAR(13), {unicodePrefix}'Breaks', CHAR(10))
+    [TestDefaultValue] {storeType} NOT NULL DEFAULT CONCAT({unicodePrefix}CHAR(13), {unicodePrefix}CHAR(10), {unicodePrefix}'Various Line', {unicodePrefix}CHAR(13), {unicodePrefix}'Breaks', {unicodePrefix}CHAR(10))
 );
 ";
             AssertSql(expectedSql);

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerStringTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerStringTypeMappingTest.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
+{
+    public class SqlServerStringTypeMappingTest
+    {
+        [ConditionalTheory]
+        [InlineData("", "''")]
+        [InlineData("'Sup", "'''Sup'")]
+        [InlineData("I'm", "'I''m'")]
+        [InlineData("lovin'", "'lovin'''")]
+        [InlineData("it", "'it'")]
+        [InlineData("'", "''''")]
+        [InlineData("''", "''''''")]
+        [InlineData("I'm lovin'", "'I''m lovin'''")]
+        [InlineData("I'm lovin' it", "'I''m lovin'' it'")]
+        [InlineData("\r", "CHAR(13)")]
+        [InlineData("\n", "CHAR(10)")]
+        [InlineData("\r\n", "CONCAT(CHAR(13), CHAR(10))")]
+        [InlineData("\n'sup", "CONCAT(CHAR(10), '''sup')")]
+        [InlineData("I'm\n", "CONCAT('I''m', CHAR(10))")]
+        [InlineData("lovin'\n", "CONCAT('lovin''', CHAR(10))")]
+        [InlineData("it\n", "CONCAT('it', CHAR(10))")]
+        [InlineData("\nit", "CONCAT(CHAR(10), 'it')")]
+        [InlineData("\nit\n", "CONCAT(CHAR(10), 'it', CHAR(10))")]
+        [InlineData("'\n", "CONCAT('''', CHAR(10))")]
+        public void GenerateProviderValueSqlLiteral_works(string value, string expected)
+        {
+            var mapping = new SqlServerStringTypeMapping("varchar(max)");
+            Assert.Equal(expected, mapping.GenerateProviderValueSqlLiteral(value));
+        }
+
+        [ConditionalTheory]
+        [InlineData("", "N''")]
+        [InlineData("'Sup", "N'''Sup'")]
+        [InlineData("I'm", "N'I''m'")]
+        [InlineData("lovin'", "N'lovin'''")]
+        [InlineData("it", "N'it'")]
+        [InlineData("'", "N''''")]
+        [InlineData("''", "N''''''")]
+        [InlineData("I'm lovin'", "N'I''m lovin'''")]
+        [InlineData("I'm lovin' it", "N'I''m lovin'' it'")]
+        [InlineData("\r", "NCHAR(13)")]
+        [InlineData("\n", "NCHAR(10)")]
+        [InlineData("\r\n", "CONCAT(NCHAR(13), NCHAR(10))")]
+        [InlineData("\n'sup", "CONCAT(NCHAR(10), N'''sup')")]
+        [InlineData("I'm\n", "CONCAT(N'I''m', NCHAR(10))")]
+        [InlineData("lovin'\n", "CONCAT(N'lovin''', NCHAR(10))")]
+        [InlineData("it\n", "CONCAT(N'it', NCHAR(10))")]
+        [InlineData("\nit", "CONCAT(NCHAR(10), N'it')")]
+        [InlineData("\nit\n", "CONCAT(NCHAR(10), N'it', NCHAR(10))")]
+        [InlineData("'\n", "CONCAT(N'''', NCHAR(10))")]
+        public void GenerateProviderValueSqlLiteral_works_unicode(string value, string expected)
+        {
+            var mapping = new SqlServerStringTypeMapping("nvarchar(max)", unicode: true);
+            Assert.Equal(expected, mapping.GenerateProviderValueSqlLiteral(value));
+        }
+    }
+}

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteStringTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteStringTypeMappingTest.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
+{
+    public class SqliteStringTypeMappingTest
+    {
+        [ConditionalTheory]
+        [InlineData("", "''")]
+        [InlineData("'Sup", "'''Sup'")]
+        [InlineData("I'm", "'I''m'")]
+        [InlineData("lovin'", "'lovin'''")]
+        [InlineData("it", "'it'")]
+        [InlineData("'", "''''")]
+        [InlineData("''", "''''''")]
+        [InlineData("'m lovin'", "'''m lovin'''")]
+        [InlineData("I'm lovin' it", "'I''m lovin'' it'")]
+        [InlineData("\r", "CHAR(13)")]
+        [InlineData("\n", "CHAR(10)")]
+        [InlineData("\r\n", "(CHAR(13) || CHAR(10))")]
+        [InlineData("\n'sup", "(CHAR(10) || '''sup')")]
+        [InlineData("I'm\n", "('I''m' || CHAR(10))")]
+        [InlineData("lovin'\n", "('lovin''' || CHAR(10))")]
+        [InlineData("it\n", "('it' || CHAR(10))")]
+        [InlineData("\nit", "(CHAR(10) || 'it')")]
+        [InlineData("\nit\n", "(CHAR(10) || 'it' || CHAR(10))")]
+        [InlineData("'\n", "('''' || CHAR(10))")]
+        public void GenerateProviderValueSqlLiteral_works(string value, string expected)
+        {
+            var mapping = new SqliteStringTypeMapping("TEXT");
+            Assert.Equal(expected, mapping.GenerateProviderValueSqlLiteral(value));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #22553

### Description

We added some code in 5.0 to escape newlines in generated migrations. Unfortunately, this code was a little naive and missed some important cases. Several customers have hit this using RC1.

### Customer Impact

This will impact many customers, as indicated by the multiple reports we already have against RC1.

### How found

Customer reported on RC1.

### Test coverage

We were lacking test coverage for the escaping. Better test coverage is included in this PR.

### Regression?

Yes, from 3.1.

cc @Pilchie
