### PR TITLE
[5.0.1] Only accept non-default store-generated values

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1271,7 +1271,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     if (storeGeneratedIndex != -1
                         && _storeGeneratedValues.TryGetValue(storeGeneratedIndex, out var value))
                     {
-                        this[property] = value;
+                        var equals = ValuesEqualFunc(property);
+                        var defaultValue = property.ClrType.GetDefaultValue();
+                        if (!equals(value, defaultValue))
+                        {
+                            this[property] = value;
+                        }
                     }
                 }
 

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1265,6 +1265,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             if (!_storeGeneratedValues.IsEmpty)
             {
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23180", out var isEnabled)
+                    && isEnabled;
                 foreach (var property in EntityType.GetProperties())
                 {
                     var storeGeneratedIndex = property.GetStoreGeneratedIndex();
@@ -1273,7 +1275,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         var equals = ValuesEqualFunc(property);
                         var defaultValue = property.ClrType.GetDefaultValue();
-                        if (!equals(value, defaultValue))
+                        if (!equals(value, defaultValue)
+                            && !useOldBehavior)
                         {
                             this[property] = value;
                         }

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTest.cs
@@ -43,13 +43,13 @@ namespace Microsoft.EntityFrameworkCore
             // FK uniqueness not enforced in in-memory database
         }
 
-        public override void Optional_One_to_one_relationships_are_one_to_one(
+        public override void Optional_one_to_one_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
         }
 
-        public override void Required_One_to_one_relationships_are_one_to_one(
+        public override void Required_one_to_one_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
@@ -104,13 +104,13 @@ namespace Microsoft.EntityFrameworkCore
             // FK uniqueness not enforced in in-memory database
         }
 
-        public override void Optional_One_to_one_with_AK_relationships_are_one_to_one(
+        public override void Optional_one_to_one_with_AK_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
         }
 
-        public override void Required_One_to_one_with_AK_relationships_are_one_to_one(
+        public override void Required_one_to_one_with_AK_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(CascadeTiming.Immediate)]
         [InlineData(CascadeTiming.Never)]
         [InlineData(null)]
-        public virtual void Optional_One_to_one_relationships_are_one_to_one(
+        public virtual void Optional_one_to_one_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             ExecuteWithStrategyInTransaction(
@@ -781,7 +781,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(CascadeTiming.Immediate)]
         [InlineData(CascadeTiming.Never)]
         [InlineData(null)]
-        public virtual void Required_One_to_one_relationships_are_one_to_one(
+        public virtual void Required_one_to_one_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             ExecuteWithStrategyInTransaction(

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(CascadeTiming.Immediate)]
         [InlineData(CascadeTiming.Never)]
         [InlineData(null)]
-        public virtual void Optional_One_to_one_with_AK_relationships_are_one_to_one(
+        public virtual void Optional_one_to_one_with_AK_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             ExecuteWithStrategyInTransaction(
@@ -959,7 +959,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData(CascadeTiming.Immediate)]
         [InlineData(CascadeTiming.Never)]
         [InlineData(null)]
-        public virtual void Required_One_to_one_with_AK_relationships_are_one_to_one(
+        public virtual void Required_one_to_one_with_AK_relationships_are_one_to_one(
             CascadeTiming? deleteOrphansTiming)
         {
             ExecuteWithStrategyInTransaction(

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -81,21 +81,6 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_multiple_dependents_when_multiple_possible_principal_sides()
-            {
-            }
-
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_valid_first_dependent_when_multiple_possible_principal_sides()
-            {
-            }
-
-            [ConditionalFact(Skip = "Issue #22582")]
-            public override void Can_add_valid_second_dependent_when_multiple_possible_principal_sides()
-            {
-            }
-
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
@@ -152,9 +137,6 @@ namespace Microsoft.EntityFrameworkCore
                     modelBuilder.Entity<OptionalOverlapping2>().ToTable(nameof(OptionalOverlapping2));
                     modelBuilder.Entity<BadCustomer>().ToTable(nameof(BadCustomer));
                     modelBuilder.Entity<BadOrder>().ToTable(nameof(BadOrder));
-                    modelBuilder.Entity<QuestTask>().ToTable(nameof(QuestTask));
-                    modelBuilder.Entity<QuizTask>().ToTable(nameof(QuizTask));
-                    modelBuilder.Entity<HiddenAreaTask>().ToTable(nameof(HiddenAreaTask));
                     modelBuilder.Entity<TaskChoice>().ToTable(nameof(TaskChoice));
                     modelBuilder.Entity<ParentAsAChild>().ToTable(nameof(ParentAsAChild));
                     modelBuilder.Entity<ChildAsAParent>().ToTable(nameof(ChildAsAParent));

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -330,6 +330,49 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public async Task Can_insert_TPT_dependents_with_identity()
+        {
+            using var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName);
+
+            var options = Fixture.CreateOptions(testDatabase);
+            using (var context = new CarContext(options))
+            {
+                context.Database.EnsureCreatedResiliently();
+
+                var ferrari = new Ferrari { Special = new Car() };
+                context.Add(ferrari);
+
+                await context.SaveChangesAsync();
+
+                Assert.NotNull(ferrari.Special);
+            }
+        }
+
+        private class CarContext : DbContext
+        {
+            public CarContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Car>().ToTable("Car");
+                modelBuilder.Entity<Ferrari>().ToTable("Ferrari");
+            }
+        }
+
+        private class Car
+        {
+            public int Id { get; set; }
+        }
+
+        private class Ferrari : Car
+        {
+            public Car Special { get; set; }
+        }
+
+        [ConditionalFact]
         public void Can_run_linq_query_on_entity_set()
         {
             using var testStore = SqlServerTestStore.GetNorthwindStore();


### PR DESCRIPTION
Fixes #23180

**Description**

When propagating store-generated value from the principal entry to the dependent we set the FK store-generated value to `null` if there was any, due to #22603. When accepting the values on the dependent entry we overwrite the propagated value with the "store-generated" `null`.

EF expects that the properties that currently have the default value to be store-generated. Therefore it is reasonable to only accept the store-generated value if it's different from the default.

**Customer Impact**

Inserting a non-TPT dependent and two principals or a TPT-dependent and a principal when the principals have store-generated primary keys will result in a navigation to principal being set to `null`. 

It is possible to manually set the navigation after calling `SaveChanges` as a workaround, but this situation is hard to detect and could lead to data corruption.

**How found**

Reported by user on RC2

**Test coverage**

This PR includes tests for the affected scenario.

**Regression?**

No, this issue existed in 3.1, but was made more likely to surface by the introduction of TPT

**Risk**

Medium. The modified code is used in all SaveChanges scenarios with store-generated values.