### PR TITLE
Disable auto-generating symbols.nupkgs

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,5 +2,6 @@
 <Project>
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
+      <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
    </PropertyGroup>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,6 +2,8 @@
 <Project>
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
+      <!-- This repo does its own symbol package generation.  Arcade's symbols.nupkg generation conflicts with the symbol package generation in 
+           this repo and causes confusion (due to empty symblos.nupkg's) in downstream processes -->
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/11032 which was discovered by post build signing.  Arcade was auto-generating some symbols.nupkgs in this repo, but this repo wasn't expecting them and didn't include them in the asset manifest.  The result was that post build signing validation would discover some symbols.nupkgs that it wasn't told to sign and validation would fail.
