### PR TITLE
[5.0.1] RevEng: Call correct overload of HasIndex when scaffolding constraints without name

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -621,7 +621,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var propertyNames = uniqueConstraint.Columns.Select(GetPropertyName).ToArray();
-            var indexBuilder = builder.HasIndex(propertyNames, uniqueConstraint.Name).IsUnique();
+            var indexBuilder = string.IsNullOrEmpty(uniqueConstraint.Name)
+                ? builder.HasIndex(propertyNames)
+                : builder.HasIndex(propertyNames, uniqueConstraint.Name);
+            indexBuilder = indexBuilder.IsUnique();
             indexBuilder.Metadata.AddAnnotations(uniqueConstraint.GetAnnotations());
 
             return indexBuilder;
@@ -671,11 +674,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var propertyNames = index.Columns.Select(GetPropertyName).ToArray();
-            var indexBuilder =
-                index.Name == null
-                    ? builder.HasIndex(propertyNames)
-                    : builder.HasIndex(propertyNames, index.Name)
-                        .IsUnique(index.IsUnique);
+            var indexBuilder = string.IsNullOrEmpty(index.Name)
+                ? builder.HasIndex(propertyNames)
+                : builder.HasIndex(propertyNames, index.Name);
+
+            indexBuilder = indexBuilder.IsUnique(index.IsUnique);
 
             if (index.Filter != null)
             {


### PR DESCRIPTION
Resolves #23268

**Description**

Regression when scaffolding from database: if a unique constraint does not have a name, then the reverse engineering tool throws an exception.

**Customer impact**

Regression such that customers who were previously able to reverse engineer a database may now not be able to do so. There is no workaround other than changing your database to name constraints.

We do not have good data on how many people have unnamed constraints, but given this was filed early after release it seems reasonable to assume there will be more.

**How found**

Customer reported on 5.0. This was a case where we didn't realize it was valid to have a constraint like this without it being named. We previously didn't reverse engineer the name, so we never ran into this until 5.0.

**Test coverage**

This PR includes test for the affected scenario.

**Regression?**

Yes, from 3.1.

**Risk**

Low. The fix calls into correct overload of method as required preserving previous path when no name is found. Also, this is a fix to a design-time scenario. Running applications should not be impacted.
