### PR TITLE
5.0 Migrations: Correctly generate UseIdentityColumn(s) API in snapshot

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -132,8 +132,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
             switch (strategy)
             {
                 case SqlServerValueGenerationStrategy.IdentityColumn:
-                    var seed = GetAndRemove<int?>(SqlServerAnnotationNames.IdentitySeed);
-                    var increment = GetAndRemove<int?>(SqlServerAnnotationNames.IdentityIncrement);
+                    var seed = GetAndRemove<int?>(SqlServerAnnotationNames.IdentitySeed) ?? 1;
+                    var increment = GetAndRemove<int?>(SqlServerAnnotationNames.IdentityIncrement) ?? 1;
                     return new List<MethodCallCodeFragment>
                     {
                         new MethodCallCodeFragment(
@@ -142,8 +142,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
                                 : nameof(SqlServerPropertyBuilderExtensions.UseIdentityColumn),
                             (seed, increment) switch
                             {
-                                (null, null) => Array.Empty<object>(),
-                                (_, null) => new object[] { seed },
+                                (1, 1) => Array.Empty<object>(),
+                                (_, 1) => new object[] { seed },
                                 _ => new object[] { seed, increment }
                             })
                     };

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -696,6 +696,82 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Assert.Equal(ProductInfo.GetVersion(), modelFromSnapshot.GetProductVersion());
         }
 
+        [ConditionalFact]
+        public virtual void Model_use_identity_columns()
+        {
+            Test(
+                builder => builder.UseIdentityColumns(),
+                AddBoilerPlate(
+                    @"
+            modelBuilder
+                .UseIdentityColumns()
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
+                o =>
+                {
+                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
+                    Assert.Equal(1, o.GetIdentitySeed());
+                    Assert.Equal(1, o.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Model_use_identity_columns_custom_seed()
+        {
+            Test(
+                builder => builder.UseIdentityColumns(5),
+                AddBoilerPlate(
+                    @"
+            modelBuilder
+                .UseIdentityColumns(5)
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
+                o =>
+                {
+                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
+                    Assert.Equal(5, o.GetIdentitySeed());
+                    Assert.Equal(1, o.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Model_use_identity_columns_custom_increment()
+        {
+            Test(
+                builder => builder.UseIdentityColumns(increment: 5),
+                AddBoilerPlate(
+                    @"
+            modelBuilder
+                .UseIdentityColumns(1, 5)
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
+                o =>
+                {
+                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
+                    Assert.Equal(1, o.GetIdentitySeed());
+                    Assert.Equal(5, o.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Model_use_identity_columns_custom_seed_increment()
+        {
+            Test(
+                builder => builder.UseIdentityColumns(5, 5),
+                AddBoilerPlate(
+                    @"
+            modelBuilder
+                .UseIdentityColumns(5, 5)
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);"),
+                o =>
+                {
+                    Assert.Equal(5, o.GetAnnotations().Count());
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, o.GetValueGenerationStrategy());
+                    Assert.Equal(5, o.GetIdentitySeed());
+                    Assert.Equal(5, o.GetIdentityIncrement());
+                });
+        }
+
         #endregion
 
         #region EntityType
@@ -2997,6 +3073,166 @@ namespace RootNamespace
                 {
                     var property = o.FindEntityType("Building").FindProperty("Id");
                     Assert.Equal("int", property.GetColumnType());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Property_with_identity_column()
+        {
+            var modelBuilder = new ModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity(
+                "Building", b =>
+                {
+                    b.Property<int>("Id").UseIdentityColumn();
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Buildings");
+                });
+
+            Test(
+                model.FinalizeModel(),
+                AddBoilerPlate(
+                    @"
+
+            modelBuilder.Entity(""Building"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn();
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""Buildings"");
+                });"),
+                o =>
+                {
+                    var property = o.FindEntityType("Building").FindProperty("Id");
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetValueGenerationStrategy());
+                    Assert.Equal(1, property.GetIdentitySeed());
+                    Assert.Equal(1, property.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Property_with_identity_column_custom_seed()
+        {
+            var modelBuilder = new ModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity(
+                "Building", b =>
+                {
+                    b.Property<int>("Id").UseIdentityColumn(5);
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Buildings");
+                });
+
+            Test(
+                model.FinalizeModel(),
+                AddBoilerPlate(
+                    @"
+
+            modelBuilder.Entity(""Building"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn(5);
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""Buildings"");
+                });"),
+                o =>
+                {
+                    var property = o.FindEntityType("Building").FindProperty("Id");
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetValueGenerationStrategy());
+                    Assert.Equal(5, property.GetIdentitySeed());
+                    Assert.Equal(1, property.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Property_with_identity_column_custom_increment()
+        {
+            var modelBuilder = new ModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity(
+                "Building", b =>
+                {
+                    b.Property<int>("Id").UseIdentityColumn(increment: 5);
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Buildings");
+                });
+
+            Test(
+                model.FinalizeModel(),
+                AddBoilerPlate(
+                    @"
+
+            modelBuilder.Entity(""Building"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn(1, 5);
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""Buildings"");
+                });"),
+                o =>
+                {
+                    var property = o.FindEntityType("Building").FindProperty("Id");
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetValueGenerationStrategy());
+                    Assert.Equal(1, property.GetIdentitySeed());
+                    Assert.Equal(5, property.GetIdentityIncrement());
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Property_with_identity_column_custom_seed_increment()
+        {
+            var modelBuilder = new ModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity(
+                "Building", b =>
+                {
+                    b.Property<int>("Id").UseIdentityColumn(5, 5);
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Buildings");
+                });
+
+            Test(
+                model.FinalizeModel(),
+                AddBoilerPlate(
+                    @"
+
+            modelBuilder.Entity(""Building"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .HasColumnType(""int"")
+                        .UseIdentityColumn(5, 5);
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""Buildings"");
+                });"),
+                o =>
+                {
+                    var property = o.FindEntityType("Building").FindProperty("Id");
+                    Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, property.GetValueGenerationStrategy());
+                    Assert.Equal(5, property.GetIdentitySeed());
+                    Assert.Equal(5, property.GetIdentityIncrement());
                 });
         }
 


### PR DESCRIPTION
Resolves #22632

**Description**

In EF Core 3.1, for provider specific annotations we generated HasAnnotation in model snapshot, which we improved to generate specific fluent API calls. For particular API call `UseIdentityColumn` we set other annotations whose values are default values in the method parameter but when generating the code, we did not account for those default values correctly generating same API with arguments.

**Customer Impact**
This change in API causes a diff when adding new migration which can cause conflict. Further changing this after 5.0 would cause diff in other direction in future release.

**How found**

Customer reported on RC1.

**Test coverage**
We did not have proper coverage for round-tripping the API. Added tests for this API for all variations.

**Regression?**
Yes, from 3.1.

**Risk**
Low. Fix is localized, and only affect aforementioned API.