### PR TITLE
Use 5.0 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-alpha.1.20472.11",
+    "dotnet": "5.0.100-rc.2.20479.15",
     "runtimes": {
       "dotnet": [
         "3.1.8"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "6.0.100-alpha.1.20472.11",
+    "version": "5.0.100-rc.2.20479.15",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },


### PR DESCRIPTION
With 3.1.8 runtime installed and 5.0-rc2 SDK installed,
- Command line build with dotnet build works
- Opening in VS without activation script or startvs script works.