### PR TITLE
Query: Use aliases when doing pushdown

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1086,7 +1086,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 else
                 {
                     var innerColumn = (SqlExpression)mapping.Value;
-                    var outerColumn = subquery.GenerateOuterColumn(innerColumn);
+                    var outerColumn = subquery.GenerateOuterColumn(innerColumn, mapping.Key.Last?.Name);
                     projectionMap[innerColumn] = outerColumn;
                     _projectionMapping[mapping.Key] = outerColumn;
                 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -5265,7 +5265,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         s.Name,
                         Gear = s.Members.Where(g => g.HasSoulPatch).Select(
-                            g => new { True = true, False = false }).FirstOrDefault()
+                            g => new { True1 = true, False1 = false }).FirstOrDefault()
                     }));
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -5935,14 +5935,14 @@ LEFT JOIN [LevelOne] AS [l1] ON [l].[Level1_Optional_Id] = [l1].[Id]");
             await base.Composite_key_join_on_groupby_aggregate_projecting_only_grouping_key(async);
 
             AssertSql(
-                @"SELECT [t].[c]
+                @"SELECT [t].[Key]
 FROM [LevelOne] AS [l]
 INNER JOIN (
-    SELECT [l0].[Id] % 3 AS [c], COALESCE(SUM([l0].[Id]), 0) AS [c0]
+    SELECT [l0].[Id] % 3 AS [Key], COALESCE(SUM([l0].[Id]), 0) AS [Sum]
     FROM [LevelTwo] AS [l0]
     GROUP BY [l0].[Id] % 3
-) AS [t] ON ([l].[Id] = [t].[c]) AND (CAST(1 AS bit) = CASE
-    WHEN [t].[c0] > 10 THEN CAST(1 AS bit)
+) AS [t] ON ([l].[Id] = [t].[Key]) AND (CAST(1 AS bit) = CASE
+    WHEN [t].[Sum] > 10 THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END)");
         }
@@ -5959,11 +5959,11 @@ END AS [Foo]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN (
-    SELECT [l1].[Name], COUNT(*) AS [c]
+    SELECT [l1].[Name] AS [Key], COUNT(*) AS [Count]
     FROM [LevelThree] AS [l1]
     GROUP BY [l1].[Name]
-) AS [t] ON [l].[Name] = [t].[Name]
-WHERE [l0].[Name] IS NOT NULL OR ([t].[c] > 0)");
+) AS [t] ON [l].[Name] = [t].[Key]
+WHERE [l0].[Name] IS NOT NULL OR ([t].[Count] > 0)");
         }
 
         public override async Task Collection_FirstOrDefault_property_accesses_in_projection(bool async)
