### PR TITLE
[5.0.1] Use default schema for view mappings

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -373,7 +373,9 @@ namespace Microsoft.EntityFrameworkCore
                 return ownership.PrincipalEntityType.GetViewSchema();
             }
 
-            return GetViewName(entityType) != null ? entityType.Model.GetDefaultSchema() : null;
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23274", out var isEnabled)
+                && isEnabled;
+            return !useOldBehavior && GetViewName(entityType) != null ? entityType.Model.GetDefaultSchema() : null;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore
                 return ownership.PrincipalEntityType.GetViewSchema();
             }
 
-            return null;
+            return GetViewName(entityType) != null ? entityType.Model.GetDefaultSchema() : null;
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -239,9 +239,16 @@ namespace TestNamespace
             Test(
                 modelBuilder => modelBuilder.Entity("Vista").ToView("Vista"),
                 new ModelCodeGenerationOptions { UseDataAnnotations = true },
-                code => Assert.Contains(".ToView(\"Vista\")", code.ContextFile.Code),
-                model => Assert.NotNull(
-                    model.FindEntityType("TestNamespace.Vista").FindAnnotation(RelationalAnnotationNames.ViewDefinitionSql)));
+                code => Assert.Contains("entity.ToView(\"Vista\");", code.ContextFile.Code),
+                model => {
+                    var entityType = model.FindEntityType("TestNamespace.Vista");
+
+                    Assert.NotNull(entityType.FindAnnotation(RelationalAnnotationNames.ViewDefinitionSql));
+                    Assert.Equal("Vista", entityType.GetViewName());
+                    Assert.Null(entityType.GetViewSchema());
+                    Assert.Null(entityType.GetTableName());
+                    Assert.Null(entityType.GetSchema());
+                });
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -160,6 +160,42 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         [ConditionalFact]
+        public void Can_get_and_set_view_schema_name_on_entity_type()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            var entityType = modelBuilder
+                .Entity<Customer>()
+                .Metadata;
+
+            Assert.Null(entityType.GetViewSchema());
+
+            modelBuilder.HasDefaultSchema("dbo");
+
+            Assert.Null(entityType.GetViewSchema());
+
+            entityType.SetViewName("CustomerView");
+
+            Assert.Equal("dbo", entityType.GetViewSchema());
+
+            entityType.SetViewSchema(null);
+
+            Assert.Equal("dbo", entityType.GetViewSchema());
+
+            entityType.SetViewSchema("db0");
+
+            Assert.Equal("db0", entityType.GetViewSchema());
+
+            entityType.SetViewName(null);
+
+            Assert.Equal("db0", entityType.GetViewSchema());
+
+            entityType.SetViewSchema(null);
+
+            Assert.Null(entityType.GetViewSchema());
+        }
+
+        [ConditionalFact]
         public void Can_get_and_set_column_type()
         {
             var modelBuilder = new ModelBuilder();


### PR DESCRIPTION
Fixes #23274

**Description**

EF doesn't use the default schema for view mappings.

**Customer Impact**

The schema needs to be specified in all `ToView` calls.

**How found**

Reported by user on 5.0.0

**Test coverage**

This PR includes tests for the affected scenario.

**Regression?**

Yes, this used to work in 3.1

**Risk**

Low. The behavior is being reverted to what it was in 3.1