### PR TITLE
[release/5.0] Move to 5.0.1 versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,11 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-7ef6d50" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-7ef6d50b/nuget/v3/index.json" />
-    <!--  End: Package sources from dotnet-runtime -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Label="Version settings">
-    <VersionPrefix>5.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <VersionPrefix>5.0.1</VersionPrefix>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>
     <!--

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15",
+    "dotnet": "5.0.100",
     "runtimes": {
       "dotnet": [
         "3.1.9"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "5.0.100-rc.2.20479.15",
+    "version": "5.0.100",
     "allowPrerelease": true,
     "rollForward": "latestMajor"
   },


### PR DESCRIPTION
- rebrand
- move to GA .NET SDK
- remove feeds that are not needed after 5.0.0 is GA