@@ -6034,13 +6034,12 @@ WHERE [l2].[Id] < 2");
         {
             await base.Projecting_columns_with_same_name_from_different_entities_making_sure_aliasing_works_after_Distinct(async);
 
-            // see #22915
             AssertSql(
                 @"@__p_0='10'
 
-SELECT [t].[Id] AS [Foo], [t].[Id0] AS [Bar], [t].[Id1] AS [Baz]
+SELECT [t].[Id1] AS [Foo], [t].[Id2] AS [Bar], [t].[Id3] AS [Baz]
 FROM (
-    SELECT DISTINCT TOP(@__p_0) [l].[Id], [l0].[Id] AS [Id0], [l1].[Id] AS [Id1], [l].[Name], [l0].[Name] AS [Name0]
+    SELECT DISTINCT TOP(@__p_0) [l].[Id] AS [Id1], [l0].[Id] AS [Id2], [l1].[Id] AS [Id3], [l].[Name] AS [Name1], [l0].[Name] AS [Name2]
     FROM [LevelOne] AS [l]
     INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
     INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -4782,12 +4782,12 @@ FROM [Squads] AS [s]");
             await base.Select_subquery_projecting_single_constant_inside_anonymous(async);
 
             AssertSql(
-                @"SELECT [s].[Name], [t0].[c]
+                @"SELECT [s].[Name], [t0].[One]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t].[c], [t].[SquadId]
+    SELECT [t].[One], [t].[SquadId]
     FROM (
-        SELECT 1 AS [c], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
+        SELECT 1 AS [One], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
         FROM [Gears] AS [g]
         WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
     ) AS [t]
@@ -4800,12 +4800,12 @@ LEFT JOIN (
             await base.Select_subquery_projecting_multiple_constants_inside_anonymous(async);
 
             AssertSql(
-                @"SELECT [s].[Name], [t0].[c], [t0].[c0], [t0].[c1]
+                @"SELECT [s].[Name], [t0].[True1], [t0].[False1], [t0].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t].[c], [t].[c0], [t].[c1], [t].[SquadId]
+    SELECT [t].[True1], [t].[False1], [t].[c], [t].[SquadId]
     FROM (
-        SELECT CAST(1 AS bit) AS [c], CAST(0 AS bit) AS [c0], 1 AS [c1], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
+        SELECT CAST(1 AS bit) AS [True1], CAST(0 AS bit) AS [False1], 1 AS [c], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
         FROM [Gears] AS [g]
         WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
     ) AS [t]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1314,13 +1314,13 @@ ORDER BY COUNT(*), [o].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
 ) AS [t]
 INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]
-INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [t].[LastOrderID] = [o0].[OrderID]");
         }
 
         public override async Task Join_GroupBy_Aggregate_multijoins(bool async)
@@ -1331,12 +1331,12 @@ INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
+INNER JOIN [Orders] AS [o0] ON [t].[LastOrderID] = [o0].[OrderID]");
         }
 
         public override async Task Join_GroupBy_Aggregate_single_join(bool async)
@@ -1344,10 +1344,10 @@ INNER JOIN [Orders] AS [o0] ON [t].[c] = [o0].[OrderID]");
             await base.Join_GroupBy_Aggregate_single_join(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [LastOrderID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[LastOrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
@@ -1359,10 +1359,10 @@ INNER JOIN (
             await base.Join_GroupBy_Aggregate_with_another_join(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [LastOrderID], [o0].[OrderID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[LastOrderID], [o0].[OrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
@@ -1375,10 +1375,10 @@ INNER JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]");
             await base.Join_GroupBy_Aggregate_with_left_join(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [LastOrderID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[LastOrderID]
 FROM [Customers] AS [c]
 LEFT JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
@@ -1411,14 +1411,14 @@ WHERE [o].[OrderID] < 10400");
             await base.Join_GroupBy_Aggregate_on_key(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [LastOrderID]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[LastOrderID]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderID]) AS [c]
+    SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderID]) AS [LastOrderID]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
     HAVING COUNT(*) > 5
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]");
+) AS [t] ON [c].[CustomerID] = [t].[Key]");
         }
 
         public override async Task GroupBy_with_result_selector(bool async)
@@ -2091,12 +2091,12 @@ GROUP BY [c].[City]");
             await base.GroupBy_based_on_renamed_property_complex(async);
 
             AssertSql(
-                @"SELECT [t].[City] AS [Key], COUNT(*) AS [Count]
+                @"SELECT [t].[Renamed] AS [Key], COUNT(*) AS [Count]
 FROM (
-    SELECT DISTINCT [c].[City], [c].[CustomerID]
+    SELECT DISTINCT [c].[City] AS [Renamed], [c].[CustomerID]
     FROM [Customers] AS [c]
 ) AS [t]
-GROUP BY [t].[City]");
+GROUP BY [t].[Renamed]");
         }
 
         public override async Task Join_groupby_anonymous_orderby_anonymous_projection(bool async)
@@ -2267,13 +2267,13 @@ GROUP BY [o].[CustomerID]");
             await base.GroupBy_aggregate_join_with_grouping_key(async);
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [Count]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[Count]
 FROM (
-    SELECT [o].[CustomerID], COUNT(*) AS [c]
+    SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
 ) AS [t]
-INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+INNER JOIN [Customers] AS [c] ON [t].[Key] = [c].[CustomerID]");
         }
 
         public override async Task GroupBy_aggregate_join_with_group_result(bool async)
@@ -2283,11 +2283,11 @@ INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
             AssertSql(
                 @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM (
-    SELECT [o].[CustomerID], MAX([o].[OrderDate]) AS [c]
+    SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderDate]) AS [LastOrderDate]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
 ) AS [t]
-INNER JOIN [Orders] AS [o0] ON (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) AND (([t].[c] = [o0].[OrderDate]) OR ([t].[c] IS NULL AND [o0].[OrderDate] IS NULL))");
+INNER JOIN [Orders] AS [o0] ON (([t].[Key] = [o0].[CustomerID]) OR ([t].[Key] IS NULL AND [o0].[CustomerID] IS NULL)) AND (([t].[LastOrderDate] = [o0].[OrderDate]) OR ([t].[LastOrderDate] IS NULL AND [o0].[OrderDate] IS NULL))");
         }
 
         public override async Task GroupBy_aggregate_from_right_side_of_join(bool async)
@@ -2297,14 +2297,14 @@ INNER JOIN [Orders] AS [o0] ON (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[
             AssertSql(
                 @"@__p_0='10'
 
-SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[c] AS [Max]
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[Max]
 FROM [Customers] AS [c]
 INNER JOIN (
-    SELECT [o].[CustomerID], MAX([o].[OrderDate]) AS [c]
+    SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderDate]) AS [Max]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
-) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
-ORDER BY [t].[c], [c].[CustomerID]
+) AS [t] ON [c].[CustomerID] = [t].[Key]
+ORDER BY [t].[Max], [c].[CustomerID]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY");
         }
 
