### PR TITLE
[5.0-rc2] Undo GetColumnName behavior change

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
         private void GenerateColumnAttribute(IProperty property)
         {
-            var columnName = property.GetColumnName();
+            var columnName = property.GetColumnBaseName();
             var columnType = property.GetConfiguredColumnType();
 
             var delimitedColumnName = columnName != null && columnName != property.Name ? _code.Literal(columnName) : null;

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             IProperty property,
             IDictionary<string, IAnnotation> annotations)
         {
-            var columnName = property.GetColumnName();
+            var columnName = property.GetColumnBaseName();
             if (columnName == property.Name)
             {
                 annotations.Remove(RelationalAnnotationNames.ColumnName);

--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Append("_")
                 .Append(principalTableName)
                 .Append("_")
-                .AppendJoin(foreignKey.Properties.Select(p => p.GetColumnName()), "_")
+                .AppendJoin(foreignKey.Properties.Select(p => p.GetColumnBaseName()), "_")
                 .ToString();
 
             return Uniquifier.Truncate(name, foreignKey.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Append("IX_")
                 .Append(tableName)
                 .Append("_")
-                .AppendJoin(index.Properties.Select(p => p.GetColumnName()), "_")
+                .AppendJoin(index.Properties.Select(p => p.GetColumnBaseName()), "_")
                 .ToString();
 
             return Uniquifier.Truncate(baseName, index.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
                     .Append("AK_")
                     .Append(tableName)
                     .Append("_")
-                    .AppendJoin(key.Properties.Select(p => p.GetColumnName()), "_")
+                    .AppendJoin(key.Properties.Select(p => p.GetColumnBaseName()), "_")
                     .ToString();
             }
 

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -24,14 +24,26 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalPropertyExtensions
     {
         /// <summary>
-        ///     Returns the name of the column to which the property is mapped.
+        ///     Returns the name of the table column to which the property is mapped.
         /// </summary>
         /// <param name="property"> The property. </param>
-        /// <returns> The name of the column to which the property is mapped. </returns>
+        /// <returns> The name of the table column to which the property is mapped. </returns>
+        [Obsolete("Use the overload that takes a StoreObjectIdentifier")]
         public static string GetColumnName([NotNull] this IProperty property)
         {
             var annotation = property.FindAnnotation(RelationalAnnotationNames.ColumnName);
             return annotation != null ? (string)annotation.Value : property.GetDefaultColumnName();
+        }
+
+        /// <summary>
+        ///     Returns the base name of the column to which the property would be mapped.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The the base name of the column to which the property would be mapped. </returns>
+        public static string GetColumnBaseName([NotNull] this IProperty property)
+        {
+            var annotation = property.FindAnnotation(RelationalAnnotationNames.ColumnName);
+            return annotation != null ? (string)annotation.Value : property.GetDefaultColumnBaseName();
         }
 
         /// <summary>
@@ -86,11 +98,23 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Returns the default column name to which the property would be mapped.
+        ///     Returns the default table column name to which the property would be mapped.
         /// </summary>
         /// <param name="property"> The property. </param>
-        /// <returns> The default column name to which the property would be mapped. </returns>
+        /// <returns> The default table column name to which the property would be mapped. </returns>
+        [Obsolete("Use the overload that takes a StoreObjectIdentifier")]
         public static string GetDefaultColumnName([NotNull] this IProperty property)
+        {
+            var table = StoreObjectIdentifier.Create(property.DeclaringEntityType, StoreObjectType.Table);
+            return table == null ? property.GetDefaultColumnBaseName() : property.GetDefaultColumnName(table.Value);
+        }
+
+        /// <summary>
+        ///     Returns the default base name of the column to which the property would be mapped
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The default base column name to which the property would be mapped. </returns>
+        public static string GetDefaultColumnBaseName([NotNull] this IProperty property)
             => Uniquifier.Truncate(property.Name, property.DeclaringEntityType.Model.GetMaxIdentifierLength());
 
         /// <summary>
@@ -170,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore
                 entityType = ownerType;
             }
 
-            var baseName = property.GetDefaultColumnName();
+            var baseName = property.GetDefaultColumnBaseName();
             if (builder == null)
             {
                 return baseName;

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             foreach (var property in entityType.GetProperties())
             {
-                var columnName = property.GetColumnName();
+                var columnName = property.GetColumnBaseName();
                 if (columnName == null)
                 {
                     continue;

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => _migrationIdColumnName ??= EnsureModel()
                 .FindEntityType(typeof(HistoryRow))
                 .FindProperty(nameof(HistoryRow.MigrationId))
-                .GetColumnName();
+                .GetColumnBaseName();
 
         private IModel EnsureModel()
         {
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => _productVersionColumnName ??= EnsureModel()
                 .FindEntityType(typeof(HistoryRow))
                 .FindProperty(nameof(HistoryRow.ProductVersion))
-                .GetColumnName();
+                .GetColumnBaseName();
 
         /// <summary>
         ///     Overridden by database providers to generate SQL that tests for existence of the history table.

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -791,9 +791,9 @@ namespace TestNamespace
                 model =>
                 {
                     var entitType = model.FindEntityType("TestNamespace.Entity");
-                    Assert.Equal("propertyA", entitType.GetProperty("A").GetColumnName());
+                    Assert.Equal("propertyA", entitType.GetProperty("A").GetColumnBaseName());
                     Assert.Equal("nchar(10)", entitType.GetProperty("B").GetColumnType());
-                    Assert.Equal("random", entitType.GetProperty("C").GetColumnName());
+                    Assert.Equal("random", entitType.GetProperty("C").GetColumnBaseName());
                     Assert.Equal("varchar(200)", entitType.GetProperty("C").GetColumnType());
                 });
         }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 },
                 col1 =>
                 {
-                    Assert.Equal("created", col1.GetColumnName());
+                    Assert.Equal("created", col1.GetColumnBaseName());
                     Assert.Equal(ValueGenerated.OnAdd, col1.ValueGenerated);
                 },
                 col2 =>
@@ -221,12 +221,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 },
                 col3 =>
                 {
-                    Assert.Equal("modified", col3.GetColumnName());
+                    Assert.Equal("modified", col3.GetColumnBaseName());
                     Assert.Equal(ValueGenerated.OnAddOrUpdate, col3.ValueGenerated);
                 },
                 col4 =>
                 {
-                    Assert.Equal("occupation", col4.GetColumnName());
+                    Assert.Equal("occupation", col4.GetColumnBaseName());
                     Assert.Equal(typeof(string), col4.ClrType);
                     Assert.False(col4.IsColumnNullable());
                     Assert.Null(col4.GetMaxLength());
@@ -495,7 +495,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var model = (EntityType)_factory.Create(info, new ModelReverseEngineerOptions()).GetEntityTypes().Single();
 
             Assert.Equal("MyPk", model.FindPrimaryKey().GetName());
-            Assert.Equal(keyProps, model.FindPrimaryKey().Properties.Select(p => p.GetColumnName()).ToArray());
+            Assert.Equal(keyProps, model.FindPrimaryKey().Properties.Select(p => p.GetColumnBaseName()).ToArray());
         }
 
         [ConditionalFact]
@@ -1272,12 +1272,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         s1 =>
                         {
                             Assert.Equal("SanItized", s1.Name);
-                            Assert.Equal("San itized", s1.GetColumnName());
+                            Assert.Equal("San itized", s1.GetColumnBaseName());
                         },
                         s2 =>
                         {
                             Assert.Equal("SanItized1", s2.Name);
-                            Assert.Equal("San+itized", s2.GetColumnName());
+                            Assert.Equal("San+itized", s2.GetColumnBaseName());
                         });
                 },
                 ef2 =>
@@ -1286,7 +1286,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     Assert.Equal("EF1", ef2.Name);
                     var id = Assert.Single(ef2.GetProperties());
                     Assert.Equal("Id", id.Name);
-                    Assert.Equal("Id", id.GetColumnName());
+                    Assert.Equal("Id", id.GetColumnBaseName());
                 });
         }
 
