### PR TITLE
Update issue templates to remove discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask_a_question.md
+++ b/.github/ISSUE_TEMPLATE/ask_a_question.md
@@ -1,14 +1,14 @@
 ---
-name: Bug in Entity Framework Core
-about: Create a report about something that isn't working
+name: Ask a question
+about: Ask a question about Entity Framework Core or Microsoft.Data.Sqlite
 labels: customer-reported
 ---
 
+## Please make your question as clear and specific as possible
+
 ### Include your code
 
-To fix any bug we mus first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
-
-It is often impossible for us to reproduce a bug when working with only code snippets since we have to guess at the missing code. 
+Usually the best way to ask a clear question and get a quick response is to show your code. Preferably, attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
 
 Use triple-tick code fences for any posted code. For example:
 
@@ -30,7 +30,7 @@ Unhandled exception. System.NullReferenceException: Object reference not set to 
 
 ### Include verbose output
 
-Please include `--verbose` output when filing bugs about the `dotnet ef` or Package Manager Console tools.
+Please include verbose output when asking questions about the `dotnet ef` or Package Manager Console tools.
 
 Use triple-tick fences for tool output. For example:
 

--- a/.github/ISSUE_TEMPLATE/ask_a_question.md
+++ b/.github/ISSUE_TEMPLATE/ask_a_question.md
@@ -4,7 +4,13 @@ about: Ask a question about Entity Framework Core or Microsoft.Data.Sqlite
 labels: customer-reported
 ---
 
-## Please make your question as clear and specific as possible
+## Ask a question
+
+Remember:
+
+* Please make your question as clear and specific as possible.
+* Please check that the [documentation](https://docs.microsoft.com/ef/) does not answer your question.
+* Please search in both [open](https://github.com/dotnet/efcore/issues) and [closed](https://github.com/dotnet/efcore/issues?q=is%3Aissue+is%3Aclosed) issues to check that your question has not already been answered.
 
 ### Include your code
 
@@ -47,6 +53,6 @@ BlogContext
 
 EF Core version:
 Database provider: (e.g. Microsoft.EntityFrameworkCore.SqlServer)
-Target framework: (e.g. .NET Core 3.0)
+Target framework: (e.g. .NET 5.0)
 Operating system:
 IDE: (e.g. Visual Studio 2019 16.3)

--- a/.github/ISSUE_TEMPLATE/bug_report_efcore.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_efcore.md
@@ -4,9 +4,16 @@ about: Create a report about something that isn't working
 labels: customer-reported
 ---
 
+## File a bug
+
+Remember:
+
+* Please check that the [documentation](https://docs.microsoft.com/ef/) does not explain the behavior you are seeing.
+* Please search in both [open](https://github.com/dotnet/efcore/issues) and [closed](https://github.com/dotnet/efcore/issues?q=is%3Aissue+is%3Aclosed) issues to check that your bug has not already been filed.
+
 ### Include your code
 
-To fix any bug we mus first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
+To fix any bug we must first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
 
 It is often impossible for us to reproduce a bug when working with only code snippets since we have to guess at the missing code. 
 
@@ -47,6 +54,6 @@ BlogContext
 
 EF Core version:
 Database provider: (e.g. Microsoft.EntityFrameworkCore.SqlServer)
-Target framework: (e.g. .NET Core 3.0)
+Target framework: (e.g. .NET 5.0)
 Operating system:
 IDE: (e.g. Visual Studio 2019 16.3)

--- a/.github/ISSUE_TEMPLATE/bug_report_sqlite.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_sqlite.md
@@ -4,28 +4,33 @@ about: Create a report about something that isn't working
 labels: area-adonet-sqlite, customer-reported
 ---
 
-<!-- Describe what isn't working as expected -->
+### Include your code
 
+To fix any bug we mus first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
 
+It is often impossible for us to reproduce a bug when working with only code snippets since we have to guess at the missing code. 
 
-### To Reproduce
+Use triple-tick code fences for any posted code. For example:
 
-<!--
-What steps can we follow to reproduce the issue?
-
-We ❤ code! Include a complete code listing or attach a simplified project
-
-``` C#
+```C#
 Console.WriteLine("Hello, World!");
 ```
 
-Got Exceptions? Include both the message and the stack trace
--->
+### Include stack traces
 
+Include the full exception message and stack trace for any exception you encounter.
 
+Use triple-tick fences for stack traces. For example:
 
-### Additional context
+```
+Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
+   at SixFour.Sub() in C:\Stuff\AllTogetherNow\SixFour\SixFour.cs:line 49
+   at SixFour.Main() in C:\Stuff\AllTogetherNow\SixFour\SixFour.cs:line 54
+```
+
+### Include version information
 
 Microsoft.Data.Sqlite version:
 Target framework: (e.g. .NET Core 3.0)
 Operating system:
+

--- a/.github/ISSUE_TEMPLATE/bug_report_sqlite.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_sqlite.md
@@ -4,11 +4,18 @@ about: Create a report about something that isn't working
 labels: area-adonet-sqlite, customer-reported
 ---
 
+## File a bug
+
+Remember:
+
+* Please check that the [documentation](https://docs.microsoft.com/ef/) does not explain the behavior you are seeing.
+* Please search in both [open](https://github.com/dotnet/efcore/issues) and [closed](https://github.com/dotnet/efcore/issues?q=is%3Aissue+is%3Aclosed) issues to check that your bug has not already been filed.
+
 ### Include your code
 
-To fix any bug we mus first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
+To fix any bug we must first reproduce it. To make this possible, please attach a small, runnable project or post a small, runnable code listing that reproduces what you are seeing.
 
-It is often impossible for us to reproduce a bug when working with only code snippets since we have to guess at the missing code. 
+It is often impossible for us to reproduce a bug when working with only code snippets since we have to guess at the missing code.
 
 Use triple-tick code fences for any posted code. For example:
 
@@ -31,6 +38,6 @@ Unhandled exception. System.NullReferenceException: Object reference not set to 
 ### Include version information
 
 Microsoft.Data.Sqlite version:
-Target framework: (e.g. .NET Core 3.0)
+Target framework: (e.g. .NET 5.0)
 Operating system:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Got a question?
-    url: https://github.com/dotnet/efcore/discussions/new
-    about: Please use discussions to ask a question about using the product.
   - name: Issue with ASP.NET Core
     url:  https://github.com/dotnet/aspnetcore/issues/new/choose
     about: Please open issues relating to ASP.NET Core in dotnet/aspnetcore.

--- a/src/EFCore/EF.cs
+++ b/src/EFCore/EF.cs
@@ -21,8 +21,9 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         References a given property on an entity instance. This is useful for shadow state properties, for which no CLR property exists. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
-        ///         property in other scenarios.
+        ///         References a given property or navigation on an entity instance. This is useful for shadow state properties, for
+        ///         which no CLR property exists. Currently this method can only be used in LINQ queries and can not be used to
+        ///         access the value assigned to a property in other scenarios.
         ///     </para>
         ///     <para>
         ///         Note that this is a static method accessed through the top-level <see cref="EF" /> static type.


### PR DESCRIPTION
Originally intended to just remove discussions, but this changed into add a template for asking a question, which itself changed into updating the templates.

Notes:
* Not sure if I'm dong this right
* Should the template text be in a comment?
* Should the template text be a template instead of instructions?
* Should we include real, runnable EF code as a starting point in the template?

Other suggestions?