@@ -2313,18 +2313,18 @@ OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY");
             await base.GroupBy_aggregate_join_another_GroupBy_aggregate(async);
 
             AssertSql(
-                @"SELECT [t].[CustomerID] AS [Key], [t].[c] AS [Total], [t0].[c] AS [ThatYear]
+                @"SELECT [t].[Key], [t].[Total], [t0].[ThatYear]
 FROM (
-    SELECT [o].[CustomerID], COUNT(*) AS [c]
+    SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Total]
     FROM [Orders] AS [o]
     GROUP BY [o].[CustomerID]
 ) AS [t]
 INNER JOIN (
-    SELECT [o0].[CustomerID], COUNT(*) AS [c]
+    SELECT [o0].[CustomerID] AS [Key], COUNT(*) AS [ThatYear]
     FROM [Orders] AS [o0]
     WHERE DATEPART(year, [o0].[OrderDate]) = 1997
     GROUP BY [o0].[CustomerID]
-) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]");
+) AS [t0] ON [t].[Key] = [t0].[Key]");
         }
 
         public override async Task GroupBy_with_grouping_key_using_Like(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -2359,11 +2359,11 @@ WHERE [c].[CustomerID] LIKE N'A%'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT DISTINCT [o].[CustomerID], [o].[OrderID]
+    SELECT DISTINCT [o].[CustomerID] AS [Id], [o].[OrderID] AS [Count]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
 ) AS [t]
-INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+INNER JOIN [Customers] AS [c] ON [t].[Id] = [c].[CustomerID]");
         }
 
         public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server_2(bool async)
@@ -2373,11 +2373,11 @@ INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
-    SELECT DISTINCT [o].[CustomerID], [o].[OrderID]
+    SELECT DISTINCT [o].[CustomerID] AS [Id], [o].[OrderID] AS [Count]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
 ) AS [t]
-INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
+INNER JOIN [Customers] AS [c] ON [t].[Id] = [c].[CustomerID]");
         }
 
         public override void Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server()