@@ -1931,7 +1931,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 new ModelReverseEngineerOptions { UseDatabaseNames = useDatabaseNames, NoPluralize = noPluralize });
 
             var user = Assert.Single(model.GetEntityTypes().Where(e => e.GetTableName() == userTableName));
-            var id = Assert.Single(user.GetProperties().Where(p => p.GetColumnName() == "id"));
+            var id = Assert.Single(user.GetProperties().Where(p => p.GetColumnBaseName() == "id"));
             var foreignKey = Assert.Single(user.GetReferencingForeignKeys());
             if (useDatabaseNames && noPluralize)
             {

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/TableSharingConcurrencyTokenConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/TableSharingConcurrencyTokenConventionTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var concurrencyProperty = animal.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
             Assert.True(concurrencyProperty.IsConcurrencyToken);
             Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal("Version", concurrencyProperty.GetColumnBaseName());
             Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var concurrencyProperty = animal.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
             Assert.True(concurrencyProperty.IsConcurrencyToken);
             Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal("Version", concurrencyProperty.GetColumnBaseName());
             Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
 
             var cat = model.FindEntityType(typeof(Cat));
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             concurrencyProperty = animalHouse.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
             Assert.True(concurrencyProperty.IsConcurrencyToken);
             Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal("Version", concurrencyProperty.GetColumnBaseName());
             Assert.Equal(ValueGenerated.OnUpdate, concurrencyProperty.ValueGenerated);
 
             var theMovie = model.FindEntityType(typeof(TheMovie));
@@ -152,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var concurrencyProperty = personEntityType.FindProperty("_TableSharingConcurrencyTokenConvention_Version");
             Assert.True(concurrencyProperty.IsConcurrencyToken);
             Assert.True(concurrencyProperty.IsShadowProperty());
-            Assert.Equal("Version", concurrencyProperty.GetColumnName());
+            Assert.Equal("Version", concurrencyProperty.GetColumnBaseName());
             Assert.Equal(ValueGenerated.OnAddOrUpdate, concurrencyProperty.ValueGenerated);
         }
 

