### PR TITLE
[5.0.1] Generate the correct overload for excluding tables for owned types.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -826,7 +826,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     var isExcludedAnnotation = annotations.Find(RelationalAnnotationNames.IsTableExcludedFromMigrations);
                     if (isExcludedAnnotation != null)
                     {
-                        
                         if (((bool?)isExcludedAnnotation.Value) == true)
                         {
                             if (entityType.IsOwned())

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -826,10 +826,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     var isExcludedAnnotation = annotations.Find(RelationalAnnotationNames.IsTableExcludedFromMigrations);
                     if (isExcludedAnnotation != null)
                     {
+                        
                         if (((bool?)isExcludedAnnotation.Value) == true)
                         {
-                            stringBuilder
-                                .Append(", t => t.ExcludeFromMigrations()");
+                            if (entityType.IsOwned())
+                            {
+                                // Issue #23173
+                                stringBuilder
+                                    .Append(", excludedFromMigrations: true");
+                            }
+                            else
+                            {
+                                stringBuilder
+                                    .Append(", t => t.ExcludeFromMigrations()");
+                            }
                         }
 
                         annotations.Remove(isExcludedAnnotation.Name);

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -197,7 +197,10 @@ namespace Microsoft.EntityFrameworkCore
         public static OwnedNavigationBuilder ToTable(
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name)
-            => ToTable(referenceOwnershipBuilder, name, schema: null, excludedFromMigrations: null);
+            => ToTable(referenceOwnershipBuilder, name, schema: null, excludedFromMigrations:
+                    AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled
+                    ? false
+                    : (bool?)null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -226,7 +229,10 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             where TRelatedEntity : class
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
-                referenceOwnershipBuilder, name, schema: null, excludedFromMigrations: null);
+                referenceOwnershipBuilder, name, schema: null, excludedFromMigrations:
+                    AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled
+                    ? false
+                    : (bool?)null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -257,7 +263,10 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name,
             [CanBeNull] string schema)
-            => ToTable(referenceOwnershipBuilder, name, schema, excludedFromMigrations: null);
+            => ToTable(referenceOwnershipBuilder, name, schema, excludedFromMigrations:
+                    AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled
+                    ? false
+                    : (bool?)null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -313,7 +322,10 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             where TRelatedEntity : class
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
-                referenceOwnershipBuilder, name, schema, excludedFromMigrations: null);
+                referenceOwnershipBuilder, name, schema, excludedFromMigrations:
+                    AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled
+                    ? false
+                    : (bool?)null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore
         public static OwnedNavigationBuilder ToTable(
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name)
-            => referenceOwnershipBuilder.ToTable(name, excludedFromMigrations: false);
+            => ToTable(referenceOwnershipBuilder, name, schema: null, excludedFromMigrations: null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             where TRelatedEntity : class
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
-                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, excludedFromMigrations: false);
+                referenceOwnershipBuilder, name, schema: null, excludedFromMigrations: null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -257,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this OwnedNavigationBuilder referenceOwnershipBuilder,
             [CanBeNull] string name,
             [CanBeNull] string schema)
-            => referenceOwnershipBuilder.ToTable(name, schema, excludedFromMigrations: false);
+            => ToTable(referenceOwnershipBuilder, name, schema, excludedFromMigrations: null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.
@@ -277,9 +277,22 @@ namespace Microsoft.EntityFrameworkCore
             Check.NullButNotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
+            return ToTable(referenceOwnershipBuilder, name, schema, (bool?)excludedFromMigrations);
+        }
+
+        private static OwnedNavigationBuilder ToTable(
+            OwnedNavigationBuilder referenceOwnershipBuilder,
+            string name,
+            string schema,
+            bool? excludedFromMigrations)
+        {
             referenceOwnershipBuilder.OwnedEntityType.SetTableName(name);
             referenceOwnershipBuilder.OwnedEntityType.SetSchema(schema);
-            referenceOwnershipBuilder.OwnedEntityType.SetIsTableExcludedFromMigrations(excludedFromMigrations);
+
+            if (excludedFromMigrations.HasValue)
+            {
+                referenceOwnershipBuilder.OwnedEntityType.SetIsTableExcludedFromMigrations(excludedFromMigrations.Value);
+            }
 
             return referenceOwnershipBuilder;
         }
@@ -300,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore
             where TEntity : class
             where TRelatedEntity : class
             => (OwnedNavigationBuilder<TEntity, TRelatedEntity>)ToTable(
-                (OwnedNavigationBuilder)referenceOwnershipBuilder, name, schema, excludedFromMigrations: false);
+                referenceOwnershipBuilder, name, schema, excludedFromMigrations: null);
 
         /// <summary>
         ///     Configures the table that the entity type maps to when targeting a relational database.

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -833,6 +833,12 @@ namespace Microsoft.EntityFrameworkCore
                 return excluded.Value;
             }
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled;
+            if (useOldBehavior && entityType.FindAnnotation(RelationalAnnotationNames.TableName) != null)
+            {
+                return false;
+            }
+
             if (entityType.BaseType != null)
             {
                 return entityType.GetRootType().IsTableExcludedFromMigrations();

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -833,11 +833,6 @@ namespace Microsoft.EntityFrameworkCore
                 return excluded.Value;
             }
 