@@ -2385,10 +2385,10 @@ INNER JOIN [Customers] AS [c] ON [t].[CustomerID] = [c].[CustomerID]");
             base.Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[CustomerID] AS [Id], [t].[OrderID] AS [Count]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[Id], [t].[Count]
 FROM [Customers] AS [c]
 CROSS JOIN (
-    SELECT DISTINCT [o].[CustomerID], [o].[OrderID]
+    SELECT DISTINCT [o].[CustomerID] AS [Id], [o].[OrderID] AS [Count]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] < 10300
 ) AS [t]
@@ -3703,12 +3703,12 @@ WHERE ([c].[CustomerID] + COALESCE([c].[City], N'')) = N'ALFKIBerlin'");
             await base.Anonymous_complex_distinct_orderby(async);
 
             AssertSql(
-                @"SELECT [t].[c] AS [A]
+                @"SELECT [t].[A]
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
     FROM [Customers] AS [c]
 ) AS [t]
-ORDER BY [t].[c]");
+ORDER BY [t].[A]");
         }
 
         public override async Task Anonymous_complex_distinct_result(bool async)
@@ -3718,10 +3718,10 @@ ORDER BY [t].[c]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [A]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[c] IS NOT NULL AND ([t].[c] LIKE N'A%')");
+WHERE [t].[A] IS NOT NULL AND ([t].[A] LIKE N'A%')");
         }
 
         public override async Task Anonymous_complex_orderby(bool async)
@@ -3771,12 +3771,12 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             await base.DTO_member_distinct_orderby(async);
 
             AssertSql(
-                @"SELECT [t].[CustomerID] AS [Property]
+                @"SELECT [t].[Property]
 FROM (
-    SELECT DISTINCT [c].[CustomerID]
+    SELECT DISTINCT [c].[CustomerID] AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-ORDER BY [t].[CustomerID]");
+ORDER BY [t].[Property]");
         }
 
         public override async Task DTO_member_distinct_result(bool async)
@@ -3786,10 +3786,10 @@ ORDER BY [t].[CustomerID]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID]
+    SELECT DISTINCT [c].[CustomerID] AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[CustomerID] LIKE N'A%'");
+WHERE [t].[Property] LIKE N'A%'");
         }
 
         public override async Task DTO_complex_distinct_where(bool async)
@@ -3807,12 +3807,12 @@ WHERE ([c].[CustomerID] + COALESCE([c].[City], N'')) = N'ALFKIBerlin'");
             await base.DTO_complex_distinct_orderby(async);
 
             AssertSql(
-                @"SELECT [t].[c] AS [Property]
+                @"SELECT [t].[Property]
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-ORDER BY [t].[c]");
+ORDER BY [t].[Property]");
         }
 
         public override async Task DTO_complex_distinct_result(bool async)
@@ -3822,10 +3822,10 @@ ORDER BY [t].[c]");
             AssertSql(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [c]
+    SELECT DISTINCT [c].[CustomerID] + COALESCE([c].[City], N'') AS [Property]
     FROM [Customers] AS [c]
 ) AS [t]
-WHERE [t].[c] IS NOT NULL AND ([t].[c] LIKE N'A%')");
+WHERE [t].[Property] IS NOT NULL AND ([t].[Property] LIKE N'A%')");
         }
 
         public override async Task DTO_complex_orderby(bool async)
