### PR TITLE
[5.0.1] Query: Don't clear projection mapping when adding single projection

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -569,6 +570,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     : unaryExpression.Update(MatchTypes(operand, unaryExpression.Operand.Type));
         }
 
+        [DebuggerStepThrough]
         private static Expression MatchTypes(Expression expression, Type targetType)
         {
             if (targetType != expression.Type

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1285,7 +1285,10 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 }
 
                 shaperExpression = remapper.RemapIndex(shaperExpression, indexMap, pendingCollectionOffset);
-                _projectionMapping.Clear();
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23266", out var isEnabled) && isEnabled)
+                {
+                    _projectionMapping.Clear();
+                }
             }
             else
             {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1168,6 +1168,12 @@ ORDER BY c[""CustomerID""]");
             return base.Select_nested_collection_deep(async);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Do_not_erase_projection_mapping_when_adding_single_projection(bool async)
+        {
+            return base.Do_not_erase_projection_mapping_when_adding_single_projection(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1450,6 +1450,38 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]");
         }
 
+        public override async Task Do_not_erase_projection_mapping_when_adding_single_projection(bool async)
+        {
+            await base.Do_not_erase_projection_mapping_when_adding_single_projection(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t0].[OrderID], [t0].[ProductID], [t0].[Discount], [t0].[Quantity], [t0].[UnitPrice], [t0].[ProductID0], [t0].[Discontinued], [t0].[ProductName], [t0].[SupplierID], [t0].[UnitPrice0], [t0].[UnitsInStock], [t0].[c], [t1].[OrderID], [t1].[ProductID], [t1].[Discount], [t1].[Quantity], [t1].[UnitPrice], [t1].[ProductID0], [t1].[Discontinued], [t1].[ProductName], [t1].[SupplierID], [t1].[UnitPrice0], [t1].[UnitsInStock], [t2].[OrderID], [t2].[ProductID], [t2].[Discount], [t2].[Quantity], [t2].[UnitPrice], [t2].[ProductID0], [t2].[Discontinued], [t2].[ProductName], [t2].[SupplierID], [t2].[UnitPrice0], [t2].[UnitsInStock]
+FROM [Orders] AS [o]
+LEFT JOIN (
+    SELECT [t].[OrderID], [t].[ProductID], [t].[Discount], [t].[Quantity], [t].[UnitPrice], [t].[ProductID0], [t].[Discontinued], [t].[ProductName], [t].[SupplierID], [t].[UnitPrice0], [t].[UnitsInStock], [t].[c]
+    FROM (
+        SELECT [o0].[OrderID], [o0].[ProductID], [o0].[Discount], [o0].[Quantity], [o0].[UnitPrice], [p].[ProductID] AS [ProductID0], [p].[Discontinued], [p].[ProductName], [p].[SupplierID], [p].[UnitPrice] AS [UnitPrice0], [p].[UnitsInStock], 1 AS [c], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[OrderID], [o0].[ProductID], [p].[ProductID]) AS [row]
+        FROM [Order Details] AS [o0]
+        INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
+        WHERE [o0].[UnitPrice] > 10.0
+    ) AS [t]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [o].[OrderID] = [t0].[OrderID]
+LEFT JOIN (
+    SELECT [o1].[OrderID], [o1].[ProductID], [o1].[Discount], [o1].[Quantity], [o1].[UnitPrice], [p0].[ProductID] AS [ProductID0], [p0].[Discontinued], [p0].[ProductName], [p0].[SupplierID], [p0].[UnitPrice] AS [UnitPrice0], [p0].[UnitsInStock]
+    FROM [Order Details] AS [o1]
+    INNER JOIN [Products] AS [p0] ON [o1].[ProductID] = [p0].[ProductID]
+) AS [t1] ON [o].[OrderID] = [t1].[OrderID]
+LEFT JOIN (
+    SELECT [o2].[OrderID], [o2].[ProductID], [o2].[Discount], [o2].[Quantity], [o2].[UnitPrice], [p1].[ProductID] AS [ProductID0], [p1].[Discontinued], [p1].[ProductName], [p1].[SupplierID], [p1].[UnitPrice] AS [UnitPrice0], [p1].[UnitsInStock]
+    FROM [Order Details] AS [o2]
+    INNER JOIN [Products] AS [p1] ON [o2].[ProductID] = [p1].[ProductID]
+    WHERE [o2].[UnitPrice] < 10.0
+) AS [t2] ON [o].[OrderID] = [t2].[OrderID]
+WHERE [o].[OrderID] < 10350
+ORDER BY [o].[OrderID], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0], [t1].[OrderID], [t1].[ProductID], [t1].[ProductID0], [t2].[OrderID], [t2].[ProductID], [t2].[ProductID0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Sometimes reclaiming memory is not the best thing to do. You never know what you will need in future.

Resolves #23266

**Description**

In 5.0, we cleared the projection mapping when adding single projection to SelectExpression. However, this is still needed if there are further subqueries to be translated in the projection. We don't need to clear here since this will be done by the projection translation.

**Customer Impact**

Regression for any query which is evaluating on client for final projection (common) and also doing FirstOrDefault (or friends) on a non-primitive type will fail with exception.

**How found**

Customer reported on 5.0.

**Test coverage**

Added test for affected scenario and existing scenario also working since clearing is happening later automatically.

**Regression?**

Yes, from 3.1.

**Risk**

Low.  Defers clearing till it is actually needed and appropriate.
