### PR TITLE
Update API docs

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -408,7 +408,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Gets the underlying ADO.NET <see cref="DbConnection" /> for this <see cref="DbContext" />.
+        ///     <para>
+        ///         Gets the underlying ADO.NET <see cref="DbConnection" /> for this <see cref="DbContext" />.
+        ///     </para>
+        ///     <para>
+        ///         This connection should not be disposed if it was created by Entity Framework. Connections are created by
+        ///         Entity Framework when a connection string rather than a DbConnection object is passed to the the 'UseMyProvider'
+        ///         method for the database provider in use. Conversely, the application is responsible for disposing a DbConnection
+        ///         passed to Entity Framework in 'UseMtyProvider'.
+        ///     </para>
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
         /// <returns> The <see cref="DbConnection" /> </returns>
@@ -605,8 +613,19 @@ namespace Microsoft.EntityFrameworkCore
         ///         Sets the timeout (in seconds) to use for commands executed with this <see cref="DbContext" />.
         ///     </para>
         ///     <para>
-        ///         Note that the command timeout is distinct from the connection timeout, which is commonly
-        ///         set on the database connection string.
+        ///         If this value is set, then it is used to set <see cref="DbCommand.CommandTimeout" /> whenever Entity Framework creates a
+        ///         <see cref="DbCommand" /> to execute a query.
+        ///     </para>
+        ///     <para>
+        ///         If this value is not set, then the default value used is defined by the underlying ADO.NET data provider.
+        ///         Consult the documentation for the implementation of <see cref="DbCommand" /> in the ADO.NET data provider for details of
+        ///         default values, etc.
+        ///     </para>
+        ///     <para>
+        ///         Note that the command timeout is distinct from the connection timeout. Connection timeouts are usually
+        ///         configured in the connection string. More recently, some ADO.NET data providers are adding the capability
+        ///         to also set a command timeout in the connection string. A value set with this API for the command timeout
+        ///         will override any value set in the connection string.
         ///     </para>
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
@@ -619,8 +638,8 @@ namespace Microsoft.EntityFrameworkCore
         ///         Sets the timeout to use for commands executed with this <see cref="DbContext" />.
         ///     </para>
         ///     <para>
-        ///         Note that the command timeout is distinct from the connection timeout, which is commonly
-        ///         set on the database connection string.
+        ///         This is a sugar method allowing a <see cref="TimeSpan" /> to be used to set the value. It delegates to
+        ///         <see cref="SetCommandTimeout(DatabaseFacade,Nullable{int})" />.
         ///     </para>
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         This connection should not be disposed if it was created by Entity Framework. Connections are created by
         ///         Entity Framework when a connection string rather than a DbConnection object is passed to the the 'UseMyProvider'
         ///         method for the database provider in use. Conversely, the application is responsible for disposing a DbConnection
-        ///         passed to Entity Framework in 'UseMtyProvider'.
+        ///         passed to Entity Framework in 'UseMyProvider'.
         ///     </para>
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>

--- a/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
@@ -14,9 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///         Allows SQL Server specific configuration to be performed on <see cref="DbContextOptions" />.
     ///     </para>
     ///     <para>
-    ///         Instances of this class are returned from a call to
-    ///         <see
-    ///             cref="SqlServerDbContextOptionsExtensions.UseSqlServer(DbContextOptionsBuilder,string,System.Action{Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder})" />
+    ///         Instances of this class are returned from a call to <see cref="M:SqlServerDbContextOptionsExtensions.UseSqlServer" />
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
@@ -33,19 +31,43 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         /// <summary>
-        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     <para>
+        ///         Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
+        ///         error numbers for transient errors that can be retried.
+        ///     </para>
+        ///     <para>
+        ///         Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+        ///     </para>
         /// </summary>
         public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure()
             => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c));
 
         /// <summary>
-        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     <para>
+        ///         Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
+        ///         error numbers for transient errors that can be retried.
+        ///     </para>
+        ///     <para>
+        ///         A default value 30 seconds for the maximum default delay is used.
+        ///     </para>
         /// </summary>
         public virtual SqlServerDbContextOptionsBuilder EnableRetryOnFailure(int maxRetryCount)
             => ExecutionStrategy(c => new SqlServerRetryingExecutionStrategy(c, maxRetryCount));
 
         /// <summary>
