### PR TITLE
[release/3.1] Fix issue where property with value generated on add is reseeded in every migration

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1794,10 +1794,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
                         foreach (var targetProperty in entry.EntityType.GetProperties())
                         {
+                            if (targetProperty.ValueGenerated != ValueGenerated.Never
+                                && targetProperty.ValueGenerated != ValueGenerated.OnAdd)
+                            {
+                                continue;
+                            }
+
                             var sourceProperty = diffContext.FindSource(targetProperty);
                             if (sourceProperty == null
-                                || !sourceEntityType.GetProperties().Contains(sourceProperty)
-                                || targetProperty.ValueGenerated != ValueGenerated.Never)
+                                || !sourceEntityType.GetProperties().Contains(sourceProperty))
                             {
                                 continue;
                             }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -671,6 +671,32 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [ConditionalFact]
+        public void Dont_reseed_value_with_value_generated_on_add_property()
+        {
+            Execute(
+                common =>
+                {
+                    common.Entity(
+                        "EntityWithValueGeneratedOnAddProperty",
+                        x =>
+                        {
+                            x.Property<int>("Id");
+                            x.Property<string>("ValueGeneratedOnAddProperty")
+                                .ValueGeneratedOnAdd();
+                            x.HasData(
+                                new
+                                {
+                                    Id = 1,
+                                    ValueGeneratedOnAddProperty = "Value"
+                                });
+                        });
+                },
+                source => { },
+                target => { },
+                operations => Assert.Equal(0, operations.Count));
+        }
+
+        [ConditionalFact]
         public void Dont_rebuild_index_with_equal_include()
         {
             Execute(


### PR DESCRIPTION
Fixes #21146

### Description

When using `ValueGeneratedOnAdd` on a property that is seeded it causes redundant `UpdateData` calls in every subsequent migration to be generated

This is porting a 5.0 fix for https://github.com/dotnet/efcore/issues/21661 (https://github.com/dotnet/efcore/commit/a8f0f4c4dfc94975bd318a6b5a5d3a627df1d5ba) to 3.1.x

### Customer Impact

This issue makes generating subsequent migrations very tedious as the redundant entries need to be found and removed manually, which is error-prone.

### How found

Multiple customer reports on 3.1.6.

### Test coverage

This PR adds a test for the affected scenario. 

### Regression?

Yes, from 3.0.3

### Risk

Low. The affected code path is only used for data seeding and the fix was validated in 5.0.

