### PR TITLE
Use LIKE for string.Contains in Sqlite

### DIFF
--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -208,7 +208,7 @@ WHERE ""c"".""ContactName"" IS NOT NULL AND (""c"".""ContactName"" LIKE '%m')");
             AssertSql(
                 @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
 FROM ""Customers"" AS ""c""
-WHERE ('M' = '') OR (instr(""c"".""ContactName"", 'M') > 0)");
+WHERE ""c"".""ContactName"" LIKE '%M%'");
         }
 
         public override async Task String_Contains_Identity(bool async)


### PR DESCRIPTION
Use `LIKE` for `string.Contains` instead of  `instr` in Sqlite

It seems are not backward compatible changes.
 - `WHERE instr("c"."ContactName", 'M') > 0`, will return records containing only `M`
 - `WHERE "c"."ContactName" LIKE '%M%'` will ignore case sensitive and return values that contains `m`  or `M`

By default, `PRAGMA case_sensitive_like=OFF;`

@bricelam @roji  Could you please suggest if we can change this behavior?

Fixes #22917

Please review,
Thank you in advance


