### PR TITLE
[5.0.1] Disable savepoints on SQL Server when MARS is enabled

### DIFF
--- a/All.sln.DotSettings
+++ b/All.sln.DotSettings
@@ -136,6 +136,7 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=PUBLIC_005FSTRUCT_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNotificationDisabled/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FK/@EntryIndexedValue">FK</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MARS/@EntryIndexedValue">MARS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=042e7460_002D3ec6_002D4f1c_002D87c3_002Dfc91240d4c90/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static, Instance" AccessRightKinds="Public" Description="Test Methods"&gt;&lt;ElementKinds&gt;&lt;Kind Name="TEST_MEMBER" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="Aa_bb" /&gt;&lt;/Policy&gt;</s:String>
@@ -220,6 +221,8 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=remapper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=requiredness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=retriable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=savepoint/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=savepoints/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaper/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spatialite/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sproc/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
+++ b/src/EFCore.SqlServer/Diagnostics/Internal/SqlServerLoggingDefinitions.cs
@@ -155,6 +155,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public EventDefinitionBase LogSavepointsDisabledBecauseOfMARS;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public EventDefinitionBase LogConflictingValueGenerationStrategies;
     }
 }

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -29,6 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ConflictingValueGenerationStrategiesWarning,
             DecimalTypeKeyWarning,
 
+            // Transaction events
+            SavepointsDisabledBecauseOfMARS,
+
             // Scaffolding events
             ColumnFound = CoreEventId.ProviderDesignBaseId,
             ColumnNotNamedWarning,
@@ -120,6 +123,22 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId ConflictingValueGenerationStrategiesWarning =
             MakeValidationId(Id.ConflictingValueGenerationStrategiesWarning);
+
+        private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
+
+        private static EventId MakeTransactionId(Id id)
+            => new EventId((int)id, _transactionPrefix + id);
+
+        /// <summary>
+        ///     <para>
+        ///         Savepoints have been disabled when saving changes with an external transaction, because Multiple Active Result Sets is
+        ///         enabled.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Database.Transaction" /> category.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId SavepointsDisabledBecauseOfMARS = MakeTransactionId(Id.SavepointsDisabledBecauseOfMARS);
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
 

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -510,5 +510,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
 
             // No DiagnosticsSource events because these are purely design-time messages
         }
+
+        /// <summary>
+        ///     Logs for the <see cref="RelationalEventId.MultipleCollectionIncludeWarning" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        public static void SavepointsDisabledBecauseOfMARS(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> diagnostics)
+        {
+            var definition = SqlServerResources.LogSavepointsDisabledBecauseOfMARS(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics);
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new EventData(
+                    definition,
+                    (d, p) => ((EventDefinition)d).GenerateMessage());
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -660,5 +660,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
 
             return (EventDefinition<string, string>)definition;
         }
+
+        /// <summary>
+        ///     Savepoints are disabled because Multiple Active Result Sets (MARS) is enabled. If 'SaveChanges' fails, then the transaction cannot be automatically rolled back to a known clean state. Instead, the transaction should be rolled back by the application before retrying 'SaveChanges'. See https://go.microsoft.com/fwlink/?linkid=2149338 for more information. To identify the code which triggers this warning, call 'ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.SavepointsDisabledBecauseOfMARS))'.
+        /// </summary>
+        public static EventDefinition LogSavepointsDisabledBecauseOfMARS([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogSavepointsDisabledBecauseOfMARS;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogSavepointsDisabledBecauseOfMARS,
+                    () => new EventDefinition(
+                        logger.Options,
+                        SqlServerEventId.SavepointsDisabledBecauseOfMARS,
+                        LogLevel.Warning,
+                        "SqlServerEventId.SavepointsDisabledBecauseOfMARS",
+                        level => LoggerMessage.Define(
+                            level,
+                            SqlServerEventId.SavepointsDisabledBecauseOfMARS,
+                            _resourceManager.GetString("LogSavepointsDisabledBecauseOfMARS"))));
+            }
+
+            return (EventDefinition)definition;
+        }
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -249,6 +249,10 @@
     <value>Skipping foreign key '{foreignKeyName}' on table '{tableName}' since all of its columns reference themselves.</value>
     <comment>Debug SqlServerEventId.ReflexiveConstraintIgnored string string</comment>
   </data>