-            if (entityType.FindAnnotation(RelationalAnnotationNames.TableName) != null)
-            {
-                return false;
-            }
-
             if (entityType.BaseType != null)
             {
                 return entityType.GetRootType().IsTableExcludedFromMigrations();

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1339,7 +1339,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         protected virtual IEnumerable<MigrationOperation> Remove([NotNull] IForeignKeyConstraint source, [NotNull] DiffContext diffContext)
         {
             var sourceTable = source.Table;
-            if (sourceTable.IsExcludedFromMigrations)
+
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled;
+            if (!useOldBehavior && sourceTable.IsExcludedFromMigrations)
             {
                 yield break;
             }
@@ -2178,8 +2180,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 foreach (var command in commandBatch.ModificationCommands)
                 {
                     var table = model.FindTable(command.TableName, command.Schema);
+                    var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23137", out var isEnabled) && isEnabled;
                     if (diffContext.FindDrop(table) != null
-                        || table.IsExcludedFromMigrations)
+                        || (!useOldBehavior && table.IsExcludedFromMigrations))
                     {
                         continue;
                     }

--- a/test/EFCore.Relational.Tests/ModelBuilding/RelationalModelBuilderGenericTestBase.cs
+++ b/test/EFCore.Relational.Tests/ModelBuilding/RelationalModelBuilderGenericTestBase.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.ModelBuilding
+{
+    public class RelationalModelBuilderTest : ModelBuilderTest
+    {
+        public abstract class TestTableBuilder<TEntity>
+            where TEntity : class
+        {
+            public abstract TestTableBuilder<TEntity> ExcludeFromMigrations(bool excluded = true);
+        }
+
+        public class GenericTestTableBuilder<TEntity> : TestTableBuilder<TEntity>
+            where TEntity : class
+        {
+            public GenericTestTableBuilder(TableBuilder<TEntity> tableBuilder)
+            {
+                TableBuilder = tableBuilder;
+            }
+
+            protected TableBuilder<TEntity> TableBuilder { get; }
+
+            protected virtual TestTableBuilder<TEntity> Wrap(TableBuilder<TEntity> tableBuilder)
+                => new GenericTestTableBuilder<TEntity>(tableBuilder);
+
+            public override TestTableBuilder<TEntity> ExcludeFromMigrations(bool excluded = true)
+                => Wrap(TableBuilder.ExcludeFromMigrations(excluded));
+        }
+
+        public class NonGenericTestTableBuilder<TEntity> : TestTableBuilder<TEntity>
+            where TEntity : class
+        {
+            public NonGenericTestTableBuilder(TableBuilder tableBuilder)
+            {
+                TableBuilder = tableBuilder;
+            }
+
+            protected TableBuilder TableBuilder { get; }
+
+            protected virtual TestTableBuilder<TEntity> Wrap(TableBuilder tableBuilder)
+                => new NonGenericTestTableBuilder<TEntity>(tableBuilder);
+
+            public override TestTableBuilder<TEntity> ExcludeFromMigrations(bool excluded = true)
+                => Wrap(TableBuilder.ExcludeFromMigrations(excluded));
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
+++ b/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -147,6 +148,49 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             return builder;
         }
 
+        public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> ToTable<TEntity>(
+            this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
+            string name,
+            Action<RelationalModelBuilderTest.TestTableBuilder<TEntity>> buildAction)
+            where TEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name,
+                        b => buildAction(new RelationalModelBuilderTest.GenericTestTableBuilder<TEntity>(b)));
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name,
+                        b => buildAction(new RelationalModelBuilderTest.NonGenericTestTableBuilder<TEntity>(b)));
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> ToTable<TEntity>(
+            this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
+            string name,
+            string schema,
+            Action<RelationalModelBuilderTest.TestTableBuilder<TEntity>> buildAction)
+            where TEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, schema,
+                        b => buildAction(new RelationalModelBuilderTest.GenericTestTableBuilder<TEntity>(b)));
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, schema,
+                        b => buildAction(new RelationalModelBuilderTest.NonGenericTestTableBuilder<TEntity>(b)));
+                    break;
+            }
+
+            return builder;
+        }
+
         public static ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
             this ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> builder,
             string name)
