### PR TITLE
Fix sql server migration transactions not rolling back on failure

### DIFF
--- a/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -32,6 +34,22 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The terminator to be used for batches of SQL statements.
         /// </summary>
         string BatchTerminator { get; }
+
+        /// <summary>
+        ///     Gets the SQL statement which enables or disables automatic rollback for the
+        ///     current transaction when statement raises a runtime error.
+        /// </summary>
+        string AutomaticTransactionRollbackStatement(bool enable = true);
+
+        /// <summary>
+        ///     Begins a SQL check to make sure the transaction is still valid.
+        /// </summary>
+        void BeginIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder);
+
+        /// <summary>
+        ///     Ends a SQL check to make sure the transaction is still valid.
+        /// </summary>
+        void EndIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder);
 
         /// <summary>
         ///     Gets the SQL for a START TRANSACTION statement.

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -58,12 +58,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Begins a SQL check to make sure the transaction is still valid.
         /// </summary>
-        public virtual void BeginIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder) { }
+        public virtual void BeginIfTransactionStateValidScript(IndentedStringBuilder builder) { }
 
         /// <summary>
         ///     Ends a SQL check to make sure the transaction is still valid.
         /// </summary>
-        public virtual void EndIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder) { }
+        public virtual void EndIfTransactionStateValidScript(IndentedStringBuilder builder) { }
 
         /// <inheritdoc />
         public virtual string StartTransactionStatement

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -46,6 +47,23 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         public virtual string BatchTerminator
             => Environment.NewLine;
+
+        /// <summary>
+        ///     Gets the SQL statement which enables or disables automatic rollback for the
+        ///     current transaction when statement raises a runtime error.
+        /// </summary>
+        public virtual string AutomaticTransactionRollbackStatement(bool enable = true)
+            => string.Empty;
+
+        /// <summary>
+        ///     Begins a SQL check to make sure the transaction is still valid.
+        /// </summary>
+        public virtual void BeginIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder) { }
+
+        /// <summary>
+        ///     Ends a SQL check to make sure the transaction is still valid.
+        /// </summary>
+        public virtual void EndIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder) { }
 
         /// <inheritdoc />
         public virtual string StartTransactionStatement

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void BeginIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder)
+        public override void BeginIfTransactionStateValidScript(IndentedStringBuilder builder)
             => builder.AppendLine("IF XACT_STATE() = 1").AppendLine("BEGIN").IncrementIndent();
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override void EndIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder)
+        public override void EndIfTransactionStateValidScript(IndentedStringBuilder builder)
             => builder.DecrementIndent().AppendLine("END").AppendLine(StatementTerminator);
 
         /// <summary>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +45,33 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// </summary>
         public override string BatchTerminator
             => "GO" + Environment.NewLine + Environment.NewLine;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override string AutomaticTransactionRollbackStatement(bool enable = true)