--- a/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
             Assert.Equal("Name", property.Name);
-            Assert.Equal("Eman", property.GetColumnName());
+            Assert.Equal("Eman", property.GetColumnBaseName());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Metadata/RelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalMetadataBuilderExtensionsTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.NotNull(propertyBuilder.IsFixedLength(true));
             Assert.True(propertyBuilder.Metadata.IsFixedLength());
             Assert.NotNull(propertyBuilder.HasColumnName("Splew"));
-            Assert.Equal("Splew", propertyBuilder.Metadata.GetColumnName());
+            Assert.Equal("Splew", propertyBuilder.Metadata.GetColumnBaseName());
             Assert.NotNull(propertyBuilder.HasColumnType("int"));
             Assert.Equal("int", propertyBuilder.Metadata.GetColumnType());
             Assert.NotNull(propertyBuilder.HasDefaultValue(1));
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.False(propertyBuilder.Metadata.IsFixedLength());
             Assert.NotNull(propertyBuilder.HasColumnName("Splow", fromDataAnnotation: true));
             Assert.Null(propertyBuilder.HasColumnName("Splod"));
-            Assert.Equal("Splow", propertyBuilder.Metadata.GetColumnName());
+            Assert.Equal("Splow", propertyBuilder.Metadata.GetColumnBaseName());
             Assert.NotNull(propertyBuilder.HasColumnType("varchar", fromDataAnnotation: true));
             Assert.Null(propertyBuilder.HasColumnType("int"));
             Assert.Equal("varchar", propertyBuilder.Metadata.GetColumnType());