@@ -180,6 +224,47 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     break;
                 case IInfrastructure<OwnedNavigationBuilder> nongenericBuilder:
                     nongenericBuilder.Instance.ToTable(name, schema);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> builder,
+            string name,
+            bool excludedFromMigrations)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<OwnedNavigationBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, excludedFromMigrations);
+                    break;
+                case IInfrastructure<OwnedNavigationBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, excludedFromMigrations);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> ToTable<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestOwnedNavigationBuilder<TEntity, TRelatedEntity> builder,
+            string name,
+            string schema,
+            bool excludedFromMigrations)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<OwnedNavigationBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, schema, excludedFromMigrations);
+                    break;
+                case IInfrastructure<OwnedNavigationBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, schema, excludedFromMigrations);
                     break;
             }
 

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -439,7 +439,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Book>(
                     bb =>
                     {
-                        bb.ToTable("BT", "BS");
+                        bb.ToTable("BT", "BS", t => t.ExcludeFromMigrations());
                         bb.OwnsOne(
                             b => b.AlternateLabel, tb =>
                             {
@@ -452,7 +452,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                                     l => l.AnotherBookLabel, ab =>
                                     {
                                         ab.Ignore(l => l.Book);
-                                        ab.ToTable("AT1", "AS1");
+                                        ab.ToTable("AT1", "AS1", excludedFromMigrations: false);
                                         ab.OwnsOne(s => s.SpecialBookLabel)
                                             .ToTable("ST11", "SS11")
                                             .Ignore(l => l.Book)
@@ -520,18 +520,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Equal("BS", book.GetSchema());
                 Assert.Equal("BT", book.GetTableName());
+                Assert.True(book.IsTableExcludedFromMigrations());
                 Assert.Equal("LS", bookOwnership1.DeclaringEntityType.GetSchema());
                 Assert.Equal("LT", bookOwnership1.DeclaringEntityType.GetTableName());
                 Assert.False(bookOwnership1.DeclaringEntityType.IsMemoryOptimized());
+                Assert.True(bookOwnership1.DeclaringEntityType.IsTableExcludedFromMigrations());
                 Assert.Equal("TS", bookOwnership2.DeclaringEntityType.GetSchema());
                 Assert.Equal("TT", bookOwnership2.DeclaringEntityType.GetTableName());
                 Assert.True(bookOwnership2.DeclaringEntityType.IsMemoryOptimized());
+                Assert.True(bookOwnership2.DeclaringEntityType.IsTableExcludedFromMigrations());
                 Assert.Equal("AS2", bookLabel1Ownership1.DeclaringEntityType.GetSchema());
                 Assert.Equal("AT2", bookLabel1Ownership1.DeclaringEntityType.GetTableName());
                 Assert.Equal("SS1", bookLabel1Ownership2.DeclaringEntityType.GetSchema());
                 Assert.Equal("ST1", bookLabel1Ownership2.DeclaringEntityType.GetTableName());
                 Assert.Equal("AS1", bookLabel2Ownership1.DeclaringEntityType.GetSchema());
                 Assert.Equal("AT1", bookLabel2Ownership1.DeclaringEntityType.GetTableName());
+                Assert.False(bookLabel2Ownership1.DeclaringEntityType.IsTableExcludedFromMigrations());
                 Assert.Equal("SS2", bookLabel2Ownership2.DeclaringEntityType.GetSchema());
                 Assert.Equal("ST2", bookLabel2Ownership2.DeclaringEntityType.GetTableName());
                 Assert.Equal("SS21", bookLabel1Ownership11.DeclaringEntityType.GetSchema());


### PR DESCRIPTION
Fixes #23137

**Description**

The fix does the following:
- Generate the correct overload for excluding tables for owned types.
- Don't generate `DropForeignKey` or data operations for excluded tables.
- Don't set excluded from migrations to `false` if it was not specified.

**Customer Impact**

When an owned entity type is excluded from migrations we generate an incorrect API call in the model snapshot that needs to be fixed manually. And when the next migration is created a `DropForeignKey` operation is generated for the foreign key to owner even though no operations should be created for tables excluded from migrations. This operation needs to be removed manually.

If both the owner and owned types are mapped to the same table and only the owner is excluded the generated snapshot throws an exception and needs to be fixed manually.

**How found**

Reported by user on RC2

**Test coverage**

This PR includes tests for the affected scenario.

**Regression?**

No, this only affects exclude table from migrations - a new feature in 5.0

**Risk**

Low. The fix only affects models with table excluded from migrations and the modified code is used only at design-time.