@@ -5280,7 +5280,7 @@ ORDER BY [c].[CustomerID]");
             AssertSql(
                 @"@__p_0='91'
 
-SELECT [t0].[City] AS [c1], [t1].[City], [t1].[City0] AS [c1]
+SELECT [t0].[City] AS [c1], [t1].[City], [t1].[c1]
 FROM (
     SELECT DISTINCT [t].[City]
     FROM (
@@ -5289,7 +5289,7 @@ FROM (
     ) AS [t]
 ) AS [t0]
 CROSS APPLY (
-    SELECT TOP(9) [e].[City], [t0].[City] AS [City0]
+    SELECT TOP(9) [e].[City], [t0].[City] AS [c1]
     FROM [Employees] AS [e]
     WHERE ([t0].[City] = [e].[City]) OR ([t0].[City] IS NULL AND [e].[City] IS NULL)
 ) AS [t1]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1161,10 +1161,10 @@ ORDER BY [c].[CustomerID], [t].[OrderID]");
             await base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async);
 
             AssertSql(
-                @"SELECT [t].[CustomerID] AS [OrderProperty], [t].[CustomerID0] AS [CustomerProperty]
+                @"SELECT [t].[OrderProperty], [t].[CustomerProperty]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [o].[CustomerID], [c].[CustomerID] AS [CustomerID0]
+    SELECT [o].[CustomerID] AS [OrderProperty], [c].[CustomerID] AS [CustomerProperty]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]");
@@ -1233,10 +1233,10 @@ WHERE [o].[OrderID] = 10243");
             await base.SelectMany_whose_selector_references_outer_source(async);
 
             AssertSql(
-                @"SELECT [t].[OrderDate], [t].[City] AS [CustomerCity]
+                @"SELECT [t].[OrderDate], [t].[CustomerCity]
 FROM [Customers] AS [c]
 CROSS APPLY (
-    SELECT [o].[OrderDate], [c].[City]
+    SELECT [o].[OrderDate], [c].[City] AS [CustomerCity]
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]");
@@ -1520,9 +1520,9 @@ OFFSET @__p_0 ROWS");
             await base.Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(async);
 
             AssertSql(
-                @"SELECT (COALESCE([t].[c], N'') + N' ') + [t].[c0] AS [Aggregate]
+                @"SELECT (COALESCE([t].[FirstLetter], N'') + N' ') + [t].[Foo] AS [Aggregate]
 FROM (
-    SELECT DISTINCT [c].[CustomerID], SUBSTRING([c].[CustomerID], 0 + 1, 1) AS [c], N'Foo' AS [c0]
+    SELECT DISTINCT [c].[CustomerID], SUBSTRING([c].[CustomerID], 0 + 1, 1) AS [FirstLetter], N'Foo' AS [Foo]
     FROM [Customers] AS [c]
 ) AS [t]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -5674,12 +5674,12 @@ FROM [Squads] AS [s]");
             await base.Select_subquery_projecting_single_constant_inside_anonymous(async);
 
             AssertSql(
-                @"SELECT [s].[Name], [t0].[c]
+                @"SELECT [s].[Name], [t0].[One]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t].[c], [t].[SquadId]
+    SELECT [t].[One], [t].[SquadId]
     FROM (
-        SELECT 1 AS [c], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
+        SELECT 1 AS [One], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
         FROM [Gears] AS [g]
         WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
     ) AS [t]
@@ -5692,12 +5692,12 @@ LEFT JOIN (
             await base.Select_subquery_projecting_multiple_constants_inside_anonymous(async);
 
             AssertSql(
-                @"SELECT [s].[Name], [t0].[c], [t0].[c0], [t0].[c1]
+                @"SELECT [s].[Name], [t0].[True1], [t0].[False1], [t0].[c]
 FROM [Squads] AS [s]
 LEFT JOIN (
-    SELECT [t].[c], [t].[c0], [t].[c1], [t].[SquadId]
+    SELECT [t].[True1], [t].[False1], [t].[c], [t].[SquadId]
     FROM (
-        SELECT CAST(1 AS bit) AS [c], CAST(0 AS bit) AS [c0], 1 AS [c1], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
+        SELECT CAST(1 AS bit) AS [True1], CAST(0 AS bit) AS [False1], 1 AS [c], [g].[SquadId], ROW_NUMBER() OVER(PARTITION BY [g].[SquadId] ORDER BY [g].[Nickname], [g].[SquadId]) AS [row]
         FROM [Gears] AS [g]
         WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
     ) AS [t]


### PR DESCRIPTION
What is life if full of care
If we have no time to stand and stare

Sqlite for some reason does not allow aliases - "True"/"False"

Resolves #22915
