### PR TITLE
Create GraphUpdatesTests for owned entities

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -375,6 +375,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 return sharedTableRootProperty.GetValueGenerationStrategy(storeObject)
                     == SqlServerValueGenerationStrategy.IdentityColumn
+                    && !property.GetContainingForeignKeys().Any(fk => !fk.IsBaseLinking())
                         ? SqlServerValueGenerationStrategy.IdentityColumn
                         : SqlServerValueGenerationStrategy.None;
             }

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -370,20 +370,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Check.DebugAssert(navigationBase is INavigation, "Issue #21673. Non-collection skip navigations not supported.");
 
                 var navigation = (INavigation)navigationBase;
-                if (!navigation.ForeignKey.IsOwnership
-                    || !navigation.IsOnDependent)
+                if (_loggingOptions.IsSensitiveDataLoggingEnabled)
                 {
-                    if (_loggingOptions.IsSensitiveDataLoggingEnabled)
-                    {
-                        _logger.ReferenceChangeDetectedSensitive(entry, navigation, snapshotValue, currentValue);
-                    }
-                    else
-                    {
-                        _logger.ReferenceChangeDetected(entry, navigation, snapshotValue, currentValue);
-                    }
-
-                    stateManager.InternalEntityEntryNotifier.NavigationReferenceChanged(entry, navigation, snapshotValue, currentValue);
+                    _logger.ReferenceChangeDetectedSensitive(entry, navigation, snapshotValue, currentValue);
                 }
