### PR TITLE
[5.0-rc2] Also clear the store generated values when setting a normal value

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -58,8 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             private readonly IDictionary<Expression, (IEntityType EntityType, Expression JObjectExpression)> _ownerMappings
                 = new Dictionary<Expression, (IEntityType, Expression)>();
 
-            private readonly IDictionary<Expression, ParameterExpression> _ordinalParameterBindings
-                = new Dictionary<Expression, ParameterExpression>();
+            private readonly IDictionary<Expression, Expression> _ordinalParameterBindings
+                = new Dictionary<Expression, Expression>();
 
             private List<IncludeExpression> _pendingIncludes
                 = new List<IncludeExpression>();
@@ -269,9 +269,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
                         var accessExpression = objectArrayProjection.InnerProjection.AccessExpression;
                         _projectionBindings[accessExpression] = jObjectParameter;
-                        _ownerMappings[accessExpression] = (
-                            objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
-                        _ordinalParameterBindings[accessExpression] = ordinalParameter;
+                        _ownerMappings[accessExpression] =
+                            (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
+                        _ordinalParameterBindings[accessExpression] = Expression.Add(
+                            ordinalParameter, Expression.Constant(1, typeof(int)));
 
                         var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
 

--- a/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
+++ b/src/EFCore.Cosmos/Update/Internal/DocumentSource.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
                 }
                 else
                 {
-                    var embeddedOrdinal = 0;
+                    var embeddedOrdinal = 1;
                     var array = new JArray();
                     foreach (var dependent in (IEnumerable)embeddedValue)
                     {
@@ -227,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
                 }
                 else
                 {
-                    var embeddedOrdinal = 0;
+                    var embeddedOrdinal = 1;
                     var ordinalKeyProperty = GetOrdinalKeyProperty(fk.DeclaringEntityType);
                     if (ordinalKeyProperty != null)
                     {
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Update.Internal
                         }
                     }
 
-                    embeddedOrdinal = 0;
+                    embeddedOrdinal = 1;
                     var array = new JArray();
                     foreach (var dependent in (IEnumerable)embeddedValue)
                     {

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1045,8 +1045,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             get
             {
-                var value = ReadPropertyValue(propertyBase);
-
                 var storeGeneratedIndex = propertyBase.GetStoreGeneratedIndex();
                 if (storeGeneratedIndex != -1)
                 {
@@ -1062,6 +1060,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         return generatedValue;
                     }
 
+                    var value = ReadPropertyValue(propertyBase);
                     if (equals(value, defaultValue))
                     {
                         if (_temporaryValues.TryGetValue(storeGeneratedIndex, out generatedValue)
@@ -1070,9 +1069,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             return generatedValue;
                         }
                     }
+
+                    return value;
                 }
 
-                return value;
+                return ReadPropertyValue(propertyBase);
             }
 
             [param: CanBeNull] set => SetProperty(propertyBase, value, isMaterialization: false);

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1178,12 +1178,24 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         WritePropertyValue(propertyBase, value, isMaterialization);
 
-                        if (currentValueType != CurrentValueType.Normal
-                            && !_temporaryValues.IsEmpty)
+                        switch (currentValueType)
                         {
-                            var defaultValue = asProperty.ClrType.GetDefaultValue();
-                            var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
-                            _temporaryValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
+                            case CurrentValueType.StoreGenerated:
+                                if (!_storeGeneratedValues.IsEmpty)
+                                {
+                                    var defaultValue = asProperty.ClrType.GetDefaultValue();
+                                    var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
+                                    _storeGeneratedValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
+                                }
+                                break;
+                            case CurrentValueType.Temporary:
+                                if (!_temporaryValues.IsEmpty)
+                                {
+                                    var defaultValue = asProperty.ClrType.GetDefaultValue();
+                                    var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
+                                    _temporaryValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
+                                }
+                                break;
                         }
                     }
                     else

--- a/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/DataAnnotationRelationalTestBase.cs
@@ -47,8 +47,11 @@ namespace Microsoft.EntityFrameworkCore
                     var dogType = model.FindEntityType(typeof(Dog));
                     Assert.Equal("Dogs", dogType.GetTableMappings().Last().Table.Name);
 
-                    context.Set<Cat>().Add(
-                        new Cat { Key = 1, Species = "Felis catus", Tag = new PetTag { TagId = 2 } });
+                    var petFood = new PetFood() { FoodName = "Fish" };
+                    context.Add(petFood);
+
+                    context.Add(
+                        new Cat { Species = "Felis catus", Tag = new PetTag { TagId = 2 }, FavoritePetFood = petFood });
 
                     context.SaveChanges();
                 },
@@ -66,10 +69,10 @@ namespace Microsoft.EntityFrameworkCore
             {
                 base.OnModelCreating(modelBuilder, context);
 
-                modelBuilder.Entity<Animal>().ToTable("Animals").Property(x => x.Key).ValueGeneratedNever();
-                modelBuilder.Entity<Pet>().ToTable("Pets").HasOne(x => x.CatFriend);
-                modelBuilder.Entity<Cat>().ToTable("Cats");
-                modelBuilder.Entity<Dog>().ToTable("Dogs");
+                modelBuilder.Entity<Animal>();
+                modelBuilder.Entity<Pet>();
+                modelBuilder.Entity<Cat>();
+                modelBuilder.Entity<Dog>();
             }
         }
 
@@ -86,10 +89,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             public string Name { get; set; }
 
-            [Column("CatFriend_Id")]
-            [ForeignKey(nameof(CatFriend))]
-            public int? CatFriendId { get; set; }
-            public Cat CatFriend { get; set; }
+            [Column("FavoritePetFood_Id")]
+            [ForeignKey(nameof(FavoritePetFood))]
+            public int? FavoritePetFoodId { get; set; }
+            public PetFood FavoritePetFood { get; set; }
 
             [Required]
             public PetTag Tag { get; set; }
@@ -112,6 +115,16 @@ namespace Microsoft.EntityFrameworkCore
         {
             [Required]
             public uint? TagId { get; set; }
+        }
+
+        [Table("PetFoods")]
+        public sealed class PetFood
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            [Column("PetFoods_Id")]
+            public int PetFoodId { get; set; }
+
+            public string FoodName { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes #22577

### Description

Usually a value is only propagated to a foreign key and the foreign key value is not store-generated, however in TPT the property might get a store-generated value before the real value is propagated to it.

### Customer Impact

The issue mostly affects a new feature - TPT when the principal key is store generated. There is a workaround where the entities to be saved are split and the dependent values cleared manually, but this isn't practical in most applications.

### How found

Customer reported on RC1.

### Test coverage

We were lacking test coverage for complex TPT models. This PR adds a test for the affected scenario. 

### Regression?

No, new feature in 5.0.

### Risk

Low. The fix mostly affects a new feature - TPT and the values that are now discarded were already being discarded before, but on completion of SaveChanges instead of during execution
