### PR TITLE
3.1.11: Disable NRTs in scaffolding

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -86,6 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             _sb.AppendLine();
 
+            _sb.AppendLine("#nullable disable");
+            _sb.AppendLine();
+
             _sb.AppendLine($"namespace {finalContextNamespace}");
             _sb.AppendLine("{");
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -86,7 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             _sb.AppendLine();
 
-            _sb.AppendLine("#nullable disable");
+            _sb.AppendLine("// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.");
+            _sb.AppendLine("// If you have enabled NRTs for your project, then un-comment the following line:");
+            _sb.AppendLine("// #nullable disable");
             _sb.AppendLine();
 
             _sb.AppendLine($"namespace {finalContextNamespace}");

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -76,6 +76,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             _sb.AppendLine();
+            _sb.AppendLine("#nullable disable");
+
+            _sb.AppendLine();
             _sb.AppendLine($"namespace {@namespace}");
             _sb.AppendLine("{");
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -76,7 +76,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             _sb.AppendLine();
-            _sb.AppendLine("#nullable disable");
+            _sb.AppendLine("// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.");
+            _sb.AppendLine("// If you have enabled NRTs for your project, then un-comment the following line:");
+            _sb.AppendLine("// #nullable disable");
 
             _sb.AppendLine();
             _sb.AppendLine($"namespace {@namespace}");

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -26,6 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class TestDbContext : DbContext
@@ -79,6 +81,8 @@ namespace TestNamespace
                         @"using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
 
 namespace TestNamespace
 {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {
@@ -82,7 +84,9 @@ namespace TestNamespace
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -38,6 +38,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class Post
@@ -98,6 +100,8 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
+#nullable disable
+
 namespace TestNamespace
 {
     public partial class Post
@@ -152,6 +156,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {
@@ -208,6 +214,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {
@@ -275,6 +283,8 @@ namespace TestNamespace
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+
+#nullable disable
 
 namespace TestNamespace
 {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -38,7 +38,9 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {
@@ -100,7 +102,9 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {
@@ -157,7 +161,9 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {
@@ -215,7 +221,9 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {
@@ -284,7 +292,9 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-#nullable disable
+// Code scaffolded by EF Core assumes nullable reference types (NRTs) are not used or disabled.
+// If you have enabled NRTs for your project, then un-comment the following line:
+// #nullable disable
 
 namespace TestNamespace
 {


### PR DESCRIPTION
Original PR merged for 5.0: #21190

**Note for Tactics**

This issue was previously approved for 3.1.11. However, our ever astute MVP @ErikEJ pointed out that since 3.1 targets .NET Standard 2.0, we will potentially be generating 

```C#
#nullable disable
```

in projects where that **won't compile**.

Therefore, we could either not do this at all, or instead generate something like:

```C#
// Code scaffolded by EF Core assumes nullable reference types (NRTs) are disabled.
// If you have enabled NRTs for your project, then un-comment the following line:
// #nullable disable
```

---

This backports the fix for #23016 to 3.1.

**Description**

This adds `#nullable disable` at the top of all C# files generated by EF Core's scaffolding.

**Customer Impact**

EF Core scaffolding is currently unaware of C# 8.0 Nullable Reference Types (NRT), and generates a code model without annotations. If the project has NRTs turned on, the model get incorrectly interpreted, i.e. nullable database text columns are represented by `string SomeProperty`, which with NRTs is interpreted as non-nullable.

**How found**

Reported by users (e.g. #23016). The issue for adding fully supporting NRTs, i.e. correctly scaffolding code with annotations (#15520) also has 28 votes (making it the 29th most requested feature), giving reason to believe many users are running into this.

**Test coverage**

This PR includes testing that the `#nullable disable` actually gets scaffolded.

**Regression?**

No.

**Risk**

Low. This touches scaffolding code only - which does not affect EF Core runtime behavior - and in a minor way.

(replaces #23053 which had a persistent CI issue)