### PR TITLE
[5.0] Use the schema of related ends for the join entity type by default

### DIFF
--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -47,12 +47,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
                 Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
                 Assert.Equal(2, productCategoryType.GetForeignKeys().Count());
-
-                Assert.Same(categoriesNavigation, productType.GetSkipNavigations().Single());
-                Assert.Same(productsNavigation, categoryType.GetSkipNavigations().Single());
-                Assert.Same(categoriesFk, productCategoryType.GetForeignKeys().Last());
-                Assert.Same(productsFk, productCategoryType.GetForeignKeys().First());
-                Assert.Equal(2, productCategoryType.GetForeignKeys().Count());
             }
 
             [ConditionalFact]


### PR DESCRIPTION
Fixes #22844

### Description

When using the new 5.0 feature many-to-many a join entity type will be used to establish the relationship. The schema it uses currently defaults to `null`, but in most scenarios it should be the same as the related entity types.

### Customer Impact

Since this affects a new feature fixing it after release would be a breaking change.

### How found

Customer report.

### Test coverage

This PR adds tests for the affected scenario. 

### Regression?

No

### Risk

Low. The change only affects many-to-many.