### PR TITLE
[release/5.0] SqlServer RevEng: Stop scaffolding included index columns

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -1005,8 +1005,6 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         index[SqlServerAnnotationNames.FillFactor] = indexGroup.Key.FillFactor;
                     }
 
-                    var includedColumns = new List<string>();
-
                     foreach (var dataRecord in indexGroup)
                     {
                         var columnName = dataRecord.GetValueOrDefault<string>("column_name");
@@ -1014,8 +1012,6 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         var isIncludedColumn = dataRecord.GetValueOrDefault<bool>("is_included_column");
                         if (isIncludedColumn)
                         {
-                            includedColumns.Add(columnName!);
-
                             continue;
                         }
 
@@ -1025,11 +1021,6 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         Check.DebugAssert(column != null, "column is null.");
 
                         index.Columns.Add(column);
-                    }
-
-                    if (includedColumns.Count != 0)
-                    {
-                        index[SqlServerAnnotationNames.Include] = includedColumns.ToArray();
                     }
 
                     table.Indexes.Add(index);

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -748,8 +748,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(max) NULL;");
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "SomeColumn"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(1, includedColumns.Count);
-                    Assert.Contains("SomeOtherColumn", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -853,8 +852,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;");
                     Assert.Contains(table.Columns.Single(c => c.Name == "FirstName"), index.Columns);
                     Assert.Contains(table.Columns.Single(c => c.Name == "LastName"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(1, includedColumns.Count);
-                    Assert.Contains("Name", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -1135,9 +1133,7 @@ ALTER TABLE [People] ALTER COLUMN [FirstName] nvarchar(450) NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -1176,9 +1172,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -1217,9 +1211,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -1260,9 +1252,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NOT NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                 });
 
             AssertSql(
@@ -1305,9 +1295,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NOT NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                     // TODO: Online index not scaffolded?
                 });
 
@@ -1352,9 +1340,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NOT NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                     // TODO: Online index not scaffolded?
                 });
 
@@ -1397,9 +1383,7 @@ ALTER TABLE [People] ALTER COLUMN [Name] nvarchar(450) NOT NULL;",
                     Assert.Equal(1, index.Columns.Count);
                     Assert.Contains(table.Columns.Single(c => c.Name == "Name"), index.Columns);
                     var includedColumns = (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include];
-                    Assert.Equal(2, includedColumns.Count);
-                    Assert.Contains("FirstName", includedColumns);
-                    Assert.Contains("LastName", includedColumns);
+                    Assert.Null(includedColumns);
                     // TODO: Online index not scaffolded?
                 });
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -1929,7 +1929,7 @@ CREATE INDEX IX_INCLUDE ON IncludeIndexTable(IndexProperty) INCLUDE (IncludeProp
                 {
                     var index = Assert.Single(dbModel.Tables.Single().Indexes);
                     Assert.Equal(new[] { "IndexProperty" }, index.Columns.Select(ic => ic.Name).ToList());
-                    Assert.Equal(new[] { "IncludeProperty" }, (IReadOnlyList<string>)index[SqlServerAnnotationNames.Include]);
+                    Assert.Null(index[SqlServerAnnotationNames.Include]);
                 },
                 "DROP TABLE IncludeIndexTable;");
         }


### PR DESCRIPTION
See https://github.com/dotnet/efcore/issues/22150

**Description**

In 5.0 we started to reverse-engineer "included columns" for indexes. However, we have a bug where if the column names are different from the mapped property names, then the result is incorrect and fails at runtime. Fixing this bug requires significant work and is not something we can do in a patch. Therefore, we want to pull this feature.

**Customer Impact**

We've had several people run into this on the previews/RCs, and the reports keep coming. On reflection, we think it's likely that many customers will have column names that don't match, and so will hit this. The workaround is to edit the generated code to fix it. But this is manual and could involve editing hundreds of lines of code. This would then need to be done again if the database is later re-reverse-engineered, which is common for some development flows. ("Database First").

On the flip side, the feature itself is not very important. Therefore, we want to pull the feature from 5.0. This will not break any existing applications since this is a design-time reverse-engineering feature. It _will_ be a take-back of a small feature that has been in the previews and RCs.

**How found**

Multiple customer reports.

**Test coverage**

We are missing test coverage in this area.

**Regression?**

Yes, we believe many customers will hit this with 5.0 when reverse-engineering databases that worked in 3.1.

**Risk**

Very low. It's a very simple feature, and removal is very unlikely to have any knock-on effects. It is also a design-time feature, so there is no chance of breaking existing applications at runtime.
