### PR TITLE
Query: Add support for set operations between 2 collection navs

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -382,6 +382,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             when genericMethod == QueryableMethods.Join:
                         {
                             var secondArgument = Visit(methodCallExpression.Arguments[1]);
+                            secondArgument = UnwrapCollectionMaterialization(secondArgument);
                             if (secondArgument is NavigationExpansionExpression innerSource)
                             {
                                 return ProcessJoin(
@@ -399,6 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             when genericMethod == QueryableExtensions.LeftJoinMethodInfo:
                         {
                             var secondArgument = Visit(methodCallExpression.Arguments[1]);
+                            secondArgument = UnwrapCollectionMaterialization(secondArgument);
                             if (secondArgument is NavigationExpansionExpression innerSource)
                             {
                                 return ProcessLeftJoin(
@@ -436,6 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             when genericMethod == QueryableMethods.Union:
                         {
                             var secondArgument = Visit(methodCallExpression.Arguments[1]);
+                            secondArgument = UnwrapCollectionMaterialization(secondArgument);
                             if (secondArgument is NavigationExpansionExpression innerSource)
                             {
                                 return ProcessSetOperation(source, genericMethod, innerSource);
@@ -1130,10 +1133,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             LambdaExpression? resultSelector)
         {
             var collectionSelectorBody = ExpandNavigationsForSource(source, RemapLambdaExpression(source, collectionSelector));
-            if (collectionSelectorBody is MaterializeCollectionNavigationExpression materializeCollectionNavigationExpression)
-            {
-                collectionSelectorBody = materializeCollectionNavigationExpression.Subquery;
-            }
+            collectionSelectorBody = UnwrapCollectionMaterialization(collectionSelectorBody);
 
             if (collectionSelectorBody is NavigationExpansionExpression collectionSource)
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -1488,31 +1488,77 @@ WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[HasSoulPatch] = 1",
-                //
-                @"@_outer_FullName6='Damon Baird' (Size = 450)
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t]
+    ORDER BY [t].[Id]) = CAST(1 AS bit))");
+        }
 
-SELECT [w6].[Id], [w6].[AmmunitionType], [w6].[IsAutomatic], [w6].[Name], [w6].[OwnerFullName], [w6].[SynergyWithId]
-FROM [Weapons] AS [w6]
-WHERE @_outer_FullName6 = [w6].[OwnerFullName]",
-                //
-                @"@_outer_FullName5='Damon Baird' (Size = 450)
+        public override async Task Where_subquery_join_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_join_firstordefault_boolean(async);
 
-SELECT [w5].[Id], [w5].[AmmunitionType], [w5].[IsAutomatic], [w5].[Name], [w5].[OwnerFullName], [w5].[SynergyWithId]
-FROM [Weapons] AS [w5]
-WHERE @_outer_FullName5 = [w5].[OwnerFullName]",
-                //
-                @"@_outer_FullName6='Marcus Fenix' (Size = 450)
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    INNER JOIN (
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t] ON [w].[Id] = [t].[Id]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) = CAST(1 AS bit))");
+        }
 
-SELECT [w6].[Id], [w6].[AmmunitionType], [w6].[IsAutomatic], [w6].[Name], [w6].[OwnerFullName], [w6].[SynergyWithId]
-FROM [Weapons] AS [w6]
-WHERE @_outer_FullName6 = [w6].[OwnerFullName]",
-                //
-                @"@_outer_FullName5='Marcus Fenix' (Size = 450)
+        public override async Task Where_subquery_left_join_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_left_join_firstordefault_boolean(async);
 
-SELECT [w5].[Id], [w5].[AmmunitionType], [w5].[IsAutomatic], [w5].[Name], [w5].[OwnerFullName], [w5].[SynergyWithId]
-FROM [Weapons] AS [w5]
-WHERE @_outer_FullName5 = [w5].[OwnerFullName]");
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    LEFT JOIN (
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t] ON [w].[Id] = [t].[Id]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) = CAST(1 AS bit))");
+        }
+
+        public override async Task Where_subquery_concat_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_concat_firstordefault_boolean(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION ALL
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t]
+    ORDER BY [t].[Id]) = CAST(1 AS bit))");
         }
 
         public override async Task Concat_with_count(bool async)
@@ -1573,6 +1619,66 @@ FROM (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
     FROM [Gears] AS [g0]
 ) AS [t]");
+        }
+
+        public override async Task Select_navigation_with_concat_and_count(bool async)
+        {
+            await base.Select_navigation_with_concat_and_count(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION ALL
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t])
+FROM [Gears] AS [g]
+WHERE [g].[HasSoulPatch] <> CAST(1 AS bit)");
+        }
+
+        public override async Task Concat_with_collection_navigations(bool async)
+        {
+            await base.Concat_with_collection_navigations(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t])
+FROM [Gears] AS [g]
+WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
+        }
+
+        public override async Task Union_with_collection_navigations(bool async)
+        {
+            await base.Union_with_collection_navigations(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        FROM [Gears] AS [g]
+        WHERE ([g1].[Nickname] = [g].[LeaderNickname]) AND ([g1].[SquadId] = [g].[LeaderSquadId])
+        UNION
+        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+        FROM [Gears] AS [g0]
+        WHERE ([g1].[Nickname] = [g0].[LeaderNickname]) AND ([g1].[SquadId] = [g0].[LeaderSquadId])
+    ) AS [t])
+FROM [Gears] AS [g1]
+WHERE [g1].[Discriminator] = N'Officer'");
         }
 
         public override async Task Select_subquery_distinct_firstordefault(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -1799,33 +1799,91 @@ WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
             await base.Where_subquery_union_firstordefault_boolean(async);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+    WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+END AS [Discriminator]
 FROM [Gears] AS [g]
-WHERE [g].[HasSoulPatch] = 1",
-                //
-                @"@_outer_FullName6='Damon Baird' (Size = 450)
+LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t]
+    ORDER BY [t].[Id]) = CAST(1 AS bit))");
+        }
 
