### PR TITLE
[5.0.1] Query: Add null check in hash computation in SqlFunctionExpression

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SqlFunctionExpression.cs
@@ -23,6 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
     /// </summary>
     public class SqlFunctionExpression : SqlExpression
     {
+        private static readonly bool _useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23336", out var enabled)
+            && enabled;
+
         /// <summary>
         ///     Creates a new instance of the <see cref="SqlFunctionExpression" /> class which represents a built-in niladic function.
         /// </summary>
@@ -394,9 +397,13 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             hash.Add(IsNiladic);
             hash.Add(Schema);
             hash.Add(Instance);
-            for (var i = 0; i < Arguments.Count; i++)
+            if (Arguments != null
+                || _useOldBehavior)
             {
-                hash.Add(Arguments[i]);
+                for (var i = 0; i < Arguments.Count; i++)
+                {
+                    hash.Add(Arguments[i]);
+                }
             }
 
             return hash.ToHashCode();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -692,6 +692,21 @@ FROM [PointEntity] AS [p]");
 FROM [PointEntity] AS [p]");
         }
 
+        public override async Task XY_with_collection_join(bool async)
+        {
+            await base.XY_with_collection_join(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[c], [t].[c0], [p0].[Id], [p0].[Geometry], [p0].[Point], [p0].[PointM], [p0].[PointZ], [p0].[PointZM]
+FROM (
+    SELECT TOP(1) [p].[Id], [p].[Point].Long AS [c], [p].[Point].Lat AS [c0]
+    FROM [PointEntity] AS [p]
+    ORDER BY [p].[Id]
+) AS [t]
+LEFT JOIN [PointEntity] AS [p0] ON [t].[Id] = [p0].[Id]
+ORDER BY [t].[Id], [p0].[Id]");
+        }
+
         public override async Task IsEmpty_equal_to_null(bool async)
         {
             await base.IsEmpty_equal_to_null(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -750,6 +750,21 @@ FROM [PointEntity] AS [p]");
 FROM [PointEntity] AS [p]");
         }
 
+        public override async Task XY_with_collection_join(bool async)
+        {
+            await base.XY_with_collection_join(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[c], [t].[c0], [p0].[Id], [p0].[Geometry], [p0].[Point], [p0].[PointM], [p0].[PointZ], [p0].[PointZM]
+FROM (
+    SELECT TOP(1) [p].[Id], [p].[Point].STX AS [c], [p].[Point].STY AS [c0]
+    FROM [PointEntity] AS [p]
+    ORDER BY [p].[Id]
+) AS [t]
+LEFT JOIN [PointEntity] AS [p0] ON [t].[Id] = [p0].[Id]
+ORDER BY [t].[Id], [p0].[Id]");
+        }
+
         public override async Task IsEmpty_equal_to_null(bool async)
         {
             await base.IsEmpty_equal_to_null(async);


### PR DESCRIPTION
Resolves #23336

**Description**

Hash code computation in SqlFunctionExpression does not check for null for niladic functions (non-parameter functions). Niladic functions are frequent in Spatial types.

**Customer Impact**

Queries involving collection projection, spatial function and FirstOrDefault will throw null ref.

**How found**

Customer reported on 5.0.

**Test coverage**

Test added for affected scenario.

**Regression?**

Yes, the buggy code existed on 3.1 too but it was not being hit in some query scenario. Other changes in query exposed this bug and made working queries from 3.1 to fail in 5.0

**Risk**

Low.
