### PR TITLE
[5.0-rc2] Throw exception for cycles in auto included navigations

### DIFF
--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -121,6 +121,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, argument);
 
         /// <summary>
+        ///     Cycle detected while auto-including navigations: {cycleNavigations}. To fix this issue, either don't configure at least one navigation in the cycle as auto included in `OnModelCreating` or call 'IgnoreAutoInclude' method on the query.
+        /// </summary>
+        public static string AutoIncludeNavigationCycle([CanBeNull] object cycleNavigations)
+            => string.Format(
+                GetString("AutoIncludeNavigationCycle", nameof(cycleNavigations)),
+                cycleNavigations);
+
+        /// <summary>
         ///     Cannot set backing field '{field}' for the indexer property '{entityType}.{property}'. Ensure no backing fields are specified for indexer properties.
         /// </summary>
         public static string BackingFieldOnIndexer([CanBeNull] object field, [CanBeNull] object entityType, [CanBeNull] object property)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -153,6 +153,9 @@
   <data name="ArgumentPropertyNull" xml:space="preserve">
     <value>The property '{property}' of the argument '{argument}' cannot be null.</value>
   </data>
+  <data name="AutoIncludeNavigationCycle" xml:space="preserve">
+    <value>Cycle detected while auto-including navigations: {cycleNavigations}. To fix this issue, either don't configure at least one navigation in the cycle as auto included in `OnModelCreating` or call 'IgnoreAutoInclude' method on the query.</value>
+  </data>
   <data name="BackingFieldOnIndexer" xml:space="preserve">
     <value>Cannot set backing field '{field}' for the indexer property '{entityType}.{property}'. Ensure no backing fields are specified for indexer properties.</value>
   </data>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo()
                 .GetDeclaredProperty(nameof(QueryContext.Context));
 
-        private static readonly IDictionary<MethodInfo, MethodInfo> _predicateLessMethodInfo = new Dictionary<MethodInfo, MethodInfo>
+        private static readonly Dictionary<MethodInfo, MethodInfo> _predicateLessMethodInfo = new Dictionary<MethodInfo, MethodInfo>
         {
             { QueryableMethods.FirstWithPredicate, QueryableMethods.FirstWithoutPredicate },
             { QueryableMethods.FirstOrDefaultWithPredicate, QueryableMethods.FirstOrDefaultWithoutPredicate },
@@ -59,8 +59,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly ReducingExpressionVisitor _reducingExpressionVisitor;
         private readonly EntityReferenceOptionalMarkingExpressionVisitor _entityReferenceOptionalMarkingExpressionVisitor;
         private readonly RemoveRedundantNavigationComparisonExpressionVisitor _removeRedundantNavigationComparisonExpressionVisitor;
-        private readonly ISet<string> _parameterNames = new HashSet<string>();
+        private readonly HashSet<string> _parameterNames = new HashSet<string>();
         private readonly ParameterExtractingExpressionVisitor _parameterExtractingExpressionVisitor;
+        private readonly HashSet<IEntityType> _nonCyclicAutoIncludeEntityTypes;
 
         private readonly Dictionary<IEntityType, LambdaExpression> _parameterizedQueryFilterPredicateCache
             = new Dictionary<IEntityType, LambdaExpression>();
@@ -95,6 +96,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _queryCompilationContext.Logger,
                 parameterize: false,
                 generateContextAccessors: true);
+
+            if (!_queryCompilationContext.IgnoreAutoIncludes)
+            {
+                _nonCyclicAutoIncludeEntityTypes = new HashSet<IEntityType>();
+            }
         }
 
         /// <summary>
@@ -1707,13 +1713,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private void PopulateEagerLoadedNavigations(IncludeTreeNode includeTreeNode)
         {
             var entityType = includeTreeNode.EntityType;
-            var outboundNavigations
-                = entityType.GetNavigations()
-                    .Cast<INavigationBase>()
-                    .Concat(entityType.GetSkipNavigations())
-                    .Concat(entityType.GetDerivedNavigations())
-                    .Concat(entityType.GetDerivedSkipNavigations())
-                    .Where(n => n.IsEagerLoaded);
+
+            if (!_queryCompilationContext.IgnoreAutoIncludes
+                && !_nonCyclicAutoIncludeEntityTypes.Contains(entityType))
+            {
+                VerifyNoAutoIncludeCycles(entityType, new HashSet<IEntityType>(), new List<INavigationBase>());
+            }
+
+            var outboundNavigations = GetOutgoingEagerLoadedNavigations(entityType);
 
             if (_queryCompilationContext.IgnoreAutoIncludes)
             {
@@ -1722,10 +1729,52 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             foreach (var navigation in outboundNavigations)
             {
-                var addedIncludeTreeNode = includeTreeNode.AddNavigation(navigation);
-                PopulateEagerLoadedNavigations(addedIncludeTreeNode);
+                includeTreeNode.AddNavigation(navigation);
             }
         }
+
+        private void VerifyNoAutoIncludeCycles(
+            IEntityType entityType, HashSet<IEntityType> visitedEntityTypes, List<INavigationBase> navigationChain)
+        {
+            if (_nonCyclicAutoIncludeEntityTypes.Contains(entityType))
+            {
+                return;
+            }
+
+            if (!visitedEntityTypes.Add(entityType))
+            {
+                throw new InvalidOperationException(CoreStrings.AutoIncludeNavigationCycle(
+                    navigationChain.Select(e => $"'{e.DeclaringEntityType.ShortName()}.{e.Name}'").Join()));
+            }
+
+            var autoIncludedNavigations = GetOutgoingEagerLoadedNavigations(entityType)
+                .Where(n => !(n is INavigation navigation && navigation.ForeignKey.IsOwnership));
+
+            foreach (var navigationBase in autoIncludedNavigations)
+            {
+                if (navigationChain.Count > 0
+                    && navigationChain[^1].Inverse == navigationBase
+                    && navigationBase is INavigation)
+                {
+                    continue;
+                }
+
+                navigationChain.Add(navigationBase);
+                VerifyNoAutoIncludeCycles(navigationBase.TargetEntityType, visitedEntityTypes, navigationChain);
+                navigationChain.Remove(navigationBase);
+            }
+
+            _nonCyclicAutoIncludeEntityTypes.Add(entityType);
+            visitedEntityTypes.Remove(entityType);
+        }
+
+        private static IEnumerable<INavigationBase> GetOutgoingEagerLoadedNavigations(IEntityType entityType)
+            => entityType.GetNavigations()
+                .Cast<INavigationBase>()
+                .Concat(entityType.GetSkipNavigations())
+                .Concat(entityType.GetDerivedNavigations())
+                .Concat(entityType.GetDerivedSkipNavigations())
+                .Where(n => n.IsEagerLoaded);
 
         private IncludeTreeNode PopulateIncludeTree(IncludeTreeNode includeTreeNode, Expression expression)
         {


### PR DESCRIPTION
Resolves #22568

**Description**
It is possible to have bad configuration of auto included navigations in the model which causes a cycle.

**Customer Impact**
Customers with bad configuration when running a query with affected types runs into stackoverflow indicating no information about the error.

**How found**

Customer reported on RC1.

**Test coverage**
It is a negative case scenario. We did not have coverage for it. We have added coverage for supported scenario with cycle and error validation for incorrect case.

**Regression?**
No, it is new feature introduced in 5.0

**Risk**
Low. It should only affect when auto includes are used. Further any error can be mitigated by ignoring auto include at query level.