--- a/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -64,16 +64,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 .Property(e => e.Name)
                 .Metadata;
 
-            Assert.Equal("Name", property.GetColumnName());
+            Assert.Equal("Name", property.GetColumnBaseName());
 
             property.SetColumnName("Eman");
 
             Assert.Equal("Name", property.Name);
-            Assert.Equal("Eman", property.GetColumnName());
+            Assert.Equal("Eman", property.GetColumnBaseName());
 
             property.SetColumnName(null);
 
-            Assert.Equal("Name", property.GetColumnName());
+            Assert.Equal("Name", property.GetColumnBaseName());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -72,13 +72,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var orderMapping = orderType.GetDefaultMappings().Single();
             Assert.True(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
-                new[] { nameof(Order.OrderId), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
+                new[] { nameof(Order.Id), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
                 orderMapping.ColumnMappings.Select(m => m.Property.Name));
 
             var ordersTable = orderMapping.Table;
             Assert.Equal(new[] { nameof(Order) }, ordersTable.EntityTypeMappings.Select(m => m.EntityType.DisplayName()));
             Assert.Equal(
-                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), "OrderDate", nameof(Order.OrderId) },
+                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.Id), "OrderDate" },
                 ordersTable.Columns.Select(m => m.Name));
             Assert.Equal("Order", ordersTable.Name);
             Assert.Null(ordersTable.Schema);
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.Same(orderType.GetViewMappings(), orderType.GetViewOrTableMappings());
             Assert.True(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
-                new[] { nameof(Order.OrderId), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
+                new[] { nameof(Order.Id), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
                 orderMapping.ColumnMappings.Select(m => m.Property.Name));
 
             var ordersView = orderMapping.View;
@@ -159,8 +159,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     "Details_BillingAddress_Street",
                     "Details_ShippingAddress_City",
                     "Details_ShippingAddress_Street",
-                    "OrderDate",
-                    nameof(Order.OrderId)
+                    nameof(Order.Id),
+                    "OrderDate"
                 },
                 ordersView.Columns.Select(m => m.Name));
             Assert.Equal("OrderView", ordersView.Name);
@@ -249,7 +249,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var orderMapping = orderType.GetTableMappings().Single();
             Assert.True(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
-                new[] { nameof(Order.OrderId), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
+                new[] { nameof(Order.Id), nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate) },
                 orderMapping.ColumnMappings.Select(m => m.Property.Name));
 
             var ordersTable = orderMapping.Table;
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Assert.Equal(
                 new[]
                 {
-                    nameof(Order.OrderId),
+                    nameof(Order.Id),
                     nameof(Order.AlternateId),
                     nameof(Order.CustomerId),
                     "Details_BillingAddress_City",
@@ -298,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var orderPkConstraint = orderPk.GetMappedConstraints().Single();
 
             Assert.Equal("PK_Order", orderPkConstraint.Name);
-            Assert.Equal(nameof(Order.OrderId), orderPkConstraint.Columns.Single().Name);
+            Assert.Equal(nameof(Order.Id), orderPkConstraint.Columns.Single().Name);
             Assert.Same(ordersTable, orderPkConstraint.Table);
             Assert.True(orderPkConstraint.GetIsPrimaryKey());
             Assert.Same(orderPkConstraint, ordersTable.UniqueConstraints.Last());
@@ -388,6 +388,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var orderDetailsPk = orderDetailsType.FindPrimaryKey();
             Assert.Same(orderPkConstraint, orderDetailsPk.GetMappedConstraints().Single());
 
+            var orderDetailsPkProperty = orderDetailsPk.Properties.Single();
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.Equal("Id", orderDetailsPkProperty.GetColumnName());
+#pragma warning restore CS0618 // Type or member is obsolete
+            Assert.Equal("OrderId", orderDetailsPkProperty.GetColumnBaseName());
+
             var billingAddressOwnership = orderDetailsType.FindNavigation(nameof(OrderDetails.BillingAddress)).ForeignKey;
             var billingAddressType = billingAddressOwnership.DeclaringEntityType;
 
@@ -395,7 +401,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var shippingAddressType = shippingAddressOwnership.DeclaringEntityType;
 
             Assert.Equal(
-                new[] { billingAddressType.FindPrimaryKey(), shippingAddressType.FindPrimaryKey(), orderPk, orderDetailsPk },
+                new[] { orderPk, billingAddressType.FindPrimaryKey(), shippingAddressType.FindPrimaryKey(), orderDetailsPk },
                 orderPkConstraint.MappedKeys);
 
             var orderDetailsDate = orderDetailsType.FindProperty(nameof(OrderDetails.OrderDate));
@@ -710,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             Assert.True(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
-                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate), nameof(Order.OrderId) },
+                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.Id), nameof(Order.OrderDate) },
                 orderMapping.ColumnMappings.Select(m => m.Property.Name));
 
             var ordersQuery = orderMapping.SqlQuery;
