### PR TITLE
Simplify string.IsNullOrEmpty translation for SqlServer

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerStringMethodTranslator.cs
@@ -37,6 +37,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         private static readonly MethodInfo _substringMethodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) });
 
+        private static readonly MethodInfo _isNullOrEmptyMethodInfo
+            = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrEmpty), new[] { typeof(string) });
+
         private static readonly MethodInfo _isNullOrWhiteSpaceMethodInfo
             = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) });
 
@@ -202,6 +205,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                     argumentsPropagateNullability: new[] { true, true, true },
                     method.ReturnType,
                     instance.TypeMapping);
+            }
+
+            if (_isNullOrEmptyMethodInfo.Equals(method))
+            {
+                var argument = arguments[0];
+
+                return _sqlExpressionFactory.OrElse(
+                    _sqlExpressionFactory.IsNull(argument),
+                    _sqlExpressionFactory.Like(
+                        argument,
+                        _sqlExpressionFactory.Constant(string.Empty)));
             }
 
             if (_isNullOrWhiteSpaceMethodInfo.Equals(method))

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1359,7 +1359,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
+WHERE [c].[Region] IS NULL OR ([c].[Region] LIKE N'')");
         }
 
         public override void IsNullOrEmpty_in_projection()
@@ -1368,7 +1368,7 @@ WHERE [c].[Region] IS NULL OR ([c].[Region] = N'')");
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
-    WHEN [c].[Region] IS NULL OR (([c].[Region] = N'') AND [c].[Region] IS NOT NULL) THEN CAST(1 AS bit)
+    WHEN [c].[Region] IS NULL OR ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Value]
 FROM [Customers] AS [c]");
@@ -1380,7 +1380,7 @@ FROM [Customers] AS [c]");
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
-    WHEN [c].[Region] IS NOT NULL AND (([c].[Region] <> N'') OR [c].[Region] IS NULL) THEN CAST(1 AS bit)
+    WHEN NOT ([c].[Region] IS NULL OR ([c].[Region] LIKE N'')) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Value]
 FROM [Customers] AS [c]");


### PR DESCRIPTION
Extends SqlServerStringMethodTranslator (without changes in [StringMethodTranslator](https://github.com/dotnet/efcore/blob/main/src/EFCore.Relational/Query/Internal/StringMethodTranslator.cs#L56)) to simplify `string.IsNullOrEmpty` translation
```
@value IS NULL OR @value LIKE N''
```
instead of
```
@value IS NULL OR @value = N''
```
Fixes #23037

Please review
Thank you in advance


