### PR TITLE
Fix the model in GraphUpdatesSqlServerTest.TptIdentity

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -1,11 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -81,21 +80,6 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_multiple_dependents_when_multiple_possible_principal_sides()
-            {
-            }
-
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_valid_first_dependent_when_multiple_possible_principal_sides()
-            {
-            }
-
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_valid_second_dependent_when_multiple_possible_principal_sides()
-            {
-            }
-
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
@@ -152,9 +136,6 @@ namespace Microsoft.EntityFrameworkCore
                     modelBuilder.Entity<OptionalOverlapping2>().ToTable(nameof(OptionalOverlapping2));
                     modelBuilder.Entity<BadCustomer>().ToTable(nameof(BadCustomer));
                     modelBuilder.Entity<BadOrder>().ToTable(nameof(BadOrder));
-                    modelBuilder.Entity<QuestTask>().ToTable(nameof(QuestTask));
-                    modelBuilder.Entity<QuizTask>().ToTable(nameof(QuizTask));
-                    modelBuilder.Entity<HiddenAreaTask>().ToTable(nameof(HiddenAreaTask));
                     modelBuilder.Entity<TaskChoice>().ToTable(nameof(TaskChoice));
                     modelBuilder.Entity<ParentAsAChild>().ToTable(nameof(ParentAsAChild));
                     modelBuilder.Entity<ChildAsAParent>().ToTable(nameof(ChildAsAParent));


### PR DESCRIPTION
The `QuestTask` hierarchy is designed to only be mapped as TPH because the leaves act as principals for the same FK property:

```C#
modelBuilder.Entity<QuizTask>()
    .HasMany(qt => qt.Choices)
    .WithOne()
    .HasForeignKey(tc => tc.QuestTaskId);

modelBuilder.Entity<HiddenAreaTask>()
    .HasMany(hat => hat.Choices)
    .WithOne()
    .HasForeignKey(tc => tc.QuestTaskId);
```

Fixes #22582


