### PR TITLE
[5.0.1] Sqlite Migrations: Handle Z and M in spatial columns

### DIFF
--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -29,13 +29,37 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
             = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "GEOMETRY",
+                "GEOMETRYZ",
+                "GEOMETRYM",
+                "GEOMETRYZM",
                 "GEOMETRYCOLLECTION",
+                "GEOMETRYCOLLECTIONZ",
+                "GEOMETRYCOLLECTIONM",
+                "GEOMETRYCOLLECTIONZM",
                 "LINESTRING",
+                "LINESTRINGZ",
+                "LINESTRINGM",
+                "LINESTRINGZM",
                 "MULTILINESTRING",
+                "MULTILINESTRINGZ",
+                "MULTILINESTRINGM",
+                "MULTILINESTRINGZM",
                 "MULTIPOINT",
+                "MULTIPOINTZ",
+                "MULTIPOINTM",
+                "MULTIPOINTZM",
                 "MULTIPOLYGON",
+                "MULTIPOLYGONZ",
+                "MULTIPOLYGONM",
+                "MULTIPOLYGONZM",
                 "POINT",
-                "POLYGON"
+                "POINTZ",
+                "POINTM",
+                "POINTZM",
+                "POLYGON",
+                "POLYGONZ",
+                "POLYGONM",
+                "POLYGONZM"
             };
 
         private const string IntegerTypeName = "INTEGER";

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationsSqlGeneratorTest.cs
@@ -234,6 +234,25 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         [ConditionalFact]
+        public virtual void AddColumnOperation_with_spatial_type()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "Geometries",
+                    Name = "Geometry",
+                    [SqliteAnnotationNames.Srid] = 4326,
+                    ColumnType = "GEOMETRYZM",
+                    IsNullable = true
+                });
+
+            AssertSql(
+                @"SELECT AddGeometryColumn('Geometries', 'Geometry', 4326, 'GEOMETRYZM', -1, 0);
+");
+        }
+
+
+        [ConditionalFact]
         public void DropSchemaOperation_is_ignored()
         {
             Generate(new DropSchemaOperation());


### PR DESCRIPTION
Fixes #23390

**Description**

We took some fixes in EF Core 5.0 to enable using additional dimensions (Z and M) in spatial data on SQLite. However, we missed some updates in Migrations resulting in the columns getting created incorrectly in the database.

**Customer Impact**

This only affects users wanting to start using Z and M in EF Core 5.0. The columns are created in a way that can read and write the data, but more advanced queries and database validation of the data won't work.

**How found**

Customer reported

**Test coverage**

We have coverage of reading and writing these values to the database, but no coverage asserting the DML we use to create the columns. This PR adds that coverage.

**Regression?**

No, Z and M did not work at all in SQLite prior to EF Core 5.0.

**Risk**

Low

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