-SELECT [w6].[Id], [w6].[AmmunitionType], [w6].[IsAutomatic], [w6].[Name], [w6].[OwnerFullName], [w6].[SynergyWithId]
-FROM [Weapons] AS [w6]
-WHERE @_outer_FullName6 = [w6].[OwnerFullName]",
-                //
-                @"@_outer_FullName5='Damon Baird' (Size = 450)
+        public override async Task Where_subquery_join_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_join_firstordefault_boolean(async);
 
-SELECT [w5].[Id], [w5].[AmmunitionType], [w5].[IsAutomatic], [w5].[Name], [w5].[OwnerFullName], [w5].[SynergyWithId]
-FROM [Weapons] AS [w5]
-WHERE @_outer_FullName5 = [w5].[OwnerFullName]",
-                //
-                @"@_outer_FullName6='Marcus Fenix' (Size = 450)
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+    WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+END AS [Discriminator]
+FROM [Gears] AS [g]
+LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    INNER JOIN (
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t] ON [w].[Id] = [t].[Id]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) = CAST(1 AS bit))");
+        }
 
-SELECT [w6].[Id], [w6].[AmmunitionType], [w6].[IsAutomatic], [w6].[Name], [w6].[OwnerFullName], [w6].[SynergyWithId]
-FROM [Weapons] AS [w6]
-WHERE @_outer_FullName6 = [w6].[OwnerFullName]",
-                //
-                @"@_outer_FullName5='Marcus Fenix' (Size = 450)
+        public override async Task Where_subquery_left_join_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_left_join_firstordefault_boolean(async);
 
-SELECT [w5].[Id], [w5].[AmmunitionType], [w5].[IsAutomatic], [w5].[Name], [w5].[OwnerFullName], [w5].[SynergyWithId]
-FROM [Weapons] AS [w5]
-WHERE @_outer_FullName5 = [w5].[OwnerFullName]");
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+    WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+END AS [Discriminator]
+FROM [Gears] AS [g]
+LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    LEFT JOIN (
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t] ON [w].[Id] = [t].[Id]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]) = CAST(1 AS bit))");
+        }
+
+        public override async Task Where_subquery_concat_firstordefault_boolean(bool async)
+        {
+            await base.Where_subquery_concat_firstordefault_boolean(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+    WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+END AS [Discriminator]
+FROM [Gears] AS [g]
+LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+WHERE ([g].[HasSoulPatch] = CAST(1 AS bit)) AND ((
+    SELECT TOP(1) [t].[IsAutomatic]
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION ALL
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t]
+    ORDER BY [t].[Id]) = CAST(1 AS bit))");
         }
 
         public override async Task Concat_with_count(bool async)
@@ -1906,6 +1964,73 @@ FROM (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t]");
+        }
+
+        public override async Task Select_navigation_with_concat_and_count(bool async)
+        {
+            await base.Select_navigation_with_concat_and_count(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION ALL
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t])
+FROM [Gears] AS [g]
+WHERE [g].[HasSoulPatch] <> CAST(1 AS bit)");
+        }
+
+        public override async Task Concat_with_collection_navigations(bool async)
+        {
+            await base.Concat_with_collection_navigations(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+        FROM [Weapons] AS [w]
+        WHERE [g].[FullName] = [w].[OwnerFullName]
+        UNION
+        SELECT [w0].[Id], [w0].[AmmunitionType], [w0].[IsAutomatic], [w0].[Name], [w0].[OwnerFullName], [w0].[SynergyWithId]
+        FROM [Weapons] AS [w0]
+        WHERE [g].[FullName] = [w0].[OwnerFullName]
+    ) AS [t])
+FROM [Gears] AS [g]
+WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
+        }
+
+        public override async Task Union_with_collection_navigations(bool async)
+        {
+            await base.Union_with_collection_navigations(async);
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM (
+        SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
+            WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
+        END AS [Discriminator]
+        FROM [Gears] AS [g]
+        LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
+        WHERE ([g1].[Nickname] = [g].[LeaderNickname]) AND ([g1].[SquadId] = [g].[LeaderSquadId])
+        UNION
+        SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank], CASE
+            WHEN [o0].[Nickname] IS NOT NULL THEN N'Officer'
+        END AS [Discriminator]
+        FROM [Gears] AS [g0]
+        LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+        WHERE ([g1].[Nickname] = [g0].[LeaderNickname]) AND ([g1].[SquadId] = [g0].[LeaderSquadId])
+    ) AS [t])
+FROM [Gears] AS [g1]
+LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
+WHERE [o1].[Nickname] IS NOT NULL");
         }
 
         public override async Task Select_subquery_distinct_firstordefault(bool async)


### PR DESCRIPTION
Resolves #17759