+  <data name="LogSavepointsDisabledBecauseOfMARS" xml:space="preserve">
+    <value>Savepoints are disabled because Multiple Active Result Sets (MARS) is enabled. If 'SaveChanges' fails, then the transaction cannot be automatically rolled back to a known clean state. Instead, the transaction should be rolled back by the application before retrying 'SaveChanges'. See https://go.microsoft.com/fwlink/?linkid=2149338 for more information. To identify the code which triggers this warning, call 'ConfigureWarnings(w =&gt; w.Throw(RelationalEventId.SavepointsDisabledBecauseOfMARS))'.</value>
+    <comment>Warning SqlServerEventId.SavepointsDisabledBecauseOfMARS</comment>
+  </data>
   <data name="MultipleIdentityColumns" xml:space="preserve">
     <value>The properties {properties} are configured to use 'Identity' value generator and are mapped to the same table '{table}'. Only one column per table can be configured as 'Identity'. Call 'ValueGeneratedNever' for properties that should not use 'Identity'.</value>
   </data>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
@@ -42,6 +43,24 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// <inheritdoc />
         protected override string GetRollbackToSavepointSql(string name)
             => "ROLLBACK TRANSACTION " + name;
+
+        /// <inheritdoc />
+        public override bool SupportsSavepoints
+        {
+            get
+            {
+                if (Connection is ISqlServerConnection sqlServerConnection && sqlServerConnection.IsMultipleActiveResultSetsEnabled)
+                {
+                    Logger.SavepointsDisabledBecauseOfMARS();
+
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        // SQL Server doesn't support releasing savepoints. Override to do nothing.
 
         /// <inheritdoc />
         public override void ReleaseSavepoint(string name) { }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTransaction.cs
@@ -20,6 +20,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
     /// </summary>
     public class SqlServerTransaction : RelationalTransaction
     {
+        private static readonly bool _useOldBehavior
+            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23305", out var enabled) && enabled;
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -49,6 +52,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         {
             get
             {
+                if (_useOldBehavior)
+                {
+                    return base.SupportsSavepoints;
+                }
+
                 if (Connection is ISqlServerConnection sqlServerConnection && sqlServerConnection.IsMultipleActiveResultSetsEnabled)
                 {
                     Logger.SavepointsDisabledBecauseOfMARS();

--- a/src/EFCore/Diagnostics/WarningsConfiguration.cs
+++ b/src/EFCore/Diagnostics/WarningsConfiguration.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
                 if (_explicitBehaviors != null)
                 {
-                    hashCode = _explicitBehaviors.Aggregate(
+                    hashCode = _explicitBehaviors.OrderBy(b => b.Key).Aggregate(
                         hashCode,
                         (t, e) => (t * 397) ^ (((long)e.Value.GetHashCode() * 3163) ^ (long)e.Key.GetHashCode()));
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsInfrastructureSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsInfrastructureSqlServerTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Identity30.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -1410,9 +1411,8 @@ DROP DATABASE TransactionSuppressed");
 
             public override MigrationsContext CreateContext()
             {
-                var options = AddOptions(
-                        new DbContextOptionsBuilder()
-                            .UseSqlServer(TestStore.ConnectionString, b => b.ApplyConfiguration()))
+                var options = AddOptions(TestStore.AddProviderOptions(new DbContextOptionsBuilder()))
+                    .UseSqlServer(TestStore.ConnectionString, b => b.ApplyConfiguration())
                     .UseInternalServiceProvider(ServiceProvider)
                     .Options;
                 return new MigrationsContext(options);

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 #pragma warning disable IDE0022 // Use block body for methods
 // ReSharper disable SuggestBaseTypeForParameter
@@ -98,7 +99,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         }
 
         public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
-            => builder.UseSqlServer(Connection, b => b.ApplyConfiguration());
+            => builder
+                .UseSqlServer(Connection, b => b.ApplyConfiguration())
+                .ConfigureWarnings(b => b.Ignore(SqlServerEventId.SavepointsDisabledBecauseOfMARS));
 
         private bool CreateDatabase(Action<DbContext> clean)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -1,9 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable MethodHasAsyncOverload
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -14,6 +20,41 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Savepoints_are_disabled_with_MARS(bool async)
+        {
+            await using var context = CreateContextWithConnectionString(
+                SqlServerTestStore.CreateConnectionString(TestStore.Name, multipleActiveResultSets: true));
+
+            await using var transaction = await context.Database.BeginTransactionAsync();
+
+            var orderId = 300;
+            foreach (var _ in context.Set<TransactionCustomer>())
+            {
+                context.Add(new TransactionOrder { Id = orderId++, Name = "Order " + orderId });
+                if (async)
+                {
+                    await context.SaveChangesAsync();
+                }
+                else
+                {
+                    context.SaveChanges();
+                }
+            }
+
+            await transaction.CommitAsync();
+
+            Assert.Contains(Fixture.ListLoggerFactory.Log, t => t.Id == SqlServerEventId.SavepointsDisabledBecauseOfMARS);
+        }
+
+        // Test relies on savepoints, which are disabled when MARS is enabled
+        public override Task SaveChanges_uses_explicit_transaction_with_failure_behavior(bool async, bool autoTransaction)
+            => new SqlConnectionStringBuilder(TestStore.ConnectionString).MultipleActiveResultSets
+                ? Task.CompletedTask
+                : base.SaveChanges_uses_explicit_transaction_with_failure_behavior(async, autoTransaction);
+
         protected override bool SnapshotSupported
             => true;
 
@@ -21,12 +62,16 @@ namespace Microsoft.EntityFrameworkCore
             => true;
 
         protected override DbContext CreateContextWithConnectionString()
+            => CreateContextWithConnectionString(null);
+
+        protected DbContext CreateContextWithConnectionString(string connectionString)
         {
             var options = Fixture.AddOptions(
                     new DbContextOptionsBuilder()
                         .UseSqlServer(
-                            TestStore.ConnectionString,
+                            connectionString ?? TestStore.ConnectionString,
                             b => b.ApplyConfiguration().ExecutionStrategy(c => new SqlServerExecutionStrategy(c))))
+                .ConfigureWarnings(b => b.Log(SqlServerEventId.SavepointsDisabledBecauseOfMARS))
                 .UseInternalServiceProvider(Fixture.ServiceProvider);
 
             return new DbContext(options.Options);
@@ -60,6 +105,7 @@ namespace Microsoft.EntityFrameworkCore
                 new SqlServerDbContextOptionsBuilder(
                         base.AddOptions(builder))
                     .ExecutionStrategy(c => new SqlServerExecutionStrategy(c));
+                builder.ConfigureWarnings(b => b.Log(SqlServerEventId.SavepointsDisabledBecauseOfMARS));
                 return builder;
             }
         }


### PR DESCRIPTION
Fixes #23269

**Additional context for Tactics**

This is a tricky one, because it is a regression in 5.0 resulting in an exception, the root cause of which is new feature added in 5.0. We don't want to break this new feature in 5.0.1 for people who are using it successfully in 5.0.0. Therefore, we are:

- Reverting the behavior here to that of 3.1, but only in the specific case that is broken. (This kind of pivot isn't ideal, but this is a tricky case.)
- Rather than doing this silently, we also generate a warning in the logs when we do this.

**Description**

EF Core 5.0 adds transaction savepoint support, and automatically uses savepoints to make SaveChanges better when an external transaction is used. Unfortunately savepoints do not work in SQL Server when the Multiple Active Result Set (MARS) feature is enabled.

**Customer Impact**

Regression for users who have turned on MARS and are using external transactions receive an error when attempting to save changes.

**How found**

User-reported on 5.0

**Test coverage**

Added in this PR. We will also revisit coverage for MARS in general.

**Regression?**

Yes, from 3.1.

**Risk**

Low. There was already infrastructure in place for checking whether savepoints are supported by the database provider or not; this PR modifies that check for SQL Server to check if MARS is enabled. When savepoints aren't supported, we revert back to the previous, 3.1 behavior.