@@ -718,7 +724,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 new[] { orderType },
                 ordersQuery.EntityTypeMappings.Select(m => m.EntityType));
             Assert.Equal(
-                new[] { nameof(Order.CustomerId), nameof(Order.OrderDate), nameof(Order.OrderId), "SomeName" },
+                new[] { nameof(Order.CustomerId), nameof(Order.Id), nameof(Order.OrderDate), "SomeName" },
                 ordersQuery.Columns.Select(m => m.Name));
             Assert.Equal("Microsoft.EntityFrameworkCore.Metadata.RelationalModelTest+Order.MappedSqlQuery", ordersQuery.Name);
             Assert.Null(ordersQuery.Schema);
@@ -791,7 +797,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             Assert.True(orderMapping.IncludesDerivedTypes);
             Assert.Equal(
-                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.OrderDate), nameof(Order.OrderId) },
+                new[] { nameof(Order.AlternateId), nameof(Order.CustomerId), nameof(Order.Id), nameof(Order.OrderDate) },
                 orderMapping.ColumnMappings.Select(m => m.Property.Name));
 
             var ordersFunction = orderMapping.StoreFunction;
@@ -800,7 +806,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 new[] { orderType },
                 ordersFunction.EntityTypeMappings.Select(m => m.EntityType));
             Assert.Equal(
-                new[] { nameof(Order.CustomerId), nameof(Order.OrderDate), nameof(Order.OrderId), "SomeName" },
+                new[] { nameof(Order.CustomerId), nameof(Order.Id), nameof(Order.OrderDate), "SomeName" },
                 ordersFunction.Columns.Select(m => m.Name));
             Assert.Equal("GetOrders", ordersFunction.Name);
             Assert.Null(ordersFunction.Schema);
@@ -879,7 +885,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         private class Order
         {
-            public int OrderId { get; set; }
+            public int Id { get; set; }
             public Guid AlternateId { get; set; }
 
             public DateTime OrderDate { get; set; }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var entityBuilder = modelBuilder.Entity<A>();
 
-            Assert.Equal("Post Name", entityBuilder.Property(e => e.Name).Metadata.GetColumnName());
+            Assert.Equal("Post Name", entityBuilder.Property(e => e.Name).Metadata.GetColumnBaseName());
             Assert.Equal("DECIMAL", entityBuilder.Property(e => e.Name).Metadata.GetColumnType());
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var entityBuilder = modelBuilder.Entity<F>();
 
-            Assert.Equal("Post Name", entityBuilder.Property<string>(nameof(F.Name)).Metadata.GetColumnName());
+            Assert.Equal("Post Name", entityBuilder.Property<string>(nameof(F.Name)).Metadata.GetColumnBaseName());
             Assert.Equal("DECIMAL", entityBuilder.Property<string>(nameof(F.Name)).Metadata.GetColumnType());
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             RunConvention(propertyBuilder);
 
-            Assert.Equal("Post Name", propertyBuilder.Metadata.GetColumnName());
+            Assert.Equal("Post Name", propertyBuilder.Metadata.GetColumnBaseName());
             Assert.Equal("DECIMAL", propertyBuilder.Metadata.GetColumnType());
             Assert.Equal("Test column comment", propertyBuilder.Metadata.GetComment());
         }
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             RunConvention(propertyBuilder);
 
