### PR TITLE
3.1.x: Disable NRTs in scaffolding

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -86,6 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             _sb.AppendLine();
 
+            _sb.AppendLine("#nullable disable");
+            _sb.AppendLine();
+
             _sb.AppendLine($"namespace {finalContextNamespace}");
             _sb.AppendLine("{");
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -76,6 +76,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             _sb.AppendLine();
+            _sb.AppendLine("#nullable disable");
+
+            _sb.AppendLine();
             _sb.AppendLine($"namespace {@namespace}");
             _sb.AppendLine("{");
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -26,6 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class TestDbContext : DbContext
@@ -79,6 +81,8 @@ namespace TestNamespace
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
 
 namespace TestNamespace
 {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -38,6 +38,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class Post
@@ -98,6 +100,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class Post
@@ -152,6 +156,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {
@@ -208,6 +214,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {
@@ -275,6 +283,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {


### PR DESCRIPTION
Original PR merged for 5.0: #21190

This backports the fix for #23016 to 3.1.

**Description**

This adds `#nullable disable` at the top of all C# files generated by EF Core's scaffolding.

**Customer Impact**

EF Core scaffolding is currently unaware of C# 8.0 Nullable Reference Types (NRT), and generates a code model without annotations. If the project has NRTs turned on, the model get incorrectly interpreted, i.e. nullable database text columns are represented by `string SomeProperty`, which with NRTs is interpreted as non-nullable.

**How found**

Reported by users (e.g. #23016). The issue for adding fully supporting NRTs, i.e. correctly scaffolding code with annotations (#15520) also has 28 votes, giving reason to believe many users are running into this.

**Test coverage**

This PR includes testing that the `#nullable disable` actually gets scaffolded.

**Regression?**

No.

**Risk**

Low. This touches scaffolding code only - which does not affect EF Core runtime behavior - and in a minor way.