### PR TITLE
[release/5.0] SqlServer Migrations: Don't omit ALTER COLUMN when old type is unknown

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -291,6 +291,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 return;
             }
 
+            var columnType = operation.ColumnType
+                ?? GetColumnType(
+                    operation.Schema,
+                    operation.Table,
+                    operation.Name,
+                    operation,
+                    model);
+
             var narrowed = false;
             var oldColumnSupported = IsOldColumnSupported(model);
             if (oldColumnSupported)
@@ -299,14 +307,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     throw new InvalidOperationException(SqlServerStrings.AlterIdentityColumn);
                 }
-
-                var type = operation.ColumnType
-                    ?? GetColumnType(
-                        operation.Schema,
-                        operation.Table,
-                        operation.Name,
-                        operation,
-                        model);
                 var oldType = operation.OldColumn.ColumnType
                     ?? GetColumnType(
                         operation.Schema,
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         operation.Name,
                         operation.OldColumn,
                         model);
-                narrowed = type != oldType
+                narrowed = columnType != oldType
                     || operation.Collation != operation.OldColumn.Collation
                     || !operation.IsNullable && operation.OldColumn.IsNullable;
             }
@@ -328,7 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var alterStatementNeeded = narrowed
                 || !oldColumnSupported
                 || operation.ClrType != operation.OldColumn.ClrType
-                || operation.ColumnType != operation.OldColumn.ColumnType
+                || columnType != operation.OldColumn.ColumnType
                 || operation.IsUnicode != operation.OldColumn.IsUnicode
                 || operation.IsFixedLength != operation.OldColumn.IsFixedLength
                 || operation.MaxLength != operation.OldColumn.MaxLength


### PR DESCRIPTION
Fixes #23045

**Description**

In EF Core 5.0, we fixed issue #21364 which sometimes omitted the ALTER COLUMN statement when it was not needed. Unfortunately, migrations generated using versions of EF Core prior to version 3.1.0 don't contain enough information to always know whether or not the column type was actually changed. This results in the ALTER COLUMN statement being erroneously omitted.

**Customer Impact**

Anyone with migrations generated prior to EF Core 3.1 who try to apply them using EF Core 5.0 may run into this issue. Their column type will not be changed as expected which can lead to subsequent issues (as reported in the original issue).

**How found**

Customer reported

**Test coverage**

We have tests that cover migrations generated using EF Core 3.1 but they didn't cover this specific scenario. This PR adds additional coverage for it.

**Regression?**

Yes.

**Risk**

Low. This merely reverts to the behavior of previous versions (i.e. includes the ALTER TABLE statement) when the old column type is null/unknown.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


