### PR TITLE
[5.0.1] Microsoft.Data.Sqlite: Don't force decryption when password unset

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -256,12 +256,12 @@ namespace Microsoft.Data.Sqlite
                         "SELECT quote($password);",
                         new SqliteParameter("$password", ConnectionOptions.Password));
                     this.ExecuteNonQuery("PRAGMA key = " + quotedPassword + ";");
-                }
 
-                if (SQLitePCLExtensions.EncryptionSupported() != false)
-                {
-                    // NB: Forces decryption. Throws when the key is incorrect.
-                    this.ExecuteNonQuery("SELECT COUNT(*) FROM sqlite_master;");
+                    if (SQLitePCLExtensions.EncryptionSupported() != false)
+                    {
+                        // NB: Forces decryption. Throws when the key is incorrect.
+                        this.ExecuteNonQuery("SELECT COUNT(*) FROM sqlite_master;");
+                    }
                 }
 
                 if (ConnectionOptions.ForeignKeys.HasValue)


### PR DESCRIPTION
Fixes #23250

**Description**

In Microsoft.Data.Sqlite 5.0 we updated the connection to throw when the database is encrypted, but not key (aka password) was provided in the connection string.

While this improved the experience for users who forgot to supply a key, it broke others who were supplying the key immediately after opening the connection.

The fix in this PR reverts to the 3.1 behavior.

**Customer Impact**

Without this fix, anyone supplying a key after opening the connection would need to update their app to supply it in the connection string instead.

```csharp
// Change this...
connection.Open();
connection.Execute("PRAGMA key = 'password'");

// ...to this
connection.ConnectionString = "" + new SqliteConnectionStringBuilder(connection.ConnectionString)
{
    Password = "password"
};
connection.Open();
```

**How found**

Customer reported

**Test coverage**

We had tests asserting the behavior introduced in 5.0. They have been updated to reflect the new behavior.

**Regression?**

Yes

**Risk**

Very low. This is the same behavior we had in 3.1

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


