### PR TITLE
[5.0.1] Query: Match types in conditional during client evaluation

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -203,6 +203,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 test = Expression.Equal(test, Expression.Constant(true, typeof(bool?)));
             }
 
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23309", out var isEnabled) && isEnabled))
+            {
+                ifTrue = MatchTypes(ifTrue, conditionalExpression.IfTrue.Type);
+                ifFalse = MatchTypes(ifFalse, conditionalExpression.IfFalse.Type);
+            }
+
             return conditionalExpression.Update(test, ifTrue, ifFalse);
         }
 

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -279,6 +279,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 test = Expression.Equal(test, Expression.Constant(true, typeof(bool?)));
             }
 
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23309", out var isEnabled) && isEnabled))
+            {
+                ifTrue = MatchTypes(ifTrue, conditionalExpression.IfTrue.Type);
+                ifFalse = MatchTypes(ifFalse, conditionalExpression.IfFalse.Type);
+            }
+
             return conditionalExpression.Update(test, ifTrue, ifFalse);
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1174,6 +1174,17 @@ ORDER BY c[""CustomerID""]");
             return base.Do_not_erase_projection_mapping_when_adding_single_projection(async);
         }
 
+        public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
+        {
+            await base.Ternary_in_client_eval_assigns_correct_types(async);
+
+            AssertSql(
+                @"SELECT VALUE {""CustomerID"" : c[""CustomerID""], ""OrderDate"" : c[""OrderDate""], ""c"" : (c[""OrderID""] - 10000)}
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))
+ORDER BY c[""OrderID""]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -1876,5 +1876,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                 },
                 entryCount: 446);
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Ternary_in_client_eval_assigns_correct_types(bool async)
+        {     return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+
+                    .Where(o => o.OrderID < 10300)
+                    .OrderBy(e => e.OrderID)
+                    .Select(
+                        o => new
+                        {
+                            CustomerID = ClientMethod(o.CustomerID),
+                            OrderDate = o.OrderDate.HasValue ? o.OrderDate.Value : new DateTime(o.OrderID - 10000, 1, 1),
+                            OrderDate2 = o.OrderDate.HasValue == false ? new DateTime(o.OrderID - 10000, 1, 1) : o.OrderDate.Value
+                        }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.CustomerID, a.CustomerID);
+                    AssertEqual(e.OrderDate, a.OrderDate);
+                    AssertEqual(e.OrderDate2, a.OrderDate2);
+                });
+        }
+
+        private static string ClientMethod(string s) => s;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1482,6 +1482,23 @@ WHERE [o].[OrderID] < 10350
 ORDER BY [o].[OrderID], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0], [t1].[OrderID], [t1].[ProductID], [t1].[ProductID0], [t2].[OrderID], [t2].[ProductID], [t2].[ProductID0]");
         }
 
+        public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
+        {
+            await base.Ternary_in_client_eval_assigns_correct_types(async);
+
+            AssertSql(
+                @"SELECT [o].[CustomerID], CASE
+    WHEN [o].[OrderDate] IS NOT NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [o].[OrderDate], [o].[OrderID] - 10000, CASE
+    WHEN [o].[OrderDate] IS NULL THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10300
+ORDER BY [o].[OrderID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #23309

**Description**

Regression when client evaluation in the final projection (common) encounters a conditional expression where one part can be null in the database. In this case we end up with mismatched types between the true/false part of the conditional, resulting in an exception.

**Customer Impact**

Regression when a ternary is used in projection when client eval happens, which is a common case.

**How found**

Customer reported on 5.0.

**Test coverage**

Added test for affected scenario.

**Regression?**

Yes, from 3.1.

**Risk**

Low. Convert node would only fail when null is encountered when non-null expected which is error.