+                else
+                {
+                    _logger.ReferenceChangeDetected(entry, navigation, snapshotValue, currentValue);
+                }
+                
+                stateManager.InternalEntityEntryNotifier.NavigationReferenceChanged(entry, navigation, snapshotValue, currentValue);
             }
         }
     }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1575,9 +1575,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
                 {
                     b.Property<int>(""Id"")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .UseIdentityColumn();
+                        .HasColumnType(""int"");
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnUpdateSometimes()
@@ -1838,9 +1836,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
                         {
                             b1.Property<int>(""AlternateId"")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .UseIdentityColumn();
+                                .HasColumnType(""int"");
 
                             b1.Property<string>(""EntityWithStringKeyId"")
                                 .HasColumnType(""nvarchar(450)"");
@@ -2063,9 +2059,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
                         {
                             b1.Property<int>(""AlternateId"")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .UseIdentityColumn();
+                                .HasColumnType(""int"");
 
                             b1.Property<string>(""EntityWithStringKeyId"")
                                 .HasColumnType(""nvarchar(450)"");
@@ -2236,9 +2230,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderBillingDetails"", b1 =>
                         {
                             b1.Property<int>(""OrderId"")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .UseIdentityColumn();
+                                .HasColumnType(""int"");
 
                             b1.HasKey(""OrderId"");
 
@@ -2250,9 +2242,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
                                 {
                                     b2.Property<int>(""OrderDetailsOrderId"")
-                                        .ValueGeneratedOnAdd()
-                                        .HasColumnType(""int"")
-                                        .UseIdentityColumn();
+                                        .HasColumnType(""int"");
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -2271,9 +2261,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderShippingDetails"", b1 =>
                         {
                             b1.Property<int>(""OrderId"")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .UseIdentityColumn();
+                                .HasColumnType(""int"");
 
                             b1.HasKey(""OrderId"");
 
@@ -2285,9 +2273,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
                                 {
                                     b2.Property<int>(""OrderDetailsOrderId"")
-                                        .ValueGeneratedOnAdd()
-                                        .HasColumnType(""int"")
-                                        .UseIdentityColumn();
+                                        .HasColumnType(""int"");
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");
@@ -2306,9 +2292,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderInfo"", b1 =>
                         {
                             b1.Property<int>(""OrderId"")
-                                .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .UseIdentityColumn();
+                                .HasColumnType(""int"");
 
                             b1.HasKey(""OrderId"");
 
@@ -2320,9 +2304,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
                                 {
                                     b2.Property<int>(""OrderInfoOrderId"")
-                                        .ValueGeneratedOnAdd()
-                                        .HasColumnType(""int"")
-                                        .UseIdentityColumn();
+                                        .HasColumnType(""int"");
 
                                     b2.Property<string>(""City"")
                                         .HasColumnType(""nvarchar(max)"");

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -723,9 +723,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             var names = new string[0];
             var result = context.Entities1
                 .Where(e => names.Contains(e.NullableStringA))
-                .Select(e => e.NullableStringA).ToList();
+                .Select(e => e.NullableStringA).ToList().Count;
 
-            Assert.Empty(result);
+            Assert.Equal(0, result);
         }
 
         [ConditionalFact]
@@ -735,9 +735,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             var names = new string[] { null };
             var result = context.Entities1
                 .Where(e => names.Contains(e.NullableStringA))
-                .Select(e => e.NullableStringA).ToList();
+                .Select(e => e.NullableStringA).ToList().Count;
 
-            Assert.Empty(result);
+            Assert.Equal(0, result);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -1413,6 +1413,7 @@ namespace Microsoft.EntityFrameworkCore
         protected class RequiredSingle1 : NotifyingEntity
         {
             private int _id;
+            private bool _bool;
             private Root _root;
             private RequiredSingle2 _single;
 
@@ -1420,6 +1421,12 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _id;
                 set => SetWithNotify(value, ref _id);
+            }
+
+            public bool Bool
+            {
+                get => _bool;
+                set => SetWithNotify(value, ref _bool);
             }
 
             public Root Root
@@ -1447,12 +1454,19 @@ namespace Microsoft.EntityFrameworkCore
         protected class RequiredSingle2 : NotifyingEntity
         {
             private int _id;
+            private bool _bool;
             private RequiredSingle1 _back;
 
             public int Id
             {
                 get => _id;
                 set => SetWithNotify(value, ref _id);
+            }
+
+            public bool Bool
+            {
+                get => _bool;
+                set => SetWithNotify(value, ref _bool);
             }
 
             public RequiredSingle1 Back

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -1224,7 +1224,11 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.False(context.ChangeTracker.HasChanges());
 
                         Assert.Null(old1.Root);
-                        Assert.Null(old2.Back);
+                        if (!context.Entry(old2).Metadata.IsOwned())
+                        {
+                            // Navigations to owners are preserved when these are owned
+                            Assert.Null(old2.Back);
+                        }
                         Assert.Equal(old1.Id, old2.Id);
                     }
                 },
@@ -1238,8 +1242,17 @@ namespace Microsoft.EntityFrameworkCore
                         AssertKeys(root, loadedRoot);
                         AssertPossiblyNullNavigations(loadedRoot);
 
-                        Assert.False(context.Set<RequiredSingle1>().Any(e => e.Id == old1.Id));
-                        Assert.False(context.Set<RequiredSingle2>().Any(e => e.Id == old2.Id));
+                        //TODO: Aggregate on optional dependent #23230
+                        //var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == old1.Id);
+                        //Assert.Equal(0, removedCount);
+
+                        Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
+
+                        //var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                        //    .Count(e => e.Id == old2.Id);
+                        //Assert.Equal(0, orphanedCount);
+
+                        Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
                     }
                 });
         }
@@ -1654,9 +1667,6 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Null(root.RequiredSingle);
 
-                        Assert.Empty(context.Set<RequiredSingle1>().Where(e => e.Id == removedId));
-                        Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == orphanedId));
-
                         Assert.Same(root, removed.Root);
                         Assert.Same(orphaned, removed.Single);
                     }
@@ -1670,8 +1680,17 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Null(root.RequiredSingle);
 
-                        Assert.Empty(context.Set<RequiredSingle1>().Where(e => e.Id == removedId));
-                        Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == orphanedId));
+                        //TODO: Aggregate on optional dependent #23230
+                        //var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                        //Assert.Equal(0, removedCount);
+
+                        Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
+
+                        //var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                        //    .Count(e => e.Id == orphanedId);
+                        //Assert.Equal(0, orphanedCount);
+
+                        Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
                     }
                 });
         }
@@ -1722,7 +1741,6 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(EntityState.Detached, context.Entry(removed).State);
 
                     Assert.Null(parent.Single);
