### PR TITLE
Simplify string.IsNullOrWhiteSpace translation for SqlServer

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
@@ -211,22 +211,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 return _sqlExpressionFactory.OrElse(
                     _sqlExpressionFactory.IsNull(argument),
                     _sqlExpressionFactory.Equal(
-                        _sqlExpressionFactory.Function(
-                            "LTRIM",
-                            new[]
-                            {
-                                _sqlExpressionFactory.Function(
-                                    "RTRIM",
-                                    new[] { argument },
-                                    nullable: true,
-                                    argumentsPropagateNullability: new[] { true },
-                                    argument.Type,
-                                    argument.TypeMapping)
-                            },
-                            nullable: true,
-                            argumentsPropagateNullability: new[] { true },
-                            argument.Type,
-                            argument.TypeMapping),
+                        argument,
                         _sqlExpressionFactory.Constant(string.Empty, argument.TypeMapping)));
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1393,7 +1393,7 @@ FROM [Customers] AS [c]");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IS NULL OR (LTRIM(RTRIM([c].[Region])) = N'')");
+WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
         }
 
         public override async Task IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(bool async)
@@ -1403,7 +1403,7 @@ WHERE [c].[Region] IS NULL OR (LTRIM(RTRIM([c].[Region])) = N'')");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE LTRIM(RTRIM([c].[CustomerID])) = N''");
+WHERE [c].[CustomerID] = N''");
         }
 
         public override async Task TrimStart_without_arguments_in_predicate(bool async)


### PR DESCRIPTION
Simplified `string.IsNullOrWhiteSpace` translation for SqlServer to
```
@value IS NULL OR @value = N''
```
instead of 
```
@value IS NULL OR LTRIM(RTRIM(@value)) = N''
```

Fixes #22916

Please review
Thank you in advance



