### PR TITLE
[5.0] Remove the correct conflicting skip navigation.

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (inverse?.Builder != null
                         && inverse.GetConfigurationSource() != ConfigurationSource.Explicit)
                     {
-                        inverse.DeclaringEntityType.Builder.HasNoSkipNavigation(conflictingSkipNavigation, configurationSource);
+                        inverse.DeclaringEntityType.Builder.HasNoSkipNavigation(inverse, configurationSource);
                     }
 
                     conflictingSkipNavigation.DeclaringEntityType.Builder.HasNoSkipNavigation(

--- a/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
@@ -13,6 +13,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public class InternalSkipNavigationBuilderTest
     {
         [ConditionalFact]
+        public void Can_only_override_lower_or_equal_source_SkipNavigation()
+        {
+            var builder = CreateInternalSkipNavigationBuilder();
+            IConventionSkipNavigation skipNavigation = builder.Metadata;
+
+            ((SkipNavigation)skipNavigation).SetConfigurationSource(ConfigurationSource.DataAnnotation);
+
+            var productEntity = skipNavigation.TargetEntityType.Builder;
+            Assert.Null(productEntity.HasRelationship(skipNavigation.DeclaringEntityType, null, nameof(Order.Products)));
+
+            Assert.NotNull(productEntity.HasRelationship(
+                skipNavigation.DeclaringEntityType, null, nameof(Order.Products), fromDataAnnotation: true));
+
+            Assert.Null(skipNavigation.Builder);
+            Assert.Empty(skipNavigation.DeclaringEntityType.GetSkipNavigations());
+        }
+
+        [ConditionalFact]
         public void Can_only_override_lower_or_equal_source_HasField()
         {
             var builder = CreateInternalSkipNavigationBuilder();


### PR DESCRIPTION
Fixes #22809

### Description

When an ambiguous many-to-many navigation is discovered the code was trying to remove the wrong navigation resulting in an exception.

### Customer Impact

This is happening by convention, before any user configuration is applied, so there is no straightforward workaround.

### How found

Customer report on daily build.

### Test coverage

This PR adds tests for the affected scenario. 

### Regression?

No.

### Risk

Low. The change only affects a new 5.0 feature many-to-many.