### PR TITLE
[5.0-rc2] Don't remove skip foreign key when join entity type is configured explicitly.

### DIFF
--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -79,7 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
                 {
                     if (foreignKey.PrincipalToDependent == null
-                        && foreignKey.DependentToPrincipal == null)
+                        && foreignKey.DependentToPrincipal == null
+                        && !foreignKey.GetReferencingSkipNavigations().Any())
                     {
                         entityType.Builder.HasNoRelationship(foreignKey, fromDataAnnotation: true);
                     }

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -26,6 +26,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Product>();
                 modelBuilder.Entity<CategoryBase>();
 
+                var sharedTypeName = nameof(Category) + nameof(Product);
+
+                modelBuilder.SharedTypeEntity<Dictionary<string, object>>(sharedTypeName);
+
                 var model = modelBuilder.FinalizeModel();
 
                 var productType = model.FindEntityType(typeof(Product));
@@ -39,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var productCategoryType = categoriesFk.DeclaringEntityType;
 
                 Assert.Equal(typeof(Dictionary<string, object>), productCategoryType.ClrType);
-                Assert.Equal(nameof(Category) + nameof(Product), productCategoryType.Name);
+                Assert.Equal(sharedTypeName, productCategoryType.Name);
                 Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
                 Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
                 Assert.Equal(2, productCategoryType.GetForeignKeys().Count());


### PR DESCRIPTION
Fixes #22521

### Description

Usually the shared-type join entity type is created by convention, but when the configuration source is upgraded to `Explicit` the declared foreign keys that are created by convention are misidentified as unnecessary and removed.

### Customer Impact

The issue only affects a new 5.0 feature - many-to-many when the join entity type created by convention is configured explicitly without configuring the associated foreign keys. The workaround is to configure the relationship fully, which requires 3-5 more lines of code.

### How found

Customer reported on RC1.

### Test coverage

This PR adds a test for the affected scenario. 

### Regression?

No, new feature in 5.0.

### Risk

Low. The fix only affects a new 5.0 feature and the issue is fixed by not removing a part of the configuration, which is generally safe.

