### PR TITLE
[5.0.1] Fix issues with property called FooId on base type Foo in TPT

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerIndexConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerIndexConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -201,12 +202,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return null;
             }
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23092_2", out var isEnabled) && isEnabled;
             var nullableColumns = new List<string>();
             var table = StoreObjectIdentifier.Table(tableName, index.DeclaringEntityType.GetSchema());
             foreach (var property in index.Properties)
             {
                 var columnName = property.GetColumnName(table);
-                if (columnName == null)
+                if (columnName == null
+                    && !useOldBehavior)
                 {
                     return null;
                 }

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerIndexConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerIndexConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -154,12 +155,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var index = indexBuilder.Metadata;
             if (index.IsUnique
                 && index.IsClustered() != true
-                && index.Properties.Any(property => property.IsColumnNullable()))
+                && GetNullableColumns(index) is List<string> nullableColumns
+                && nullableColumns.Count > 0)
             {
                 if (columnNameChanged
                     || index.GetFilter() == null)
                 {
-                    indexBuilder.HasFilter(CreateIndexFilter(index));
+                    indexBuilder.HasFilter(CreateIndexFilter(nullableColumns));
                 }
             }
             else
@@ -173,20 +175,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             return indexBuilder;
         }
 
-        private string CreateIndexFilter(IIndex index)
+        private string CreateIndexFilter(List<string> nullableColumns)
         {
-            var tableName = index.DeclaringEntityType.GetTableName();
-            if (tableName == null)
-            {
-                return null;
-            }
-
-            var table = StoreObjectIdentifier.Table(tableName, index.DeclaringEntityType.GetSchema());
-            var nullableColumns = index.Properties
-                .Where(property => property.IsColumnNullable(table))
-                .Select(property => property.GetColumnName(table))
-                .ToList();
-
             var builder = new StringBuilder();
             for (var i = 0; i < nullableColumns.Count; i++)
             {
@@ -201,6 +191,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
 
             return builder.ToString();
+        }
+
+        private List<string> GetNullableColumns(IIndex index)
+        {
+            var tableName = index.DeclaringEntityType.GetTableName();
+            if (tableName == null)
+            {
+                return null;
+            }
+
+            var nullableColumns = new List<string>();
+            var table = StoreObjectIdentifier.Table(tableName, index.DeclaringEntityType.GetSchema());
+            foreach (var property in index.Properties)
+            {
+                var columnName = property.GetColumnName(table);
+                if (columnName == null)
+                {
+                    return null;
+                }
+
+                if (!property.IsColumnNullable(table))
+                {
+                    continue;
+                }
+
+                nullableColumns.Add(columnName);
+            }
+
+            return nullableColumns;
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -129,12 +129,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionForeignKeyBuilder relationshipBuilder,
             IConventionContext context)
         {
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23092_1", out var isEnabled) && isEnabled;
+
             var foreignKey = relationshipBuilder.Metadata;
             var foreignKeyProperties = FindCandidateForeignKeyProperties(relationshipBuilder.Metadata, onDependent: true);
             var propertiesConfigurationSource = foreignKey.GetPropertiesConfigurationSource();
             if (!ConfigurationSource.Convention.OverridesStrictly(propertiesConfigurationSource)
                 && (propertiesConfigurationSource != ConfigurationSource.Convention
-                    || (foreignKey.Properties.All(p => !p.IsImplicitlyCreated())
+                    || (!useOldBehavior
+                        && foreignKey.Properties.All(p => !p.IsImplicitlyCreated())
                         && (foreignKeyProperties == null
                             || !foreignKey.Properties.SequenceEqual(foreignKeyProperties)))))
             {


### PR DESCRIPTION
Fixes #23092

**Description**

The fix does the following:
- Don't discover FK properties for an identifying FK created by convention
- Silently ignore inherited properties in TPT in `SqlServerIndexConvention` instead of throwing an exception

**Customer Impact**

Currently when there's property with name in form of *Foo*Id on base type named *Foo* in a TPT hierarchy an exception is thrown when a convention is applied. The workaround is non-obvious and might not work when there are multiple types with this pattern.

**How found**

Reported by user on RC2

**Test coverage**

This PR includes tests for the affected scenario.

**Regression?**

No, this only affects TPT - a new feature in 5.0

**Risk**

Low. The fix only affects models using TPT.