-            Assert.Equal("ExplicitName", propertyBuilder.Metadata.GetColumnName());
+            Assert.Equal("ExplicitName", propertyBuilder.Metadata.GetColumnBaseName());
             Assert.Equal("BYTE", propertyBuilder.Metadata.GetColumnType());
             Assert.Equal("ExplicitComment", propertyBuilder.Metadata.GetComment());
         }

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Non_public_annotations_are_enabled();
 
             var property = GetProperty<PrivateMemberAnnotationClass>(modelBuilder, "PersonFirstName");
-            Assert.Equal("dsdsd", property.GetColumnName());
+            Assert.Equal("dsdsd", property.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", property.GetColumnType());
 
             return modelBuilder;
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Field_annotations_are_enabled();
 
             var property = GetProperty<FieldAnnotationClass>(modelBuilder, "_personFirstName");
-            Assert.Equal("dsdsd", property.GetColumnName());
+            Assert.Equal("dsdsd", property.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", property.GetColumnType());
 
             return modelBuilder;
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_column_work_together();
 
             var relational = GetProperty<ColumnKeyAnnotationClass1>(modelBuilder, "PersonFirstName");
-            Assert.Equal("dsdsd", relational.GetColumnName());
+            Assert.Equal("dsdsd", relational.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", relational.GetColumnType());
 
             return modelBuilder;
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 "Unique_No",
-                modelBuilder.Model.FindEntityType(typeof(One)).FindProperty(nameof(One.UniqueNo)).GetColumnName());
+                modelBuilder.Model.FindEntityType(typeof(One)).FindProperty(nameof(One.UniqueNo)).GetColumnBaseName());
         }
 
         public override ModelBuilder DatabaseGeneratedOption_Identity_does_not_throw_on_noninteger_properties()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -31,15 +31,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             var cokeType = context.Model.FindEntityType(typeof(Coke));
             var teaType = context.Model.FindEntityType(typeof(Tea));
 
-            Assert.Equal("SugarGrams", cokeType.FindProperty("SugarGrams").GetColumnName());
-            Assert.Equal("CaffeineGrams", cokeType.FindProperty("CaffeineGrams").GetColumnName());
-            Assert.Equal("CokeCO2", cokeType.FindProperty("Carbonation").GetColumnName());
+            Assert.Equal("SugarGrams", cokeType.FindProperty("SugarGrams").GetColumnBaseName());
+            Assert.Equal("CaffeineGrams", cokeType.FindProperty("CaffeineGrams").GetColumnBaseName());
+            Assert.Equal("CokeCO2", cokeType.FindProperty("Carbonation").GetColumnBaseName());
 
-            Assert.Equal("SugarGrams", liltType.FindProperty("SugarGrams").GetColumnName());
-            Assert.Equal("LiltCO2", liltType.FindProperty("Carbonation").GetColumnName());
+            Assert.Equal("SugarGrams", liltType.FindProperty("SugarGrams").GetColumnBaseName());
+            Assert.Equal("LiltCO2", liltType.FindProperty("Carbonation").GetColumnBaseName());
 
