### PR TITLE
[5.0.1] Query: Pushdown into subquery when applying group by over a group by

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1288,9 +1288,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => from order in ss.Set<Order>()
                       group new
-                          {
-                              IsAlfki = order.CustomerID == "ALFKI", OrderId = order.OrderID > 1000 ? order.OrderID : -order.OrderID
-                          } by
+                      {
+                          IsAlfki = order.CustomerID == "ALFKI",
+                          OrderId = order.OrderID > 1000 ? order.OrderID : -order.OrderID
+                      } by
                           new { order.OrderID }
                       into g
                       select new { g.Key.OrderID, Aggregate = g.Sum(s => s.IsAlfki ? s.OrderId : -s.OrderId) });
@@ -2326,6 +2327,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: o => o.Key);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_aggregate_followed_another_GroupBy_aggregate(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, o.OrderDate.Value.Year })
+                    .Select(g => new { g.Key.CustomerID, g.Key.Year })
+                    .GroupBy(e => e.CustomerID)
+                    .Select(g => new { g.Key, Count = g.Count() }),
+                elementSorter: o => o.Key);
+        }
+
         #endregion
 
         #region GroupByAggregateChainComposition
@@ -2523,7 +2538,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         g =>
                             new
                             {
-                                g.Key, Max = g.Distinct().Select(e => e.OrderDate).Distinct().Max(),
+                                g.Key,
+                                Max = g.Distinct().Select(e => e.OrderDate).Distinct().Max(),
                             }),
                 elementSorter: e => e.Key);
         }
@@ -2540,7 +2556,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         g =>
                             new
                             {
-                                g.Key, Max = g.Where(e => e.OrderDate.HasValue).Select(e => e.OrderDate).Distinct().Max(),
+                                g.Key,
+                                Max = g.Where(e => e.OrderDate.HasValue).Select(e => e.OrderDate).Distinct().Max(),
                             }),
                 elementSorter: e => e.Key);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2327,6 +2327,20 @@ INNER JOIN (
 ) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]");
         }
 
+        public override async Task GroupBy_aggregate_followed_another_GroupBy_aggregate(bool async)
+        {
+            await base.GroupBy_aggregate_followed_another_GroupBy_aggregate(async);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID] AS [Key], COUNT(*) AS [Count]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID], DATEPART(year, [o].[OrderDate])
+) AS [t]
+GROUP BY [t].[CustomerID]");
+        }
+
         public override async Task GroupBy_with_grouping_key_using_Like(bool async)
         {
             await base.GroupBy_with_grouping_key_using_Like(async);


### PR DESCRIPTION
Resolves #23265

Everyone wants their own set of conditions for pushdown. ¯\\_(ツ)_/¯

**Description**

When applying GroupBy over result of another GroupBy-aggregate, we missed doing a push-down of the subquery causing incorrect results. This is a regression from 3.1 in a reasonably common query pattern.

**Customer Impact**

Incorrect results which can cause data corruption in customer apps.

**How found**

Customer reported on 5.0.

**Test coverage**

Added test for affected scenario.

**Regression?**

Yes, this worked in 3.1.

**Risk**

Low.  This brings back same set of condition which were in place for push-down in 3.1
