### PR TITLE
Work around mono bug affecting Xamarin Android

### DIFF
--- a/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NonNullableConventionBase.cs
@@ -57,10 +57,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var state = GetOrInitializeState(modelBuilder);
 
             // First check for [MaybeNull] on the return value. If it exists, the member is nullable.
+            // Note: avoid using GetCustomAttribute<> below because of https://github.com/mono/mono/issues/17477
             var isMaybeNull = memberInfo switch
             {
-                FieldInfo f => f.GetCustomAttribute<CA.MaybeNullAttribute>() != null,
-                PropertyInfo p => p.GetMethod?.ReturnParameter?.GetCustomAttribute<CA.MaybeNullAttribute>() != null,
+                FieldInfo f
+                    => f.CustomAttributes.Any(a => a.AttributeType == typeof(CA.MaybeNullAttribute)),
+                PropertyInfo p
+                    => p.GetMethod?.ReturnParameter?.CustomAttributes?.Any(a => a.AttributeType == typeof(CA.MaybeNullAttribute)) == true,
                 _ => false
             };
 


### PR DESCRIPTION
This works around a mono bug preventing using Xamarin, see https://github.com/dotnet/efcore/issues/22665#issuecomment-707734584 for details.

Fixes #22665

**Description**

A mono bug currently prevents EF Core 5.0 from being used on Xamarin Android (and possibly other mono-based platforms). This PR replaces the API call causing issues on mono with a workaround that does not.

**Customer Impact**

EF Core 5.0 is currently unusable with Xamarin Android.

**How found**

Reported by a user: #22665

**Test coverage**

We unfortunately do not have test coverage for Xamarin yet (#8792). We do have testing around this code area which confirms the fix doesn't introduce other regressions in general.

**Regression?**

Yes, from 3.1.x

**Risk**

Low, the change is a very local replacement of a single API call with another code pattern that does the same thing.