### PR TITLE
[TINY] Fix to #23121 - Query: improve optimization of "false==(expr)"

### DIFF
--- a/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
+++ b/src/EFCore.Relational/Query/SqlNullabilityProcessor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -1195,7 +1194,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 // true != a -> !a
                 // false != a -> a
                 return sqlBinaryExpression.OperatorType == ExpressionType.Equal ^ leftBoolValue
-                    ? _sqlExpressionFactory.Not(right)
+                    ? OptimizeNonNullableNotExpression(_sqlExpressionFactory.Not(right))
                     : right;
             }
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -725,7 +725,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Where(e => names.Contains(e.NullableStringA))
                 .Select(e => e.NullableStringA).ToList();
 
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [ConditionalFact]
@@ -737,7 +737,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Where(e => names.Contains(e.NullableStringA))
                 .Select(e => e.NullableStringA).ToList();
 
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [ConditionalTheory]
@@ -1526,6 +1526,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => 0 != e.NullableStringA.CompareTo(e.NullableStringB).CompareTo(0)),
                 ss => ss.Set<NullSemanticsEntity1>().Where(e => e.NullableStringA != e.NullableStringB));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task False_compared_to_negated_is_null(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(e => false == (!(e.NullableStringA == null))));
         }
 
         private string NormalizeDelimitersInRawString(string sql)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1884,6 +1884,16 @@ FROM [Entities1] AS [e]
 WHERE (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL)");
         }
 
+        public override async Task False_compared_to_negated_is_null(bool async)
+        {
+            await base.False_compared_to_negated_is_null(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] IS NULL");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
When optimizing false == x -> !x we were not running optimization for the Not that we just created, like we do for x == false

Fixes #23121