-                    Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == removedId));
                     Assert.Same(parent, removed.Back);
                 },
                 context =>
@@ -1731,7 +1749,13 @@ namespace Microsoft.EntityFrameworkCore
                     var parent = root.RequiredSingle;
 
                     Assert.Null(parent.Single);
-                    Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == removedId));
+
+                    //TODO: Aggregate on optional dependent #23230
+                    //var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                    //    .Count(e => e.Id == removedId);
+                    //Assert.Equal(0, removedCount);
+
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
                 });
         }
 
@@ -1868,7 +1892,6 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(EntityState.Detached, context.Entry(removed).State);
 
                     Assert.Null(parent.Single);
-                    Assert.Empty(context.Set<RequiredNonPkSingle2>().Where(e => e.Id == removedId));
                     Assert.Same(parent, removed.Back);
                 },
                 context =>
@@ -1940,9 +1963,6 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
 
                         Assert.Null(root.RequiredSingle);
-
-                        Assert.Empty(context.Set<RequiredSingle1>().Where(e => e.Id == removedId));
-                        Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == orphanedId));
 
                         Assert.Same(root, removed.Root);
                         Assert.Same(orphaned, removed.Single);
@@ -2127,8 +2147,17 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         Assert.Null(root.RequiredSingle);
 
-                        Assert.Empty(context.Set<RequiredSingle1>().Where(e => e.Id == removedId));
-                        Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == orphanedId));
+                        //TODO: Aggregate on optional dependent #23230
+                        //var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                        //Assert.Equal(0, removedCount);
+
+                        Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
+
+                        //var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                        //    .Count(e => e.Id == orphanedId);
+                        //Assert.Equal(0, orphanedCount);
+
+                        Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
                     }
                 });
         }
@@ -2317,8 +2346,17 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Null(root.RequiredSingle);
 
-                        Assert.Empty(context.Set<RequiredSingle1>().Where(e => e.Id == removedId));
-                        Assert.Empty(context.Set<RequiredSingle2>().Where(e => e.Id == orphanedId));
+                        //TODO: Aggregate on optional dependent #23230
+                        //var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                        //Assert.Equal(0, removedCount);
+
+                        Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
+
+                        //var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                        //    .Count(e => e.Id == orphanedId);
+                        //Assert.Equal(0, orphanedCount);
+
+                        Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
                     }
                 });
         }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -188,6 +190,419 @@ namespace Microsoft.EntityFrameworkCore
                     modelBuilder.UseHiLo();
 
                     base.OnModelCreating(modelBuilder, context);