-        ///     Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     <para>
+        ///         Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
+        ///         error numbers for transient errors that can be retried, but additional error numbers can also be supplied.
+        ///     </para>
         /// </summary>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
         /// <param name="maxRetryDelay"> The maximum delay between retries. </param>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -79,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         This method uses a double-dispatch mechanism to call one of the 'Generate' methods that are
-        ///         specific to a certain subtype of <see cref="MigrationOperation" />. Typically database providers
+        ///         This method uses a double-dispatch mechanism to call one of the <see cref="M:MigrationsSqlGenerator.Generate" /> methods
+        ///         that are specific to a certain subtype of <see cref="MigrationOperation" />. Typically database providers
         ///         will override these specific methods rather than this method. However, providers can override
         ///         this methods to handle provider-specific operations.
         ///     </para>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -79,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         This method uses a double-dispatch mechanism to call one of the <see cref="M:MigrationsSqlGenerator.Generate" /> methods
-        ///         that are specific to a certain subtype of <see cref="MigrationOperation" />. Typically database providers
+        ///         This method uses a double-dispatch mechanism to call the <see cref="M:MigrationsSqlGenerator.Generate" /> method
+        ///         that is specific to a certain subtype of <see cref="MigrationOperation" />. Typically database providers
         ///         will override these specific methods rather than this method. However, providers can override
         ///         this methods to handle provider-specific operations.
         ///     </para>

