### PR TITLE
Nullable annotations for metadata 2

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private ValueGenerator TryGetValueGenerator(IProperty property)
         {
-            var generationProperty = property.GetGenerationProperty();
+            var generationProperty = property.FindGenerationProperty();
 
             return generationProperty != null
                 ? _valueGeneratorSelector.Select(generationProperty, generationProperty.DeclaringEntityType)

--- a/src/EFCore/ChangeTracking/Internal/KeyValueFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyValueFactoryFactory.cs
@@ -28,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 ? CreateSimpleFactory<TKey>(key)
                 : (IPrincipalKeyValueFactory<TKey>)CreateCompositeFactory(key);
 
-        [UsedImplicitly]
         private static SimplePrincipalKeyValueFactory<TKey> CreateSimpleFactory<TKey>(IKey key)
         {
             var dependentFactory = new DependentKeyValueFactoryFactory();

--- a/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>

--- a/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/ConventionEntityTypeExtensions.cs
@@ -14,6 +14,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -93,10 +95,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            while (entityType != null)
+            var tmp = (IConventionEntityType?)entityType;
+            while (tmp != null)
             {
-                yield return entityType;
-                entityType = entityType.BaseType;
+                yield return tmp;
+                tmp = tmp.BaseType;
             }
         }
 
@@ -181,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the property to remove. </param>
         /// <returns> The property that was removed. </returns>
-        public static IConventionProperty RemoveProperty([NotNull] this IConventionEntityType entityType, [NotNull] string name)
+        public static IConventionProperty? RemoveProperty([NotNull] this IConventionEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).RemoveProperty(name);
 
         /// <summary>
@@ -191,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property that the key is defined on. </param>
         /// <returns> The key, or null if none is defined. </returns>
-        public static IConventionKey FindKey([NotNull] this IConventionEntityType entityType, [NotNull] IProperty property)
+        public static IConventionKey? FindKey([NotNull] this IConventionEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -205,7 +208,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property to use as an alternate key. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created key. </returns>
-        public static IConventionKey AddKey(
+        public static IConventionKey? AddKey(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IConventionProperty property,
             bool fromDataAnnotation = false)
@@ -217,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="properties"> The properties that make up the key. </param>
         /// <returns> The key that was removed. </returns>
-        public static IConventionKey RemoveKey(
+        public static IConventionKey? RemoveKey(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IReadOnlyList<IConventionProperty> properties)
             => ((EntityType)entityType).RemoveKey(properties);
@@ -289,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     base type of the hierarchy).
         /// </param>
         /// <returns> The foreign key, or <see langword="null" /> if none is defined. </returns>
-        public static IConventionForeignKey FindForeignKey(
+        public static IConventionForeignKey? FindForeignKey(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IProperty property,
             [NotNull] IKey principalKey,
@@ -334,7 +337,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The relationship to the owner if this is an owned type or <see langword="null" /> otherwise. </returns>
-        public static IConventionForeignKey FindOwnership([NotNull] this IConventionEntityType entityType)
+        public static IConventionForeignKey? FindOwnership([NotNull] this IConventionEntityType entityType)
             => ((EntityType)entityType).FindOwnership();
 
         /// <summary>
@@ -350,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created foreign key. </returns>
-        public static IConventionForeignKey AddForeignKey(
+        public static IConventionForeignKey? AddForeignKey(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IConventionProperty property,
             [NotNull] IConventionKey principalKey,
@@ -371,7 +374,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     base type of the hierarchy).
         /// </param>
         /// <returns> The foreign key that was removed. </returns>
-        public static IConventionForeignKey RemoveForeignKey(
+        public static IConventionForeignKey? RemoveForeignKey(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IReadOnlyList<IConventionProperty> properties,
             [NotNull] IConventionKey principalKey,
@@ -384,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="memberInfo"> The navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IConventionNavigation FindNavigation(
+        public static IConventionNavigation? FindNavigation(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] MemberInfo memberInfo)
             => Check.NotNull(entityType, nameof(entityType))
@@ -396,7 +399,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IConventionNavigation FindNavigation([NotNull] this IConventionEntityType entityType, [NotNull] string name)
+        public static IConventionNavigation? FindNavigation([NotNull] this IConventionEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindNavigation(name);
 
         /// <summary>
@@ -406,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IConventionNavigation FindDeclaredNavigation([NotNull] this IConventionEntityType entityType, [NotNull] string name)
+        public static IConventionNavigation? FindDeclaredNavigation([NotNull] this IConventionEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindDeclaredNavigation(Check.NotNull(name, nameof(name)));
 
         /// <summary>
@@ -414,8 +417,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The defining navigation if one exists or <see langword="null" /> otherwise. </returns>
-        public static IConventionNavigation FindDefiningNavigation([NotNull] this IConventionEntityType entityType)
-            => (IConventionNavigation)((IEntityType)entityType).FindDefiningNavigation();
+        public static IConventionNavigation? FindDefiningNavigation([NotNull] this IConventionEntityType entityType)
+            => (IConventionNavigation?)((IEntityType)entityType).FindDefiningNavigation();
 
         /// <summary>
         ///     Gets all navigation properties on the given entity type.
@@ -437,7 +440,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="memberInfo"> The property on the entity class. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IConventionProperty FindProperty([NotNull] this IConventionEntityType entityType, [NotNull] MemberInfo memberInfo)
+        public static IConventionProperty? FindProperty([NotNull] this IConventionEntityType entityType, [NotNull] MemberInfo memberInfo)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(memberInfo, nameof(memberInfo));
@@ -458,7 +461,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="propertyNames"> The property names. </param>
         /// <returns> The properties, or <see langword="null" /> if any property is not found. </returns>
-        public static IReadOnlyList<IConventionProperty> FindProperties(
+        public static IReadOnlyList<IConventionProperty>? FindProperties(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IReadOnlyList<string> propertyNames)
             => ((EntityType)entityType).FindProperties(Check.NotNull(propertyNames, nameof(propertyNames)));
@@ -470,7 +473,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The property name. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IConventionProperty FindDeclaredProperty([NotNull] this IConventionEntityType entityType, [NotNull] string name)
+        public static IConventionProperty? FindDeclaredProperty([NotNull] this IConventionEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindDeclaredProperty(name);
 
         /// <summary>
@@ -480,7 +483,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="memberInfo"> The corresponding member on the entity class. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created property. </returns>
-        public static IConventionProperty AddProperty(
+        public static IConventionProperty? AddProperty(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] MemberInfo memberInfo,
             bool fromDataAnnotation = false)
@@ -495,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The name of the property to add. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created property. </returns>
-        public static IConventionProperty AddProperty(
+        public static IConventionProperty? AddProperty(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] string name,
             bool fromDataAnnotation = false)
@@ -511,7 +514,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="setTypeConfigurationSource"> Indicates whether the type configuration source should be set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created property. </returns>
-        public static IConventionProperty AddProperty(
+        public static IConventionProperty? AddProperty(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] string name,
             [NotNull] Type propertyType,
@@ -534,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="setTypeConfigurationSource"> Indicates whether the type configuration source should be set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created property. </returns>
-        public static IConventionProperty AddIndexerProperty(
+        public static IConventionProperty? AddIndexerProperty(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] string name,
             [NotNull] Type propertyType,
@@ -564,7 +567,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property to find the index on. </param>
         /// <returns> The index, or null if none is found. </returns>
-        public static IConventionIndex FindIndex([NotNull] this IConventionEntityType entityType, [NotNull] IProperty property)
+        public static IConventionIndex? FindIndex([NotNull] this IConventionEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -578,7 +581,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property to be indexed. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created index. </returns>
-        public static IConventionIndex AddIndex(
+        public static IConventionIndex? AddIndex(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IConventionProperty property,
             bool fromDataAnnotation = false)
@@ -590,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="properties"> The properties that make up the index. </param>
         /// <returns> The index that was removed. </returns>
-        public static IConventionIndex RemoveIndex(
+        public static IConventionIndex? RemoveIndex(
             [NotNull] this IConventionEntityType entityType,
             [NotNull] IReadOnlyList<IConventionProperty> properties)
             => ((EntityType)entityType).RemoveIndex(properties);
@@ -627,9 +630,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="queryFilter"> The LINQ expression filter. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured filter. </returns>
-        public static LambdaExpression SetQueryFilter(
+        public static LambdaExpression? SetQueryFilter(
             [NotNull] this IConventionEntityType entityType,
-            [CanBeNull] LambdaExpression queryFilter,
+            [CanBeNull] LambdaExpression? queryFilter,
             bool fromDataAnnotation = false)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
                 .SetQueryFilter(
@@ -653,7 +656,7 @@ namespace Microsoft.EntityFrameworkCore
         [Obsolete("Use InMemoryEntityTypeExtensions.SetInMemoryQuery")]
         public static void SetDefiningQuery(
             [NotNull] this IConventionEntityType entityType,
-            [CanBeNull] LambdaExpression definingQuery,
+            [CanBeNull] LambdaExpression? definingQuery,
             bool fromDataAnnotation = false)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
                 .SetDefiningQuery(
@@ -673,8 +676,8 @@ namespace Microsoft.EntityFrameworkCore
         ///     Returns the <see cref="IConventionProperty" /> that will be used for storing a discriminator value.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        public static IConventionProperty GetDiscriminatorProperty([NotNull] this IConventionEntityType entityType)
-            => (IConventionProperty)((IEntityType)entityType).GetDiscriminatorProperty();
+        public static IConventionProperty? GetDiscriminatorProperty([NotNull] this IConventionEntityType entityType)
+            => (IConventionProperty?)((IEntityType)entityType).GetDiscriminatorProperty();
 
         /// <summary>
         ///     Sets the <see cref="IProperty" /> that will be used for storing a discriminator value.
@@ -683,13 +686,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The discriminator property. </returns>
-        public static IConventionProperty SetDiscriminatorProperty(
+        public static IConventionProperty? SetDiscriminatorProperty(
             [NotNull] this IConventionEntityType entityType,
-            [CanBeNull] IProperty property,
+            [CanBeNull] IProperty? property,
             bool fromDataAnnotation = false)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
                 .SetDiscriminatorProperty(
-                    (Property)property,
+                    (Property?)property,
                     fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -739,7 +742,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The configured value. </returns>
         public static object SetDiscriminatorValue(
             [NotNull] this IConventionEntityType entityType,
-            [CanBeNull] object value,
+            [CanBeNull] object? value,
             bool fromDataAnnotation = false)
         {
             entityType.AsEntityType().CheckDiscriminatorValue(entityType, value);
@@ -754,7 +757,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The removed discriminator value. </returns>
-        public static object RemoveDiscriminatorValue([NotNull] this IConventionEntityType entityType)
+        public static object? RemoveDiscriminatorValue([NotNull] this IConventionEntityType entityType)
             => entityType.RemoveAnnotation(CoreAnnotationNames.DiscriminatorValue)?.Value;
 
         /// <summary>

--- a/src/EFCore/Extensions/ConventionNavigationExtensions.cs
+++ b/src/EFCore/Extensions/ConventionNavigationExtensions.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/ConventionPropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/ConventionPropertyBaseExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/ConventionPropertyExtensions.cs
+++ b/src/EFCore/Extensions/ConventionPropertyExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -26,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The foreign key property. </param>
         /// <returns> The first associated principal property, or <see langword="null" /> if none exists. </returns>
-        public static IConventionProperty FindFirstPrincipal([NotNull] this IConventionProperty property)
-            => (IConventionProperty)((IProperty)property).FindFirstPrincipal();
+        public static IConventionProperty? FindFirstPrincipal([NotNull] this IConventionProperty property)
+            => (IConventionProperty?)((IProperty)property).FindFirstPrincipal();
 
         /// <summary>
         ///     Finds the list of principal properties including the given property that the given property is constrained by
@@ -68,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The primary that use this property, or <see langword="null" /> if it is not part of the primary key.
         /// </returns>
-        public static IConventionKey FindContainingPrimaryKey([NotNull] this IConventionProperty property)
-            => (IConventionKey)((IProperty)property).FindContainingPrimaryKey();
+        public static IConventionKey? FindContainingPrimaryKey([NotNull] this IConventionProperty property)
+            => (IConventionKey?)((IProperty)property).FindContainingPrimaryKey();
 
         /// <summary>
         ///     Gets all primary or alternate keys that use this property (including composite keys in which this property
@@ -280,7 +282,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        public static Func<IProperty, IEntityType, ValueGenerator> SetValueGeneratorFactory(
+        public static Func<IProperty, IEntityType, ValueGenerator>? SetValueGeneratorFactory(
             [NotNull] this IConventionProperty property,
             [NotNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory,
             bool fromDataAnnotation = false)
@@ -302,9 +304,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="converter"> The converter, or <see langword="null" /> to remove any previously set converter. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        public static ValueConverter SetValueConverter(
+        public static ValueConverter? SetValueConverter(
             [NotNull] this IConventionProperty property,
-            [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueConverter? converter,
             bool fromDataAnnotation = false)
             => property.AsProperty().SetValueConverter(
                 converter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -324,9 +326,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="providerClrType"> The type to use, or <see langword="null" /> to remove any previously set type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        public static Type SetProviderClrType(
+        public static Type? SetProviderClrType(
             [NotNull] this IConventionProperty property,
-            [CanBeNull] Type providerClrType,
+            [CanBeNull] Type? providerClrType,
             bool fromDataAnnotation = false)
             => property.AsProperty().SetProviderClrType(
                 providerClrType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -346,9 +348,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="comparer"> The comparer, or <see langword="null" /> to remove any previously set comparer. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        public static ValueComparer SetValueComparer(
+        public static ValueComparer? SetValueComparer(
             [NotNull] this IConventionProperty property,
-            [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer? comparer,
             bool fromDataAnnotation = false)
             => property.AsProperty().SetValueComparer(
                 comparer, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -370,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore
         [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static void SetKeyValueComparer(
             [NotNull] this IConventionProperty property,
-            [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer? comparer,
             bool fromDataAnnotation = false)
             => property.AsProperty().SetValueComparer(
                 comparer, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
@@ -393,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore
         [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
         public static void SetStructuralValueComparer(
             [NotNull] this IConventionProperty property,
-            [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer? comparer,
             bool fromDataAnnotation = false)
             => property.SetKeyValueComparer(comparer, fromDataAnnotation);
 

--- a/src/EFCore/Extensions/ConventionTypeBaseExtensions.cs
+++ b/src/EFCore/Extensions/ConventionTypeBaseExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/EntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/EntityTypeExtensions.cs
@@ -16,6 +16,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -138,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The closest common parent of <paramref name="entityType1" /> and <paramref name="entityType2" />,
         ///     or null if they have not common parent.
         /// </returns>
-        public static IEntityType GetClosestCommonParent([NotNull] this IEntityType entityType1, [NotNull] IEntityType entityType2)
+        public static IEntityType? GetClosestCommonParent([NotNull] this IEntityType entityType1, [NotNull] IEntityType entityType2)
         {
             Check.NotNull(entityType1, nameof(entityType1));
             Check.NotNull(entityType2, nameof(entityType2));
@@ -174,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The least derived type between the specified two.
         ///     If the given entity types are not related, then <see langword="null" /> is returned.
         /// </returns>
-        public static IEntityType LeastDerivedType([NotNull] this IEntityType entityType, [NotNull] IEntityType otherEntityType)
+        public static IEntityType? LeastDerivedType([NotNull] this IEntityType entityType, [NotNull] IEntityType otherEntityType)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(otherEntityType, nameof(otherEntityType));
@@ -203,10 +205,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            while (entityType != null)
+            var tmp = (IEntityType?)entityType;
+            while (tmp != null)
             {
-                yield return entityType;
-                entityType = entityType.BaseType;
+                yield return tmp;
+                tmp = tmp.BaseType;
             }
         }
 
@@ -360,7 +363,8 @@ namespace Microsoft.EntityFrameworkCore
                     break;
                 }
 
-                root = root.DefiningEntityType;
+                // TODO-NULLABLE: Put MemberNotNull on DefiningNavigationName (or check HasDefiningNavigation) when we target net5.0
+                root = root.DefiningEntityType!;
                 path.Push("#");
                 path.Push(definingNavigationName);
                 path.Push(".");
@@ -452,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property that the key is defined on. </param>
         /// <returns> The key, or null if none is defined. </returns>
-        public static IKey FindKey([NotNull] this IEntityType entityType, [NotNull] IProperty property)
+        public static IKey? FindKey([NotNull] this IEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -501,7 +505,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     base type of the hierarchy).
         /// </param>
         /// <returns> The foreign key, or <see langword="null" /> if none is defined. </returns>
-        public static IForeignKey FindForeignKey(
+        public static IForeignKey? FindForeignKey(
             [NotNull] this IEntityType entityType,
             [NotNull] IProperty property,
             [NotNull] IKey principalKey,
@@ -533,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The relationship to the owner if this is an owned type or <see langword="null" /> otherwise. </returns>
-        public static IForeignKey FindOwnership([NotNull] this IEntityType entityType)
+        public static IForeignKey? FindOwnership([NotNull] this IEntityType entityType)
             => ((EntityType)entityType).FindOwnership();
 
         /// <summary>
@@ -542,7 +546,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="memberInfo"> The navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static INavigation FindNavigation([NotNull] this IEntityType entityType, [NotNull] MemberInfo memberInfo)
+        public static INavigation? FindNavigation([NotNull] this IEntityType entityType, [NotNull] MemberInfo memberInfo)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(memberInfo, nameof(memberInfo));
@@ -556,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static INavigation FindNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
+        public static INavigation? FindNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType().FindNavigation(Check.NotNull(name, nameof(name)));
 
         /// <summary>
@@ -566,7 +570,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static INavigation FindDeclaredNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
+        public static INavigation? FindDeclaredNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType().FindDeclaredNavigation(Check.NotNull(name, nameof(name)));
 
         /// <summary>
@@ -574,14 +578,15 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The defining navigation if one exists or <see langword="null" /> otherwise. </returns>
-        public static INavigation FindDefiningNavigation([NotNull] this IEntityType entityType)
+        public static INavigation? FindDefiningNavigation([NotNull] this IEntityType entityType)
         {
             if (!entityType.HasDefiningNavigation())
             {
                 return null;
             }
 
-            var definingNavigation = entityType.DefiningEntityType.FindNavigation(entityType.DefiningNavigationName);
+            // TODO-NULLABLE: Put two MemberNotNulls on HasDefiningNavigation when we target net5.0
+            var definingNavigation = entityType.DefiningEntityType!.FindNavigation(entityType.DefiningNavigationName!);
             return definingNavigation?.TargetEntityType == entityType ? definingNavigation : null;
         }
 
@@ -605,7 +610,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="memberInfo"> The member on the entity class. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IProperty FindProperty([NotNull] this IEntityType entityType, [NotNull] MemberInfo memberInfo)
+        public static IProperty? FindProperty([NotNull] this IEntityType entityType, [NotNull] MemberInfo memberInfo)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(memberInfo, nameof(memberInfo));
@@ -660,7 +665,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="propertyNames"> The property names. </param>
         /// <returns> The properties, or <see langword="null" /> if any property is not found. </returns>
-        public static IReadOnlyList<IProperty> FindProperties(
+        public static IReadOnlyList<IProperty>? FindProperties(
             [NotNull] this IEntityType entityType,
             [NotNull] IReadOnlyList<string> propertyNames)
             => entityType.AsEntityType().FindProperties(Check.NotNull(propertyNames, nameof(propertyNames)));
@@ -672,7 +677,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The property name. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IProperty FindDeclaredProperty([NotNull] this IEntityType entityType, [NotNull] string name)
+        public static IProperty? FindDeclaredProperty([NotNull] this IEntityType entityType, [NotNull] string name)
             => entityType.AsEntityType().FindDeclaredProperty(name);
 
         /// <summary>
@@ -686,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property to find the index on. </param>
         /// <returns> The index, or null if none is found. </returns>
-        public static IIndex FindIndex([NotNull] this IEntityType entityType, [NotNull] IProperty property)
+        public static IIndex? FindIndex([NotNull] this IEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -709,7 +714,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="providerValues"> If true, then provider values are used. </param>
         /// <returns> The data. </returns>
-        public static IEnumerable<IDictionary<string, object>> GetSeedData(
+        public static IEnumerable<IDictionary<string, object?>> GetSeedData(
             [NotNull] this IEntityType entityType,
             bool providerValues = false)
             => entityType.AsEntityType().GetSeedData(providerValues);
@@ -719,11 +724,11 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type to get the query filter for. </param>
         /// <returns> The LINQ expression filter. </returns>
-        public static LambdaExpression GetQueryFilter([NotNull] this IEntityType entityType)
+        public static LambdaExpression? GetQueryFilter([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            return (LambdaExpression)entityType[CoreAnnotationNames.QueryFilter];
+            return (LambdaExpression?)entityType[CoreAnnotationNames.QueryFilter];
         }
 
         /// <summary>
@@ -732,25 +737,25 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type to get the defining query for. </param>
         /// <returns> The LINQ query used as the default source. </returns>
         [Obsolete("Use InMemoryEntityTypeExtensions.GetInMemoryQuery")]
-        public static LambdaExpression GetDefiningQuery([NotNull] this IEntityType entityType)
+        public static LambdaExpression? GetDefiningQuery([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            return (LambdaExpression)entityType[CoreAnnotationNames.DefiningQuery];
+            return (LambdaExpression?)entityType[CoreAnnotationNames.DefiningQuery];
         }
 
         /// <summary>
         ///     Returns the <see cref="IProperty" /> that will be used for storing a discriminator value.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        public static IProperty GetDiscriminatorProperty([NotNull] this IEntityType entityType)
+        public static IProperty? GetDiscriminatorProperty([NotNull] this IEntityType entityType)
         {
             if (entityType.BaseType != null)
             {
                 return entityType.GetRootType().GetDiscriminatorProperty();
             }
 
-            var propertyName = (string)entityType[CoreAnnotationNames.DiscriminatorProperty];
+            var propertyName = (string?)entityType[CoreAnnotationNames.DiscriminatorProperty];
 
             return propertyName == null ? null : entityType.FindProperty(propertyName);
         }
@@ -771,7 +776,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The discriminator value for this entity type. </returns>
-        public static object GetDiscriminatorValue([NotNull] this IEntityType entityType)
+        public static object? GetDiscriminatorValue([NotNull] this IEntityType entityType)
             => entityType[CoreAnnotationNames.DiscriminatorValue];
 
         /// <summary>

--- a/src/EFCore/Extensions/ForeignKeyExtensions.cs
+++ b/src/EFCore/Extensions/ForeignKeyExtensions.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -32,9 +34,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="foreignKey"> The <see cref="IForeignKey" /> for which a factory is needed. </param>
         /// <typeparam name="TKey"> The type of key instanceas. </typeparam>
         /// <returns> A new factory. </returns>
-        public static IDependentKeyValueFactory<TKey> GetDependentKeyValueFactory<TKey>(
+        public static IDependentKeyValueFactory<TKey>? GetDependentKeyValueFactory<TKey>(
             [NotNull] this IForeignKey foreignKey)
-            => (IDependentKeyValueFactory<TKey>)foreignKey.AsForeignKey().DependentKeyValueFactory;
+            => (IDependentKeyValueFactory<TKey>?)foreignKey.AsForeignKey().DependentKeyValueFactory;
 
         /// <summary>
         ///     Gets the entity type related to the given one.
@@ -67,9 +69,9 @@ namespace Microsoft.EntityFrameworkCore
         ///     A value indicating whether the navigation is on the dependent type pointing to the principal type.
         /// </param>
         /// <returns>
-        ///     A navigation associated with this foreign key or null.
+        ///     A navigation associated with this foreign key or <see langword="null" />.
         /// </returns>
-        public static INavigation GetNavigation([NotNull] this IForeignKey foreignKey, bool pointsToPrincipal)
+        public static INavigation? GetNavigation([NotNull] this IForeignKey foreignKey, bool pointsToPrincipal)
             => pointsToPrincipal ? foreignKey.DependentToPrincipal : foreignKey.PrincipalToDependent;
 
         /// <summary>

--- a/src/EFCore/Extensions/IndexExtensions.cs
+++ b/src/EFCore/Extensions/IndexExtensions.cs
@@ -9,6 +9,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/KeyExtensions.cs
+++ b/src/EFCore/Extensions/KeyExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/ModelExtensions.cs
+++ b/src/EFCore/Extensions/ModelExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="type"> The type to find the corresponding entity type for. </param>
         /// <returns> The entity type, or <see langword="null" /> if none if found. </returns>
         [DebuggerStepThrough]
-        public static IEntityType FindEntityType([NotNull] this IModel model, [NotNull] Type type)
+        public static IEntityType? FindEntityType([NotNull] this IModel model, [NotNull] Type type)
             => ((Model)model).FindEntityType(Check.NotNull(type, nameof(type)));
 
         /// <summary>
@@ -41,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the entity type in. </param>
         /// <param name="type"> The type to find the corresponding entity type for. </param>
         /// <returns> The entity type, or <see langword="null" /> if none if found. </returns>
-        public static IEntityType FindRuntimeEntityType([NotNull] this IModel model, [NotNull] Type type)
+        public static IEntityType? FindRuntimeEntityType([NotNull] this IModel model, [NotNull] Type type)
         {
             Check.NotNull(type, nameof(type));
             var realModel = (Model)Check.NotNull(model, nameof(model));
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="definingEntityType"> The defining entity type of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
         [DebuggerStepThrough]
-        public static IEntityType FindEntityType(
+        public static IEntityType? FindEntityType(
             [NotNull] this IModel model,
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
@@ -162,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     Gets the EF Core assembly version used to build this model
         /// </summary>
         /// <param name="model"> The model to get the version for. </param>
-        public static string GetProductVersion([NotNull] this IModel model)
+        public static string? GetProductVersion([NotNull] this IModel model)
             => model[CoreAnnotationNames.ProductVersion] as string;
 
         /// <summary>

--- a/src/EFCore/Extensions/MutableAnnotatableExtensions.cs
+++ b/src/EFCore/Extensions/MutableAnnotatableExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -49,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore
         public static void SetOrRemoveAnnotation(
             [NotNull] this IMutableAnnotatable annotatable,
             [NotNull] string name,
-            [CanBeNull] object value)
+            [CanBeNull] object? value)
             => ((ConventionAnnotatable)annotatable).SetOrRemoveAnnotation(name, value, ConfigurationSource.Explicit);
     }
 }

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -155,8 +157,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the property to remove. </param>
-        /// <returns> The property that was removed. </returns>
-        public static IMutableProperty RemoveProperty([NotNull] this IMutableEntityType entityType, [NotNull] string name)
+        /// <returns> The removed property, or <see langword="null" /> if the property was not found. </returns>
+        public static IMutableProperty? RemoveProperty([NotNull] this IMutableEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).RemoveProperty(name);
 
         /// <summary>
@@ -166,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property that the key is defined on. </param>
         /// <returns> The key, or null if none is defined. </returns>
-        public static IMutableKey FindKey([NotNull] this IMutableEntityType entityType, [NotNull] IProperty property)
+        public static IMutableKey? FindKey([NotNull] this IMutableEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -189,8 +191,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="properties"> The properties that make up the key. </param>
-        /// <returns> The key that was removed. </returns>
-        public static IMutableKey RemoveKey(
+        /// <returns> The removed key, or <see langword="null" /> if the key was not found. </returns>
+        public static IMutableKey? RemoveKey(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] IReadOnlyList<IMutableProperty> properties)
             => ((EntityType)entityType).RemoveKey(properties);
@@ -262,7 +264,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     base type of the hierarchy).
         /// </param>
         /// <returns> The foreign key, or <see langword="null" /> if none is defined. </returns>
-        public static IMutableForeignKey FindForeignKey(
+        public static IMutableForeignKey? FindForeignKey(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] IProperty property,
             [NotNull] IKey principalKey,
@@ -330,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The relationship to the owner if this is an owned type or <see langword="null" /> otherwise. </returns>
-        public static IMutableForeignKey FindOwnership([NotNull] this IMutableEntityType entityType)
+        public static IMutableForeignKey? FindOwnership([NotNull] this IMutableEntityType entityType)
             => ((EntityType)entityType).FindOwnership();
 
         /// <summary>
@@ -344,8 +346,8 @@ namespace Microsoft.EntityFrameworkCore
         ///     is defined on when the relationship targets a derived type in an inheritance hierarchy (since the key is defined on the
         ///     base type of the hierarchy).
         /// </param>
-        /// <returns> The foreign key that was removed. </returns>
-        public static IMutableForeignKey RemoveForeignKey(
+        /// <returns> The removed foreign key, or <see langword="null" /> if the index was not found. </returns>
+        public static IMutableForeignKey? RemoveForeignKey(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] IReadOnlyList<IMutableProperty> properties,
             [NotNull] IMutableKey principalKey,
@@ -358,7 +360,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="memberInfo"> The navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IMutableNavigation FindNavigation(
+        public static IMutableNavigation? FindNavigation(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] MemberInfo memberInfo)
             => Check.NotNull(entityType, nameof(entityType))
@@ -370,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IMutableNavigation FindNavigation([NotNull] this IMutableEntityType entityType, [NotNull] string name)
+        public static IMutableNavigation? FindNavigation([NotNull] this IMutableEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindNavigation(name);
 
         /// <summary>
@@ -380,7 +382,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The name of the navigation property on the entity class. </param>
         /// <returns> The navigation property, or <see langword="null" /> if none is found. </returns>
-        public static IMutableNavigation FindDeclaredNavigation([NotNull] this IMutableEntityType entityType, [NotNull] string name)
+        public static IMutableNavigation? FindDeclaredNavigation([NotNull] this IMutableEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindDeclaredNavigation(Check.NotNull(name, nameof(name)));
 
         /// <summary>
@@ -388,8 +390,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <returns> The defining navigation if one exists or <see langword="null" /> otherwise. </returns>
-        public static IMutableNavigation FindDefiningNavigation([NotNull] this IMutableEntityType entityType)
-            => (IMutableNavigation)((IEntityType)entityType).FindDefiningNavigation();
+        public static IMutableNavigation? FindDefiningNavigation([NotNull] this IMutableEntityType entityType)
+            => (IMutableNavigation?)((IEntityType)entityType).FindDefiningNavigation();
 
         /// <summary>
         ///     Gets all navigation properties on the given entity type.
@@ -411,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="propertyInfo"> The property on the entity class. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IMutableProperty FindProperty([NotNull] this IMutableEntityType entityType, [NotNull] PropertyInfo propertyInfo)
+        public static IMutableProperty? FindProperty([NotNull] this IMutableEntityType entityType, [NotNull] PropertyInfo propertyInfo)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(propertyInfo, nameof(propertyInfo));
@@ -430,7 +432,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="propertyNames"> The property names. </param>
         /// <returns> The properties, or <see langword="null" /> if any property is not found. </returns>
-        public static IReadOnlyList<IMutableProperty> FindProperties(
+        public static IReadOnlyList<IMutableProperty>? FindProperties(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] IReadOnlyList<string> propertyNames)
             => ((EntityType)entityType).FindProperties(Check.NotNull(propertyNames, nameof(propertyNames)));
@@ -442,7 +444,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="name"> The property name. </param>
         /// <returns> The property, or <see langword="null" /> if none is found. </returns>
-        public static IMutableProperty FindDeclaredProperty([NotNull] this IMutableEntityType entityType, [NotNull] string name)
+        public static IMutableProperty? FindDeclaredProperty([NotNull] this IMutableEntityType entityType, [NotNull] string name)
             => ((EntityType)entityType).FindDeclaredProperty(name);
 
         /// <summary>
@@ -466,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore
         public static IMutableProperty AddProperty(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] string name)
-            => ((EntityType)entityType).AddProperty(name, ConfigurationSource.Explicit);
+            => ((EntityType)entityType).AddProperty(name, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     Adds a property to this entity type.
@@ -479,7 +481,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this IMutableEntityType entityType,
             [NotNull] string name,
             [NotNull] Type propertyType)
-            => ((EntityType)entityType).AddProperty(name, propertyType, ConfigurationSource.Explicit, ConfigurationSource.Explicit);
+            => ((EntityType)entityType).AddProperty(name, propertyType, ConfigurationSource.Explicit, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     Adds a property backed up by an indexer to this entity type.
@@ -511,7 +513,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property to find the index on. </param>
         /// <returns> The index, or null if none is found. </returns>
-        public static IMutableIndex FindIndex([NotNull] this IMutableEntityType entityType, [NotNull] IProperty property)
+        public static IMutableIndex? FindIndex([NotNull] this IMutableEntityType entityType, [NotNull] IProperty property)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -534,8 +536,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="properties"> The properties that make up the index. </param>
-        /// <returns> The index that was removed. </returns>
-        public static IMutableIndex RemoveIndex(
+        /// <returns> The removed index, or <see langword="null" /> if the index was not found. </returns>
+        public static IMutableIndex? RemoveIndex(
             [NotNull] this IMutableEntityType entityType,
             [NotNull] IReadOnlyList<IMutableProperty> properties)
             => ((EntityType)entityType).RemoveIndex(properties);
@@ -558,7 +560,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="queryFilter"> The LINQ expression filter. </param>
         public static void SetQueryFilter(
             [NotNull] this IMutableEntityType entityType,
-            [CanBeNull] LambdaExpression queryFilter)
+            [CanBeNull] LambdaExpression? queryFilter)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
                 .SetQueryFilter(queryFilter, ConfigurationSource.Explicit);
 
@@ -570,7 +572,7 @@ namespace Microsoft.EntityFrameworkCore
         [Obsolete("Use InMemoryEntityTypeExtensions.SetInMemoryQuery")]
         public static void SetDefiningQuery(
             [NotNull] this IMutableEntityType entityType,
-            [CanBeNull] LambdaExpression definingQuery)
+            [CanBeNull] LambdaExpression? definingQuery)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
                 .SetDefiningQuery(definingQuery, ConfigurationSource.Explicit);
 
@@ -578,17 +580,17 @@ namespace Microsoft.EntityFrameworkCore
         ///     Returns the <see cref="IMutableProperty" /> that will be used for storing a discriminator value.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
-        public static IMutableProperty GetDiscriminatorProperty([NotNull] this IMutableEntityType entityType)
-            => (IMutableProperty)((IEntityType)entityType).GetDiscriminatorProperty();
+        public static IMutableProperty? GetDiscriminatorProperty([NotNull] this IMutableEntityType entityType)
+            => (IMutableProperty?)((IEntityType)entityType).GetDiscriminatorProperty();
 
         /// <summary>
         ///     Sets the <see cref="IProperty" /> that will be used for storing a discriminator value.
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="property"> The property to set. </param>
-        public static void SetDiscriminatorProperty([NotNull] this IMutableEntityType entityType, [CanBeNull] IProperty property)
+        public static void SetDiscriminatorProperty([NotNull] this IMutableEntityType entityType, [CanBeNull] IProperty? property)
             => Check.NotNull(entityType, nameof(entityType)).AsEntityType()
-                .SetDiscriminatorProperty((Property)property, ConfigurationSource.Explicit);
+                .SetDiscriminatorProperty((Property?)property, ConfigurationSource.Explicit);
 
         /// <summary>
         ///     Sets the value indicating whether the discriminator mapping is complete.
@@ -607,7 +609,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="value"> The value to set. </param>
-        public static void SetDiscriminatorValue([NotNull] this IMutableEntityType entityType, [CanBeNull] object value)
+        public static void SetDiscriminatorValue([NotNull] this IMutableEntityType entityType, [CanBeNull] object? value)
         {
             entityType.AsEntityType().CheckDiscriminatorValue(entityType, value);
 

--- a/src/EFCore/Extensions/MutableForeignKeyExtensions.cs
+++ b/src/EFCore/Extensions/MutableForeignKeyExtensions.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -33,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     A navigation associated with this foreign key or <see langword="null" />.
         /// </returns>
-        public static IMutableNavigation GetNavigation([NotNull] this IMutableForeignKey foreignKey, bool pointsToPrincipal)
+        public static IMutableNavigation? GetNavigation([NotNull] this IMutableForeignKey foreignKey, bool pointsToPrincipal)
             => pointsToPrincipal ? foreignKey.DependentToPrincipal : foreignKey.PrincipalToDependent;
     }
 }

--- a/src/EFCore/Extensions/MutableKeyExtensions.cs
+++ b/src/EFCore/Extensions/MutableKeyExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -9,6 +9,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the entity type in. </param>
         /// <param name="type"> The type to find the corresponding entity type for. </param>
         /// <returns> The entity type, or <see langword="null" /> if none if found. </returns>
-        public static IMutableEntityType FindEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
+        public static IMutableEntityType? FindEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
             => ((Model)model).FindEntityType(type);
 
         /// <summary>
@@ -37,12 +39,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="definingNavigationName"> The defining navigation of the entity type to find. </param>
         /// <param name="definingEntityType"> The defining entity type of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
-        public static IMutableEntityType FindEntityType(
+        public static IMutableEntityType? FindEntityType(
             [NotNull] this IMutableModel model,
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
             [NotNull] IMutableEntityType definingEntityType)
-            => (IMutableEntityType)((IModel)model).FindEntityType(type, definingNavigationName, definingEntityType);
+            => (IMutableEntityType?)((IModel)model).FindEntityType(type, definingNavigationName, definingEntityType);
 
         /// <summary>
         ///     Gets the entity types matching the given type.
@@ -70,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to remove the entity type from. </param>
         /// <param name="type"> The entity type to be removed. </param>
         /// <returns> The entity type that was removed. </returns>
-        public static IMutableEntityType RemoveEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
+        public static IMutableEntityType? RemoveEntityType([NotNull] this IMutableModel model, [NotNull] Type type)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(type, nameof(type));
@@ -86,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="definingNavigationName"> The defining navigation. </param>
         /// <param name="definingEntityType"> The defining entity type. </param>
         /// <returns> The entity type that was removed. </returns>
-        public static IMutableEntityType RemoveEntityType(
+        public static IMutableEntityType? RemoveEntityType(
             [NotNull] this IMutableModel model,
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
@@ -102,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to remove the entity type from. </param>
         /// <param name="name"> The name of the entity type to be removed. </param>
         /// <returns> The entity type that was removed. </returns>
-        public static IMutableEntityType RemoveEntityType(
+        public static IMutableEntityType? RemoveEntityType(
             [NotNull] this IMutableModel model,
             [NotNull] string name)
         {
@@ -120,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="definingNavigationName"> The defining navigation. </param>
         /// <param name="definingEntityType"> The defining entity type. </param>
         /// <returns> The entity type that was removed. </returns>
-        public static IMutableEntityType RemoveEntityType(
+        public static IMutableEntityType? RemoveEntityType(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
             [NotNull] string definingNavigationName,
@@ -144,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore
         public static IReadOnlyList<IMutableEntityType> FindLeastDerivedEntityTypes(
             [NotNull] this IMutableModel model,
             [NotNull] Type type,
-            [CanBeNull] Func<IMutableEntityType, bool> condition = null)
+            [CanBeNull] Func<IMutableEntityType, bool>? condition = null)
             => Check.NotNull((Model)model, nameof(model))
                 .FindLeastDerivedEntityTypes(type, condition);
 
@@ -154,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to remove the ignored entity type from. </param>
         /// <param name="type"> The ignored entity type to be removed. </param>
         /// <returns> The name of the removed ignored type. </returns>
-        public static string RemoveIgnored([NotNull] this IMutableModel model, [NotNull] Type type)
+        public static string? RemoveIgnored([NotNull] this IMutableModel model, [NotNull] Type type)
             => Check.NotNull((Model)model, nameof(model)).RemoveIgnored(
                 Check.NotNull(type, nameof(type)));
 
@@ -206,7 +208,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The name of the ignored type. </returns>
         public static string AddIgnored([NotNull] this IMutableModel model, [NotNull] Type type)
             => Check.NotNull((Model)model, nameof(model)).AddIgnored(
-                Check.NotNull(type, nameof(type)), ConfigurationSource.Explicit);
+                Check.NotNull(type, nameof(type)), ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     Returns a value indicating whether the entity types using the given type should be configured
@@ -239,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to remove the owned type name from. </param>
         /// <param name="type"> The type of the entity type that should not be owned. </param>
         /// <returns> The name of the removed owned type. </returns>
-        public static string RemoveOwned([NotNull] this IMutableModel model, [NotNull] Type type)
+        public static string? RemoveOwned([NotNull] this IMutableModel model, [NotNull] Type type)
             => Check.NotNull((Model)model, nameof(model)).RemoveOwned(
                 Check.NotNull(type, nameof(type)));
 
@@ -261,6 +263,6 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to finalize. </param>
         /// <returns> The finalized <see cref="IModel" />. </returns>
         public static IModel FinalizeModel([NotNull] this IMutableModel model)
-            => ((Model)model).FinalizeModel();
+            => ((Model)model).FinalizeModel()!;
     }
 }

--- a/src/EFCore/Extensions/MutableNavigationExtensions.cs
+++ b/src/EFCore/Extensions/MutableNavigationExtensions.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/MutablePropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyBaseExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -26,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The foreign key property. </param>
         /// <returns> The first associated principal property, or <see langword="null" /> if none exists. </returns>
-        public static IMutableProperty FindFirstPrincipal([NotNull] this IMutableProperty property)
-            => (IMutableProperty)((IProperty)property).FindFirstPrincipal();
+        public static IMutableProperty? FindFirstPrincipal([NotNull] this IMutableProperty property)
+            => (IMutableProperty?)((IProperty)property).FindFirstPrincipal();
 
         /// <summary>
         ///     Finds the list of principal properties including the given property that the given property is constrained by
@@ -68,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     The primary that use this property, or <see langword="null" /> if it is not part of the primary key.
         /// </returns>
-        public static IMutableKey FindContainingPrimaryKey([NotNull] this IMutableProperty property)
-            => (IMutableKey)((IProperty)property).FindContainingPrimaryKey();
+        public static IMutableKey? FindContainingPrimaryKey([NotNull] this IMutableProperty property)
+            => (IMutableKey?)((IProperty)property).FindContainingPrimaryKey();
 
         /// <summary>
         ///     Gets all primary or alternate keys that use this property (including composite keys in which this property
@@ -189,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="converter"> The converter, or <see langword="null" /> to remove any previously set converter. </param>
-        public static void SetValueConverter([NotNull] this IMutableProperty property, [CanBeNull] ValueConverter converter)
+        public static void SetValueConverter([NotNull] this IMutableProperty property, [CanBeNull] ValueConverter? converter)
             => property.AsProperty().SetValueConverter(converter, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -197,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="providerClrType"> The type to use, or <see langword="null" /> to remove any previously set type. </param>
-        public static void SetProviderClrType([NotNull] this IMutableProperty property, [CanBeNull] Type providerClrType)
+        public static void SetProviderClrType([NotNull] this IMutableProperty property, [CanBeNull] Type? providerClrType)
             => property.AsProperty().SetProviderClrType(providerClrType, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -215,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <see langword="null" /> to remove any previously set comparer. </param>
-        public static void SetValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        public static void SetValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer? comparer)
             => property.AsProperty().SetValueComparer(comparer, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -224,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <see langword="null" /> to remove any previously set comparer. </param>
         [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
-        public static void SetKeyValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        public static void SetKeyValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer? comparer)
             => property.AsProperty().SetValueComparer(comparer, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -233,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <see langword="null" /> to remove any previously set comparer. </param>
         [Obsolete("Use SetValueComparer. Only a single value comparer is allowed for a given property.")]
-        public static void SetStructuralValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        public static void SetStructuralValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer? comparer)
             => property.SetValueComparer(comparer);
     }
 }

--- a/src/EFCore/Extensions/MutableTypeBaseExtensions.cs
+++ b/src/EFCore/Extensions/MutableTypeBaseExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/NavigationExtensions.cs
+++ b/src/EFCore/Extensions/NavigationExtensions.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/PropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/PropertyBaseExtensions.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -79,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="propertyBase"> The property for which the backing field will be returned. </param>
         /// <returns> The name of the backing field, or <see langword="null" />. </returns>
-        public static string GetFieldName([NotNull] this IPropertyBase propertyBase)
+        public static string? GetFieldName([NotNull] this IPropertyBase propertyBase)
             => propertyBase.FieldInfo?.GetSimpleMemberName();
 
         /// <summary>

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -17,6 +17,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -47,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <see langword="null" /> if none was found. </returns>
-        public static CoreTypeMapping FindTypeMapping([NotNull] this IProperty property)
+        public static CoreTypeMapping? FindTypeMapping([NotNull] this IProperty property)
             => ((Property)property).TypeMapping;
 
         /// <summary>
@@ -56,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The foreign key property. </param>
         /// <returns> The first associated principal property, or <see langword="null" /> if none exists. </returns>
-        public static IProperty FindFirstPrincipal([NotNull] this IProperty property)
+        public static IProperty? FindFirstPrincipal([NotNull] this IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
@@ -181,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property to get primary key for. </param>
         /// <returns> The primary that use this property, or <see langword="null" /> if it is not part of the primary key. </returns>
-        public static IKey FindContainingPrimaryKey([NotNull] this IProperty property)
+        public static IKey? FindContainingPrimaryKey([NotNull] this IProperty property)
             => Check.NotNull((Property)property, nameof(property)).PrimaryKey;
 
         /// <summary>
@@ -294,8 +296,8 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property to get the value generator factory for. </param>
         /// <returns> The factory, or <see langword="null" /> if no factory has been set. </returns>
-        public static Func<IProperty, IEntityType, ValueGenerator> GetValueGeneratorFactory([NotNull] this IProperty property)
-            => (Func<IProperty, IEntityType, ValueGenerator>)
+        public static Func<IProperty, IEntityType, ValueGenerator>? GetValueGeneratorFactory([NotNull] this IProperty property)
+            => (Func<IProperty, IEntityType, ValueGenerator>?)
                 Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueGeneratorFactory];
 
         /// <summary>
@@ -303,27 +305,27 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The converter, or <see langword="null" /> if none has been set. </returns>
-        public static ValueConverter GetValueConverter([NotNull] this IProperty property)
-            => (ValueConverter)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueConverter];
+        public static ValueConverter? GetValueConverter([NotNull] this IProperty property)
+            => (ValueConverter?)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueConverter];
 
         /// <summary>
         ///     Gets the type that the property value will be converted to before being sent to the database provider.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The provider type, or <see langword="null" /> if none has been set. </returns>
-        public static Type GetProviderClrType([NotNull] this IProperty property)
-            => (Type)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ProviderClrType];
+        public static Type? GetProviderClrType([NotNull] this IProperty property)
+            => (Type?)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ProviderClrType];
 
         /// <summary>
         ///     Gets the <see cref="ValueComparer" /> for this property, or <see langword="null" /> if none is set.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The comparer, or <see langword="null" /> if none has been set. </returns>
-        public static ValueComparer GetValueComparer([NotNull] this IProperty property)
+        public static ValueComparer? GetValueComparer([NotNull] this IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
-            return (ValueComparer)property[CoreAnnotationNames.ValueComparer]
+            return (ValueComparer?)property[CoreAnnotationNames.ValueComparer]
                 ?? property.FindTypeMapping()?.Comparer;
         }
 
@@ -332,11 +334,11 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The comparer, or <see langword="null" /> if none has been set. </returns>
-        public static ValueComparer GetKeyValueComparer([NotNull] this IProperty property)
+        public static ValueComparer? GetKeyValueComparer([NotNull] this IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
-            return (ValueComparer)property[CoreAnnotationNames.ValueComparer]
+            return (ValueComparer?)property[CoreAnnotationNames.ValueComparer]
                 ?? property.FindTypeMapping()?.KeyComparer;
         }
 
@@ -346,7 +348,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="property"> The property. </param>
         /// <returns> The comparer, or <see langword="null" /> if none has been set. </returns>
         [Obsolete("Use GetKeyValueComparer. A separate structural comparer is no longer supported.")]
-        public static ValueComparer GetStructuralValueComparer([NotNull] this IProperty property)
+        public static ValueComparer? GetStructuralValueComparer([NotNull] this IProperty property)
             => property.GetKeyValueComparer();
 
         /// <summary>
@@ -357,7 +359,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> A new equality comparer. </returns>
         public static IEqualityComparer<TProperty> CreateKeyEqualityComparer<TProperty>([NotNull] this IProperty property)
         {
-            var comparer = property.GetKeyValueComparer();
+            // TODO-NULLABLE: #22031
+            var comparer = property.GetKeyValueComparer()!;
 
             return comparer is IEqualityComparer<TProperty> nullableComparer
                 ? nullableComparer

--- a/src/EFCore/Extensions/ServicePropertyExtensions.cs
+++ b/src/EFCore/Extensions/ServicePropertyExtensions.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/SkipNavigationExtensions.cs
+++ b/src/EFCore/Extensions/SkipNavigationExtensions.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Extensions/TypeBaseExtensions.cs
+++ b/src/EFCore/Extensions/TypeBaseExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore/Infrastructure/AnnotatableExtensions.cs
+++ b/src/EFCore/Infrastructure/AnnotatableExtensions.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
     /// <summary>

--- a/src/EFCore/Infrastructure/ConventionAnnotatable.cs
+++ b/src/EFCore/Infrastructure/ConventionAnnotatable.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
     /// <summary>
@@ -39,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> The added annotation. </returns>
         public virtual ConventionAnnotation AddAnnotation(
             [NotNull] string name,
-            [CanBeNull] object value,
+            [CanBeNull] object? value,
             ConfigurationSource configurationSource)
             => (ConventionAnnotation)base.AddAnnotation(name, CreateAnnotation(name, value, configurationSource));
 
@@ -50,9 +52,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="name"> The key of the annotation to be added. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <param name="configurationSource"> The configuration source of the annotation to be set. </param>
-        public virtual ConventionAnnotation SetAnnotation(
+        public virtual ConventionAnnotation? SetAnnotation(
             [NotNull] string name,
-            [CanBeNull] object value,
+            [CanBeNull] object? value,
             ConfigurationSource configurationSource)
         {
             var oldAnnotation = FindAnnotation(name);
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 configurationSource = configurationSource.Max(oldAnnotation.GetConfigurationSource());
             }
 
-            return (ConventionAnnotation)base.SetAnnotation(name, CreateAnnotation(name, value, configurationSource), oldAnnotation);
+            return (ConventionAnnotation?)base.SetAnnotation(name, CreateAnnotation(name, value, configurationSource), oldAnnotation);
         }
 
         /// <summary>
@@ -77,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="annotation"> The annotation set. </param>
         /// <param name="oldAnnotation"> The old annotation. </param>
         /// <returns> The annotation that was set. </returns>
-        protected override Annotation OnAnnotationSet(string name, Annotation annotation, Annotation oldAnnotation)
-            => (Annotation)OnAnnotationSet(name, (IConventionAnnotation)annotation, (IConventionAnnotation)oldAnnotation);
+        protected override Annotation? OnAnnotationSet(string name, Annotation? annotation, Annotation? oldAnnotation)
+            => (Annotation?)OnAnnotationSet(name, (IConventionAnnotation?)annotation, (IConventionAnnotation?)oldAnnotation);
 
         /// <summary>
         ///     Called when an annotation was set or removed.
@@ -87,10 +89,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="annotation"> The annotation set. </param>
         /// <param name="oldAnnotation"> The old annotation. </param>
         /// <returns> The annotation that was set. </returns>
-        protected virtual IConventionAnnotation OnAnnotationSet(
+        protected virtual IConventionAnnotation? OnAnnotationSet(
             [NotNull] string name,
-            [CanBeNull] IConventionAnnotation annotation,
-            [CanBeNull] IConventionAnnotation oldAnnotation)
+            [CanBeNull] IConventionAnnotation? annotation,
+            [CanBeNull] IConventionAnnotation? oldAnnotation)
             => annotation;
 
         /// <summary>
@@ -100,24 +102,24 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns>
         ///     The existing annotation if an annotation with the specified name already exists. Otherwise, <see langword="null" />.
         /// </returns>
-        public new virtual ConventionAnnotation FindAnnotation([NotNull] string name)
-            => (ConventionAnnotation)base.FindAnnotation(name);
+        public new virtual ConventionAnnotation? FindAnnotation([NotNull] string name)
+            => (ConventionAnnotation?)base.FindAnnotation(name);
 
         /// <summary>
         ///     Removes the given annotation from this object.
         /// </summary>
         /// <param name="name"> The annotation to remove. </param>
         /// <returns> The annotation that was removed. </returns>
-        public new virtual ConventionAnnotation RemoveAnnotation([NotNull] string name)
-            => (ConventionAnnotation)base.RemoveAnnotation(name);
+        public new virtual ConventionAnnotation? RemoveAnnotation([NotNull] string name)
+            => (ConventionAnnotation?)base.RemoveAnnotation(name);
 
         /// <inheritdoc />
-        protected override Annotation CreateAnnotation(string name, object value)
+        protected override Annotation CreateAnnotation(string name, object? value)
             => CreateAnnotation(name, value, ConfigurationSource.Explicit);
 
         private static ConventionAnnotation CreateAnnotation(
             string name,
-            object value,
+            object? value,
             ConfigurationSource configurationSource)
             => new ConventionAnnotation(name, value, configurationSource);
 
@@ -132,16 +134,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionAnnotation IConventionAnnotatable.SetAnnotation(string name, object value, bool fromDataAnnotation)
+        IConventionAnnotation? IConventionAnnotatable.SetAnnotation(string name, object? value, bool fromDataAnnotation)
             => SetAnnotation(name, value, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        void IMutableAnnotatable.SetAnnotation(string name, object value)
+        void IMutableAnnotatable.SetAnnotation(string name, object? value)
             => SetAnnotation(name, value, ConfigurationSource.Explicit);
 
         /// <inheritdoc />
-        object IMutableAnnotatable.this[string name]
+        object? IMutableAnnotatable.this[string name]
         {
             [DebuggerStepThrough]
             get => this[name];
@@ -161,17 +163,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionAnnotation IConventionAnnotatable.AddAnnotation(string name, object value, bool fromDataAnnotation)
+        IConventionAnnotation IConventionAnnotatable.AddAnnotation(string name, object? value, bool fromDataAnnotation)
             => AddAnnotation(name, value, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionAnnotation IConventionAnnotatable.FindAnnotation(string name)
+        IConventionAnnotation? IConventionAnnotatable.FindAnnotation(string name)
             => FindAnnotation(name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionAnnotation IConventionAnnotatable.RemoveAnnotation(string name)
+        IConventionAnnotation? IConventionAnnotatable.RemoveAnnotation(string name)
             => RemoveAnnotation(name);
     }
 }

--- a/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionPropertyBuilder.cs
@@ -334,18 +334,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The same builder instance if the configuration was applied,
         ///     <see langword="null" /> otherwise.
         /// </returns>
-        IConventionPropertyBuilder HasTypeMapping([CanBeNull] CoreTypeMapping typeMapping, bool fromDataAnnotation = false);
+        IConventionPropertyBuilder HasTypeMapping([NotNull] CoreTypeMapping typeMapping, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns a value indicating whether the given <see cref="CoreTypeMapping" />
         ///     can be configured for this property from the current configuration source.
         /// </summary>
-        /// <param name="typeMapping"> The type mapping, or <see langword="null" /> to remove any previously set type mapping. </param>
+        /// <param name="typeMapping"> The type mapping. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns>
         ///     <see langword="true" /> if the given <see cref="ValueComparer" /> can be configured for this property.
         /// </returns>
-        bool CanSetTypeMapping([CanBeNull] CoreTypeMapping typeMapping, bool fromDataAnnotation = false);
+        bool CanSetTypeMapping([NotNull] CoreTypeMapping typeMapping, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Configures the <see cref="ValueComparer" /> for this property.

--- a/src/EFCore/Metadata/IConventionAnnotatable.cs
+++ b/src/EFCore/Metadata/IConventionAnnotatable.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new annotation. </returns>
-        IConventionAnnotation SetAnnotation([NotNull] string name, [CanBeNull] object? value, bool fromDataAnnotation = false);
+        IConventionAnnotation? SetAnnotation([NotNull] string name, [CanBeNull] object? value, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the annotation with the given name, returning <see langword="null" /> if it does not exist.

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a primary or alternate key from this entity type.
         /// </summary>
         /// <param name="key"> The key to be removed. </param>
-        /// <returns> The removed key. </returns>
+        /// <returns> The removed key, or <see langword="null" /> if the key was not found. </returns>
         IConventionKey? RemoveKey([NotNull] IConventionKey key);
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a foreign key from this entity type.
         /// </summary>
         /// <param name="foreignKey"> The foreign key to be removed. </param>
-        /// <returns> The removed foreign key. </returns>
+        /// <returns> The removed foreign key, or <see langword="null" /> if the index was not found. </returns>
         IConventionForeignKey? RemoveForeignKey([NotNull] IConventionForeignKey foreignKey);
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a skip navigation property from this entity type.
         /// </summary>
         /// <param name="navigation"> The skip navigation to be removed. </param>
-        /// <returns> The removed skip navigation. </returns>
+        /// <returns> The removed skip navigation, or <see langword="null" /> if the skip navigation was not found. </returns>
         IConventionSkipNavigation? RemoveSkipNavigation([NotNull] IConventionSkipNavigation navigation);
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes an index from this entity type.
         /// </summary>
         /// <param name="index"> The index to remove. </param>
-        /// <returns> The removed index. </returns>
+        /// <returns> The removed index, or <see langword="null" /> if the index was not found. </returns>
         IConventionIndex? RemoveIndex([NotNull] IConventionIndex index);
 
         /// <summary>
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a property from this entity type.
         /// </summary>
         /// <param name="property"> The property to remove. </param>
-        /// <returns> The removed property. </returns>
+        /// <returns> The removed property, or <see langword="null" /> if the property was not found. </returns>
         IConventionProperty? RemoveProperty([NotNull] IConventionProperty property);
 
         /// <summary>

--- a/src/EFCore/Metadata/IConventionForeignKey.cs
+++ b/src/EFCore/Metadata/IConventionForeignKey.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this foreign key.
         /// </summary>
-        new IConventionForeignKeyBuilder Builder { get; }
+        new IConventionForeignKeyBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the foreign key properties in the dependent entity.
@@ -54,12 +56,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the navigation property on the dependent entity type that points to the principal entity.
         /// </summary>
-        new IConventionNavigation DependentToPrincipal { get; }
+        new IConventionNavigation? DependentToPrincipal { get; }
 
         /// <summary>
         ///     Gets the navigation property on the principal entity type that points to the dependent entity.
         /// </summary>
-        new IConventionNavigation PrincipalToDependent { get; }
+        new IConventionNavigation? PrincipalToDependent { get; }
 
         /// <summary>
         ///     Returns the configuration source for this property.
@@ -183,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
-        IConventionNavigation SetDependentToPrincipal([CanBeNull] string name, bool fromDataAnnotation = false);
+        IConventionNavigation? SetDependentToPrincipal([CanBeNull] string? name, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the navigation property on the dependent entity type that points to the principal entity.
@@ -194,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
-        IConventionNavigation SetDependentToPrincipal([CanBeNull] MemberInfo property, bool fromDataAnnotation = false);
+        IConventionNavigation? SetDependentToPrincipal([CanBeNull] MemberInfo? property, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the navigation property on the dependent entity type that points to the principal entity.
@@ -206,7 +208,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetDependentToPrincipal")]
-        IConventionNavigation HasDependentToPrincipal([CanBeNull] string name, bool fromDataAnnotation = false)
+        IConventionNavigation? HasDependentToPrincipal([CanBeNull] string? name, bool fromDataAnnotation = false)
             => SetDependentToPrincipal(name, fromDataAnnotation);
 
         /// <summary>
@@ -219,7 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetDependentToPrincipal")]
-        IConventionNavigation HasDependentToPrincipal([CanBeNull] MemberInfo property, bool fromDataAnnotation = false)
+        IConventionNavigation? HasDependentToPrincipal([CanBeNull] MemberInfo? property, bool fromDataAnnotation = false)
             => SetDependentToPrincipal(property, fromDataAnnotation);
 
         /// <summary>
@@ -237,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
-        IConventionNavigation SetPrincipalToDependent([CanBeNull] string name, bool fromDataAnnotation = false);
+        IConventionNavigation? SetPrincipalToDependent([CanBeNull] string? name, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the navigation property on the principal entity type that points to the dependent entity.
@@ -248,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
-        IConventionNavigation SetPrincipalToDependent([CanBeNull] MemberInfo property, bool fromDataAnnotation = false);
+        IConventionNavigation? SetPrincipalToDependent([CanBeNull] MemberInfo? property, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the navigation property on the principal entity type that points to the dependent entity.
@@ -260,7 +262,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetPrincipalToDependent")]
-        IConventionNavigation HasPrincipalToDependent([CanBeNull] string name, bool fromDataAnnotation = false)
+        IConventionNavigation? HasPrincipalToDependent([CanBeNull] string? name, bool fromDataAnnotation = false)
             => SetPrincipalToDependent(name, fromDataAnnotation);
 
         /// <summary>
@@ -273,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetPrincipalToDependent")]
-        IConventionNavigation HasPrincipalToDependent([CanBeNull] MemberInfo property, bool fromDataAnnotation = false)
+        IConventionNavigation? HasPrincipalToDependent([CanBeNull] MemberInfo? property, bool fromDataAnnotation = false)
             => SetPrincipalToDependent(property, fromDataAnnotation);
 
         /// <summary>

--- a/src/EFCore/Metadata/IConventionIndex.cs
+++ b/src/EFCore/Metadata/IConventionIndex.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this index.
         /// </summary>
-        new IConventionIndexBuilder Builder { get; }
+        new IConventionIndexBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the properties that this index is defined on.

--- a/src/EFCore/Metadata/IConventionKey.cs
+++ b/src/EFCore/Metadata/IConventionKey.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this key.
         /// </summary>
-        new IConventionKeyBuilder Builder { get; }
+        new IConventionKeyBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the properties that make up the key.

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this model.
         /// </summary>
-        new IConventionModelBuilder Builder { get; }
+        new IConventionModelBuilder? Builder { get; }
 
         /// <summary>
         ///     <para>
@@ -39,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The name of the entity to be added. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new entity type. </returns>
-        IConventionEntityType AddEntityType([NotNull] string name, bool fromDataAnnotation = false);
+        IConventionEntityType? AddEntityType([NotNull] string name, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Adds an entity type to the model.
@@ -47,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="type"> The CLR class that is used to represent instances of the entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new entity type. </returns>
-        IConventionEntityType AddEntityType([NotNull] Type type, bool fromDataAnnotation = false);
+        IConventionEntityType? AddEntityType([NotNull] Type type, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     <para>
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="clrType"> The CLR class that is used to represent instances of the entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new entity type. </returns>
-        IConventionEntityType AddEntityType([NotNull] string name, [NotNull] Type clrType, bool fromDataAnnotation = false);
+        IConventionEntityType? AddEntityType([NotNull] string name, [NotNull] Type clrType, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Adds an entity type with a defining navigation to the model.
@@ -72,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="definingEntityType"> The defining entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new entity type. </returns>
-        IConventionEntityType AddEntityType(
+        IConventionEntityType? AddEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] IConventionEntityType definingEntityType,
@@ -86,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="definingEntityType"> The defining entity type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new entity type. </returns>
-        IConventionEntityType AddEntityType(
+        IConventionEntityType? AddEntityType(
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
             [NotNull] IConventionEntityType definingEntityType,
@@ -99,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
-        new IConventionEntityType FindEntityType([NotNull] string name);
+        new IConventionEntityType? FindEntityType([NotNull] string name);
 
         /// <summary>
         ///     Gets the entity type for the given name, defining navigation name
@@ -109,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="definingNavigationName"> The defining navigation of the entity type to find. </param>
         /// <param name="definingEntityType"> The defining entity type of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
-        IConventionEntityType FindEntityType(
+        IConventionEntityType? FindEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] IConventionEntityType definingEntityType);
@@ -118,8 +120,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes an entity type from the model.
         /// </summary>
         /// <param name="entityType"> The entity type to be removed. </param>
-        /// <returns> The removed entity type. </returns>
-        IConventionEntityType RemoveEntityType([NotNull] IConventionEntityType entityType);
+        /// <returns> The removed entity type, or <see langword="null" /> if the entity type was not found. </returns>
+        IConventionEntityType? RemoveEntityType([NotNull] IConventionEntityType entityType);
 
         /// <summary>
         ///     Gets all entity types defined in the model.
@@ -133,14 +135,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="typeName"> The name of the entity type to be ignored. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The name of the ignored entity type. </returns>
-        string AddIgnored([NotNull] string typeName, bool fromDataAnnotation = false);
+        string? AddIgnored([NotNull] string typeName, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Removes the ignored entity type name.
         /// </summary>
         /// <param name="typeName"> The name of the ignored entity type to be removed. </param>
         /// <returns> The removed ignored type name. </returns>
-        string RemoveIgnored([NotNull] string typeName);
+        string? RemoveIgnored([NotNull] string typeName);
 
         /// <summary>
         ///     Gets whether the CLR type is used by shared type entities in the model.

--- a/src/EFCore/Metadata/IConventionNavigation.cs
+++ b/src/EFCore/Metadata/IConventionNavigation.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this navigation.
         /// </summary>
-        new IConventionNavigationBuilder Builder { get; }
+        new IConventionNavigationBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the type that this navigation property belongs to.
@@ -49,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ConfigurationSource IConventionPropertyBase.GetConfigurationSource()
             => (ConfigurationSource)(IsOnDependent
                 ? ForeignKey.GetDependentToPrincipalConfigurationSource()
-                : ForeignKey.GetPrincipalToDependentConfigurationSource());
+                : ForeignKey.GetPrincipalToDependentConfigurationSource())!;
 
         /// <summary>
         ///     Gets the foreign key that defines the relationship this navigation property will navigate.
@@ -78,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new inverse navigation. </returns>
-        IConventionNavigation SetInverse([CanBeNull] string inverseName, bool fromDataAnnotation = false);
+        IConventionNavigation? SetInverse([CanBeNull] string? inverseName, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Sets the inverse navigation.
@@ -89,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new inverse navigation. </returns>
-        IConventionNavigation SetInverse([CanBeNull] MemberInfo inverse, bool fromDataAnnotation = false);
+        IConventionNavigation? SetInverse([CanBeNull] MemberInfo? inverse, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="Inverse" />.

--- a/src/EFCore/Metadata/IConventionNavigationBase.cs
+++ b/src/EFCore/Metadata/IConventionNavigationBase.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this property.
         /// </summary>
-        new IConventionPropertyBuilder Builder { get; }
+        new IConventionPropertyBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the type that this property belongs to.

--- a/src/EFCore/Metadata/IConventionSkipNavigation.cs
+++ b/src/EFCore/Metadata/IConventionSkipNavigation.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this property.
         /// </summary>
-        new IConventionSkipNavigationBuilder Builder { get; }
+        new IConventionSkipNavigationBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the type that this navigation property belongs to.
@@ -45,19 +47,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the join type used by the foreign key.
         /// </summary>
-        new IConventionEntityType JoinEntityType
+        new IConventionEntityType? JoinEntityType
         {
             [DebuggerStepThrough]
-            get => (IConventionEntityType)((ISkipNavigation)this).JoinEntityType;
+            get => (IConventionEntityType?)((ISkipNavigation)this).JoinEntityType;
         }
 
         /// <summary>
         ///     Gets the foreign key to the join type.
         /// </summary>
-        new IConventionForeignKey ForeignKey
+        new IConventionForeignKey? ForeignKey
         {
             [DebuggerStepThrough]
-            get => (IConventionForeignKey)((ISkipNavigation)this).ForeignKey;
+            get => (IConventionForeignKey?)((ISkipNavigation)this).ForeignKey;
         }
 
         /// <summary>
@@ -68,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new foreign key. </returns>
-        IConventionForeignKey SetForeignKey([CanBeNull] IConventionForeignKey foreignKey, bool fromDataAnnotation = false);
+        IConventionForeignKey? SetForeignKey([CanBeNull] IConventionForeignKey? foreignKey, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="ForeignKey" />.
@@ -79,10 +81,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse skip navigation.
         /// </summary>
-        new IConventionSkipNavigation Inverse
+        new IConventionSkipNavigation? Inverse
         {
             [DebuggerStepThrough]
-            get => (IConventionSkipNavigation)((ISkipNavigation)this).Inverse;
+            get => (IConventionSkipNavigation?)((ISkipNavigation)this).Inverse;
         }
 
         /// <summary>
@@ -93,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         [DebuggerStepThrough]
-        IConventionSkipNavigation SetInverse([CanBeNull] IConventionSkipNavigation inverse, bool fromDataAnnotation = false);
+        IConventionSkipNavigation? SetInverse([CanBeNull] IConventionSkipNavigation? inverse, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="Inverse" />.

--- a/src/EFCore/Metadata/IForeignKey.cs
+++ b/src/EFCore/Metadata/IForeignKey.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -40,12 +42,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the navigation property on the dependent entity type that points to the principal entity.
         /// </summary>
-        INavigation DependentToPrincipal { get; }
+        INavigation? DependentToPrincipal { get; }
 
         /// <summary>
         ///     Gets the navigation property on the principal entity type that points to the dependent entity.
         /// </summary>
-        INavigation PrincipalToDependent { get; }
+        INavigation? PrincipalToDependent { get; }
 
         /// <summary>
         ///     Gets a value indicating whether the values assigned to the foreign key properties are unique.

--- a/src/EFCore/Metadata/IIndex.cs
+++ b/src/EFCore/Metadata/IIndex.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the name of this index.
         /// </summary>
-        string Name { get; }
+        string? Name { get; }
 
         /// <summary>
         ///     Gets a value indicating whether the values assigned to the indexed properties are unique.

--- a/src/EFCore/Metadata/IKey.cs
+++ b/src/EFCore/Metadata/IKey.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IModel.cs
+++ b/src/EFCore/Metadata/IModel.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -37,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>
         /// <returns> The entity type, or null if none are found. </returns>
-        IEntityType FindEntityType([NotNull] string name);
+        IEntityType? FindEntityType([NotNull] string name);
 
         /// <summary>
         ///     Gets the entity type for the given name, defining navigation name
@@ -47,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="definingNavigationName"> The defining navigation of the entity type to find. </param>
         /// <param name="definingEntityType"> The defining entity type of the entity type to find. </param>
         /// <returns> The entity type, or null if none are found. </returns>
-        IEntityType FindEntityType(
+        IEntityType? FindEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] IEntityType definingEntityType);

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="properties"> The properties that make up the alternate key. </param>
         /// <returns> The newly created key. </returns>
-        IMutableKey? AddKey([NotNull] IReadOnlyList<IMutableProperty> properties);
+        IMutableKey AddKey([NotNull] IReadOnlyList<IMutableProperty> properties);
 
         /// <summary>
         ///     Gets the primary or alternate key that is defined on the given properties.
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a primary or alternate key from this entity type.
         /// </summary>
         /// <param name="key"> The key to be removed. </param>
-        /// <returns> The removed key. </returns>
+        /// <returns> The removed key, or <see langword="null" /> if the key was not found. </returns>
         IMutableKey? RemoveKey([NotNull] IMutableKey key);
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     base type of the hierarchy).
         /// </param>
         /// <returns> The newly created foreign key. </returns>
-        IMutableForeignKey? AddForeignKey(
+        IMutableForeignKey AddForeignKey(
             [NotNull] IReadOnlyList<IMutableProperty> properties,
             [NotNull] IMutableKey principalKey,
             [NotNull] IMutableEntityType principalEntityType);
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a foreign key from this entity type.
         /// </summary>
         /// <param name="foreignKey"> The foreign key to be removed. </param>
-        /// <returns> The removed foreign key. </returns>
+        /// <returns> The removed foreign key, or <see langword="null" /> if the index was not found. </returns>
         IMutableForeignKey? RemoveForeignKey([NotNull] IMutableForeignKey foreignKey);
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Whether the navigation property is defined on the dependent side of the underlying foreign key.
         /// </param>
         /// <returns> The newly created skip navigation property. </returns>
-        IMutableSkipNavigation? AddSkipNavigation(
+        IMutableSkipNavigation AddSkipNavigation(
             [NotNull] string name,
             [CanBeNull] MemberInfo? memberInfo,
             [NotNull] IMutableEntityType targetEntityType,
@@ -212,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a skip navigation properties from this entity type.
         /// </summary>
         /// <param name="navigation"> The skip navigation to be removed. </param>
-        /// <returns> The removed skip navigation. </returns>
+        /// <returns> The removed skip navigation, or <see langword="null" /> if the skip navigation was not found. </returns>
         IMutableSkipNavigation? RemoveSkipNavigation([NotNull] IMutableSkipNavigation navigation);
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="properties"> The properties that are to be indexed. </param>
         /// <returns> The newly created index. </returns>
-        IMutableIndex? AddIndex([NotNull] IReadOnlyList<IMutableProperty> properties);
+        IMutableIndex AddIndex([NotNull] IReadOnlyList<IMutableProperty> properties);
 
         /// <summary>
         ///     Adds a named index to this entity type.
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="properties"> The properties that are to be indexed. </param>
         /// <param name="name"> The name of the index. </param>
         /// <returns> The newly created index. </returns>
-        IMutableIndex? AddIndex(
+        IMutableIndex AddIndex(
             [NotNull] IReadOnlyList<IMutableProperty> properties,
             [NotNull] string name);
 
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes an index from this entity type.
         /// </summary>
         /// <param name="index"> The index to remove. </param>
-        /// <returns> The removed index. </returns>
+        /// <returns> The removed index, or <see langword="null" /> if the index was not found. </returns>
         IMutableIndex? RemoveIndex([NotNull] IMutableIndex index);
 
         /// <summary>
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     </para>
         /// </param>
         /// <returns> The newly created property. </returns>
-        IMutableProperty? AddProperty([NotNull] string name, [NotNull] Type propertyType, [CanBeNull] MemberInfo? memberInfo);
+        IMutableProperty AddProperty([NotNull] string name, [NotNull] Type propertyType, [CanBeNull] MemberInfo? memberInfo);
 
         /// <summary>
         ///     <para>
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes a property from this entity type.
         /// </summary>
         /// <param name="property"> The property to remove. </param>
-        /// <returns> The removed property. </returns>
+        /// <returns> The removed property, or <see langword="null" /> if the property was not found. </returns>
         IMutableProperty? RemoveProperty([NotNull] IMutableProperty property);
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="memberInfo"> The <see cref="PropertyInfo" /> or <see cref="FieldInfo" /> of the property to add. </param>
         /// <returns> The newly created property. </returns>
-        IMutableServiceProperty? AddServiceProperty([NotNull] MemberInfo memberInfo);
+        IMutableServiceProperty AddServiceProperty([NotNull] MemberInfo memberInfo);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/IMutableForeignKey.cs
+++ b/src/EFCore/Metadata/IMutableForeignKey.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -77,12 +79,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the navigation property on the dependent entity type that points to the principal entity.
         /// </summary>
-        new IMutableNavigation DependentToPrincipal { get; }
+        new IMutableNavigation? DependentToPrincipal { get; }
 
         /// <summary>
         ///     Gets the navigation property on the principal entity type that points to the dependent entity.
         /// </summary>
-        new IMutableNavigation PrincipalToDependent { get; }
+        new IMutableNavigation? PrincipalToDependent { get; }
 
         /// <summary>
         ///     Sets the foreign key properties and that target principal key.
@@ -99,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no navigation property defined.
         /// </param>
         /// <returns> The newly set navigation property. </returns>
-        IMutableNavigation SetDependentToPrincipal([CanBeNull] string name);
+        IMutableNavigation? SetDependentToPrincipal([CanBeNull] string name);
 
         /// <summary>
         ///     Sets the navigation property on the dependent entity type that points to the principal entity.
@@ -109,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no navigation property defined.
         /// </param>
         /// <returns> The newly set navigation property. </returns>
-        IMutableNavigation SetDependentToPrincipal([CanBeNull] MemberInfo property);
+        IMutableNavigation? SetDependentToPrincipal([CanBeNull] MemberInfo property);
 
         /// <summary>
         ///     Sets the navigation property on the dependent entity type that points to the principal entity.
@@ -120,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetDependentToPrincipal")]
-        IMutableNavigation HasDependentToPrincipal([CanBeNull] string name)
+        IMutableNavigation? HasDependentToPrincipal([CanBeNull] string name)
             => SetDependentToPrincipal(name);
 
         /// <summary>
@@ -132,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetDependentToPrincipal")]
-        IMutableNavigation HasDependentToPrincipal([CanBeNull] MemberInfo property)
+        IMutableNavigation? HasDependentToPrincipal([CanBeNull] MemberInfo property)
             => SetDependentToPrincipal(property);
 
         /// <summary>
@@ -143,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no navigation property defined.
         /// </param>
         /// <returns> The newly set navigation property. </returns>
-        IMutableNavigation SetPrincipalToDependent([CanBeNull] string name);
+        IMutableNavigation? SetPrincipalToDependent([CanBeNull] string name);
 
         /// <summary>
         ///     Sets the navigation property on the principal entity type that points to the dependent entity.
@@ -153,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no navigation property defined.
         /// </param>
         /// <returns> The newly set navigation property. </returns>
-        IMutableNavigation SetPrincipalToDependent([CanBeNull] MemberInfo property);
+        IMutableNavigation? SetPrincipalToDependent([CanBeNull] MemberInfo property);
 
         /// <summary>
         ///     Sets the navigation property on the principal entity type that points to the dependent entity.
@@ -164,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetPrincipalToDependent")]
-        IMutableNavigation HasPrincipalToDependent([CanBeNull] string name)
+        IMutableNavigation? HasPrincipalToDependent([CanBeNull] string name)
             => SetPrincipalToDependent(name);
 
         /// <summary>
@@ -176,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <returns> The newly created navigation property. </returns>
         [Obsolete("Use SetPrincipalToDependent")]
-        IMutableNavigation HasPrincipalToDependent([CanBeNull] MemberInfo property)
+        IMutableNavigation? HasPrincipalToDependent([CanBeNull] MemberInfo property)
             => SetPrincipalToDependent(property);
 
         /// <summary>

--- a/src/EFCore/Metadata/IMutableIndex.cs
+++ b/src/EFCore/Metadata/IMutableIndex.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IMutableKey.cs
+++ b/src/EFCore/Metadata/IMutableKey.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -86,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="name"> The name of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
-        new IMutableEntityType FindEntityType([NotNull] string name);
+        new IMutableEntityType? FindEntityType([NotNull] string name);
 
         /// <summary>
         ///     Gets the entity type for the given name, defining navigation name
@@ -96,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="definingNavigationName"> The defining navigation of the entity type to find. </param>
         /// <param name="definingEntityType"> The defining entity type of the entity type to find. </param>
         /// <returns> The entity type, or <see langword="null" /> if none are found. </returns>
-        IMutableEntityType FindEntityType(
+        IMutableEntityType? FindEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] IMutableEntityType definingEntityType);
@@ -105,8 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes an entity type from the model.
         /// </summary>
         /// <param name="entityType"> The entity type to be removed. </param>
-        /// <returns> The removed entity type. </returns>
-        IMutableEntityType RemoveEntityType([NotNull] IMutableEntityType entityType);
+        /// <returns> The removed entity type, or <see langword="null" /> if the entity type was not found. </returns>
+        IMutableEntityType? RemoveEntityType([NotNull] IMutableEntityType entityType);
 
         /// <summary>
         ///     Gets all entity types defined in the model.
@@ -126,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="typeName"> The name of the ignored entity type to be removed. </param>
         /// <returns> The removed ignored type name. </returns>
-        string RemoveIgnored([NotNull] string typeName);
+        string? RemoveIgnored([NotNull] string typeName);
 
         /// <summary>
         ///     Indicates whether the given entity type name is ignored.

--- a/src/EFCore/Metadata/IMutableNavigation.cs
+++ b/src/EFCore/Metadata/IMutableNavigation.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no inverse navigation property defined.
         /// </param>
         /// <returns> The inverse navigation. </returns>
-        IMutableNavigation SetInverse([CanBeNull] string inverseName);
+        IMutableNavigation? SetInverse([CanBeNull] string? inverseName);
 
         /// <summary>
         ///     Sets the inverse navigation.
@@ -72,6 +74,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     no inverse navigation property defined.
         /// </param>
         /// <returns> The inverse navigation. </returns>
-        IMutableNavigation SetInverse([CanBeNull] MemberInfo inverse);
+        IMutableNavigation? SetInverse([CanBeNull] MemberInfo? inverse);
     }
 }

--- a/src/EFCore/Metadata/IMutableNavigationBase.cs
+++ b/src/EFCore/Metadata/IMutableNavigationBase.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IMutablePropertyBase.cs
+++ b/src/EFCore/Metadata/IMutablePropertyBase.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets or sets the underlying CLR field for this property.
         ///     This may be <see langword="null" /> for shadow properties or if the backing field for the property is not known.
         /// </summary>
-        new FieldInfo FieldInfo { get; [param: CanBeNull] set; }
+        new FieldInfo? FieldInfo { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     <para>
@@ -47,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     </para>
         /// </summary>
         /// <param name="fieldName"> The name of the field to use. </param>
-        void SetField([CanBeNull] string fieldName)
+        void SetField([CanBeNull] string? fieldName)
             => this.AsPropertyBase().SetField(fieldName, ConfigurationSource.Explicit);
     }
 }

--- a/src/EFCore/Metadata/IMutableServiceProperty.cs
+++ b/src/EFCore/Metadata/IMutableServiceProperty.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -25,6 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets or sets <see cref="ServiceParameterBinding" /> for this property.
         /// </summary>
-        new ServiceParameterBinding ParameterBinding { get; [param: CanBeNull] set; }
+        new ServiceParameterBinding? ParameterBinding { get; [param: CanBeNull] set; }
     }
 }

--- a/src/EFCore/Metadata/IMutableSkipNavigation.cs
+++ b/src/EFCore/Metadata/IMutableSkipNavigation.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -39,19 +41,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the join type used by the foreign key.
         /// </summary>
-        new IMutableEntityType JoinEntityType
+        new IMutableEntityType? JoinEntityType
         {
             [DebuggerStepThrough]
-            get => (IMutableEntityType)((ISkipNavigation)this).JoinEntityType;
+            get => (IMutableEntityType?)((ISkipNavigation)this).JoinEntityType;
         }
 
         /// <summary>
         ///     Gets the foreign key to the join type.
         /// </summary>
-        new IMutableForeignKey ForeignKey
+        new IMutableForeignKey? ForeignKey
         {
             [DebuggerStepThrough]
-            get => (IMutableForeignKey)((ISkipNavigation)this).ForeignKey;
+            get => (IMutableForeignKey?)((ISkipNavigation)this).ForeignKey;
         }
 
         /// <summary>
@@ -60,15 +62,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="foreignKey">
         ///     The foreign key. Passing <see langword="null" /> will result in there being no foreign key associated.
         /// </param>
-        void SetForeignKey([CanBeNull] IMutableForeignKey foreignKey);
+        void SetForeignKey([CanBeNull] IMutableForeignKey? foreignKey);
 
         /// <summary>
         ///     Gets the inverse skip navigation.
         /// </summary>
-        new IMutableSkipNavigation Inverse
+        new IMutableSkipNavigation? Inverse
         {
             [DebuggerStepThrough]
-            get => (IMutableSkipNavigation)((ISkipNavigation)this).Inverse;
+            get => (IMutableSkipNavigation?)((ISkipNavigation)this).Inverse;
         }
 
         /// <summary>
@@ -78,6 +80,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The inverse skip navigation. Passing <see langword="null" /> will result in there being no inverse navigation property defined.
         /// </param>
         [DebuggerStepThrough]
-        IMutableSkipNavigation SetInverse([CanBeNull] IMutableSkipNavigation inverse);
+        IMutableSkipNavigation? SetInverse([CanBeNull] IMutableSkipNavigation? inverse);
     }
 }

--- a/src/EFCore/Metadata/IMutableTypeBase.cs
+++ b/src/EFCore/Metadata/IMutableTypeBase.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -34,8 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Removes the ignored member name.
         /// </summary>
         /// <param name="memberName"> The name of the member to be removed. </param>
-        /// <returns> The removed ignored member name. </returns>
-        string RemoveIgnored([NotNull] string memberName);
+        /// <returns> The removed ignored member name, or <see langword="null" /> if the member name was not found. </returns>
+        string? RemoveIgnored([NotNull] string memberName);
 
         /// <summary>
         ///     Indicates whether the given member name is ignored.

--- a/src/EFCore/Metadata/IPropertyBase.cs
+++ b/src/EFCore/Metadata/IPropertyBase.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -32,13 +34,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the <see cref="PropertyInfo" /> for the underlying CLR property for this property-like object.
         ///     This may be <see langword="null" /> for shadow properties or if mapped directly to a field.
         /// </summary>
-        PropertyInfo PropertyInfo { get; }
+        PropertyInfo? PropertyInfo { get; }
 
         /// <summary>
         ///     Gets the <see cref="FieldInfo" /> for the underlying CLR field for this property-like object.
         ///     This may be <see langword="null" /> for shadow properties or if the backing field is not known.
         /// </summary>
-        FieldInfo FieldInfo { get; }
+        FieldInfo? FieldInfo { get; }
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/ISkipNavigation.cs
+++ b/src/EFCore/Metadata/ISkipNavigation.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the join type used by the foreign key.
         /// </summary>
-        IEntityType JoinEntityType
+        IEntityType? JoinEntityType
             => IsOnDependent ? ForeignKey?.PrincipalEntityType : ForeignKey?.DeclaringEntityType;
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/ConventionAnnotatableExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ConventionAnnotatableExtensions.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -20,10 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static ConventionAnnotation SetOrRemoveAnnotation(
+        public static ConventionAnnotation? SetOrRemoveAnnotation(
             [NotNull] this ConventionAnnotatable annotatable,
             [NotNull] string name,
-            [CanBeNull] object value,
+            [CanBeNull] object? value,
             ConfigurationSource configurationSource)
         {
             if (value == null)

--- a/src/EFCore/Metadata/Internal/ConventionAnnotation.cs
+++ b/src/EFCore/Metadata/Internal/ConventionAnnotation.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public ConventionAnnotation([NotNull] string name, [CanBeNull] object value, ConfigurationSource configurationSource)
+        public ConventionAnnotation([NotNull] string name, [CanBeNull] object? value, ConfigurationSource configurationSource)
             : base(name, value)
         {
             _configurationSource = configurationSource;

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable ArgumentsStyleOther
 // ReSharper disable ArgumentsStyleNamedExpression
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -51,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IForeignKey FindDeclaredOwnership([NotNull] this IEntityType entityType)
+        public static IForeignKey? FindDeclaredOwnership([NotNull] this IEntityType entityType)
             => ((EntityType)entityType).FindDeclaredOwnership();
 
         /// <summary>
@@ -60,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IEntityType FindInDefinitionPath([NotNull] this IEntityType entityType, [NotNull] Type targetType)
+        public static IEntityType? FindInDefinitionPath([NotNull] this IEntityType entityType, [NotNull] Type targetType)
         {
             var root = entityType;
             while (root != null)
@@ -82,8 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static EntityType FindInDefinitionPath([NotNull] this EntityType entityType, [NotNull] Type targetType)
-            => (EntityType)((IEntityType)entityType).FindInDefinitionPath(targetType);
+        public static EntityType? FindInDefinitionPath([NotNull] this EntityType entityType, [NotNull] Type targetType)
+            => (EntityType?)((IEntityType)entityType).FindInDefinitionPath(targetType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -91,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IEntityType FindInDefinitionPath([NotNull] this IEntityType entityType, [NotNull] string targetTypeName)
+        public static IEntityType? FindInDefinitionPath([NotNull] this IEntityType entityType, [NotNull] string targetTypeName)
         {
             var root = entityType;
             while (root != null)
@@ -113,8 +115,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static EntityType FindInDefinitionPath([NotNull] this EntityType entityType, [NotNull] string targetTypeName)
-            => (EntityType)((IEntityType)entityType).FindInDefinitionPath(targetTypeName);
+        public static EntityType? FindInDefinitionPath([NotNull] this EntityType entityType, [NotNull] string targetTypeName)
+            => (EntityType?)((IEntityType)entityType).FindInDefinitionPath(targetTypeName);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -140,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IEntityType FindInOwnershipPath([NotNull] this IEntityType entityType, [NotNull] Type targetType)
+        public static IEntityType? FindInOwnershipPath([NotNull] this IEntityType entityType, [NotNull] Type targetType)
         {
             var owner = entityType;
             while (true)
@@ -152,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 owner = ownership.PrincipalEntityType;
-                if (owner.ClrType.IsAssignableFrom(targetType))
+                if (owner.ClrType?.IsAssignableFrom(targetType) == true)
                 {
                     return owner;
                 }
@@ -345,8 +347,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static EntityType LeastDerivedType([NotNull] this EntityType entityType, [NotNull] EntityType otherEntityType)
-            => (EntityType)((IEntityType)entityType).LeastDerivedType(otherEntityType);
+        public static EntityType? LeastDerivedType([NotNull] this EntityType entityType, [NotNull] EntityType otherEntityType)
+            => (EntityType?)((IEntityType)entityType).LeastDerivedType(otherEntityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -354,7 +356,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IKey FindDeclaredPrimaryKey([NotNull] this IEntityType entityType)
+        public static IKey? FindDeclaredPrimaryKey([NotNull] this IEntityType entityType)
             => entityType.BaseType == null ? entityType.FindPrimaryKey() : null;
 
         /// <summary>
@@ -405,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static IEnumerable<IPropertyBase> GetNotificationProperties(
             [NotNull] this IEntityType entityType,
-            [CanBeNull] string propertyName)
+            [CanBeNull] string? propertyName)
         {
             if (string.IsNullOrEmpty(propertyName))
             {
@@ -430,7 +432,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 // ReSharper disable once AssignNullToNotNullAttribute
                 var property = entityType.FindProperty(propertyName)
                     ?? entityType.FindNavigation(propertyName)
-                    ?? (IPropertyBase)entityType.FindSkipNavigation(propertyName);
+                    ?? (IPropertyBase?)entityType.FindSkipNavigation(propertyName);
 
                 if (property != null)
                 {

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -117,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalForeignKeyBuilder Builder
+        public virtual InternalForeignKeyBuilder? Builder
         {
             get;
 
@@ -131,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedSet<SkipNavigation> ReferencingSkipNavigations { get; [param: CanBeNull] set; }
+        public virtual SortedSet<SkipNavigation>? ReferencingSkipNavigations { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -175,9 +177,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
-            => Builder.ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAnnotationChanged(Builder, name, annotation, oldAnnotation);
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
+            => Builder!.ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAnnotationChanged(Builder, name, annotation, oldAnnotation);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -293,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation DependentToPrincipal { [DebuggerStepThrough] get; private set; }
+        public virtual Navigation? DependentToPrincipal { [DebuggerStepThrough] get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -301,8 +303,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation SetDependentToPrincipal(
-            [CanBeNull] string name,
+        public virtual Navigation? SetDependentToPrincipal(
+            [CanBeNull] string? name,
             ConfigurationSource configurationSource)
             => Navigation(MemberIdentity.Create(name), configurationSource, pointsToPrincipal: true);
 
@@ -312,8 +314,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation SetDependentToPrincipal(
-            [CanBeNull] MemberInfo property,
+        public virtual Navigation? SetDependentToPrincipal(
+            [CanBeNull] MemberInfo? property,
             ConfigurationSource configurationSource)
             => Navigation(MemberIdentity.Create(property), configurationSource, pointsToPrincipal: true);
 
@@ -342,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation PrincipalToDependent { [DebuggerStepThrough] get; private set; }
+        public virtual Navigation? PrincipalToDependent { [DebuggerStepThrough] get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -350,8 +352,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation HasPrincipalToDependent(
-            [CanBeNull] string name,
+        public virtual Navigation? HasPrincipalToDependent(
+            [CanBeNull] string? name,
             ConfigurationSource configurationSource)
             => Navigation(MemberIdentity.Create(name), configurationSource, pointsToPrincipal: false);
 
@@ -361,8 +363,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation HasPrincipalToDependent(
-            [CanBeNull] MemberInfo property,
+        public virtual Navigation? HasPrincipalToDependent(
+            [CanBeNull] MemberInfo? property,
             ConfigurationSource configurationSource)
             => Navigation(MemberIdentity.Create(property), configurationSource, pointsToPrincipal: false);
 
@@ -391,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        private Navigation Navigation(
+        private Navigation? Navigation(
             MemberIdentity? propertyIdentity,
             ConfigurationSource configurationSource,
             bool pointsToPrincipal)
@@ -423,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     UpdatePrincipalToDependentConfigurationSource(configurationSource);
                 }
 
-                return oldNavigation;
+                return oldNavigation!;
             }
 
             if (oldNavigation != null)
@@ -440,7 +442,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            Navigation navigation = null;
+            Navigation? navigation = null;
             var property = propertyIdentity?.MemberInfo;
             if (property != null)
             {
@@ -473,16 +475,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (pointsToPrincipal)
                 {
                     DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
-                        DeclaringEntityType.Builder,
-                        PrincipalEntityType.Builder,
+                        DeclaringEntityType.Builder!,
+                        PrincipalEntityType.Builder!,
                         oldNavigation.Name,
                         oldNavigation.GetIdentifyingMemberInfo());
                 }
                 else
                 {
                     DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
-                        PrincipalEntityType.Builder,
-                        DeclaringEntityType.Builder,
+                        PrincipalEntityType.Builder!,
+                        DeclaringEntityType.Builder!,
                         oldNavigation.Name,
                         oldNavigation.GetIdentifyingMemberInfo());
                 }
@@ -490,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (navigation != null)
             {
-                navigation = (Navigation)DeclaringEntityType.Model.ConventionDispatcher.OnNavigationAdded(navigation.Builder)?.Metadata;
+                navigation = (Navigation?)DeclaringEntityType.Model.ConventionDispatcher.OnNavigationAdded(navigation.Builder)?.Metadata;
             }
 
             return navigation ?? oldNavigation;
@@ -528,6 +530,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (unique.HasValue
                 && PrincipalEntityType.ClrType != null
+                && DeclaringEntityType.ClrType != null
                 && PrincipalToDependent != null)
             {
                 if (!Internal.Navigation.IsCompatible(
@@ -537,10 +540,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     !unique,
                     shouldThrow: false))
                 {
+                    // TODO-NULLABLE: Bug if PropertyInfo is null (FieldInfo?)
                     throw new InvalidOperationException(
                         CoreStrings.UnableToSetIsUnique(
                             unique.Value,
-                            PrincipalToDependent.PropertyInfo.Name,
+                            PrincipalToDependent.Name,
                             PrincipalEntityType.DisplayName()));
                 }
             }
@@ -831,7 +835,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual object DependentKeyValueFactory { get; [param: NotNull] set; }
+        public virtual object? DependentKeyValueFactory { get; [param: NotNull] set; }
 
         // Note: This is set and used only by IdentityMapFactoryFactory, which ensures thread-safety
         /// <summary>
@@ -840,7 +844,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Func<IDependentsMap> DependentsMapFactory { get; [param: NotNull] set; }
+        public virtual Func<IDependentsMap>? DependentsMapFactory { get; [param: NotNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -892,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        INavigation IForeignKey.DependentToPrincipal
+        INavigation? IForeignKey.DependentToPrincipal
         {
             [DebuggerStepThrough] get => DependentToPrincipal;
         }
@@ -903,7 +907,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        INavigation IForeignKey.PrincipalToDependent
+        INavigation? IForeignKey.PrincipalToDependent
         {
             [DebuggerStepThrough] get => PrincipalToDependent;
         }
@@ -958,7 +962,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableNavigation IMutableForeignKey.DependentToPrincipal
+        IMutableNavigation? IMutableForeignKey.DependentToPrincipal
         {
             [DebuggerStepThrough] get => DependentToPrincipal;
         }
@@ -969,7 +973,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableNavigation IMutableForeignKey.PrincipalToDependent
+        IMutableNavigation? IMutableForeignKey.PrincipalToDependent
         {
             [DebuggerStepThrough] get => PrincipalToDependent;
         }
@@ -990,7 +994,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableNavigation IMutableForeignKey.SetDependentToPrincipal(string name)
+        IMutableNavigation? IMutableForeignKey.SetDependentToPrincipal(string name)
             => SetDependentToPrincipal(name, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -1000,7 +1004,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        IMutableNavigation IMutableForeignKey.SetDependentToPrincipal(MemberInfo property)
+        IMutableNavigation? IMutableForeignKey.SetDependentToPrincipal(MemberInfo property)
             => SetDependentToPrincipal(property, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -1010,7 +1014,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        IMutableNavigation IMutableForeignKey.SetPrincipalToDependent(string name)
+        IMutableNavigation? IMutableForeignKey.SetPrincipalToDependent(string name)
             => HasPrincipalToDependent(name, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -1020,7 +1024,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        IMutableNavigation IMutableForeignKey.SetPrincipalToDependent(MemberInfo property)
+        IMutableNavigation? IMutableForeignKey.SetPrincipalToDependent(MemberInfo property)
             => HasPrincipalToDependent(property, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -1073,7 +1077,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionNavigation IConventionForeignKey.DependentToPrincipal
+        IConventionNavigation? IConventionForeignKey.DependentToPrincipal
         {
             [DebuggerStepThrough] get => DependentToPrincipal;
         }
@@ -1084,7 +1088,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionNavigation IConventionForeignKey.PrincipalToDependent
+        IConventionNavigation? IConventionForeignKey.PrincipalToDependent
         {
             [DebuggerStepThrough] get => PrincipalToDependent;
         }
@@ -1095,7 +1099,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionForeignKeyBuilder IConventionForeignKey.Builder
+        IConventionForeignKeyBuilder? IConventionForeignKey.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -1106,7 +1110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -1123,22 +1127,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionNavigation IConventionForeignKey.SetDependentToPrincipal(string name, bool fromDataAnnotation)
+        IConventionNavigation? IConventionForeignKey.SetDependentToPrincipal(string? name, bool fromDataAnnotation)
             => SetDependentToPrincipal(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionNavigation IConventionForeignKey.SetDependentToPrincipal(MemberInfo property, bool fromDataAnnotation)
+        IConventionNavigation? IConventionForeignKey.SetDependentToPrincipal(MemberInfo? property, bool fromDataAnnotation)
             => SetDependentToPrincipal(property, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionNavigation IConventionForeignKey.SetPrincipalToDependent(string name, bool fromDataAnnotation)
+        IConventionNavigation? IConventionForeignKey.SetPrincipalToDependent(string? name, bool fromDataAnnotation)
             => HasPrincipalToDependent(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionNavigation IConventionForeignKey.SetPrincipalToDependent(MemberInfo property, bool fromDataAnnotation)
+        IConventionNavigation? IConventionForeignKey.SetPrincipalToDependent(MemberInfo? property, bool fromDataAnnotation)
             => HasPrincipalToDependent(property, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -1258,10 +1262,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static bool AreCompatible(
             [NotNull] EntityType principalEntityType,
             [NotNull] EntityType dependentEntityType,
-            [CanBeNull] MemberInfo navigationToPrincipal,
-            [CanBeNull] MemberInfo navigationToDependent,
-            [CanBeNull] IReadOnlyList<Property> dependentProperties,
-            [CanBeNull] IReadOnlyList<Property> principalProperties,
+            [CanBeNull] MemberInfo? navigationToPrincipal,
+            [CanBeNull] MemberInfo? navigationToDependent,
+            [CanBeNull] IReadOnlyList<Property>? dependentProperties,
+            [CanBeNull] IReadOnlyList<Property>? principalProperties,
             bool? unique,
             bool shouldThrow)
         {
@@ -1283,8 +1287,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (navigationToPrincipal != null
                 && !Internal.Navigation.IsCompatible(
                     navigationToPrincipal,
-                    dependentEntityType.ClrType,
-                    principalEntityType.ClrType,
+                    dependentEntityType.ClrType!,
+                    principalEntityType.ClrType!,
                     shouldBeCollection: false,
                     shouldThrow: shouldThrow))
             {
@@ -1294,8 +1298,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (navigationToDependent != null
                 && !Internal.Navigation.IsCompatible(
                     navigationToDependent,
-                    principalEntityType.ClrType,
-                    dependentEntityType.ClrType,
+                    principalEntityType.ClrType!,
+                    dependentEntityType.ClrType!,
                     shouldBeCollection: !unique,
                     shouldThrow: shouldThrow))
             {

--- a/src/EFCore/Metadata/Internal/ForeignKeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKeyExtensions.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -243,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static IDependentsMap CreateDependentsMapFactory([NotNull] this IForeignKey foreignKey)
-            => foreignKey.AsForeignKey().DependentsMapFactory();
+            => foreignKey.AsForeignKey().DependentsMapFactory!(); // TODO-NULLABLE: #22031
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ConfigurationSource? _isUniqueConfigurationSource;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
-        private object _nullableValueFactory;
+        private object? _nullableValueFactory;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string Name { [DebuggerStepThrough] get; }
+        public virtual string? Name { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -99,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalIndexBuilder Builder
+        public virtual InternalIndexBuilder? Builder
         {
             [DebuggerStepThrough] get;
             [DebuggerStepThrough]
@@ -187,9 +189,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
-            => Builder.ModelBuilder.Metadata.ConventionDispatcher.OnIndexAnnotationChanged(Builder, name, annotation, oldAnnotation);
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
+            => Builder!.ModelBuilder.Metadata.ConventionDispatcher.OnIndexAnnotationChanged(Builder, name, annotation, oldAnnotation);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -271,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionIndexBuilder IConventionIndex.Builder
+        IConventionIndexBuilder? IConventionIndex.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -282,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }

--- a/src/EFCore/Metadata/Internal/IndexExtensions.cs
+++ b/src/EFCore/Metadata/Internal/IndexExtensions.cs
@@ -4,6 +4,8 @@
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -482,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual InternalPropertyBuilder HasTypeMapping(
-            [CanBeNull] CoreTypeMapping typeMapping,
+            [NotNull] CoreTypeMapping typeMapping,
             ConfigurationSource configurationSource)
         {
             if (CanSetTypeMapping(typeMapping, configurationSource))

--- a/src/EFCore/Metadata/Internal/Key.cs
+++ b/src/EFCore/Metadata/Internal/Key.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -26,9 +28,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ConfigurationSource _configurationSource;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
-        private Func<bool, IIdentityMap> _identityMapFactory;
+        private Func<bool, IIdentityMap>? _identityMapFactory;
 
-        private object _principalKeyValueFactory;
+        private object? _principalKeyValueFactory;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -72,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalKeyBuilder Builder
+        public virtual InternalKeyBuilder? Builder
         {
             [DebuggerStepThrough] get;
             [DebuggerStepThrough]
@@ -114,9 +116,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
-            => Builder.ModelBuilder.Metadata.ConventionDispatcher.OnKeyAnnotationChanged(Builder, name, annotation, oldAnnotation);
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
+            => Builder!.ModelBuilder.Metadata.ConventionDispatcher.OnKeyAnnotationChanged(Builder, name, annotation, oldAnnotation);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -153,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ISet<ForeignKey> ReferencingForeignKeys { get; [param: CanBeNull] set; }
+        public virtual ISet<ForeignKey>? ReferencingForeignKeys { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -225,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionKeyBuilder IConventionKey.Builder
+        IConventionKeyBuilder? IConventionKey.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -236,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough]
             get => Builder;

--- a/src/EFCore/Metadata/Internal/KeyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/KeyExtensions.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -17,6 +17,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Model([NotNull] ConventionSet conventions, [CanBeNull] ModelDependencies modelDependencies = null)
+        public Model([NotNull] ConventionSet conventions, [CanBeNull] ModelDependencies? modelDependencies = null)
         {
             ModelDependencies = modelDependencies;
             var dispatcher = new ConventionDispatcher(conventions);
@@ -99,6 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        // Becomes null once the model becomes read only; after this point, should never get accessed.
         public virtual ConventionDispatcher ConventionDispatcher { get; private set; }
 
         /// <summary>
@@ -107,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ModelDependencies ModelDependencies { get; private set; }
+        public virtual ModelDependencies? ModelDependencies { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -149,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType AddEntityType(
+        public virtual EntityType? AddEntityType(
             [NotNull] string name,
             ConfigurationSource configurationSource)
         {
@@ -166,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType AddEntityType(
+        public virtual EntityType? AddEntityType(
             [NotNull] Type type,
             ConfigurationSource configurationSource)
         {
@@ -183,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType AddEntityType(
+        public virtual EntityType? AddEntityType(
             [NotNull] string name,
             [NotNull] Type type,
             ConfigurationSource configurationSource)
@@ -196,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return AddEntityType(entityType);
         }
 
-        private EntityType AddEntityType(EntityType entityType)
+        private EntityType? AddEntityType(EntityType entityType)
         {
             var entityTypeName = entityType.Name;
             if (entityType.HasDefiningNavigation())
@@ -211,8 +214,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     for (var i = 0; i < detachedEntityTypes.Count; i++)
                     {
                         var (definingNavigation, definingEntityType) = detachedEntityTypes[i];
+                        // TODO-NULLABLE: Put MemberNotNull on HasDefiningNavigation when we target net5.0
                         if (definingNavigation == entityType.DefiningNavigationName
-                            && definingEntityType == entityType.DefiningEntityType.Name)
+                            && definingEntityType == entityType.DefiningEntityType!.Name)
                         {
                             detachedEntityTypes.RemoveAt(i);
                             break;
@@ -251,6 +255,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             CoreStrings.ClashingNonSharedType(entityType.Name, entityType.ClrType.DisplayName()));
                     }
 
+                    // TODO-NULLABLE: Put MemberNotNull on HasSharedClrType when we target net5.0
+                    Check.DebugAssert(entityType.ClrType != null, "entityType.ClrType is null");
                     if (_sharedTypes.TryGetValue(entityType.ClrType, out var existingConfigurationSource))
                     {
                         _sharedTypes[entityType.ClrType] = entityType.GetConfigurationSource().Max(existingConfigurationSource);
@@ -269,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _entityTypes.Add(entityTypeName, entityType);
             }
 
-            return (EntityType)ConventionDispatcher.OnEntityTypeAdded(entityType.Builder)?.Metadata;
+            return (EntityType?)ConventionDispatcher.OnEntityTypeAdded(entityType.Builder)?.Metadata;
         }
 
         /// <summary>
@@ -278,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType FindEntityType([NotNull] Type type)
+        public virtual EntityType? FindEntityType([NotNull] Type type)
             => FindEntityType(GetDisplayName(type));
 
         /// <summary>
@@ -287,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType FindEntityType([NotNull] string name)
+        public virtual EntityType? FindEntityType([NotNull] string name)
         {
             Check.DebugAssert(!string.IsNullOrEmpty(name), "name is null or empty");
             return _entityTypes.TryGetValue(name, out var entityType)
@@ -301,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType RemoveEntityType([NotNull] Type type)
+        public virtual EntityType? RemoveEntityType([NotNull] Type type)
             => RemoveEntityType(FindEntityType(type));
 
         /// <summary>
@@ -310,7 +316,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType RemoveEntityType([NotNull] string name)
+        public virtual EntityType? RemoveEntityType([NotNull] string name)
             => RemoveEntityType(FindEntityType(name));
 
         private static void AssertCanRemove(EntityType entityType)
@@ -351,7 +357,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType RemoveEntityType([CanBeNull] EntityType entityType)
+        public virtual EntityType? RemoveEntityType([CanBeNull] EntityType? entityType)
         {
             if (entityType?.Builder == null)
             {
@@ -393,7 +399,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType AddEntityType(
+        public virtual EntityType? AddEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType,
@@ -412,7 +418,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType AddEntityType(
+        public virtual EntityType? AddEntityType(
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType,
@@ -496,8 +502,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (_detachedEntityTypesWithDefiningNavigation.TryGetValue(entityType.Name, out var detachedEntityTypesWithSameType))
             {
+                // TODO-NULLABLE: Put MemberNotNull on HasDefiningNavigation when we target net5.0
                 if (detachedEntityTypesWithSameType.Any(
-                    e => e.Item1 != entityType.DefiningNavigationName || e.Item2 != entityType.DefiningEntityType.Name))
+                    e => e.Item1 != entityType.DefiningNavigationName || e.Item2 != entityType.DefiningEntityType!.Name))
                 {
                     return true;
                 }
@@ -535,7 +542,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType FindEntityType(
+        public virtual EntityType? FindEntityType(
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType)
@@ -547,7 +554,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType FindEntityType(
+        public virtual EntityType? FindEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType)
@@ -562,12 +569,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType FindActualEntityType([NotNull] EntityType entityType)
+        public virtual EntityType? FindActualEntityType([NotNull] EntityType entityType)
+            // TODO-NULLABLE: Put MemberNotNull on HasDefiningNavigation when we target net5.0
             => entityType.Builder != null
                 ? entityType
                 : (entityType.HasDefiningNavigation()
-                    ? FindActualEntityType(entityType.DefiningEntityType)
-                        ?.FindNavigation(entityType.DefiningNavigationName)?.TargetEntityType
+                    ? FindActualEntityType(entityType.DefiningEntityType!)
+                        ?.FindNavigation(entityType.DefiningNavigationName!)?.TargetEntityType
                     : FindEntityType(entityType.Name));
 
         /// <summary>
@@ -576,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Type FindClrType([NotNull] string name)
+        public virtual Type? FindClrType([NotNull] string name)
             => _entityTypes.TryGetValue(name, out var entityType)
                 ? entityType.HasSharedClrType
                     ? null
@@ -621,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IReadOnlyList<EntityType> FindLeastDerivedEntityTypes(
             [NotNull] Type type,
-            [CanBeNull] Func<EntityType, bool> condition = null)
+            [CanBeNull] Func<EntityType, bool>? condition = null)
         {
             var derivedLevels = new Dictionary<Type, int> { [type] = 0 };
 
@@ -647,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return new List<EntityType>();
         }
 
-        private static int GetDerivedLevel(Type derivedType, Dictionary<Type, int> derivedLevels)
+        private static int GetDerivedLevel(Type? derivedType, Dictionary<Type, int> derivedLevels)
         {
             if (derivedType?.BaseType == null)
             {
@@ -672,7 +680,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType RemoveEntityType(
+        public virtual EntityType? RemoveEntityType(
             [NotNull] Type type,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType)
@@ -684,7 +692,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType RemoveEntityType(
+        public virtual EntityType? RemoveEntityType(
             [NotNull] string name,
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType)
@@ -696,7 +704,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string AddIgnored(
+        public virtual string? AddIgnored(
             [NotNull] Type type,
             ConfigurationSource configurationSource)
             => AddIgnored(GetDisplayName(Check.NotNull(type, nameof(type))), type, configurationSource);
@@ -707,7 +715,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string AddIgnored(
+        public virtual string? AddIgnored(
             [NotNull] string name,
             ConfigurationSource configurationSource)
             => AddIgnored(Check.NotNull(name, nameof(name)), null, configurationSource);
@@ -718,9 +726,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string AddIgnored(
+        public virtual string? AddIgnored(
             [NotNull] string name,
-            [CanBeNull] Type type,
+            [CanBeNull] Type? type,
             ConfigurationSource configurationSource)
         {
             if (_ignoredTypeNames.TryGetValue(name, out var existingIgnoredConfigurationSource))
@@ -801,7 +809,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string RemoveIgnored([NotNull] Type type)
+        public virtual string? RemoveIgnored([NotNull] Type type)
         {
             Check.NotNull(type, nameof(type));
             return RemoveIgnored(GetDisplayName(type));
@@ -813,7 +821,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string RemoveIgnored(string name)
+        public virtual string? RemoveIgnored(string name)
         {
             Check.NotNull(name, nameof(name));
 
@@ -885,7 +893,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string RemoveOwned([NotNull] Type type)
+        public virtual string? RemoveOwned([NotNull] Type type)
         {
             if (!(this[CoreAnnotationNames.OwnedTypes] is Dictionary<string, ConfigurationSource> ownedTypes))
             {
@@ -981,8 +989,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
             => ConventionDispatcher.OnModelAnnotationChanged(Builder, name, annotation, oldAnnotation);
 
         /// <summary>
@@ -994,13 +1002,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IModel FinalizeModel()
         {
             ConventionDispatcher.AssertNoScope();
-            IModel finalizedModel = ConventionDispatcher.OnModelFinalizing(Builder)?.Metadata;
+            IModel? finalizedModel = ConventionDispatcher.OnModelFinalizing(Builder)?.Metadata;
             if (finalizedModel != null)
             {
                 finalizedModel = ConventionDispatcher.OnModelFinalized(finalizedModel);
             }
 
-            return (finalizedModel as Model)?.MakeReadonly() ?? finalizedModel;
+            return (finalizedModel as Model)?.MakeReadonly() ?? finalizedModel!;
         }
 
         /// <summary>
@@ -1011,7 +1019,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         private IModel MakeReadonly()
         {
-            ConventionDispatcher = null;
+            // ConventionDispatcher should never be accessed once the model is made read-only.
+            ConventionDispatcher = null!;
             ModelDependencies = null;
             IsValidated = true;
             return this;
@@ -1057,7 +1066,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual object RelationalModel
+        public virtual object? RelationalModel
             => this["Relational:RelationalModel"];
 
         /// <summary>
@@ -1077,7 +1086,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IEntityType IModel.FindEntityType(string name)
+        IEntityType? IModel.FindEntityType(string name)
             => FindEntityType(name);
 
         /// <summary>
@@ -1095,7 +1104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableEntityType IMutableModel.FindEntityType(string name)
+        IMutableEntityType? IMutableModel.FindEntityType(string name)
             => FindEntityType(name);
 
         /// <summary>
@@ -1105,7 +1114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IMutableEntityType IMutableModel.AddEntityType(string name)
-            => AddEntityType(name, ConfigurationSource.Explicit);
+            => AddEntityType(name, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1114,7 +1123,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IMutableEntityType IMutableModel.AddEntityType(Type type)
-            => AddEntityType(type, ConfigurationSource.Explicit);
+            => AddEntityType(type, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1123,7 +1132,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IMutableEntityType IMutableModel.AddEntityType(string name, Type type)
-            => AddEntityType(name, type, ConfigurationSource.Explicit);
+            => AddEntityType(name, type, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1131,7 +1140,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableEntityType IMutableModel.RemoveEntityType(IMutableEntityType entityType)
+        IMutableEntityType? IMutableModel.RemoveEntityType(IMutableEntityType entityType)
             => RemoveEntityType((EntityType)entityType);
 
         /// <summary>
@@ -1140,7 +1149,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IEntityType IModel.FindEntityType(string name, string definingNavigationName, IEntityType definingEntityType)
+        IEntityType? IModel.FindEntityType(string name, string definingNavigationName, IEntityType definingEntityType)
             => FindEntityType(name, definingNavigationName, (EntityType)definingEntityType);
 
         /// <summary>
@@ -1149,7 +1158,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IMutableEntityType IMutableModel.FindEntityType(
+        IMutableEntityType? IMutableModel.FindEntityType(
             string name,
             string definingNavigationName,
             IMutableEntityType definingEntityType)
@@ -1165,7 +1174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             string name,
             string definingNavigationName,
             IMutableEntityType definingEntityType)
-            => AddEntityType(name, definingNavigationName, (EntityType)definingEntityType, ConfigurationSource.Explicit);
+            => AddEntityType(name, definingNavigationName, (EntityType)definingEntityType, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1177,7 +1186,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Type type,
             string definingNavigationName,
             IMutableEntityType definingEntityType)
-            => AddEntityType(type, definingNavigationName, (EntityType)definingEntityType, ConfigurationSource.Explicit);
+            => AddEntityType(type, definingNavigationName, (EntityType)definingEntityType, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1195,7 +1204,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         string IMutableModel.AddIgnored(string name)
-            => AddIgnored(name, ConfigurationSource.Explicit);
+            => AddIgnored(name, ConfigurationSource.Explicit)!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1227,7 +1236,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.FindEntityType(string name)
+        IConventionEntityType? IConventionModel.FindEntityType(string name)
             => FindEntityType(name);
 
         /// <summary>
@@ -1236,7 +1245,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.FindEntityType(
+        IConventionEntityType? IConventionModel.FindEntityType(
             string name,
             string definingNavigationName,
             IConventionEntityType definingEntityType)
@@ -1248,7 +1257,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.AddEntityType(string name, bool fromDataAnnotation)
+        IConventionEntityType? IConventionModel.AddEntityType(string name, bool fromDataAnnotation)
             => AddEntityType(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -1257,7 +1266,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.AddEntityType(Type type, bool fromDataAnnotation)
+        IConventionEntityType? IConventionModel.AddEntityType(Type type, bool fromDataAnnotation)
             => AddEntityType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -1266,7 +1275,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.AddEntityType(string name, Type type, bool fromDataAnnotation)
+        IConventionEntityType? IConventionModel.AddEntityType(string name, Type type, bool fromDataAnnotation)
             => AddEntityType(name, type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -1275,7 +1284,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.AddEntityType(
+        IConventionEntityType? IConventionModel.AddEntityType(
             string name,
             string definingNavigationName,
             IConventionEntityType definingEntityType,
@@ -1290,7 +1299,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.AddEntityType(
+        IConventionEntityType? IConventionModel.AddEntityType(
             Type type,
             string definingNavigationName,
             IConventionEntityType definingEntityType,
@@ -1305,7 +1314,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionEntityType IConventionModel.RemoveEntityType(IConventionEntityType entityType)
+        IConventionEntityType? IConventionModel.RemoveEntityType(IConventionEntityType entityType)
             => RemoveEntityType((EntityType)entityType);
 
         /// <summary>
@@ -1323,7 +1332,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        string IConventionModel.AddIgnored(string name, bool fromDataAnnotation)
+        string? IConventionModel.AddIgnored(string name, bool fromDataAnnotation)
             => AddIgnored(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/ModelExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ModelExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/MutableEntityTypeExtensions.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public class Navigation : PropertyBase, IMutableNavigation, IConventionNavigation
     {
         // Warning: Never access these fields directly as access needs to be thread-safe
-        private IClrCollectionAccessor _collectionAccessor;
+        private IClrCollectionAccessor? _collectionAccessor;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -32,8 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public Navigation(
             [NotNull] string name,
-            [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
+            [CanBeNull] PropertyInfo? propertyInfo,
+            [CanBeNull] FieldInfo? fieldInfo,
             [NotNull] ForeignKey foreignKey)
             : base(name, propertyInfo, fieldInfo, ConfigurationSource.Convention)
         {
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalNavigationBuilder Builder { get; [param: CanBeNull] set; }
+        public virtual InternalNavigationBuilder? Builder { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -126,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public override ConfigurationSource GetConfigurationSource()
             => (ConfigurationSource)(IsOnDependent
                 ? ForeignKey.GetDependentToPrincipalConfigurationSource()
-                : ForeignKey.GetPrincipalToDependentConfigurationSource());
+                : ForeignKey.GetPrincipalToDependentConfigurationSource())!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -163,12 +165,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static bool IsCompatible(
             [NotNull] string navigationName,
-            [CanBeNull] MemberInfo navigationProperty,
+            [CanBeNull] MemberInfo? navigationProperty,
             [NotNull] EntityType sourceType,
             [NotNull] EntityType targetType,
             bool? shouldBeCollection,
             bool shouldThrow)
         {
+            var sourceClrType = sourceType.ClrType;
+            if (sourceClrType == null)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(CoreStrings.NavigationFromShadowEntity(navigationName, sourceType.DisplayName()));
+                }
+
+                return false;
+            }
+
             var targetClrType = targetType.ClrType;
             if (targetClrType == null)
             {
@@ -182,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return navigationProperty == null
-                || IsCompatible(navigationProperty, sourceType.ClrType, targetClrType, shouldBeCollection, shouldThrow);
+                || IsCompatible(navigationProperty, sourceClrType, targetClrType, shouldBeCollection, shouldThrow);
         }
 
         /// <summary>
@@ -265,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation SetInverse([CanBeNull] string inverseName, ConfigurationSource configurationSource)
+        public virtual Navigation? SetInverse([CanBeNull] string? inverseName, ConfigurationSource configurationSource)
             => IsOnDependent
                 ? ForeignKey.HasPrincipalToDependent(inverseName, configurationSource)
                 : ForeignKey.SetDependentToPrincipal(inverseName, configurationSource);
@@ -276,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation SetInverse([CanBeNull] MemberInfo inverse, ConfigurationSource configurationSource)
+        public virtual Navigation? SetInverse([CanBeNull] MemberInfo? inverse, ConfigurationSource configurationSource)
             => IsOnDependent
                 ? ForeignKey.HasPrincipalToDependent(inverse, configurationSource)
                 : ForeignKey.SetDependentToPrincipal(inverse, configurationSource);
@@ -311,8 +324,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
             => DeclaringType.Model.ConventionDispatcher.OnNavigationAnnotationChanged(
                 ForeignKey.Builder, this, name, annotation, oldAnnotation);
 
@@ -348,22 +361,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [DebuggerStepThrough]
-        IMutableNavigation IMutableNavigation.SetInverse([CanBeNull] string inverseName)
+        IMutableNavigation? IMutableNavigation.SetInverse(string? inverseName)
             => SetInverse(inverseName, ConfigurationSource.Explicit);
 
         [DebuggerStepThrough]
-        IMutableNavigation IMutableNavigation.SetInverse([CanBeNull] MemberInfo inverse)
+        IMutableNavigation? IMutableNavigation.SetInverse(MemberInfo? inverse)
             => SetInverse(inverse, ConfigurationSource.Explicit);
 
         [DebuggerStepThrough]
-        IConventionNavigation IConventionNavigation.SetInverse([CanBeNull] string inverseName, bool fromDataAnnotation)
+        IConventionNavigation? IConventionNavigation.SetInverse(string? inverseName, bool fromDataAnnotation)
             => SetInverse(inverseName, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         [DebuggerStepThrough]
-        IConventionNavigation IConventionNavigation.SetInverse([CanBeNull] MemberInfo inverse, bool fromDataAnnotation)
+        IConventionNavigation? IConventionNavigation.SetInverse(MemberInfo? inverse, bool fromDataAnnotation)
             => SetInverse(inverse, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
-        IConventionNavigationBuilder IConventionNavigation.Builder
+        IConventionNavigationBuilder? IConventionNavigation.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -374,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }

--- a/src/EFCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/NavigationExtensions.cs
@@ -5,6 +5,8 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static MemberIdentity CreateMemberIdentity([CanBeNull] this INavigation navigation)
+        public static MemberIdentity CreateMemberIdentity([CanBeNull] this INavigation? navigation)
             => navigation?.GetIdentifyingMemberInfo() == null
                 ? MemberIdentity.Create(navigation?.Name)
                 : MemberIdentity.Create(navigation.GetIdentifyingMemberInfo());

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -15,6 +15,9 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -29,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private bool? _isConcurrencyToken;
         private bool? _isNullable;
         private ValueGenerated? _valueGenerated;
-        private CoreTypeMapping _typeMapping;
+        private CoreTypeMapping? _typeMapping;
 
         private ConfigurationSource? _typeConfigurationSource;
         private ConfigurationSource? _isNullableConfigurationSource;
@@ -46,8 +49,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public Property(
             [NotNull] string name,
             [NotNull] Type clrType,
-            [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
+            [CanBeNull] PropertyInfo? propertyInfo,
+            [CanBeNull] FieldInfo? fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource,
             ConfigurationSource? typeConfigurationSource)
@@ -97,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalPropertyBuilder Builder { get; [param: CanBeNull] set; }
+        public virtual InternalPropertyBuilder? Builder { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -194,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override FieldInfo OnFieldInfoSet(FieldInfo newFieldInfo, FieldInfo oldFieldInfo)
+        protected override FieldInfo? OnFieldInfoSet(FieldInfo? newFieldInfo, FieldInfo? oldFieldInfo)
             => DeclaringEntityType.Model.ConventionDispatcher.OnPropertyFieldChanged(Builder, newFieldInfo, oldFieldInfo);
 
         /// <summary>
@@ -395,7 +398,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string CheckAfterSaveBehavior(PropertySaveBehavior behavior)
+        public virtual string? CheckAfterSaveBehavior(PropertySaveBehavior behavior)
             => behavior != PropertySaveBehavior.Throw
                 && this.IsKey()
                     ? CoreStrings.KeyPropertyMustBeReadOnly(Name, DeclaringEntityType.DisplayName())
@@ -407,8 +410,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Func<IProperty, IEntityType, ValueGenerator> SetValueGeneratorFactory(
-            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> factory,
+        public virtual Func<IProperty, IEntityType, ValueGenerator>? SetValueGeneratorFactory(
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator>? factory,
             ConfigurationSource configurationSource)
         {
             SetAnnotation(CoreAnnotationNames.ValueGeneratorFactory, factory, configurationSource);
@@ -422,8 +425,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ValueConverter SetValueConverter(
-            [CanBeNull] ValueConverter converter,
+        public virtual ValueConverter? SetValueConverter(
+            [CanBeNull] ValueConverter? converter,
             ConfigurationSource configurationSource)
         {
             var errorString = CheckValueConverter(converter);
@@ -443,7 +446,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string CheckValueConverter([CanBeNull] ValueConverter converter)
+        public virtual string? CheckValueConverter([CanBeNull] ValueConverter? converter)
             => converter != null
                 && converter.ModelClrType.UnwrapNullableType() != ClrType.UnwrapNullableType()
                     ? CoreStrings.ConverterPropertyMismatch(
@@ -459,7 +462,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Type SetProviderClrType([CanBeNull] Type providerClrType, ConfigurationSource configurationSource)
+        public virtual Type? SetProviderClrType([CanBeNull] Type? providerClrType, ConfigurationSource configurationSource)
         {
             this.SetOrRemoveAnnotation(CoreAnnotationNames.ProviderClrType, providerClrType, configurationSource);
 
@@ -472,7 +475,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual CoreTypeMapping TypeMapping
+        [CA.DisallowNull]
+        public virtual CoreTypeMapping? TypeMapping
         {
             get => _typeMapping;
             [param: NotNull]
@@ -488,9 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual CoreTypeMapping SetTypeMapping([NotNull] CoreTypeMapping typeMapping, ConfigurationSource configurationSource)
         {
             _typeMapping = typeMapping;
-            _typeMappingConfigurationSource = typeMapping == null
-                ? (ConfigurationSource?)null
-                : configurationSource.Max(_typeMappingConfigurationSource);
+            _typeMappingConfigurationSource = configurationSource.Max(_typeMappingConfigurationSource);
 
             return typeMapping;
         }
@@ -510,7 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ValueComparer SetValueComparer([CanBeNull] ValueComparer comparer, ConfigurationSource configurationSource)
+        public virtual ValueComparer? SetValueComparer([CanBeNull] ValueComparer? comparer, ConfigurationSource configurationSource)
         {
             var errorString = CheckValueComparer(comparer);
             if (errorString != null)
@@ -529,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string CheckValueComparer([CanBeNull] ValueComparer comparer)
+        public virtual string? CheckValueComparer([CanBeNull] ValueComparer? comparer)
             => comparer != null
                 && comparer.Type != ClrType
                     ? CoreStrings.ComparerPropertyMismatch(
@@ -545,7 +547,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IKey PrimaryKey { get; [param: CanBeNull] set; }
+        public virtual IKey? PrimaryKey { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -553,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual List<Key> Keys { get; [param: CanBeNull] set; }
+        public virtual List<Key>? Keys { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -570,7 +572,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual List<ForeignKey> ForeignKeys { get; [param: CanBeNull] set; }
+        public virtual List<ForeignKey>? ForeignKeys { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -587,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual List<Index> Indexes { get; [param: CanBeNull] set; }
+        public virtual List<Index>? Indexes { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -605,10 +607,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <param name="annotation"> The annotation set. </param>
         /// <param name="oldAnnotation"> The old annotation. </param>
         /// <returns> The annotation that was set. </returns>
-        protected override IConventionAnnotation OnAnnotationSet(
+        protected override IConventionAnnotation? OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
             => DeclaringType.Model.ConventionDispatcher.OnPropertyAnnotationChanged(Builder, name, annotation, oldAnnotation);
 
         /// <summary>
@@ -640,9 +642,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     property.IsShadowProperty()
                     || (entityType.HasClrType()
                         && ((property.PropertyInfo != null
-                                && entityType.GetRuntimeProperties().ContainsKey(property.Name))
+                                && entityType.GetRuntimeProperties()!.ContainsKey(property.Name))
                             || (property.FieldInfo != null
-                                && entityType.GetRuntimeFields().ContainsKey(property.Name)))));
+                                && entityType.GetRuntimeFields()!.ContainsKey(property.Name)))));
         }
 
         /// <summary>
@@ -671,7 +673,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionPropertyBuilder IConventionProperty.Builder
+        IConventionPropertyBuilder? IConventionProperty.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -682,7 +684,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough]
             get => Builder;

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -13,6 +13,9 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -24,17 +27,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public abstract class PropertyBase : ConventionAnnotatable, IMutablePropertyBase, IConventionPropertyBase
     {
-        private FieldInfo _fieldInfo;
+        private FieldInfo? _fieldInfo;
+        private ConfigurationSource _configurationSource;
         private ConfigurationSource? _fieldInfoConfigurationSource;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
-        private IClrPropertyGetter _getter;
-        private IClrPropertySetter _setter;
-        private IClrPropertySetter _materializationSetter;
-        private PropertyAccessors _accessors;
-        private PropertyIndexes _indexes;
-        private ConfigurationSource _configurationSource;
-        private IComparer<IUpdateEntry> _currentValueComparer;
+        private IClrPropertyGetter? _getter;
+        private IClrPropertySetter? _setter;
+        private IClrPropertySetter? _materializationSetter;
+        private PropertyAccessors? _accessors;
+        private PropertyIndexes? _indexes;
+        private IComparer<IUpdateEntry>? _currentValueComparer;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -44,8 +47,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         protected PropertyBase(
             [NotNull] string name,
-            [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
+            [CanBeNull] PropertyInfo? propertyInfo,
+            [CanBeNull] FieldInfo? fieldInfo,
             ConfigurationSource configurationSource)
         {
             Check.NotEmpty(name, nameof(name));
@@ -78,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual PropertyInfo PropertyInfo { [DebuggerStepThrough] get; }
+        public virtual PropertyInfo? PropertyInfo { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -86,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual FieldInfo FieldInfo
+        public virtual FieldInfo? FieldInfo
         {
             [DebuggerStepThrough] get => _fieldInfo;
             [DebuggerStepThrough] set => SetFieldInfo(value, ConfigurationSource.Explicit);
@@ -129,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual FieldInfo SetField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+        public virtual FieldInfo? SetField([CanBeNull] string? fieldName, ConfigurationSource configurationSource)
         {
             if (fieldName == null)
             {
@@ -159,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Check.DebugAssert(propertyName != null || !shouldThrow, "propertyName is null");
 
-            if (!type.GetRuntimeFields().TryGetValue(fieldName, out var fieldInfo)
+            if (!type.GetRuntimeFields()!.TryGetValue(fieldName, out var fieldInfo)
                 && shouldThrow)
             {
                 throw new InvalidOperationException(
@@ -175,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual FieldInfo SetFieldInfo([CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource)
+        public virtual FieldInfo? SetFieldInfo([CanBeNull] FieldInfo? fieldInfo, ConfigurationSource configurationSource)
         {
             if (Equals(FieldInfo, fieldInfo))
             {
@@ -241,9 +244,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static bool IsCompatible(
             [NotNull] FieldInfo fieldInfo,
-            [CanBeNull] Type propertyType,
-            [CanBeNull] Type entityType,
-            [CanBeNull] string propertyName,
+            [CanBeNull] Type? propertyType,
+            [CanBeNull] Type? entityType,
+            [CanBeNull] string? propertyName,
             bool shouldThrow)
         {
             Check.DebugAssert(propertyName != null || !shouldThrow, "propertyName is null");
@@ -287,6 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [CA.AllowNull]
         public virtual PropertyIndexes PropertyIndexes
         {
             get
@@ -319,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected virtual FieldInfo OnFieldInfoSet([CanBeNull] FieldInfo newFieldInfo, [CanBeNull] FieldInfo oldFieldInfo)
+        protected virtual FieldInfo? OnFieldInfoSet([CanBeNull] FieldInfo? newFieldInfo, [CanBeNull] FieldInfo? oldFieldInfo)
             => newFieldInfo;
 
         /// <summary>
@@ -465,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        FieldInfo IConventionPropertyBase.SetFieldInfo(FieldInfo fieldInfo, bool fromDataAnnotation)
+        FieldInfo? IConventionPropertyBase.SetFieldInfo(FieldInfo fieldInfo, bool fromDataAnnotation)
             => SetFieldInfo(fieldInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -7,6 +7,8 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -59,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static IProperty GetGenerationProperty([NotNull] this IProperty property)
+        public static IProperty? FindGenerationProperty([NotNull] this IProperty property)
         {
             var traversalList = new List<IProperty> { property };
 
@@ -144,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (property.IsKey()
                 || property.IsForeignKey())
             {
-                var generationProperty = property.GetGenerationProperty();
+                var generationProperty = property.FindGenerationProperty();
                 return (generationProperty != null)
                     && (generationProperty.ValueGenerated != ValueGenerated.Never);
             }

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -9,6 +9,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class ServiceProperty : PropertyBase, IMutableServiceProperty, IConventionServiceProperty
     {
-        private ServiceParameterBinding _parameterBinding;
+        private ServiceParameterBinding? _parameterBinding;
 
         private ConfigurationSource? _parameterBindingConfigurationSource;
 
@@ -31,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public ServiceProperty(
             [NotNull] string name,
-            [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
+            [CanBeNull] PropertyInfo? propertyInfo,
+            [CanBeNull] FieldInfo? fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource)
             : base(name, propertyInfo, fieldInfo, configurationSource)
@@ -40,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
-            ClrType = propertyInfo?.PropertyType ?? fieldInfo?.FieldType;
+            ClrType = (propertyInfo?.PropertyType ?? fieldInfo?.FieldType)!;
 
             Builder = new InternalServicePropertyBuilder(this, declaringEntityType.Model.Builder);
         }
@@ -78,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalServicePropertyBuilder Builder
+        public virtual InternalServicePropertyBuilder? Builder
         {
             get;
             [param: CanBeNull] set;
@@ -90,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ServiceParameterBinding ParameterBinding
+        public virtual ServiceParameterBinding? ParameterBinding
         {
             get => _parameterBinding;
             set => SetParameterBinding(value, ConfigurationSource.Explicit);
@@ -102,8 +104,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ServiceParameterBinding SetParameterBinding(
-            [CanBeNull] ServiceParameterBinding parameterBinding,
+        public virtual ServiceParameterBinding? SetParameterBinding(
+            [CanBeNull] ServiceParameterBinding? parameterBinding,
             ConfigurationSource configurationSource)
         {
             _parameterBinding = parameterBinding;
@@ -119,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        ServiceParameterBinding IConventionServiceProperty.SetParameterBinding(
+        ServiceParameterBinding? IConventionServiceProperty.SetParameterBinding(
             ServiceParameterBinding parameterBinding,
             bool fromDataAnnotation)
             => SetParameterBinding(
@@ -165,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionServicePropertyBuilder IConventionServiceProperty.Builder
+        IConventionServicePropertyBuilder? IConventionServiceProperty.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }
@@ -176,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough] get => Builder;
         }

--- a/src/EFCore/Metadata/Internal/ServicePropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ServicePropertyExtensions.cs
@@ -4,6 +4,8 @@
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static ServiceParameterBinding GetParameterBinding([NotNull] this IServiceProperty serviceProperty)
+        public static ServiceParameterBinding? GetParameterBinding([NotNull] this IServiceProperty serviceProperty)
             => serviceProperty.AsServiceProperty().ParameterBinding;
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/SkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigation.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -26,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ConfigurationSource? _inverseConfigurationSource;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
-        private IClrCollectionAccessor _collectionAccessor;
-        private ICollectionLoader _manyToManyLoader;
+        private IClrCollectionAccessor? _collectionAccessor;
+        private ICollectionLoader? _manyToManyLoader;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -37,8 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public SkipNavigation(
             [NotNull] string name,
-            [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
+            [CanBeNull] PropertyInfo? propertyInfo,
+            [CanBeNull] FieldInfo? fieldInfo,
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType targetEntityType,
             bool collection,
@@ -77,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override Type ClrType
-            => this.GetIdentifyingMemberInfo()?.GetMemberType();
+            => this.GetIdentifyingMemberInfo().GetMemberType();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -85,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalSkipNavigationBuilder Builder { get; [param: CanBeNull] set; }
+        public virtual InternalSkipNavigationBuilder? Builder { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -118,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual EntityType JoinEntityType
+        public virtual EntityType? JoinEntityType
             => IsOnDependent ? ForeignKey?.PrincipalEntityType : ForeignKey?.DeclaringEntityType;
 
         /// <summary>
@@ -127,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ForeignKey ForeignKey { get; [param: CanBeNull] private set; }
+        public virtual ForeignKey? ForeignKey { get; [param: CanBeNull] private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -135,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SkipNavigation Inverse { get; [param: CanBeNull] private set; }
+        public virtual SkipNavigation? Inverse { get; [param: CanBeNull] private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -159,15 +161,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ForeignKey SetForeignKey([CanBeNull] ForeignKey foreignKey, ConfigurationSource configurationSource)
+        public virtual ForeignKey? SetForeignKey([CanBeNull] ForeignKey? foreignKey, ConfigurationSource configurationSource)
         {
             var oldForeignKey = ForeignKey;
             var isChanging = foreignKey != ForeignKey;
 
-            if (oldForeignKey != null)
-            {
-                oldForeignKey.ReferencingSkipNavigations.Remove(this);
-            }
+            oldForeignKey?.ReferencingSkipNavigations!.Remove(this);
 
             if (foreignKey == null)
             {
@@ -175,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _foreignKeyConfigurationSource = null;
 
                 return isChanging
-                    ? (ForeignKey)DeclaringEntityType.Model.ConventionDispatcher
+                    ? (ForeignKey?)DeclaringEntityType.Model.ConventionDispatcher
                         .OnSkipNavigationForeignKeyChanged(Builder, foreignKey, oldForeignKey)
                     : foreignKey;
             }
@@ -200,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 throw new InvalidOperationException(
                     CoreStrings.SkipInverseMismatchedForeignKey(
                         foreignKey.Properties.Format(),
-                        Name, JoinEntityType.DisplayName(),
+                        Name, JoinEntityType!.DisplayName(),
                         Inverse.Name, Inverse.JoinEntityType.DisplayName()));
             }
 
@@ -234,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SkipNavigation SetInverse([CanBeNull] SkipNavigation inverse, ConfigurationSource configurationSource)
+        public virtual SkipNavigation? SetInverse([CanBeNull] SkipNavigation? inverse, ConfigurationSource configurationSource)
         {
             var oldInverse = Inverse;
             var isChanging = inverse != Inverse;
@@ -310,8 +309,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <returns> The annotation that was set. </returns>
         protected override IConventionAnnotation OnAnnotationSet(
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation)
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation)
             => DeclaringType.Model.ConventionDispatcher.OnSkipNavigationAnnotationChanged(
                 Builder, name, annotation, oldAnnotation);
 
@@ -357,14 +356,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
         /// <inheritdoc />
-        IConventionSkipNavigationBuilder IConventionSkipNavigation.Builder
+        IConventionSkipNavigationBuilder? IConventionSkipNavigation.Builder
         {
             [DebuggerStepThrough]
             get => Builder;
         }
 
         /// <inheritdoc />
-        IConventionAnnotatableBuilder IConventionAnnotatable.Builder
+        IConventionAnnotatableBuilder? IConventionAnnotatable.Builder
         {
             [DebuggerStepThrough]
             get => Builder;
@@ -387,39 +386,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <inheritdoc />
         IForeignKey ISkipNavigation.ForeignKey
         {
+            // ModelValidator makes sure ForeignKey isn't null, so we expose it as non-nullable.
             [DebuggerStepThrough]
-            get => ForeignKey;
+            get => ForeignKey!;
         }
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        void IMutableSkipNavigation.SetForeignKey([CanBeNull] IMutableForeignKey foreignKey)
-            => SetForeignKey((ForeignKey)foreignKey, ConfigurationSource.Explicit);
+        void IMutableSkipNavigation.SetForeignKey(IMutableForeignKey? foreignKey)
+            => SetForeignKey((ForeignKey?)foreignKey, ConfigurationSource.Explicit);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionForeignKey IConventionSkipNavigation.SetForeignKey([CanBeNull] IConventionForeignKey foreignKey, bool fromDataAnnotation)
+        IConventionForeignKey? IConventionSkipNavigation.SetForeignKey(IConventionForeignKey? foreignKey, bool fromDataAnnotation)
             => SetForeignKey(
-                (ForeignKey)foreignKey, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+                (ForeignKey?)foreignKey, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         ISkipNavigation ISkipNavigation.Inverse
         {
+            // ModelValidator makes sure ForeignKey isn't null, so we expose it as non-nullable.
             [DebuggerStepThrough]
-            get => Inverse;
+            get => Inverse!;
         }
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IMutableSkipNavigation IMutableSkipNavigation.SetInverse([CanBeNull] IMutableSkipNavigation inverse)
-            => SetInverse((SkipNavigation)inverse, ConfigurationSource.Explicit);
+        IMutableSkipNavigation? IMutableSkipNavigation.SetInverse(IMutableSkipNavigation? inverse)
+            => SetInverse((SkipNavigation?)inverse, ConfigurationSource.Explicit);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSkipNavigation IConventionSkipNavigation.SetInverse(
-            [CanBeNull] IConventionSkipNavigation inverse,
+        IConventionSkipNavigation? IConventionSkipNavigation.SetInverse(
+            IConventionSkipNavigation? inverse,
             bool fromDataAnnotation)
             => SetInverse(
-                (SkipNavigation)inverse, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+                (SkipNavigation?)inverse, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }
 }

--- a/src/EFCore/Metadata/Internal/SkipNavigationComparer.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigationComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static MemberIdentity CreateMemberIdentity([CanBeNull] this ISkipNavigation navigation)
+        public static MemberIdentity CreateMemberIdentity([CanBeNull] this ISkipNavigation? navigation)
             => navigation?.GetIdentifyingMemberInfo() == null
                 ? MemberIdentity.Create(navigation?.Name)
                 : MemberIdentity.Create(navigation.GetIdentifyingMemberInfo());

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1620,6 +1620,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
+        ///     The navigation '{navigation}' cannot be added to the entity type '{entityType}' because it is defined in shadow state, and navigations properties cannot originate from shadow state entities.
+        /// </summary>
+        public static string NavigationFromShadowEntity([CanBeNull] object navigation, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("NavigationFromShadowEntity", nameof(navigation), nameof(entityType)),
+                navigation, entityType);
+
+        /// <summary>
         ///     The navigation '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state, and navigations properties cannot point to shadow state entities.
         /// </summary>
         public static string NavigationToShadowEntity([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1024,6 +1024,9 @@
   <data name="NavigationToKeylessType" xml:space="preserve">
     <value>The navigation '{navigation}' cannot be added because it targets the keyless entity type '{entityType}'. Navigations can only target entity types with keys.</value>
   </data>
+  <data name="NavigationFromShadowEntity" xml:space="preserve">
+    <value>The navigation '{navigation}' cannot be added to the entity type '{entityType}' because it is defined in shadow state, and navigations properties cannot originate from shadow state entities.</value>
+  </data>
   <data name="NavigationToShadowEntity" xml:space="preserve">
     <value>The navigation '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state, and navigations properties cannot point to shadow state entities.</value>
   </data>

--- a/src/EFCore/Query/EntityShaperExpression.cs
+++ b/src/EFCore/Query/EntityShaperExpression.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var exception = CreateUnableToDiscriminateExceptionExpression(entityType, discriminatorValueVariable);
 
-                var discriminatorComparer = discriminatorProperty.GetKeyValueComparer();
+                var discriminatorComparer = discriminatorProperty.GetKeyValueComparer()!;
                 if (discriminatorComparer.IsDefault())
                 {
                     var switchCases = new SwitchCase[concreteEntityTypes.Length];

--- a/src/EFCore/Query/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Query/Internal/EntityMaterializerSource.cs
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var readValueExpression
                     = property is IServiceProperty serviceProperty
-                        ? serviceProperty.GetParameterBinding().BindToParameter(bindingInfo)
+                        ? serviceProperty.GetParameterBinding()!.BindToParameter(bindingInfo)
                         : valueBufferExpression.CreateValueBufferReadValueExpression(
                             memberInfo.GetMemberType(),
                             property.GetIndex(),
@@ -151,9 +151,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         private ConcurrentDictionary<IEntityType, Func<MaterializationContext, object>> Materializers
             => LazyInitializer.EnsureInitialized(
-                // TODO: Even though we should be able to pass nullable here for some reason it is inferring generic type incorrectly
-                ref _materializers!,
-                () => new ConcurrentDictionary<IEntityType, Func<MaterializationContext, object>>());
+                // TODO-NULLABLE: LazyInitializer not yet null-annotated in netstandard2.1, can remove bang after targeting net5.0
+                ref _materializers,
+                () => new ConcurrentDictionary<IEntityType, Func<MaterializationContext, object>>())!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1646,9 +1646,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             else
             {
                 foreach (var derivedNavigation in entityType.GetDerivedTypes()
-                    .Select(et => et.FindDeclaredNavigation(navigationName)).Where(n => n != null))
+                    .Select(et => et.FindDeclaredNavigation(navigationName)))
                 {
-                    yield return derivedNavigation;
+                    if (derivedNavigation != null)
+                    {
+                        yield return derivedNavigation;
+                    }
                 }
             }
 

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -9,13 +9,15 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using CA = System.Diagnostics.CodeAnalysis;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
     [DebuggerStepThrough]
     internal static class Check
     {
         [ContractAnnotation("value:null => halt")]
-        public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
+        public static T NotNull<T>([NoEnumeration, CA.AllowNull, CA.NotNull] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
 #pragma warning disable IDE0041 // Use 'is null' check
             if (ReferenceEquals(value, null))
@@ -30,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         }
 
         [ContractAnnotation("value:null => halt")]
-        public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
+        public static IReadOnlyList<T> NotEmpty<T>(
+            [CA.NotNull] IReadOnlyList<T>? value, [InvokerParameterName] [NotNull] string parameterName)
         {
             NotNull(value, parameterName);
 
@@ -45,29 +48,24 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         }
 
         [ContractAnnotation("value:null => halt")]
-        public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
+        public static string NotEmpty([CA.NotNull] string? value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            Exception e = null;
             if (value is null)
             {
-                e = new ArgumentNullException(parameterName);
-            }
-            else if (value.Trim().Length == 0)
-            {
-                e = new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentNullException(parameterName);
             }
 
-            if (e != null)
+            if (value.Trim().Length == 0)
             {
                 NotEmpty(parameterName, nameof(parameterName));
-
-                throw e;
+                throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
             }
 
             return value;
         }
 
-        public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
+        public static string? NullButNotEmpty(string? value, [InvokerParameterName] [NotNull] string parameterName)
         {
             if (!(value is null)
                 && value.Length == 0)
@@ -80,7 +78,8 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             return value;
         }
 
-        public static IReadOnlyList<T> HasNoNulls<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
+        public static IReadOnlyList<T> HasNoNulls<T>(
+            [CA.NotNull] IReadOnlyList<T>? value, [InvokerParameterName] [NotNull] string parameterName)
             where T : class
         {
             NotNull(value, parameterName);
@@ -96,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         }
 
         public static IReadOnlyList<string> HasNoEmptyElements(
-            IReadOnlyList<string> value,
+            [CA.NotNull] IReadOnlyList<string>? value,
             [InvokerParameterName] [NotNull] string parameterName)
         {
             NotNull(value, parameterName);

--- a/test/EFCore.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/PropertyExtensionsTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore
             var entityType = model.AddEntityType("Entity");
             var property = entityType.AddProperty("Property", typeof(int));
 
-            Assert.Null(property.GetGenerationProperty());
+            Assert.Null(property.FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore
 
             property.ValueGenerated = ValueGenerated.OnAdd;
 
-            Assert.Equal(property, property.GetGenerationProperty());
+            Assert.Equal(property, property.FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore
 
             firstProperty.ValueGenerated = ValueGenerated.OnAdd;
 
-            Assert.Equal(firstProperty, thirdProperty.GetGenerationProperty());
+            Assert.Equal(firstProperty, thirdProperty.FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore
 
             rightId2.ValueGenerated = ValueGenerated.OnAdd;
 
-            Assert.Equal(rightId2, endProperty.GetGenerationProperty());
+            Assert.Equal(rightId2, endProperty.FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore
 
             leafId1.ValueGenerated = ValueGenerated.OnAdd;
 
-            Assert.Equal(leafId1, secondId1.GetGenerationProperty());
+            Assert.Equal(leafId1, secondId1.FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -199,19 +199,19 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 model.FindEntityType(typeof(Product)).FindProperty("Id"),
-                model.FindEntityType(typeof(ProductDetails)).GetForeignKeys().Single().Properties[0].GetGenerationProperty());
+                model.FindEntityType(typeof(ProductDetails)).GetForeignKeys().Single().Properties[0].FindGenerationProperty());
 
             Assert.Equal(
                 model.FindEntityType(typeof(Product)).FindProperty("Id"),
-                model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[0].GetGenerationProperty());
+                model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[0].FindGenerationProperty());
 
             Assert.Equal(
                 model.FindEntityType(typeof(ProductDetails)).FindProperty("Id2"),
-                model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[1].GetGenerationProperty());
+                model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[1].FindGenerationProperty());
 
             Assert.Equal(
                 model.FindEntityType(typeof(ProductDetails)).FindProperty("Id2"),
-                model.FindEntityType(typeof(ProductDetailsTagDetails)).GetForeignKeys().Single().Properties[0].GetGenerationProperty());
+                model.FindEntityType(typeof(ProductDetailsTagDetails)).GetForeignKeys().Single().Properties[0].FindGenerationProperty());
         }
 
         [ConditionalFact]
@@ -222,12 +222,12 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(
                 model.FindEntityType(typeof(Order)).FindProperty("Id"),
                 model.FindEntityType(typeof(OrderDetails)).GetForeignKeys().Single(k => k.Properties.First().Name == "OrderId")
-                    .Properties[0].GetGenerationProperty());
+                    .Properties[0].FindGenerationProperty());
 
             Assert.Equal(
                 model.FindEntityType(typeof(Product)).FindProperty("Id"),
                 model.FindEntityType(typeof(OrderDetails)).GetForeignKeys().Single(k => k.Properties.First().Name == "ProductId")
-                    .Properties[0].GetGenerationProperty());
+                    .Properties[0].FindGenerationProperty());
         }
 
         private class Category


### PR DESCRIPTION
Am just going to drop this here, sorry @AndriySvyryd... This annotates Model, Property, Navigation, Key, Index, and all their extensions.

* ISkipNavigation.ForeignKey and Inverse are non-nullable (ModelValidator ensures this), but these are nullable on IMutableSkipNavigation and IConventionSkipNavigation. Seems like a pretty satisfactory solution, no?
* ~IPropertyBase.ClrType is nullable (because of skip navigations), but IProperty overrides it to be non-nullable.~
* Changes a bit of query too (/cc @smitpatel)

Part of #19007

