### PR TITLE
[release/5.0] SqlServer Migrations: Don't generate EXEC(CONCAT())

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1343,12 +1343,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             if (Options.HasFlag(MigrationsSqlGenerationOptions.Idempotent))
             {
-                var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
                 builder
-                    .Append("EXEC(")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(sqlBuilder.ToString().TrimEnd('\n', '\r', ';')))
-                    .Append(")")
+                    .Append("EXEC(N'")
+                    .Append(sqlBuilder.ToString().TrimEnd('\n', '\r', ';').Replace("'", "''"))
+                    .Append("')")
                     .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
             }
             else
@@ -2016,12 +2014,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 var subBuilder = new MigrationCommandListBuilder(Dependencies);
                 generate(subBuilder);
 
-                var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
                 var command = subBuilder.GetCommandList().Single();
                 builder
-                    .Append("EXEC(")
-                    .Append(stringTypeMapping.GenerateSqlLiteral(command.CommandText.TrimEnd('\n', '\r', ';')))
-                    .Append(")")
+                    .Append("EXEC(N'")
+                    .Append(command.CommandText.TrimEnd('\n', '\r', ';').Replace("'", "''"))
+                    .Append("')")
                     .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                     .EndCommand(command.TransactionSuppressed);
 

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -18,9 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 {
     public class SqlServerMigrationsSqlGeneratorTest : MigrationsSqlGeneratorTestBase
     {
-        protected static string SQL_EOL
-            => string.Join(", ", EOL.Select(c => "NCHAR(" + (short)c + ")"));
-
         [ConditionalFact]
         public virtual void AddColumnOperation_identity_legacy()
         {
@@ -1017,7 +1013,9 @@ SELECT @@ROWCOUNT;
                 MigrationsSqlGenerationOptions.Idempotent);
 
             AssertSql(
-                @$"EXEC(CONCAT(N'DELETE FROM [Table1]', {SQL_EOL}, N'WHERE [Id] = 1;', {SQL_EOL}, N'SELECT @@ROWCOUNT'));
+                @$"EXEC(N'DELETE FROM [Table1]
+WHERE [Id] = 1;
+SELECT @@ROWCOUNT');
 ");
         }
 
@@ -1038,7 +1036,8 @@ SELECT @@ROWCOUNT;
             AssertSql(
                 @$"IF EXISTS (SELECT * FROM [sys].[identity_columns] WHERE [name] IN (N'Id') AND [object_id] = OBJECT_ID(N'[Table1]'))
     SET IDENTITY_INSERT [Table1] ON;
-EXEC(CONCAT(N'INSERT INTO [Table1] ([Id])', {SQL_EOL}, N'VALUES (1)'));
+EXEC(N'INSERT INTO [Table1] ([Id])
+VALUES (1)');
 IF EXISTS (SELECT * FROM [sys].[identity_columns] WHERE [name] IN (N'Id') AND [object_id] = OBJECT_ID(N'[Table1]'))
     SET IDENTITY_INSERT [Table1] OFF;
 ");
@@ -1066,7 +1065,9 @@ IF EXISTS (SELECT * FROM [sys].[identity_columns] WHERE [name] IN (N'Id') AND [o
                 MigrationsSqlGenerationOptions.Idempotent);
 
             AssertSql(
-                @$"EXEC(CONCAT(N'UPDATE [Table1] SET [Column1] = 2', {SQL_EOL}, N'WHERE [Id] = 1;', {SQL_EOL}, N'SELECT @@ROWCOUNT'));
+                @$"EXEC(N'UPDATE [Table1] SET [Column1] = 2
+WHERE [Id] = 1;
+SELECT @@ROWCOUNT');
 ");
         }
 


### PR DESCRIPTION
Fixes #22611

### Description

In 5.0 we started generating EXEC calls in idempotent migration SQL scripts to work around quirks in the SQL Server parser. Unfortunately, this code didn't integrate well with another change we made to generate CONCAT calls for string literals containing new lines. The resulting SQL--`EXEC(CONCAT(...))`--is invalid.

### Customer Impact

This will only affect users generating idempotent migration scripts containing seed data. One customer has reported it so far.

### How found

Customer reported on RC2.

### Test coverage

We have tests comparing the generated SQL against a baseline. However, we don't have any tests that execute the SQL scripts due to the complexity of executing scripts containing utility statements like GO that aren't supported by SqlClient and only work in tools like SSMS, SDT, and SQLCMD. We previously failed to manually verify that the scripts executed correctly. This verification has now been done for the current baselines.

### Regression?

Yes, for certain scenarios from 3.1. Although some scripts would have failed in 3.1 because of the missing EXEC calls, others would have worked that are now broken in 5.0.

cc @Pilchie

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