--- a/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
+++ b/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
@@ -12,20 +12,27 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     An <see cref="IExecutionStrategy" /> implementation for retrying failed executions
-    ///     on SQL Server.
+    ///     <para>
+    ///         An <see cref="IExecutionStrategy" /> implementation for retrying failed executions on SQL Server.
+    ///     </para>
+    ///     <para>
+    ///         This strategy is specifically tailored to SQL Server (including SQL Azure). It is pre-configured with
+    ///         error numbers for transient errors that can be retried. Additional error numbers to retry on can also be supplied.
+    ///     </para>
     /// </summary>
     public class SqlServerRetryingExecutionStrategy : ExecutionStrategy
     {
         private readonly ICollection<int> _additionalErrorNumbers;
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     <para>
+        ///         Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+        ///     </para>
         /// </summary>
         /// <param name="context"> The context on which the operations will be invoked. </param>
-        /// <remarks>
-        ///     The default retry limit is 6, which means that the total amount of time spent before failing is about a minute.
-        /// </remarks>
         public SqlServerRetryingExecutionStrategy(
             [NotNull] DbContext context)
             : this(context, DefaultMaxRetryCount)
@@ -33,7 +40,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     <para>
+        ///         Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         Default values of 6 for the maximum retry count and 30 seconds for the maximum default delay are used.
+        ///     </para>
         /// </summary>
         /// <param name="dependencies"> Parameter object containing service dependencies. </param>
         public SqlServerRetryingExecutionStrategy(
@@ -43,7 +55,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     <para>
+        ///         Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         A default value 30 seconds for the maximum default delay is used.
+        ///     </para>
         /// </summary>
         /// <param name="context"> The context on which the operations will be invoked. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
@@ -55,7 +72,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     <para>
+        ///         Creates a new instance of <see cref="SqlServerRetryingExecutionStrategy" />.
+        ///     </para>
+        ///     <para>
+        ///         A default value 30 seconds for the maximum default delay is used.
+        ///     </para>
         /// </summary>
         /// <param name="dependencies"> Parameter object containing service dependencies. </param>
         /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -153,8 +153,19 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Gets an <see cref="EntityEntry" /> for each entity being tracked by the context.
-        ///     The entries provide access to change tracking information and operations for each entity.
+        ///     <para>
+        ///         Returns an <see cref="EntityEntry" /> for each entity being tracked by the context.
+        ///         The entries provide access to change tracking information and operations for each entity.
+        ///     </para>
+        ///     <para>
+        ///         This method calls <see cref="DetectChanges" /> to ensure all entries returned reflect up-to-date state.
+        ///         Use <see cref="AutoDetectChangesEnabled" /> to prevent DetectChanges from being called automatically.
+        ///     </para>
+        ///     <para>
+        ///         Note that modification of entity state while iterating over the returned enumeration may result in
+        ///         an <see cref="InvalidOperationException" /> indicating that the collection was modified while enumerating.
+        ///         To avoid this, create a defensive copy using <see cref="Enumerable.ToList{TSource}" /> or similar before iterating.
+        ///     </para>
         /// </summary>
         /// <returns> An entry for each entity being tracked. </returns>
         public virtual IEnumerable<EntityEntry> Entries()

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
@@ -11,8 +11,13 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
-    ///     Provides access to change tracking information and operations for a node in a
-    ///     graph of entities that is being traversed.
+    ///     <para>
+    ///         Provides access to change tracking information and operations for a node in a
+    ///         graph of entities that is being traversed.
+    ///     </para>
+    ///     <para>
+    ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
+    ///     </para>
     /// </summary>
     public class EntityEntryGraphNode : IInfrastructure<InternalEntityEntry>
     {
@@ -40,18 +45,34 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         }
 
         /// <summary>
-        ///     Gets the entry tracking information about this entity.
+        ///     <para>
+        ///         An <see cref="EntityEntry" /> for the entity instance from which a navigation property was traversed to the the instance
+        ///         represented by this node.
+        ///     </para>
+        ///     <para>
+        ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
+        ///     </para>
         /// </summary>
         public virtual EntityEntry SourceEntry
             => _sourceEntry == null ? null : new EntityEntry(_sourceEntry);
 
         /// <summary>
-        ///     Gets the navigation property that is being traversed to reach this node in the graph.
+        ///     <para>
+        ///         Gets the navigation property that is being traversed to reach this node in the graph.
+        ///     </para>
+        ///     <para>
+        ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
+        ///     </para>
         /// </summary>
         public virtual INavigationBase InboundNavigation { get; }
 
         /// <summary>
-        ///     Gets the entry tracking information about this entity.
+        ///     <para>
+        ///         An <see cref="EntityEntry" /> for the entity instance represented by this node.
+        ///     </para>
+        ///     <para>
+        ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
+        ///     </para>
         /// </summary>
         public virtual EntityEntry Entry
             => new EntityEntry(_entry);
@@ -65,6 +86,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///         application code.
         ///     </para>
         /// </summary>
+        [EntityFrameworkInternal]
         InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance
             => _entry;
 

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -69,8 +69,8 @@ namespace Microsoft.EntityFrameworkCore
         ///         for logging done by this context.
         ///     </para>
         ///     <para>
-        ///         There is no need to call this method when using one of the 'AddDbContext' methods.
-        ///         'AddDbContext' will ensure that the <see cref="ILoggerFactory" /> used by EF is obtained from the
+        ///         There is no need to call this method when using one of the <see cref="M:EntityFrameworkServiceCollectionExtensions.AddDbContext" />
+        ///         methods. 'AddDbContext' will ensure that the <see cref="ILoggerFactory" /> used by EF is obtained from the
         ///         application service provider.
         ///     </para>
         ///     <para>

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -92,6 +92,10 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="LocalView{TEntity}.ToObservableCollection" /> for WPF binding, or
         ///         <see cref="LocalView{TEntity}.ToBindingList" /> for WinForms.
         ///     </para>
+        ///     <para>
+        ///         Note that this method calls <see cref="ChangeTracker.DetectChanges" /> unless
+        ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" /> has been set to <see langword="false" />.
+        ///     </para>
         /// </summary>
         public virtual LocalView<TEntity> Local
             => throw new NotImplementedException();

--- a/src/EFCore/Diagnostics/InterceptionResult.cs
+++ b/src/EFCore/Diagnostics/InterceptionResult.cs
@@ -5,7 +5,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
     ///     <para>
-    ///         Represents a result from an <see cref="IInterceptor" /> such as an 'IDbConnectionInterceptor' to allow
+    ///         Represents a result from an <see cref="IInterceptor" /> such as an <see cref="ISaveChangesInterceptor" /> to allow
     ///         suppression of the normal operation being intercepted.
     ///     </para>
     ///     <para>

--- a/src/EFCore/Diagnostics/InterceptionResult`.cs
+++ b/src/EFCore/Diagnostics/InterceptionResult`.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
     ///     <para>
-    ///         Represents a result from an <see cref="IInterceptor" /> such as an 'IDbCommandInterceptor' to allow
+    ///         Represents a result from an <see cref="IInterceptor" /> such as an <see cref="ISaveChangesInterceptor" /> to allow
     ///         suppression of the normal operation being intercepted.
     ///     </para>
     ///     <para>

--- a/src/EFCore/Diagnostics/WarningsConfigurationBuilder.cs
+++ b/src/EFCore/Diagnostics/WarningsConfigurationBuilder.cs
@@ -36,7 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
-        ///     Sets the default behavior when a warning is generated.
+        ///     <para>
+        ///         Sets the default behavior when a warning is generated.
+        ///     </para>
+        ///     <para>
+        ///         Event ID values can be found in <see cref="CoreEventId" /> and
+        ///         <see cref="T:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId" />.
+        ///         The database provider being used may also define provider-specific event IDs in a similar class.
+        ///     </para>
         /// </summary>
         /// <param name="warningBehavior"> The desired behavior. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
@@ -44,10 +51,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => WithOption(e => e.WithDefaultBehavior(warningBehavior));
 
         /// <summary>
-        ///     Causes an exception to be thrown when the specified event occurs, regardless of default configuration.
+        ///     <para>
+        ///         Causes an exception to be thrown when the specified event occurs, regardless of default configuration.
+        ///     </para>
+        ///     <para>
+        ///         Event ID values can be found in <see cref="CoreEventId" /> and
+        ///         <see cref="T:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId" />.
+        ///         The database provider being used may also define provider-specific event IDs in a similar class.
+        ///     </para>
         /// </summary>
         /// <param name="eventIds">
-        ///     The <see cref="CoreEventId" /> and 'RelationalEventId' for the warnings.
+        ///     The IDs for events to configure.
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual WarningsConfigurationBuilder Throw(
@@ -59,10 +73,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
-        ///     Causes an event to be logged, regardless of default configuration.
+        ///     <para>
+        ///         Causes an event to be logged, regardless of default configuration.
+        ///     </para>
+        ///     <para>
+        ///         Event ID values can be found in <see cref="CoreEventId" /> and
+        ///         <see cref="T:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId" />.
+        ///         The database provider being used may also define provider-specific event IDs in a similar class.
+        ///     </para>
         /// </summary>
         /// <param name="eventIds">
-        ///     The <see cref="CoreEventId" /> and 'RelationalEventId' for EF Core events.
+        ///     The IDs for events to configure.
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual WarningsConfigurationBuilder Log(
@@ -74,10 +95,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
-        ///     Causes an event to be logged at the specified level, regardless of default configuration.
+        ///     <para>
+        ///         Causes an event to be logged at the specified level, regardless of default configuration.
+        ///     </para>
+        ///     <para>
+        ///         Event ID values can be found in <see cref="CoreEventId" /> and
+        ///         <see cref="T:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId" />.
+        ///         The database provider being used may also define provider-specific event IDs in a similar class.
+        ///     </para>
         /// </summary>
         /// <param name="eventsAndLevels">
-        ///     The <see cref="CoreEventId" /> and 'RelationalEventId' for EF Core events.
+        ///     The event IDs and levels to configure.
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual WarningsConfigurationBuilder Log(
@@ -89,10 +117,17 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
-        ///     Causes nothing to happen when the specified event occurs, regardless of default configuration.
+        ///     <para>
+        ///         Causes nothing to happen when the specified event occurs, regardless of default configuration.
+        ///     </para>
+        ///     <para>
+        ///         Event ID values can be found in <see cref="CoreEventId" /> and
+        ///         <see cref="T:Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId" />.
+        ///         The database provider being used may also define provider-specific event IDs in a similar class.
+        ///     </para>
         /// </summary>
         /// <param name="eventIds">
-        ///     The <see cref="CoreEventId" /> and 'RelationalEventId' for EF Core events.
+        ///     The IDs for events to configure.
         /// </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual WarningsConfigurationBuilder Ignore(

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -20,9 +20,14 @@ namespace Microsoft.EntityFrameworkCore
             = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Property));
 
         /// <summary>
-        ///     Addresses a given property on an entity instance. This is useful when you want to reference a shadow state property in a
-        ///     LINQ query. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
-        ///     property in other scenarios.
+        ///     <para>
+        ///         Addresses a given property on an entity instance. This is useful when you want to reference a shadow state property in a
+        ///         LINQ query. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
+        ///         property in other scenarios.
+        ///     </para>
+        ///     <para>
+        ///         Note that this is a static method accessed through the top-level <see cref="EF" /> static type.
+        ///     </para>
         /// </summary>
         /// <example>
         ///     <para>
@@ -43,8 +48,13 @@ namespace Microsoft.EntityFrameworkCore
             => throw new InvalidOperationException(CoreStrings.PropertyMethodInvoked);
 
         /// <summary>
-        ///     Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
-        ///     Calling these methods in other contexts (e.g. LINQ to Objects) will throw a <see cref="NotSupportedException" />.
+        ///     <para>
+        ///         Provides CLR methods that get translated to database functions when used in LINQ to Entities queries.
+        ///         Calling these methods in other contexts (e.g. LINQ to Objects) will throw a <see cref="NotSupportedException" />.
+        ///     </para>
+        ///     <para>
+        ///         Note that this is a static property accessed through the top-level <see cref="EF" /> static type.
+        ///     </para>
         /// </summary>
         public static DbFunctions Functions
             => DbFunctions.Instance;

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -21,8 +21,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Addresses a given property on an entity instance. This is useful when you want to reference a shadow state property in a
-        ///         LINQ query. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
+        ///         References a given property on an entity instance. This is useful for shadow state properties, for which no CLR property exists. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
         ///         property in other scenarios.
         ///     </para>
         ///     <para>

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -41,15 +41,38 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <summary>
         ///     <para>
-        ///         Ensures that the database for the context exists. If it exists, no action is taken. If it does not
-        ///         exist then the database and all its schema are created. If the database exists, then no effort is made
-        ///         to ensure it is compatible with the model for this context.
+        ///         Ensures that the database for the context exists.
+        ///     </para>
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>
+        ///                 If the database exists and has any tables, then no action is taken. Nothing is done to ensure
+        ///                 the database schema is compatible with the Entity Framework model.
+        ///             </description>
+        ///         </item>
+        ///         <item>
+        ///             <description>
+        ///                 If the database exists but does not have any tables, then the Entity Framework model is used to
+        ///                 populate the database schema.
+        ///             </description>
+        ///         </item>
+        ///         <item>
+        ///             <description>
+        ///                 If the database does not exist, then the database is created and the Entity Framework model is used to
+        ///                 populate the database schema.
+        ///             </description>
+        ///         </item>
+        ///     </list>
+        ///     <para>
+        ///         It is common to use <see cref="EnsureCreated" /> immediately following <see cref="EnsureDeleted" /> when
+        ///         testing or prototyping using Entity Framework. This ensures that the database is in a clean state before each
+        ///         execution of the test/prototype. Note, however, that data in the database is not preserved.
         ///     </para>
         ///     <para>
-        ///         Note that this API does not use migrations to create the database. In addition, the database that is
+        ///         Note that this API does **not** use migrations to create the database. In addition, the database that is
         ///         created cannot be later updated using migrations. If you are targeting a relational database and using migrations,
-        ///         you can use the DbContext.Database.Migrate() method to ensure the database is created and all migrations
-        ///         are applied.
+        ///         then you can use <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.Migrate" />
+        ///         to ensure the database is created using migrations and that all migrations have been applied.
         ///     </para>
         /// </summary>
         /// <returns> <see langword="true" /> if the database is created, false if it already existed. </returns>
@@ -58,15 +81,38 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously ensures that the database for the context exists. If it exists, no action is taken. If it does not
-        ///         exist then the database and all its schema are created. If the database exists, then no effort is made
-        ///         to ensure it is compatible with the model for this context.
+        ///         Ensures that the database for the context exists.
+        ///     </para>
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>
+        ///                 If the database exists and has any tables, then no action is taken. Nothing is done to ensure
+        ///                 the database schema is compatible with the Entity Framework model.
+        ///             </description>
+        ///         </item>
+        ///         <item>
+        ///             <description>
+        ///                 If the database exists but does not have any tables, then the Entity Framework model is used to
+        ///                 populate the database schema.
+        ///             </description>
+        ///         </item>
+        ///         <item>
+        ///             <description>
+        ///                 If the database does not exist, then the database is created and the Entity Framework model is used to
+        ///                 populate the database schema.
+        ///             </description>
+        ///         </item>
+        ///     </list>
+        ///     <para>
+        ///         It is common to use <see cref="EnsureCreatedAsync" /> immediately following <see cref="EnsureDeletedAsync" /> when
+        ///         testing or prototyping using Entity Framework. This ensures that the database is in a clean state before each
+        ///         execution of the test/prototype. Note, however, that data in the database is not preserved.
         ///     </para>
         ///     <para>
-        ///         Note that this API does not use migrations to create the database. In addition, the database that is
+        ///         Note that this API does **not** use migrations to create the database. In addition, the database that is
         ///         created cannot be later updated using migrations. If you are targeting a relational database and using migrations,
-        ///         you can use the DbContext.Database.Migrate() method to ensure the database is created and all migrations
-        ///         are applied.
+        ///         then you can use <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.MigrateAsync" />
+        ///         to ensure the database is created using migrations and that all migrations have been applied.
         ///     </para>
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
@@ -86,6 +132,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         Warning: The entire database is deleted, and no effort is made to remove just the database objects that are used by
         ///         the model for this context.
         ///     </para>
+        ///     <para>
+        ///         It is common to use <see cref="EnsureCreated" /> immediately following <see cref="EnsureDeleted" /> when
+        ///         testing or prototyping using Entity Framework. This ensures that the database is in a clean state before each
+        ///         execution of the test/prototype. Note, however, that data in the database is not preserved.
+        ///     </para>
         /// </summary>
         /// <returns> <see langword="true" /> if the database is deleted, false if it did not exist. </returns>
         public virtual bool EnsureDeleted()
@@ -99,6 +150,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     <para>
         ///         Warning: The entire database is deleted, and no effort is made to remove just the database objects that are used by
         ///         the model for this context.
+        ///     </para>
+        ///     <para>
+        ///         It is common to use <see cref="EnsureCreatedAsync" /> immediately following <see cref="EnsureDeletedAsync" /> when
+        ///         testing or prototyping using Entity Framework. This ensures that the database is in a clean state before each
+        ///         execution of the test/prototype. Note, however, that data in the database is not preserved.
         ///     </para>
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
@@ -211,13 +267,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         if no transaction is in use.
         ///     </para>
         ///     <para>
-        ///         This property will be null unless one of the 'BeginTransaction' or 'UseTransaction' methods has
-        ///         been called, some of which are available as extension methods installed by EF providers.
+        ///         This property will be null unless one of the <see cref="M:BeginTransaction" />, <see cref="M:UseTransaction" />,
+        ///         <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.BeginTransaction" />, or
+        ///         <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.UseTransaction" />
+        ///         has been called.
         ///         No attempt is made to obtain a transaction from the current DbConnection or similar.
         ///     </para>
         ///     <para>
-        ///         For relational databases, the underlying DbTransaction can be obtained using the
-        ///         'Microsoft.EntityFrameworkCore.Storage.GetDbTransaction' extension method
+        ///         For relational databases, the underlying DbTransaction can be obtained using
+        ///         <see cref="M:Microsoft.EntityFrameworkCore.Storage.GetDbTransaction" />
         ///         on the returned <see cref="IDbContextTransaction" />.
         ///     </para>
         /// </summary>
@@ -249,8 +307,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     <para>
         ///         Returns the name of the database provider currently in use.
         ///         The name is typically the name of the provider assembly.
-        ///         It is usually easier to use a sugar method such as 'IsSqlServer()' instead of
-        ///         calling this method directly.
+        ///         It is usually easier to use a sugar method such as
+        ///         <see cref="M:Microsoft.EntityFrameworkCore.SqlServerDatabaseFacadeExtensions.IsSqlServer" />
+        ///         instead of calling this method directly.
         ///     </para>
         ///     <para>
         ///         This method can only be used after the <see cref="DbContext" /> has been configured because

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -53,13 +53,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         <item>
         ///             <description>
         ///                 If the database exists but does not have any tables, then the Entity Framework model is used to
-        ///                 populate the database schema.
+        ///                 create the database schema.
         ///             </description>
         ///         </item>
         ///         <item>
         ///             <description>
         ///                 If the database does not exist, then the database is created and the Entity Framework model is used to
-        ///                 populate the database schema.
+        ///                 create the database schema.
         ///             </description>
         ///         </item>
         ///     </list>
@@ -93,13 +93,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         <item>
         ///             <description>
         ///                 If the database exists but does not have any tables, then the Entity Framework model is used to
-        ///                 populate the database schema.
+        ///                 create the database schema.
         ///             </description>
         ///         </item>
         ///         <item>
         ///             <description>
         ///                 If the database does not exist, then the database is created and the Entity Framework model is used to
-        ///                 populate the database schema.
+        ///                 create the database schema.
         ///             </description>
         ///         </item>
         ///     </list>
@@ -267,14 +267,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         if no transaction is in use.
         ///     </para>
         ///     <para>
-        ///         This property will be null unless one of the <see cref="M:BeginTransaction" />, <see cref="M:UseTransaction" />,
+        ///         This property is null unless one of <see cref="M:BeginTransaction" />, <see cref="M:UseTransaction" />,
         ///         <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.BeginTransaction" />, or
         ///         <see cref="M:Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions.UseTransaction" />
         ///         has been called.
         ///         No attempt is made to obtain a transaction from the current DbConnection or similar.
         ///     </para>
         ///     <para>
-        ///         For relational databases, the underlying DbTransaction can be obtained using
+        ///         For relational databases, the underlying <see cref="T:System.Data.Common.DbTransaction" /> can be obtained using
         ///         <see cref="M:Microsoft.EntityFrameworkCore.Storage.GetDbTransaction" />
         ///         on the returned <see cref="IDbContextTransaction" />.
         ///     </para>

--- a/src/EFCore/Infrastructure/IModelCustomizer.cs
+++ b/src/EFCore/Infrastructure/IModelCustomizer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///     </para>
     ///     <para>
     ///         When replacing this service consider deriving the implementation from <see cref="ModelCustomizer" /> or
-    ///         'RelationalModelCustomizer' to preserve the default behavior.
+    ///         <see cref="T:Microsoft.EntityFrameworkCore.Infrastructure.RelationalModelCustomizer" /> to preserve the default behavior.
     ///     </para>
     ///     <para>
     ///         The service lifetime is <see cref="ServiceLifetime.Singleton" />. This means a single instance


### PR DESCRIPTION
* Document connection obtained from DatabaseFacade.GetDbConnection() should normally not be disposed Fixes #11415
* Add XML docs referencing how to determine the default CommandTimeout Fixes #17503
* Clarify behavior for EnsureExists with an empty database Fixes #17563
* A hyperlink to the DbContext.Database.Migrate() method would be useful Fixes #17571
* Default values for maxRetryCount, maxRetryDelay, and errorNumbersToAdd Fixes #17574
* Document that modifying entity states while iterating over entries can result in "Collection was modified" exception Fixes #18389
* Update API doc links to correctly reference external dependencies Fixes #18580
* Make it clearer how to access EF.Functions Fixes #21424
* Improve API docs for TrackGraph Fixes #22529
