### PR TITLE
[5.0 RC2] Missing cancellation tokens for 5.0

### DIFF
--- a/src/EFCore/Query/Internal/EntityQueryable`.cs
+++ b/src/EFCore/Query/Internal/EntityQueryable`.cs
@@ -106,7 +106,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-            => _queryProvider.ExecuteAsync<IAsyncEnumerable<TResult>>(Expression).GetAsyncEnumerator(cancellationToken);
+            => _queryProvider
+                .ExecuteAsync<IAsyncEnumerable<TResult>>(Expression, cancellationToken)
+                .GetAsyncEnumerator(cancellationToken);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Storage/ExecutionStrategyExtensions.cs
+++ b/src/EFCore/Storage/ExecutionStrategyExtensions.cs
@@ -740,7 +740,7 @@ namespace Microsoft.EntityFrameworkCore
                     return s.Result;
                 }, async (c, s, ct) => new ExecutionResult<TResult>(
                     s.CommitFailed && await s.VerifySucceeded(s.State, ct).ConfigureAwait(false),
-                    s.Result));
+                    s.Result), cancellationToken);
 
         private sealed class ExecutionState<TState, TResult>
         {


### PR DESCRIPTION
Flows cancellation tokens in two cases where they were missing.

Discovered via code analysis as part of #22625