-            Assert.Equal("CaffeineGrams", teaType.FindProperty("CaffeineGrams").GetColumnName());
-            Assert.Equal("HasMilk", teaType.FindProperty("HasMilk").GetColumnName());
+            Assert.Equal("CaffeineGrams", teaType.FindProperty("CaffeineGrams").GetColumnBaseName());
+            Assert.Equal("HasMilk", teaType.FindProperty("HasMilk").GetColumnBaseName());
         }
 
         public override async Task Can_query_when_shared_column(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
@@ -28,15 +28,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             var cokeType = context.Model.FindEntityType(typeof(Coke));
             var teaType = context.Model.FindEntityType(typeof(Tea));
 
-            Assert.Equal("SugarGrams", cokeType.FindProperty("SugarGrams").GetColumnName());
-            Assert.Equal("CaffeineGrams", cokeType.FindProperty("CaffeineGrams").GetColumnName());
-            Assert.Equal("CokeCO2", cokeType.FindProperty("Carbonation").GetColumnName());
+            Assert.Equal("SugarGrams", cokeType.FindProperty("SugarGrams").GetColumnBaseName());
+            Assert.Equal("CaffeineGrams", cokeType.FindProperty("CaffeineGrams").GetColumnBaseName());
+            Assert.Equal("CokeCO2", cokeType.FindProperty("Carbonation").GetColumnBaseName());
 
-            Assert.Equal("SugarGrams", liltType.FindProperty("SugarGrams").GetColumnName());
-            Assert.Equal("LiltCO2", liltType.FindProperty("Carbonation").GetColumnName());
+            Assert.Equal("SugarGrams", liltType.FindProperty("SugarGrams").GetColumnBaseName());
+            Assert.Equal("LiltCO2", liltType.FindProperty("Carbonation").GetColumnBaseName());
 
-            Assert.Equal("CaffeineGrams", teaType.FindProperty("CaffeineGrams").GetColumnName());
-            Assert.Equal("HasMilk", teaType.FindProperty("HasMilk").GetColumnName());
+            Assert.Equal("CaffeineGrams", teaType.FindProperty("CaffeineGrams").GetColumnBaseName());
+            Assert.Equal("HasMilk", teaType.FindProperty("HasMilk").GetColumnBaseName());
         }
 
         public override async Task Can_query_when_shared_column(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -118,10 +118,10 @@ SELECT @@ROWCOUNT;");
                 entityType2.GetKeys().Single().GetName());
             Assert.Equal(
                 "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCo~",
-                entityType2.GetProperties().ElementAt(1).GetColumnName());
+                entityType2.GetProperties().ElementAt(1).GetColumnBaseName());
             Assert.Equal(
                 "ExtraPropertyWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingC~1",
-                entityType2.GetProperties().ElementAt(2).GetColumnName());
+                entityType2.GetProperties().ElementAt(2).GetColumnBaseName());
             Assert.Equal(
                 "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWor~1",
                 entityType2.GetIndexes().Single().GetDatabaseName());

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -102,23 +102,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 .Property(e => e.Name)
                 .Metadata;
 
-            Assert.Equal("Name", property.GetColumnName());
+            Assert.Equal("Name", property.GetColumnBaseName());
             Assert.Null(((IConventionProperty)property).GetColumnNameConfigurationSource());
 
             ((IConventionProperty)property).SetColumnName("Eman", fromDataAnnotation: true);
 
-            Assert.Equal("Eman", property.GetColumnName());
+            Assert.Equal("Eman", property.GetColumnBaseName());
             Assert.Equal(ConfigurationSource.DataAnnotation, ((IConventionProperty)property).GetColumnNameConfigurationSource());
 
             property.SetColumnName("MyNameIs");
 
             Assert.Equal("Name", property.Name);
-            Assert.Equal("MyNameIs", property.GetColumnName());
+            Assert.Equal("MyNameIs", property.GetColumnBaseName());
             Assert.Equal(ConfigurationSource.Explicit, ((IConventionProperty)property).GetColumnNameConfigurationSource());
 
             property.SetColumnName(null);
 
