### PR TITLE
[5.0.1] Clear events when DbContext is disposed or returned to the pool

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -192,6 +192,7 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileEF4F00E20178B341995BD2EFE53739B5/RelativePriority/@EntryValue">2</s:Double>
 	<s:String x:Key="/Default/Environment/PerformanceGuide/SwitchBehaviour/=VsBulb/@EntryIndexedValue">DO_NOTHING</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -756,9 +756,7 @@ namespace Microsoft.EntityFrameworkCore
                 service.ResetState();
             }
 
-            SavingChanges = null;
-            SavedChanges = null;
-            SaveChangesFailed = null;
+            ClearEvents();
 
             _disposed = true;
         }
@@ -769,7 +767,6 @@ namespace Microsoft.EntityFrameworkCore
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         [EntityFrameworkInternal]
         async Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
         {
@@ -777,6 +774,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 await service.ResetStateAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            ClearEvents();
 
             _disposed = true;
         }
@@ -825,6 +824,9 @@ namespace Microsoft.EntityFrameworkCore
                 if (_lease.ContextDisposed())
                 {
                     _disposed = true;
+
+                    ClearEvents();
+
                     _lease = DbContextLease.InactiveLease;
                 }
             }
@@ -842,6 +844,8 @@ namespace Microsoft.EntityFrameworkCore
                 _changeTracker = null;
                 _database = null;
 
+                ClearEvents();
+
                 return true;
             }
 
@@ -853,6 +857,14 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         public virtual ValueTask DisposeAsync()
             => DisposeSync() ? _serviceScope.DisposeAsyncIfAvailable() : default;
+
+
+        private void ClearEvents()
+        {
+            SavingChanges = null;
+            SavedChanges = null;
+            SaveChangesFailed = null;
+        }
 
         /// <summary>
         ///     Gets an <see cref="EntityEntry{TEntity}" /> for the given entity. The entry provides

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -775,7 +775,10 @@ namespace Microsoft.EntityFrameworkCore
                 await service.ResetStateAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            ClearEvents();
+            if (!_dontClearEvents)
+            {
+                ClearEvents();
+            }
 
             _disposed = true;
         }
@@ -825,7 +828,10 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     _disposed = true;
 
-                    ClearEvents();
+                    if (!_dontClearEvents)
+                    {
+                        ClearEvents();
+                    }
 
                     _lease = DbContextLease.InactiveLease;
                 }
@@ -844,7 +850,10 @@ namespace Microsoft.EntityFrameworkCore
                 _changeTracker = null;
                 _database = null;
 
-                ClearEvents();
+                if (!_dontClearEvents)
+                {
+                    ClearEvents();
+                }
 
                 return true;
             }
@@ -858,6 +867,9 @@ namespace Microsoft.EntityFrameworkCore
         public virtual ValueTask DisposeAsync()
             => DisposeSync() ? _serviceScope.DisposeAsyncIfAvailable() : default;
 
+
+        private static readonly bool _dontClearEvents
+            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23108", out var isEnabled) && isEnabled;
 
         private void ClearEvents()
         {


### PR DESCRIPTION
Fixes #23108

**Description**

We added three new .NET events on DbContext in 5.0. These events are not cleared when the DbContext is disposed, which can lead to memory leaks.

**Customer Impact**

Potential memory leak. (We had a similar bug in the early days of EF6 that resulted in several hard-to-find customer memory leaks.)

**How found**

Internal code review.

**Test coverage**

We were missing coverage for this. Added in this PR.

**Regression?**

No; these events are new in 5.0.

**Risk**

Very low. Set the event handlers to null when the context is disposed (and hence it is invalid to use it anymore and any operation on it will call ObjectDisposedException. Also quirked.
