### PR TITLE
3.1.11: Add missing Ordinal to parameter StartsWith comparison

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
@@ -57,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     A valid name based on the candidate name.
         /// </returns>
         public virtual string GenerateParameterName(string name)
-            => name.StartsWith("@")
+            => name.StartsWith("@", StringComparison.Ordinal)
                 ? name
                 : "@" + name;
 


### PR DESCRIPTION
Original PR merged for 5.0: #18873

This backports the fix for #18831 to 3.1.

**Description**

A missing StringComparison.Ordinal causes a string comparison to be culture-sensitive, and incorrectly omits the @ placeholder character for parameter names when using the Thai culture.

**Customer Impact**

EF Core 3.1 is largely unusable when using the Thai culture, without a specific non-trivial workaround (replace the ISqlGenerationHelper service).

**How found**

Reported three times: #18831, #23032, https://github.com/npgsql/efcore.pg/issues/1508

**Test coverage**

#22625 added the new code analysis support coming with Roslyn for 5.0, including checks for StringComparison. Using the overload without StringComparison now generates a compilation error.

**Regression?**

Not within 3.1.x.

**Risk**

Extremely low - the change adds a missing StringComparison.Ordinal in a single call site.