+            => "SET XACT_ABORT " + (enable ? "ON" : "OFF") + StatementTerminator + Environment.NewLine + Environment.NewLine;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override void BeginIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder)
+            => builder.AppendLine("IF XACT_STATE() = 1").AppendLine("BEGIN").IncrementIndent();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override void EndIfTransactionStateValidScript([NotNull] IndentedStringBuilder builder)
+            => builder.DecrementIndent().AppendLine("END").AppendLine(StatementTerminator);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override void EndIfTransactionStateValidScript(IndentedStringBuilder builder)
-            => builder.DecrementIndent().AppendLine("END").AppendLine(StatementTerminator);
+            => builder.DecrementIndent().Append("END").AppendLine(StatementTerminator);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsInfrastructureSqlServerTest.cs
@@ -32,7 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             base.Can_generate_migration_from_initial_database_to_initial();
 
             Assert.Equal(
-                @"IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+                @"SET XACT_ABORT ON;
+
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
 BEGIN
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
@@ -52,7 +54,9 @@ GO
             base.Can_generate_no_migration_script();
 
             Assert.Equal(
-                @"IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+                @"SET XACT_ABORT ON;
+
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
 BEGIN
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
@@ -72,7 +76,9 @@ GO
             base.Can_generate_up_scripts();
 
             Assert.Equal(
-                @"IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+                @"SET XACT_ABORT ON;
+
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
 BEGIN
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
@@ -85,31 +91,49 @@ GO
 BEGIN TRANSACTION;
 GO
 
-CREATE TABLE [Table1] (
-    [Id] int NOT NULL,
-    [Foo] int NOT NULL,
-    CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-);
+IF XACT_STATE() = 1
+BEGIN
+    CREATE TABLE [Table1] (
+        [Id] int NOT NULL,
+        [Foo] int NOT NULL,
+        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
+    );
+END;
 GO
 
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+IF XACT_STATE() = 1
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+END;
 GO
 
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+IF XACT_STATE() = 1
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 CREATE DATABASE TransactionSuppressed;
@@ -121,11 +145,17 @@ GO
 BEGIN TRANSACTION;
 GO
 
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+IF XACT_STATE() = 1
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -186,17 +216,28 @@ GO
             base.Can_generate_one_up_script();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+END;
 GO
 
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+IF XACT_STATE() = 1
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -209,17 +250,28 @@ GO
             base.Can_generate_up_script_using_names();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+END;
 GO
 
-INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+IF XACT_STATE() = 1
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -232,7 +284,9 @@ GO
             base.Can_generate_idempotent_up_scripts();
 
             Assert.Equal(
-                @"IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+                @"SET XACT_ABORT ON;
+
+IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
 BEGIN
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
@@ -245,43 +299,61 @@ GO
 BEGIN TRANSACTION;
 GO
 
-IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+IF XACT_STATE() = 1
 BEGIN
-    CREATE TABLE [Table1] (
-        [Id] int NOT NULL,
-        [Foo] int NOT NULL,
-        CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
-    );
+    IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+    BEGIN
+        CREATE TABLE [Table1] (
+            [Id] int NOT NULL,
+            [Foo] int NOT NULL,
+            CONSTRAINT [PK_Table1] PRIMARY KEY ([Id])
+        );
+    END;
 END;
 GO
 
-IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+IF XACT_STATE() = 1
 BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+    IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+    BEGIN
+        INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+        VALUES (N'00000000000001_Migration1', N'7.0.0-test');
+    END;
 END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 BEGIN TRANSACTION;
 GO
 
-IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+IF XACT_STATE() = 1
 BEGIN
-    EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+    IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+    BEGIN
+        EXEC sp_rename N'[Table1].[Foo]', N'Bar', N'COLUMN';
+    END;
 END;
 GO
 
-IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+IF XACT_STATE() = 1
 BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+    IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+    BEGIN
+        INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+        VALUES (N'00000000000002_Migration2', N'7.0.0-test');
+    END;
 END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000003_Migration3')
@@ -299,14 +371,20 @@ GO
 BEGIN TRANSACTION;
 GO
 
-IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000003_Migration3')
+IF XACT_STATE() = 1
 BEGIN
-    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-    VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+    IF NOT EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000003_Migration3')
+    BEGIN
+        INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+        VALUES (N'00000000000003_Migration3', N'7.0.0-test');
+    END;
 END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -388,30 +466,50 @@ GO
             base.Can_generate_down_scripts();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+END;
 GO
 
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000002_Migration2';
+IF XACT_STATE() = 1
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2';
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 BEGIN TRANSACTION;
 GO
 
-DROP TABLE [Table1];
+IF XACT_STATE() = 1
+BEGIN
+    DROP TABLE [Table1];
+END;
 GO
 
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000001_Migration1';
+IF XACT_STATE() = 1
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000001_Migration1';
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -424,42 +522,62 @@ GO
             base.Can_generate_idempotent_down_scripts();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+IF XACT_STATE() = 1
 BEGIN
-    EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+    IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+    BEGIN
+        EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+    END;
 END;
 GO
 
-IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+IF XACT_STATE() = 1
 BEGIN
-    DELETE FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000002_Migration2';
+    IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000002_Migration2')
+    BEGIN
+        DELETE FROM [__EFMigrationsHistory]
+        WHERE [MigrationId] = N'00000000000002_Migration2';
+    END;
 END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 BEGIN TRANSACTION;
 GO
 
-IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+IF XACT_STATE() = 1
 BEGIN
-    DROP TABLE [Table1];
+    IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+    BEGIN
+        DROP TABLE [Table1];
+    END;
 END;
 GO
 
-IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+IF XACT_STATE() = 1
 BEGIN
-    DELETE FROM [__EFMigrationsHistory]
-    WHERE [MigrationId] = N'00000000000001_Migration1';
+    IF EXISTS(SELECT * FROM [__EFMigrationsHistory] WHERE [MigrationId] = N'00000000000001_Migration1')
+    BEGIN
+        DELETE FROM [__EFMigrationsHistory]
+        WHERE [MigrationId] = N'00000000000001_Migration1';
+    END;
 END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -472,17 +590,28 @@ GO
             base.Can_generate_one_down_script();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+END;
 GO
 
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000002_Migration2';
+IF XACT_STATE() = 1
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2';
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",
@@ -495,17 +624,28 @@ GO
             base.Can_generate_down_script_using_names();
 
             Assert.Equal(
-                @"BEGIN TRANSACTION;
+                @"SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
 GO
 
-EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+IF XACT_STATE() = 1
+BEGIN
+    EXEC sp_rename N'[Table1].[Bar]', N'Foo', N'COLUMN';
+END;
 GO
 
-DELETE FROM [__EFMigrationsHistory]
-WHERE [MigrationId] = N'00000000000002_Migration2';
+IF XACT_STATE() = 1
+BEGIN
+    DELETE FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'00000000000002_Migration2';
+END;
 GO
 
-COMMIT;
+IF XACT_STATE() = 1
+BEGIN
+    COMMIT;
+END;
 GO
 
 ",


### PR DESCRIPTION
- Start each migration script with `SET XACT_ABORT ON`
- Wrap each migration command in `IF XACT_STATE() = 1`

Fixes #22613


