### PR TITLE
[5.0-rc2] Mark join entities as Added when either side is Added

### DIFF
--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysLeft.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysLeft.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
+{
+    public class GeneratedKeysLeft
+    {
+        public virtual int Id { get; set; }
+        public virtual string Name { get; set; }
+
+        public virtual ICollection<GeneratedKeysRight> Rights { get; } = new ObservableCollection<GeneratedKeysRight>();
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysRight.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysRight.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
+{
+    public class GeneratedKeysRight
+    {
+        public virtual int Id { get; set; }
+        public virtual string Name { get; set; }
+
+        public virtual ICollection<GeneratedKeysLeft> Lefts { get; } = new ObservableCollection<GeneratedKeysLeft>();
+    }
+}

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
@@ -22,6 +22,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
         public DbSet<EntityRoot> EntityRoots { get; set; }
         public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; }
         public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; }
+        public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; }
+        public DbSet<GeneratedKeysRight> GeneratedKeysRights { get; set; }
 
         public static void Seed(ManyToManyContext context)
             => ManyToManyData.Seed(context);
@@ -29,14 +31,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel
 
     public static class ManyToManyContextExtensions
     {
-        public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool> configureEntity)
+        public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool> configureEntity = null)
             where TEntity : class, new()
         {
             var isProxy = set.GetService<IDbContextOptions>().FindExtension<ProxiesOptionsExtension>()?.UseChangeTrackingProxies == true;
 
             var entity = isProxy ? set.CreateProxy() : new TEntity();
 
-            configureEntity(entity, isProxy);
+            configureEntity?.Invoke(entity, isProxy);
 
             return entity;
         }


### PR DESCRIPTION
Fixes #22647

**Description**

If the entity on either end of a many-to-many relationship is Added, then any join entity instance must be new since it references a new entity via a required relationship. This change improves the many-to-many experience by detecting this case.

**Customer Impact**

This is an improvement to the experience for the new many-to-many feature. Doing this now instead of in the future avoids a breaking change after 5.0. Therefore, doing this now will help customers have a seamless update to 6.0.

**How found**

Customer reported on RC1.

**Test coverage**

Added additional test coverage around this case.

**Regression?**

No; new feature.

**Risk**

Low; small change in behavior.