-            Assert.Equal("Name", property.GetColumnName());
+            Assert.Equal("Name", property.GetColumnBaseName());
             Assert.Null(((IConventionProperty)property).GetColumnNameConfigurationSource());
         }
 

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -93,10 +93,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var property1 = modelBuilder.Model.FindEntityType(typeof(DisjointChildSubclass1)).FindProperty("ParentId");
                 Assert.True(property1.IsForeignKey());
-                Assert.Equal("ParentId", property1.GetColumnName());
+                Assert.Equal("ParentId", property1.GetColumnBaseName());
                 var property2 = modelBuilder.Model.FindEntityType(typeof(DisjointChildSubclass2)).FindProperty("ParentId");
                 Assert.True(property2.IsForeignKey());
-                Assert.Equal("DisjointChildSubclass2_ParentId", property2.GetColumnName());
+                Assert.Equal("DisjointChildSubclass2_ParentId", property2.GetColumnBaseName());
             }
 
             [ConditionalFact]
@@ -111,9 +111,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.FinalizeModel();
 
                 var property1 = modelBuilder.Model.FindEntityType(typeof(DisjointChildSubclass1)).FindProperty(nameof(Child.Name));
-                Assert.Equal(nameof(Child.Name), property1.GetColumnName());
+                Assert.Equal(nameof(Child.Name), property1.GetColumnBaseName());
                 var property2 = modelBuilder.Model.FindEntityType(typeof(DisjointChildSubclass2)).FindProperty(nameof(Child.Name));
-                Assert.Equal(nameof(Child.Name), property2.GetColumnName());
+                Assert.Equal(nameof(Child.Name), property2.GetColumnBaseName());
             }
 
             [ConditionalFact] //Issue#10659
@@ -526,7 +526,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Single(owned.GetIndexes());
                 Assert.Equal(
                     new[] { nameof(Order.OrderId), nameof(Order.AnotherCustomerId), nameof(Order.CustomerId) },
-                    owned.GetProperties().Select(p => p.GetColumnName()));
+                    owned.GetProperties().Select(p => p.GetColumnBaseName()));
                 Assert.Equal(nameof(Order), owned.GetTableName());
                 Assert.Null(owned.GetSchema());
                 Assert.True(owned.IsMemoryOptimized());

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Non_public_annotations_are_enabled();
 
             var relational = GetProperty<PrivateMemberAnnotationClass>(modelBuilder, "PersonFirstName");
-            Assert.Equal("dsdsd", relational.GetColumnName());
+            Assert.Equal("dsdsd", relational.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", relational.GetColumnType());
 
             return modelBuilder;
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Field_annotations_are_enabled();
 
             var relational = GetProperty<FieldAnnotationClass>(modelBuilder, "_personFirstName");
-            Assert.Equal("dsdsd", relational.GetColumnName());
+            Assert.Equal("dsdsd", relational.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", relational.GetColumnType());
 
             return modelBuilder;
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_column_work_together();
 
             var relational = GetProperty<ColumnKeyAnnotationClass1>(modelBuilder, "PersonFirstName");
-            Assert.Equal("dsdsd", relational.GetColumnName());
+            Assert.Equal("dsdsd", relational.GetColumnBaseName());
             Assert.Equal("nvarchar(128)", relational.GetColumnType());
 
             return modelBuilder;


### PR DESCRIPTION
Fixes #22608

### Description

In 5.0 complex mapping support was introduced allowing to map an entity type to multiple tables, views, functions and queries. This subtly changed the meaning of `GetColumnName` return type from a table column name to a base column name to be used for any mapping.

### Customer Impact

`GetColumnName` is used commonly for batch column name processing and the value returned for properties in owned types is different now compared to 3.1

### How found

Customer reported on RC1.

### Test coverage

This PR adds a test for the affected scenario. 

### Regression?

Yes.

### Risk

Low. The modified method isn't used internally after this change, so there is no danger of other features being affected.

