### PR TITLE
[5.0] Add validation for seed data with skip navigations

### DIFF
--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2944,7 +2944,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var data = new List<Dictionary<string, object>>();
             var valueConverters = new Dictionary<string, ValueConverter>(StringComparer.Ordinal);
-            var properties = this.GetPropertiesAndNavigations().ToDictionary(p => p.Name);
+            var properties = GetProperties()
+                .Concat<IPropertyBase>(GetNavigations())
+                .Concat(GetSkipNavigations())
+                .ToDictionary(p => p.Name);
             foreach (var rawSeed in _data)
             {
                 var seed = new Dictionary<string, object>(StringComparer.Ordinal);
@@ -2958,13 +2961,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         ValueConverter valueConverter = null;
                         if (providerValues
+                            && propertyBase is IProperty property
                             && !valueConverters.TryGetValue(propertyBase.Name, out valueConverter))
                         {
-                            if (propertyBase is IProperty property)
-                            {
-                                valueConverter = property.GetTypeMapping().Converter;
-                            }
-
+                            valueConverter = property.GetTypeMapping().Converter;
                             valueConverters[propertyBase.Name] = valueConverter;
                         }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2334,7 +2334,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property);
 
         /// <summary>
-        ///     The seed entity for entity type '{entityType}' cannot be added because it has the navigation '{navigation}' set. To seed relationships,  add the related entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.
+        ///     The seed entity for entity type '{entityType}' cannot be added because it has the navigation '{navigation}' set. To seed relationships,  add the entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.
         /// </summary>
         public static string SeedDatumNavigation([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object relatedEntityType, [CanBeNull] object foreignKeyProperties)
             => string.Format(
@@ -2342,7 +2342,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, navigation, relatedEntityType, foreignKeyProperties);
 
         /// <summary>
-        ///     The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the navigation '{navigation}' set. To seed relationships, add the related entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}.
+        ///     The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the navigation '{navigation}' set. To seed relationships, add the entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}.
         /// </summary>
         public static string SeedDatumNavigationSensitive([CanBeNull] object entityType, [CanBeNull] object keyValue, [CanBeNull] object navigation, [CanBeNull] object relatedEntityType, [CanBeNull] object foreignKeyProperties)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1302,10 +1302,10 @@
     <value>The seed entity for entity type '{entityType}' cannot be added because no value was provided for the required property '{property}'.</value>
   </data>
   <data name="SeedDatumNavigation" xml:space="preserve">
-    <value>The seed entity for entity type '{entityType}' cannot be added because it has the navigation '{navigation}' set. To seed relationships,  add the related entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.</value>
+    <value>The seed entity for entity type '{entityType}' cannot be added because it has the navigation '{navigation}' set. To seed relationships,  add the entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.</value>
   </data>
   <data name="SeedDatumNavigationSensitive" xml:space="preserve">
-    <value>The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the navigation '{navigation}' set. To seed relationships, add the related entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}.</value>
+    <value>The seed entity for entity type '{entityType}' with the key value '{keyValue}' cannot be added because it has the navigation '{navigation}' set. To seed relationships, add the entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}.</value>
   </data>
   <data name="SeedDatumSignedNumericValue" xml:space="preserve">
     <value>The seed entity for entity type '{entityType}' cannot be added because a non-zero value is required for property '{property}'. Consider providing a negative value to avoid collisions with non-seed data.</value>

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -1215,6 +1215,37 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
+        public virtual void Detects_reference_navigations_in_seeds2(bool sensitiveDataLoggingEnabled)
+        {
+            var modelBuilder = CreateConventionalModelBuilder(sensitiveDataLoggingEnabled);
+            modelBuilder.Entity<Order>(
+                e =>
+                {
+                    e.HasMany(o => o.Products)
+                     .WithMany(p => p.Orders);
+                    e.HasData(
+                        new Order { Id = 1, Products = new List<Product> { new Product() } });
+                });
+
+            VerifyError(
+                sensitiveDataLoggingEnabled
+                    ? CoreStrings.SeedDatumNavigationSensitive(
+                        nameof(Order),
+                        $"{nameof(Order.Id)}:1",
+                        nameof(Order.Products),
+                        "OrderProduct (Dictionary<string, object>)",
+                        "{'OrdersId'}")
+                    : CoreStrings.SeedDatumNavigation(
+                        nameof(Order),
+                        nameof(Order.Products),
+                        "OrderProduct (Dictionary<string, object>)",
+                        "{'OrdersId'}"),
+                modelBuilder.Model);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
         public virtual void Detects_collection_navigations_in_seeds(bool sensitiveDataLoggingEnabled)
         {
             var modelBuilder = CreateConventionalModelBuilder(sensitiveDataLoggingEnabled);


### PR DESCRIPTION
Part of #22883

**Description**

Skip navigations (i.e. many-to-many navigations; new for 5.0) could contain entities when used in seed data. However they will be ignored.

**Customer Impact**

With this change EF will throw an exception explaining the supported way to add seed data. Making this change after 5.0 would be a bigger breaking change as more users could be affected.

**How found**

Code examination.

**Test coverage**

This PR adds tests for the affected case.

**Regression?**

No.

**Risk**

Low. The change only affects skip navigations, which are new in 5.0.
