### PR TITLE
[TINY] Fix to #23370 - Function and parameter names flipped for DbFunctionInvalidParameterName

### DIFF
--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
             if (parameter == null)
             {
                 throw new ArgumentException(
-                    RelationalStrings.DbFunctionInvalidParameterName(name, Metadata.MethodInfo.DisplayName()));
+                    RelationalStrings.DbFunctionInvalidParameterName(Metadata.MethodInfo.DisplayName(), name));
             }
 
             return parameter.Builder;

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -731,7 +731,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var dbFuncBuilder = modelBuilder.HasDbFunction(MethodBmi);
 
             Assert.Equal(
-                RelationalStrings.DbFunctionInvalidParameterName("q", dbFuncBuilder.Metadata.MethodInfo.DisplayName()),
+                RelationalStrings.DbFunctionInvalidParameterName(dbFuncBuilder.Metadata.MethodInfo.DisplayName(), "q"),
                 Assert.Throws<ArgumentException>(() => dbFuncBuilder.HasParameter("q")).Message);
         }
 


### PR DESCRIPTION
Fixes #23370