+                }
+            }
+        }
+
+        public class Owned : GraphUpdatesSqlServerTestBase<Owned.SqlServerFixture>
+        {
+            public Owned(SqlServerFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            // Owned dependents are always loaded
+            public override void Required_one_to_one_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming, CascadeTiming? deleteOrphansTiming)
+            {
+            }
+
+
+            public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming, CascadeTiming? deleteOrphansTiming)
+            {
+            }
+
+            public override void Required_one_to_one_relationships_are_one_to_one(CascadeTiming? deleteOrphansTiming)
+            {
+            }
+
+            public override void Required_one_to_one_with_AK_relationships_are_one_to_one(CascadeTiming? deleteOrphansTiming)
+            {
+            }
+
+            protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+                => facade.UseTransaction(transaction.GetDbTransaction());
+
+            public class SqlServerFixture : GraphUpdatesSqlServerFixtureBase
+            {
+                protected override string StoreName { get; } = "GraphOwnedUpdatesTest";
+
+                protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+                {
+                    modelBuilder.Entity<Root>(
+                        b =>
+                        {
+                            b.Property(e => e.AlternateId).ValueGeneratedOnAdd();
+
+                            // TODO: Owned inheritance support #9630
+                            b.HasMany(e => e.RequiredChildren)
+                                .WithOne(e => e.Parent)
+                                .HasForeignKey(e => e.ParentId);
+
+                            modelBuilder.Entity<Required1>()
+                                .HasMany(e => e.Children)
+                                .WithOne(e => e.Parent)
+                                .HasForeignKey(e => e.ParentId);
+
+                            modelBuilder.Entity<Required1Derived>();
+                            modelBuilder.Entity<Required1MoreDerived>();
+                            modelBuilder.Entity<Required2Derived>();
+                            modelBuilder.Entity<Required2MoreDerived>();
+
+                            b.HasMany(e => e.OptionalChildren)
+                                .WithOne(e => e.Parent)
+                                .HasForeignKey(e => e.ParentId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.OwnsOne(e => e.RequiredSingle, r =>
+                            {
+                                r.WithOwner(e => e.Root)
+                                    .HasForeignKey(e => e.Id);
+
+                                r.OwnsOne(e => e.Single)
+                                    .WithOwner(e => e.Back)
+                                    .HasForeignKey(e => e.Id);
+                            });
+
+                            b.HasOne(e => e.OptionalSingle)
+                                .WithOne(e => e.Root)
+                                .HasForeignKey<OptionalSingle1>(e => e.RootId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.HasOne(e => e.OptionalSingleDerived)
+                                .WithOne(e => e.DerivedRoot)
+                                .HasForeignKey<OptionalSingle1Derived>(e => e.DerivedRootId)
+                                .OnDelete(DeleteBehavior.ClientSetNull);
+
+                            b.HasOne(e => e.OptionalSingleMoreDerived)
+                                .WithOne(e => e.MoreDerivedRoot)
+                                .HasForeignKey<OptionalSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                                .OnDelete(DeleteBehavior.ClientSetNull);
+
+                            // TODO: Owned inheritance support #9630
+                            b.HasOne(e => e.RequiredNonPkSingle)
+                                .WithOne(e => e.Root)
+                                .HasForeignKey<RequiredNonPkSingle1>(e => e.RootId);
+
+                            b.HasOne(e => e.RequiredNonPkSingleDerived)
+                                .WithOne(e => e.DerivedRoot)
+                                .HasForeignKey<RequiredNonPkSingle1Derived>(e => e.DerivedRootId)
+                                .OnDelete(DeleteBehavior.Restrict);
+
+                            b.HasOne(e => e.RequiredNonPkSingleMoreDerived)
+                                .WithOne(e => e.MoreDerivedRoot)
+                                .HasForeignKey<RequiredNonPkSingle1MoreDerived>(e => e.MoreDerivedRootId)
+                                .OnDelete(DeleteBehavior.Restrict);
+
+                            // TODO: Owned inheritance support #9630
+                            b.HasMany(e => e.RequiredChildrenAk)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(e => e.AlternateId)
+                                .HasForeignKey(e => e.ParentId);
+
+                            modelBuilder.Entity<RequiredAk1>(
+                                b =>
+                                {
+                                    b.Property(e => e.AlternateId)
+                                        .ValueGeneratedOnAdd();
+
+                                    b.HasMany(e => e.Children)
+                                        .WithOne(e => e.Parent)
+                                        .HasPrincipalKey(e => e.AlternateId)
+                                        .HasForeignKey(e => e.ParentId);
+
+                                    b.HasMany(e => e.CompositeChildren)
+                                        .WithOne(e => e.Parent)
+                                        .HasPrincipalKey(
+                                            e => new { e.Id, e.AlternateId })
+                                        .HasForeignKey(
+                                            e => new { e.ParentId, e.ParentAlternateId });
+                                });
+
+                            modelBuilder.Entity<RequiredAk2>()
+                                .Property(e => e.AlternateId)
+                                .ValueGeneratedOnAdd();
+
+                            modelBuilder.Entity<RequiredAk2Derived>();
+                            modelBuilder.Entity<RequiredAk2MoreDerived>();
+
+                            modelBuilder.Entity<RequiredAk1Derived>();
+                            modelBuilder.Entity<RequiredAk1MoreDerived>();
+
+                            b.HasMany(e => e.OptionalChildrenAk)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(e => e.AlternateId)
+                                .HasForeignKey(e => e.ParentId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.OwnsOne(e => e.RequiredSingleAk, r =>
+                            {
+                                r.WithOwner(e => e.Root)
+                                    .HasPrincipalKey(e => e.AlternateId)
+                                    .HasForeignKey(e => e.RootId);
+
+                                r.HasKey(e => e.Id);
+
+                                r.Property(e => e.AlternateId)
+                                    .ValueGeneratedOnAdd();
+
+                                r.OwnsOne(e => e.Single, r2 =>
+                                {
+                                    r2.WithOwner(e => e.Back)
+                                        .HasForeignKey(e => e.BackId)
+                                        .HasPrincipalKey(e => e.AlternateId);
+
+                                    r2.HasKey(e => e.Id);
+
+                                    r2.Property(e => e.Id)
+                                        .ValueGeneratedOnAdd();
+
+                                    r2.Property(e => e.AlternateId)
+                                        .ValueGeneratedOnAdd();
+
+                                    r2.ToTable("RequiredSingleAk2");
+                                });
+
+                                r.OwnsOne(e => e.SingleComposite, r2 =>
+                                {
+                                    r2.WithOwner(e => e.Back)
+                                        .HasForeignKey(e => new { e.BackId, e.BackAlternateId })
+                                        .HasPrincipalKey(e => new { e.Id, e.AlternateId });
+
+                                    r2.HasKey(e => e.Id);
+
+                                    r2.ToTable("RequiredSingleComposite2");
+                                });
+
+                                // Table splitting using AK is not supported #23208
+                                r.ToTable("RequiredSingleAk1");
+                            });
+
+                            b.HasOne(e => e.OptionalSingleAk)
+                                .WithOne(e => e.Root)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<OptionalSingleAk1>(e => e.RootId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.HasOne(e => e.OptionalSingleAkDerived)
+                                .WithOne(e => e.DerivedRoot)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<OptionalSingleAk1Derived>(e => e.DerivedRootId)
+                                .OnDelete(DeleteBehavior.ClientSetNull);
+
+                            b.HasOne(e => e.OptionalSingleAkMoreDerived)
+                                .WithOne(e => e.MoreDerivedRoot)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<OptionalSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                                .OnDelete(DeleteBehavior.ClientSetNull);
+
+                            b.HasOne(e => e.RequiredNonPkSingleAk)
+                                .WithOne(e => e.Root)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
+
+                            b.HasOne(e => e.RequiredNonPkSingleAkDerived)
+                                .WithOne(e => e.DerivedRoot)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<RequiredNonPkSingleAk1Derived>(e => e.DerivedRootId)
+                                .OnDelete(DeleteBehavior.Restrict);
+
+                            b.HasOne(e => e.RequiredNonPkSingleAkMoreDerived)
+                                .WithOne(e => e.MoreDerivedRoot)
+                                .HasPrincipalKey<Root>(e => e.AlternateId)
+                                .HasForeignKey<RequiredNonPkSingleAk1MoreDerived>(e => e.MoreDerivedRootId)
+                                .OnDelete(DeleteBehavior.Restrict);
+
+                            b.HasMany(e => e.RequiredCompositeChildren)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(e => e.AlternateId)
+                                .HasForeignKey(e => e.ParentAlternateId);
+                        });
+
+                    modelBuilder.Entity<Optional1>(
+                        b =>
+                        {
+                            b.HasMany(e => e.Children)
+                                .WithOne(e => e.Parent)
+                                .HasForeignKey(e => e.ParentId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.HasMany(e => e.CompositeChildren)
+                                .WithOne(e => e.Parent2)
+                                .HasForeignKey(e => new { e.Parent2Id });
+                        });
+
+                    modelBuilder.Entity<Optional1Derived>();
+                    modelBuilder.Entity<Optional1MoreDerived>();
+                    modelBuilder.Entity<Optional2Derived>();
+                    modelBuilder.Entity<Optional2MoreDerived>();
+
+                    modelBuilder.Entity<OptionalSingle1>()
+                        .HasOne(e => e.Single)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<OptionalSingle2>(e => e.BackId)
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    modelBuilder.Entity<OptionalSingle2>(
+                        b =>
+                        {
+                            b.HasDiscriminator(e => e.Disc)
+                                .HasValue<OptionalSingle2>(new MyDiscriminator(1))
+                                .HasValue<OptionalSingle2Derived>(new MyDiscriminator(2))
+                                .HasValue<OptionalSingle2MoreDerived>(new MyDiscriminator(3));
+
+                            b.Property(e => e.Disc)
+                                .HasConversion(
+                                    v => v.Value,
+                                    v => new MyDiscriminator(v),
+                                    new ValueComparer<MyDiscriminator>(
+                                        (l, r) => l.Value == r.Value,
+                                        v => v.Value.GetHashCode(),
+                                        v => new MyDiscriminator(v.Value)))
+                                .Metadata
+                                .SetAfterSaveBehavior(PropertySaveBehavior.Save);
+                        });
+
+                    modelBuilder.Entity<RequiredNonPkSingle1>()
+                        .HasOne(e => e.Single)
+                        .WithOne(e => e.Back)
+                        .HasForeignKey<RequiredNonPkSingle2>(e => e.BackId);
+
+                    modelBuilder.Entity<RequiredNonPkSingle2Derived>();
+                    modelBuilder.Entity<RequiredNonPkSingle2MoreDerived>();
+
+                    modelBuilder.Entity<RequiredNonPkSingleAk1>(
+                        b =>
+                        {
+                            b.Property(e => e.AlternateId)
+                                .ValueGeneratedOnAdd();
+
+                            b.HasOne(e => e.Single)
+                                .WithOne(e => e.Back)
+                                .HasForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
+                                .HasPrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId);
+                        });
+
+                    modelBuilder.Entity<OptionalAk1>(
+                        b =>
+                        {
+                            b.Property(e => e.AlternateId)
+                                .ValueGeneratedOnAdd();
+
+                            b.HasMany(e => e.Children)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(e => e.AlternateId)
+                                .HasForeignKey(e => e.ParentId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.HasMany(e => e.CompositeChildren)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(
+                                    e => new { e.Id, e.AlternateId })
+                                .HasForeignKey(
+                                    e => new { e.ParentId, e.ParentAlternateId });
+                        });
+
+                    modelBuilder.Entity<OptionalAk1Derived>();
+                    modelBuilder.Entity<OptionalAk1MoreDerived>();
+
+                    modelBuilder.Entity<OptionalAk2>()
+                        .Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
+
+                    modelBuilder.Entity<OptionalAk2Derived>();
+                    modelBuilder.Entity<OptionalAk2MoreDerived>();
+
+                    modelBuilder.Entity<RequiredNonPkSingleAk2>()
+                        .Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
+
+                    modelBuilder.Entity<RequiredNonPkSingleAk2Derived>();
+                    modelBuilder.Entity<RequiredNonPkSingleAk2MoreDerived>();
+
+                    modelBuilder.Entity<OptionalSingleAk1>(
+                        b =>
+                        {
+                            b.Property(e => e.AlternateId)
+                                .ValueGeneratedOnAdd();
+
+                            b.HasOne(e => e.Single)
+                                .WithOne(e => e.Back)
+                                .HasForeignKey<OptionalSingleAk2>(e => e.BackId)
+                                .HasPrincipalKey<OptionalSingleAk1>(e => e.AlternateId)
+                                .OnDelete(DeleteBehavior.SetNull);
+
+                            b.HasOne(e => e.SingleComposite)
+                                .WithOne(e => e.Back)
+                                .HasForeignKey<OptionalSingleComposite2>(
+                                    e => new { e.BackId, e.ParentAlternateId })
+                                .HasPrincipalKey<OptionalSingleAk1>(
+                                    e => new { e.Id, e.AlternateId });
+                        });
+
+                    modelBuilder.Entity<OptionalSingleAk2>()
+                        .Property(e => e.AlternateId)
+                        .ValueGeneratedOnAdd();
+
+                    modelBuilder.Entity<OptionalSingleAk2Derived>();
+                    modelBuilder.Entity<OptionalSingleAk2MoreDerived>();
+
+                    modelBuilder.Entity<RequiredComposite1>(
+                        eb =>
+                        {
+                            eb.Property(e => e.Id).ValueGeneratedNever();
+
+                            eb.HasKey(
+                                e => new { e.Id, e.ParentAlternateId });
+
+                            eb.HasMany(e => e.CompositeChildren)
+                                .WithOne(e => e.Parent)
+                                .HasPrincipalKey(
+                                    e => new { e.Id, e.ParentAlternateId })
+                                .HasForeignKey(
+                                    e => new { e.ParentId, e.ParentAlternateId });
+                        });
+
+                    modelBuilder.Entity<OptionalOverlapping2>(
+                        eb =>
+                        {
+                            eb.Property(e => e.Id).ValueGeneratedNever();
+
+                            eb.HasKey(
+                                e => new { e.Id, e.ParentAlternateId });
+
+                            eb.HasOne(e => e.Root)
+                                .WithMany()
+                                .HasPrincipalKey(e => e.AlternateId)
+                                .HasForeignKey(e => e.ParentAlternateId);
+                        });
+
+                    modelBuilder.Entity<BadCustomer>();
+                    modelBuilder.Entity<BadOrder>();
+
+                    modelBuilder.Entity<QuestTask>();
+
+                    modelBuilder.Entity<QuizTask>()
+                        .HasMany(qt => qt.Choices)
+                        .WithOne()
+                        .HasForeignKey(tc => tc.QuestTaskId);
+
+                    modelBuilder.Entity<HiddenAreaTask>()
+                        .HasMany(hat => hat.Choices)
+                        .WithOne()
+                        .HasForeignKey(tc => tc.QuestTaskId);
+
+                    modelBuilder.Entity<TaskChoice>();
+                    modelBuilder.Entity<ParentAsAChild>();
+                    modelBuilder.Entity<ChildAsAParent>();
+
+                    modelBuilder.Entity<Poost>();
+                    modelBuilder.Entity<Bloog>();
+
+                    modelBuilder.Entity<Produce>()
+                        .HasIndex(e => e.BarCode)
+                        .IsUnique();
                 }
             }
         }

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.Entity<Dog>(
                 db =>
                 {
-                    db.Property(d => d.Identity).ValueGeneratedNever().HasColumnName(nameof(Dog.Identity));
+                    db.Property(d => d.Identity).UseHiLo().HasColumnName(nameof(Dog.Identity));
                 });
 
             VerifyError(

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -2845,6 +2845,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             principal2.Child1 = dependent;
             principal1.Child2 = null;
 
+            if (entityState != EntityState.Added)
+            {                
+                Assert.Equal(CoreStrings.KeyReadOnly("ParentId", "Parent.Child2#Child"),
+                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                return;
+            }
+
             context.ChangeTracker.DetectChanges();
 
             Assert.True(context.ChangeTracker.HasChanges());
@@ -3043,6 +3050,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             principal2.ChildCollection1 = principal1.ChildCollection2;
             principal1.ChildCollection2 = null;
 
+            if (entityState != EntityState.Added)
+            {
+                Assert.Equal(CoreStrings.KeyReadOnly("ParentId", "Parent.ChildCollection2#Child"),
+                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                return;
+            }
+
             context.ChangeTracker.DetectChanges();
 
             Assert.True(context.ChangeTracker.HasChanges());
@@ -3211,6 +3225,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             principal2.Child1 = dependent1;
             principal1.Child2 = dependent2;
+
+            if (entityState != EntityState.Added)
+            {
+                Assert.Equal(CoreStrings.KeyReadOnly("ParentId", "Parent.Child2#Child"),
+                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                return;
+            }
 
             context.ChangeTracker.DetectChanges();
 
@@ -3499,6 +3520,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
                 .FindEntry(subDependent2);
             newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
+
+            if (entityState != EntityState.Added)
+            {
+                Assert.Equal(CoreStrings.KeyReadOnly("ParentId", "Parent.ChildCollection2#Child"),
+                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
+                return;
+            }
 
             context.ChangeTracker.DetectChanges();
 


### PR DESCRIPTION
Disable owned entity reparenting if it leads to key modification
Fix default SQL Server value generation strategy for shared columns
Query: Detect parent identifier correctly when parent has owned navs

Fixes #16454