### PR TITLE
Annotate metadata for nullability, leaving only builders and conventions

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosAnnotationNames.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosNavigationExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosNavigationExtensions.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -29,11 +29,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
                 property.DeclaringEntityType.IsOwned(), $"Expected {property.DeclaringEntityType.DisplayName()} to be owned.");
             Check.DebugAssert(property.GetJsonPropertyName().Length == 0, $"Expected {property.Name} to be non-persisted.");
 
-            return property.IsPrimaryKey()
+            return property.FindContainingPrimaryKey() is IKey key
+                && key.Properties.Count > 1
                 && !property.IsForeignKey()
                 && property.ClrType == typeof(int)
                 && property.ValueGenerated == ValueGenerated.OnAdd
-                && property.DeclaringEntityType.FindPrimaryKey().Properties.Count > 1;
+                && property.FindContainingPrimaryKey()!.Properties.Count > 1;
         }
     }
 }

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosPropertyExtensions.cs
@@ -33,8 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
                 && key.Properties.Count > 1
                 && !property.IsForeignKey()
                 && property.ClrType == typeof(int)
-                && property.ValueGenerated == ValueGenerated.OnAdd
-                && property.FindContainingPrimaryKey()!.Properties.Count > 1;
+                && property.ValueGenerated == ValueGenerated.OnAdd;
         }
     }
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
             var property = member.MemberInfo != null
                 ? entityType.FindProperty(member.MemberInfo)
-                : entityType.FindProperty(member.Name);
+                : entityType.FindProperty(member.Name!);
 
             if (property != null)
             {
@@ -1424,7 +1424,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             {
                 case ConstantExpression constantExpression:
                     return Expression.Constant(
-                        property.GetGetter().GetClrValue(constantExpression.Value), property.ClrType.MakeNullable());
+                        constantExpression.Value is null
+                            ? null
+                            : property.GetGetter().GetClrValue(constantExpression.Value),
+                        property.ClrType.MakeNullable());
 
                 case MethodCallExpression methodCallExpression
                     when methodCallExpression.Method.IsGenericMethod

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1390,7 +1390,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
                 var navigation = member.MemberInfo != null
                     ? entityType.FindNavigation(member.MemberInfo)
-                    : entityType.FindNavigation(member.Name);
+                    : entityType.FindNavigation(member.Name!);
 
                 if (navigation == null)
                 {

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -225,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 Type entityType,
                 Type relatedEntityType,
                 INavigationBase navigation,
-                INavigationBase inverseNavigation)
+                INavigationBase? inverseNavigation)
             {
                 var entityParameter = Expression.Parameter(entityType);
                 var relatedEntityParameter = Expression.Parameter(relatedEntityType);

--- a/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The sequence name. </param>
         /// <param name="schema"> The schema name, or <see langword="null" /> to use the default schema. </param>
         /// <returns> The sequence. </returns>
-        public static IMutableSequence AddSequence(
+        public static IMutableSequence? AddSequence(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
             [CanBeNull] string? schema = null)
@@ -250,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="schema"> The schema name, or <see langword="null" /> to use the default schema. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The sequence. </returns>
-        public static IConventionSequence AddSequence(
+        public static IConventionSequence? AddSequence(
             [NotNull] this IConventionModel model,
             [NotNull] string name,
             [CanBeNull] string? schema = null,
@@ -376,7 +376,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to add the function to. </param>
         /// <param name="methodInfo"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The new <see cref="IMutableDbFunction" />. </returns>
-        public static IMutableDbFunction AddDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo methodInfo)
+        public static IMutableDbFunction? AddDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo methodInfo)
             => DbFunction.AddDbFunction(
                 model, Check.NotNull(methodInfo, nameof(methodInfo)), ConfigurationSource.Explicit);
 
@@ -387,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="methodInfo"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new <see cref="IConventionDbFunction" />. </returns>
-        public static IConventionDbFunction AddDbFunction(
+        public static IConventionDbFunction? AddDbFunction(
             [NotNull] this IConventionModel model,
             [NotNull] MethodInfo methodInfo,
             bool fromDataAnnotation = false)
@@ -402,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="name"> The model name of the function. </param>
         /// <param name="returnType"> The function return type. </param>
         /// <returns> The new <see cref="IMutableDbFunction" />. </returns>
-        public static IMutableDbFunction AddDbFunction(
+        public static IMutableDbFunction? AddDbFunction(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
             [NotNull] Type returnType)
@@ -417,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="returnType"> The function return type. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new <see cref="IConventionDbFunction" />. </returns>
-        public static IConventionDbFunction AddDbFunction(
+        public static IConventionDbFunction? AddDbFunction(
             [NotNull] this IConventionModel model,
             [NotNull] string name,
             [NotNull] Type returnType,

--- a/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalModelExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
@@ -86,15 +88,15 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model to get the default schema for. </param>
         /// <returns> The default schema. </returns>
-        public static string GetDefaultSchema([NotNull] this IModel model)
-            => (string)Check.NotNull(model, nameof(model))[RelationalAnnotationNames.DefaultSchema];
+        public static string? GetDefaultSchema([NotNull] this IModel model)
+            => (string?)Check.NotNull(model, nameof(model))[RelationalAnnotationNames.DefaultSchema];
 
         /// <summary>
         ///     Sets the default schema.
         /// </summary>
         /// <param name="model"> The model to set the default schema for. </param>
         /// <param name="value"> The value to set. </param>
-        public static void SetDefaultSchema([NotNull] this IMutableModel model, [CanBeNull] string value)
+        public static void SetDefaultSchema([NotNull] this IMutableModel model, [CanBeNull] string? value)
             => model.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.DefaultSchema,
                 Check.NullButNotEmpty(value, nameof(value)));
@@ -106,9 +108,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="value"> The value to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured schema. </returns>
-        public static string SetDefaultSchema(
+        public static string? SetDefaultSchema(
             [NotNull] this IConventionModel model,
-            [CanBeNull] string value,
+            [CanBeNull] string? value,
             bool fromDataAnnotation = false)
         {
             model.SetOrRemoveAnnotation(
@@ -132,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The database model. </returns>
         public static IRelationalModel GetRelationalModel([NotNull] this IModel model)
         {
-            var databaseModel = (IRelationalModel)model[RelationalAnnotationNames.RelationalModel];
+            var databaseModel = (IRelationalModel?)model[RelationalAnnotationNames.RelationalModel];
             if (databaseModel == null)
             {
                 throw new InvalidOperationException(RelationalStrings.DatabaseModelMissing);
@@ -189,7 +191,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The <see cref="ISequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        public static ISequence FindSequence([NotNull] this IModel model, [NotNull] string name, [CanBeNull] string schema = null)
+        public static ISequence? FindSequence([NotNull] this IModel model, [NotNull] string name, [CanBeNull] string? schema = null)
             => Sequence.FindSequence(
                 Check.NotNull(model, nameof(model)), Check.NotEmpty(name, nameof(name)), Check.NullButNotEmpty(schema, nameof(schema)));
 
@@ -203,11 +205,11 @@ namespace Microsoft.EntityFrameworkCore
         ///     The <see cref="IMutableSequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        public static IMutableSequence FindSequence(
+        public static IMutableSequence? FindSequence(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null)
-            => (IMutableSequence)((IModel)model).FindSequence(name, schema);
+            [CanBeNull] string? schema = null)
+            => (IMutableSequence?)((IModel)model).FindSequence(name, schema);
 
         /// <summary>
         ///     Finds an <see cref="IConventionSequence" /> with the given name.
@@ -219,11 +221,11 @@ namespace Microsoft.EntityFrameworkCore
         ///     The <see cref="IConventionSequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        public static IConventionSequence FindSequence(
+        public static IConventionSequence? FindSequence(
             [NotNull] this IConventionModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null)
-            => (IConventionSequence)((IModel)model).FindSequence(name, schema);
+            [CanBeNull] string? schema = null)
+            => (IConventionSequence?)((IModel)model).FindSequence(name, schema);
 
         /// <summary>
         ///     Either returns the existing <see cref="IMutableSequence" /> with the given name in the given schema
@@ -236,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore
         public static IMutableSequence AddSequence(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null)
+            [CanBeNull] string? schema = null)
             => Sequence.AddSequence(model, name, schema, ConfigurationSource.Explicit);
 
         /// <summary>
@@ -251,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore
         public static IConventionSequence AddSequence(
             [NotNull] this IConventionModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null,
+            [CanBeNull] string? schema = null,
             bool fromDataAnnotation = false)
             => Sequence.AddSequence(
                 (IMutableModel)model, name, schema,
@@ -267,10 +269,10 @@ namespace Microsoft.EntityFrameworkCore
         ///     The removed <see cref="IMutableSequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        public static IMutableSequence RemoveSequence(
+        public static IMutableSequence? RemoveSequence(
             [NotNull] this IMutableModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null)
+            [CanBeNull] string? schema = null)
             => Sequence.RemoveSequence(Check.NotNull(model, nameof(model)), name, schema);
 
         /// <summary>
@@ -283,10 +285,10 @@ namespace Microsoft.EntityFrameworkCore
         ///     The removed <see cref="IConventionSequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        public static IConventionSequence RemoveSequence(
+        public static IConventionSequence? RemoveSequence(
             [NotNull] this IConventionModel model,
             [NotNull] string name,
-            [CanBeNull] string schema = null)
+            [CanBeNull] string? schema = null)
             => Sequence.RemoveSequence((IMutableModel)Check.NotNull(model, nameof(model)), name, schema);
 
         /// <summary>
@@ -316,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="method"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The <see cref="IDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IDbFunction FindDbFunction([NotNull] this IModel model, [NotNull] MethodInfo method)
+        public static IDbFunction? FindDbFunction([NotNull] this IModel model, [NotNull] MethodInfo method)
             => DbFunction.FindDbFunction(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(method, nameof(method)));
@@ -327,8 +329,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="method"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The <see cref="IMutableDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IMutableDbFunction FindDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo method)
-            => (IMutableDbFunction)((IModel)model).FindDbFunction(method);
+        public static IMutableDbFunction? FindDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo method)
+            => (IMutableDbFunction?)((IModel)model).FindDbFunction(method);
 
         /// <summary>
         ///     Finds a <see cref="IConventionDbFunction" /> that is mapped to the method represented by the given <see cref="MethodInfo" />.
@@ -336,8 +338,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="method"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The <see cref="IConventionDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IConventionDbFunction FindDbFunction([NotNull] this IConventionModel model, [NotNull] MethodInfo method)
-            => (IConventionDbFunction)((IModel)model).FindDbFunction(method);
+        public static IConventionDbFunction? FindDbFunction([NotNull] this IConventionModel model, [NotNull] MethodInfo method)
+            => (IConventionDbFunction?)((IModel)model).FindDbFunction(method);
 
         /// <summary>
         ///     Finds an <see cref="IDbFunction" /> that is mapped to the method represented by the given name.
@@ -345,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
         /// <returns> The <see cref="IDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IDbFunction FindDbFunction([NotNull] this IModel model, [NotNull] string name)
+        public static IDbFunction? FindDbFunction([NotNull] this IModel model, [NotNull] string name)
             => DbFunction.FindDbFunction(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(name, nameof(name)));
@@ -356,8 +358,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
         /// <returns> The <see cref="IMutableDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IMutableDbFunction FindDbFunction([NotNull] this IMutableModel model, [NotNull] string name)
-            => (IMutableDbFunction)((IModel)model).FindDbFunction(name);
+        public static IMutableDbFunction? FindDbFunction([NotNull] this IMutableModel model, [NotNull] string name)
+            => (IMutableDbFunction?)((IModel)model).FindDbFunction(name);
 
         /// <summary>
         ///     Finds an <see cref="IConventionDbFunction" /> that is mapped to the method represented by the given name.
@@ -365,8 +367,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
         /// <returns> The <see cref="IConventionDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IConventionDbFunction FindDbFunction([NotNull] this IConventionModel model, [NotNull] string name)
-            => (IConventionDbFunction)((IModel)model).FindDbFunction(name);
+        public static IConventionDbFunction? FindDbFunction([NotNull] this IConventionModel model, [NotNull] string name)
+            => (IConventionDbFunction?)((IModel)model).FindDbFunction(name);
 
         /// <summary>
         ///     Creates an <see cref="IMutableDbFunction" /> mapped to the given method.
@@ -433,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="method"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The removed <see cref="IMutableDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IMutableDbFunction RemoveDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo method)
+        public static IMutableDbFunction? RemoveDbFunction([NotNull] this IMutableModel model, [NotNull] MethodInfo method)
             => DbFunction.RemoveDbFunction(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(method, nameof(method)));
@@ -445,8 +447,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="method"> The <see cref="MethodInfo" /> for the method that is mapped to the function. </param>
         /// <returns> The removed <see cref="IConventionDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IConventionDbFunction RemoveDbFunction([NotNull] this IConventionModel model, [NotNull] MethodInfo method)
-            => (IConventionDbFunction)((IMutableModel)model).RemoveDbFunction(method);
+        public static IConventionDbFunction? RemoveDbFunction([NotNull] this IConventionModel model, [NotNull] MethodInfo method)
+            => (IConventionDbFunction?)((IMutableModel)model).RemoveDbFunction(method);
 
         /// <summary>
         ///     Removes the <see cref="IMutableDbFunction" /> that is mapped to the method represented by the given
@@ -455,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
         /// <returns> The removed <see cref="IMutableDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IMutableDbFunction RemoveDbFunction([NotNull] this IMutableModel model, [NotNull] string name)
+        public static IMutableDbFunction? RemoveDbFunction([NotNull] this IMutableModel model, [NotNull] string name)
             => DbFunction.RemoveDbFunction(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(name, nameof(name)));
@@ -467,8 +469,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="model"> The model to find the function in. </param>
         /// <param name="name"> The model name of the function. </param>
         /// <returns> The removed <see cref="IConventionDbFunction" /> or <see langword="null" /> if the method is not mapped. </returns>
-        public static IConventionDbFunction RemoveDbFunction([NotNull] this IConventionModel model, [NotNull] string name)
-            => (IConventionDbFunction)((IMutableModel)model).RemoveDbFunction(name);
+        public static IConventionDbFunction? RemoveDbFunction([NotNull] this IConventionModel model, [NotNull] string name)
+            => (IConventionDbFunction?)((IMutableModel)model).RemoveDbFunction(name);
 
         /// <summary>
         ///     Returns all <see cref="IDbFunction" />s contained in the model.
@@ -496,15 +498,15 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="model"> The model to get the collation for. </param>
         /// <returns> The collation. </returns>
-        public static string GetCollation([NotNull] this IModel model)
-            => (string)model[RelationalAnnotationNames.Collation];
+        public static string? GetCollation([NotNull] this IModel model)
+            => (string?)model[RelationalAnnotationNames.Collation];
 
         /// <summary>
         ///     Sets the database collation.
         /// </summary>
         /// <param name="model"> The model to set the collation for. </param>
         /// <param name="value"> The value to set. </param>
-        public static void SetCollation([NotNull] this IMutableModel model, [CanBeNull] string value)
+        public static void SetCollation([NotNull] this IMutableModel model, [CanBeNull] string? value)
             => model.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.Collation,
                 Check.NullButNotEmpty(value, nameof(value)));
@@ -516,7 +518,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="value"> The value to set. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured collation. </returns>
-        public static string SetCollation([NotNull] this IConventionModel model, [CanBeNull] string value, bool fromDataAnnotation = false)
+        public static string? SetCollation([NotNull] this IConventionModel model, [CanBeNull] string? value, bool fromDataAnnotation = false)
         {
             model.SetOrRemoveAnnotation(
                 RelationalAnnotationNames.Collation,

--- a/src/EFCore.Relational/Infrastructure/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalPropertyExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="properties"> The properties to format. </param>
         /// <param name="storeObject"> The identifier of the table-like store object containing the column. </param>
         /// <returns> A list of column names. </returns>
-        public static IReadOnlyList<string> GetColumnNames(
+        public static IReadOnlyList<string>? GetColumnNames(
             [NotNull] this IEnumerable<IProperty> properties,
             in StoreObjectIdentifier storeObject)
         {

--- a/src/EFCore.Relational/Metadata/CheckConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/CheckConstraintExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ColumnExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ColumnMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/DbFunctionExtensions.cs
+++ b/src/EFCore.Relational/Metadata/DbFunctionExtensions.cs
@@ -6,6 +6,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/DbFunctionParameterExtensions.cs
+++ b/src/EFCore.Relational/Metadata/DbFunctionParameterExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ForeignKeyConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ForeignKeyConstraintExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/FunctionColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/FunctionColumnExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/FunctionColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/FunctionColumnMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/FunctionMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/FunctionMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ICheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/ICheckConstraint.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IColumn.cs
+++ b/src/EFCore.Relational/Metadata/IColumn.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -65,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Returns the object that is used as the default value for this column.
         /// </summary>
-        public virtual object DefaultValue
+        public virtual object? DefaultValue
         {
             get
             {
@@ -82,14 +84,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Returns the SQL expression that is used as the default value for this column.
         /// </summary>
-        public virtual string DefaultValueSql
+        public virtual string? DefaultValueSql
             => PropertyMappings.First().Property
                 .GetDefaultValueSql(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
 
         /// <summary>
         ///     Returns the SQL expression that is used as the computed value for this column.
         /// </summary>
-        public virtual string ComputedColumnSql
+        public virtual string? ComputedColumnSql
             => PropertyMappings.First().Property
                 .GetComputedColumnSql(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
 
@@ -104,14 +106,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Comment for this column
         /// </summary>
-        public virtual string Comment
+        public virtual string? Comment
             => PropertyMappings.First().Property
                 .GetComment(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
 
         /// <summary>
         ///     Collation for this column
         /// </summary>
-        public virtual string Collation
+        public virtual string? Collation
             => PropertyMappings.First().Property
                 .GetCollation(StoreObjectIdentifier.Table(Table.Name, Table.Schema));
     }

--- a/src/EFCore.Relational/Metadata/IColumnBase.cs
+++ b/src/EFCore.Relational/Metadata/IColumnBase.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/IColumnMapping.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IColumnMappingBase.cs
+++ b/src/EFCore.Relational/Metadata/IColumnMappingBase.cs
@@ -4,6 +4,8 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IConventionCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IConventionCheckConstraint.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunction.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -24,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this function.
         /// </summary>
-        new IConventionDbFunctionBuilder Builder { get; }
+        new IConventionDbFunctionBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the configuration source for this function.
@@ -38,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The name of the function in the database. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        string SetName([CanBeNull] string name, bool fromDataAnnotation = false);
+        string? SetName([CanBeNull] string? name, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="IDbFunction.Name" />.
@@ -52,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="schema"> The schema of the function in the database. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        string SetSchema([CanBeNull] string schema, bool fromDataAnnotation = false);
+        string? SetSchema([CanBeNull] string? schema, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="IDbFunction.Schema" />.
@@ -94,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="storeType"> The store type of the function in the database. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        string SetStoreType([CanBeNull] string storeType, bool fromDataAnnotation = false);
+        string? SetStoreType([CanBeNull] string? storeType, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="IDbFunction.StoreType" />.
@@ -108,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="typeMapping"> The type mapping of the function in the database. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        RelationalTypeMapping SetTypeMapping([CanBeNull] RelationalTypeMapping typeMapping, bool fromDataAnnotation = false);
+        RelationalTypeMapping? SetTypeMapping([CanBeNull] RelationalTypeMapping? typeMapping, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="IDbFunction.TypeMapping" />.
@@ -124,8 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        Func<IReadOnlyCollection<SqlExpression>, SqlExpression> SetTranslation(
-            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
+        Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? SetTranslation(
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? translation,
             bool fromDataAnnotation = false);
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/IConventionDbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IConventionDbFunctionParameter.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     The <see cref="IConventionDbFunctionParameterBuilder" /> for configuring this function parameter.
         /// </summary>
-        new IConventionDbFunctionParameterBuilder Builder { get; }
+        new IConventionDbFunctionParameterBuilder? Builder { get; }
 
         /// <summary>
         ///     Returns the configuration source for the parameter.
@@ -33,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="storeType"> The store type of the parameter. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        string SetStoreType([CanBeNull] string storeType, bool fromDataAnnotation = false);
+        string? SetStoreType([CanBeNull] string? storeType, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="IDbFunctionParameter.StoreType" />.
@@ -46,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="typeMapping"> The type mapping of the parameter in the database. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
-        RelationalTypeMapping SetTypeMapping([CanBeNull] RelationalTypeMapping typeMapping, bool fromDataAnnotation = false);
+        RelationalTypeMapping? SetTypeMapping([CanBeNull] RelationalTypeMapping? typeMapping, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="IDbFunctionParameter.TypeMapping" />.

--- a/src/EFCore.Relational/Metadata/IConventionSequence.cs
+++ b/src/EFCore.Relational/Metadata/IConventionSequence.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this sequence.
         /// </summary>
-        new IConventionSequenceBuilder Builder { get; }
+        new IConventionSequenceBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the configuration source for this <see cref="IConventionSequence" />.
@@ -91,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="type"> The <see cref="Type" /> of values returned by the sequence. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
-        Type SetType([CanBeNull] Type type, bool fromDataAnnotation = false);
+        Type? SetType([CanBeNull] Type? type, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="ISequence.ClrType" />.
@@ -106,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured value. </returns>
         [Obsolete("Use SetType")]
-        Type SetClrType([CanBeNull] Type type, bool fromDataAnnotation = false);
+        Type? SetClrType([CanBeNull] Type? type, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the configuration source for <see cref="ISequence.ClrType" />.

--- a/src/EFCore.Relational/Metadata/IDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunction.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
@@ -23,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the schema of the function in the database.
         /// </summary>
-        string Schema { get; }
+        string? Schema { get; }
 
         /// <summary>
         ///     Gets the name of the function in the model.
@@ -38,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the CLR method which maps to the function in the database.
         /// </summary>
-        MethodInfo MethodInfo { get; }
+        MethodInfo? MethodInfo { get; }
 
         /// <summary>
         ///     Gets the value indicating whether the database function is built-in.
@@ -48,6 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the value indicating whether this function returns scalar value.
         /// </summary>
+        [CA.MemberNotNullWhen(true, nameof(TypeMapping))]
         bool IsScalar { get; }
 
         /// <summary>
@@ -63,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the configured store type string.
         /// </summary>
-        string StoreType { get; }
+        string? StoreType { get; }
 
         /// <summary>
         ///     Gets the returned CLR type.
@@ -73,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the type mapping for the function's return type.
         /// </summary>
-        RelationalTypeMapping TypeMapping { get; }
+        RelationalTypeMapping? TypeMapping { get; }
 
         /// <summary>
         ///     Gets the parameters for this function.
@@ -83,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the translation callback for performing custom translation of the method call into a SQL expression fragment.
         /// </summary>
-        Func<IReadOnlyCollection<SqlExpression>, SqlExpression> Translation { get; }
+        Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? Translation { get; }
 
         /// <summary>
         ///     Gets the associated <see cref="IStoreFunction" />.

--- a/src/EFCore.Relational/Metadata/IDbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunctionParameter.cs
@@ -5,6 +5,8 @@ using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -46,6 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the associated <see cref="IStoreFunctionParameter" />.
         /// </summary>
-        IStoreFunctionParameter StoreFunctionParameter { get; }
+        // TODO-NULLABLE: Not sure about what this is for or if it should be nullable
+        IStoreFunctionParameter? StoreFunctionParameter { get; }
     }
 }

--- a/src/EFCore.Relational/Metadata/IForeignKeyConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IForeignKeyConstraint.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IFunctionColumn.cs
+++ b/src/EFCore.Relational/Metadata/IFunctionColumn.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IFunctionColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/IFunctionColumnMapping.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IFunctionMapping.cs
+++ b/src/EFCore.Relational/Metadata/IFunctionMapping.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IMutableCheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IMutableCheckConstraint.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IMutableDbFunction.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets or sets the schema of the function in the database.
         /// </summary>
-        new string Schema { get; [param: CanBeNull] set; }
+        new string? Schema { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Gets or sets the value indicating whether the database function is built-in or not.
@@ -38,12 +40,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets or sets the store type of the function in the database.
         /// </summary>
-        new string StoreType { get; [param: CanBeNull] set; }
+        new string? StoreType { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Gets or sets the type mapping of the function in the database.
         /// </summary>
-        new RelationalTypeMapping TypeMapping { get; [param: CanBeNull] set; }
+        new RelationalTypeMapping? TypeMapping { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Gets the <see cref="IMutableModel" /> in which this function is defined.
@@ -58,6 +60,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets or sets the translation callback for performing custom translation of the method call into a SQL expression fragment.
         /// </summary>
-        new Func<IReadOnlyCollection<SqlExpression>, SqlExpression> Translation { get; [param: CanBeNull] set; }
+        new Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? Translation { get; [param: CanBeNull] set; }
     }
 }

--- a/src/EFCore.Relational/Metadata/IMutableDbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IMutableDbFunctionParameter.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -19,11 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets or sets the store type of this parameter.
         /// </summary>
-        new string StoreType { get; [param: CanBeNull] set; }
+        new string? StoreType { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     Gets or sets the <see cref="RelationalTypeMapping" /> for this parameter.
         /// </summary>
-        new RelationalTypeMapping TypeMapping { get; [param: CanBeNull] set; }
+        new RelationalTypeMapping? TypeMapping { get; [param: CanBeNull] set; }
     }
 }

--- a/src/EFCore.Relational/Metadata/IMutableSequence.cs
+++ b/src/EFCore.Relational/Metadata/IMutableSequence.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IPrimaryKeyConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IPrimaryKeyConstraint.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IRelationalAnnotationProvider.cs
+++ b/src/EFCore.Relational/Metadata/IRelationalAnnotationProvider.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IRelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/IRelationalModel.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -48,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Returns the database collation.
         /// </summary>
-        string Collation
+        string? Collation
             => Model.GetCollation();
 
         /// <summary>
@@ -57,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The name of the table. </param>
         /// <param name="schema"> The schema of the table. </param>
         /// <returns> The table with a given name or <see langword="null" /> if no table with the given name is defined. </returns>
-        ITable FindTable([NotNull] string name, [CanBeNull] string schema);
+        ITable? FindTable([NotNull] string name, [CanBeNull] string? schema);
 
         /// <summary>
         ///     Gets the view with the given name. Returns <see langword="null" /> if no view with the given name is defined.
@@ -65,14 +67,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The name of the view. </param>
         /// <param name="schema"> The schema of the view. </param>
         /// <returns> The view with a given name or <see langword="null" /> if no view with the given name is defined. </returns>
-        IView FindView([NotNull] string name, [CanBeNull] string schema);
+        IView? FindView([NotNull] string name, [CanBeNull] string? schema);
 
         /// <summary>
         ///     Gets the SQL query with the given name. Returns <see langword="null" /> if no SQL query with the given name is defined.
         /// </summary>
         /// <param name="name"> The name of the SQL query. </param>
         /// <returns> The SQL query with a given name or <see langword="null" /> if no SQL query with the given name is defined. </returns>
-        ISqlQuery FindQuery([NotNull] string name);
+        ISqlQuery? FindQuery([NotNull] string name);
 
         /// <summary>
         ///     Finds an <see cref="ISequence" /> with the given name.
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The <see cref="ISequence" /> or <see langword="null" /> if no sequence with the given name in
         ///     the given schema was found.
         /// </returns>
-        ISequence FindSequence([NotNull] string name, [CanBeNull] string schema)
+        ISequence? FindSequence([NotNull] string name, [CanBeNull] string? schema)
             => Model.FindSequence(name, schema);
 
         /// <summary>
@@ -93,6 +95,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="schema"> The schema of the function. </param>
         /// <param name="parameters"> A list of parameter types. </param>
         /// <returns> The <see cref="IStoreFunction" /> or <see langword="null" /> if no function with the given name was defined. </returns>
-        IStoreFunction FindFunction([NotNull] string name, [CanBeNull] string schema, [NotNull] IReadOnlyList<string> parameters);
+        IStoreFunction? FindFunction([NotNull] string name, [CanBeNull] string? schema, [NotNull] IReadOnlyList<string> parameters);
     }
 }

--- a/src/EFCore.Relational/Metadata/ISequence.cs
+++ b/src/EFCore.Relational/Metadata/ISequence.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the database schema that contains the sequence.
         /// </summary>
-        string Schema { get; }
+        string? Schema { get; }
 
         /// <summary>
         ///     Gets the <see cref="IModel" /> in which this sequence is defined.

--- a/src/EFCore.Relational/Metadata/ISqlQuery.cs
+++ b/src/EFCore.Relational/Metadata/ISqlQuery.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -24,12 +26,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the column with the given name. Returns <see langword="null" /> if no column with the given name is defined.
         /// </summary>
-        new ISqlQueryColumn FindColumn([NotNull] string name);
+        new ISqlQueryColumn? FindColumn([NotNull] string name);
 
         /// <summary>
         ///     Gets the column mapped to the given property. Returns <see langword="null" /> if no column is mapped to the given property.
         /// </summary>
-        new ISqlQueryColumn FindColumn([NotNull] IProperty property);
+        new ISqlQueryColumn? FindColumn([NotNull] IProperty property);
 
         /// <summary>
         ///     Gets the SQL query string.

--- a/src/EFCore.Relational/Metadata/ISqlQueryColumn.cs
+++ b/src/EFCore.Relational/Metadata/ISqlQueryColumn.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ISqlQueryColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/ISqlQueryColumnMapping.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ISqlQueryMapping.cs
+++ b/src/EFCore.Relational/Metadata/ISqlQueryMapping.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IStoreFunction.cs
+++ b/src/EFCore.Relational/Metadata/IStoreFunction.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the scalar return type.
         /// </summary>
-        string ReturnType { get; }
+        string? ReturnType { get; }
 
         /// <summary>
         ///     Gets the entity type mappings for the returned row set.
@@ -45,11 +47,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Gets the column with the given name. Returns <see langword="null" />
         ///     if no column with the given name is defined for the returned row set.
         /// </summary>
-        new IFunctionColumn FindColumn([NotNull] string name);
+        new IFunctionColumn? FindColumn([NotNull] string name);
 
         /// <summary>
         ///     Gets the column mapped to the given property. Returns <see langword="null" /> if no column is mapped to the given property.
         /// </summary>
-        new IFunctionColumn FindColumn([NotNull] IProperty property);
+        new IFunctionColumn? FindColumn([NotNull] IProperty property);
     }
 }

--- a/src/EFCore.Relational/Metadata/IStoreFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/IStoreFunctionParameter.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ITable.cs
+++ b/src/EFCore.Relational/Metadata/ITable.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -42,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the primary key for this table.
         /// </summary>
-        IPrimaryKeyConstraint PrimaryKey { get; }
+        IPrimaryKeyConstraint? PrimaryKey { get; }
 
         /// <summary>
         ///     Gets the indexes for this table.
@@ -59,17 +61,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the comment for this table.
         /// </summary>
-        public virtual string Comment
+        public virtual string? Comment
             => EntityTypeMappings.Select(e => e.EntityType.GetComment()).FirstOrDefault(c => c != null);
 
         /// <summary>
         ///     Gets the column with a given name. Returns <see langword="null" /> if no column with the given name is defined.
         /// </summary>
-        new IColumn FindColumn([NotNull] string name);
+        new IColumn? FindColumn([NotNull] string name);
 
         /// <summary>
         ///     Gets the column mapped to the given property. Returns <see langword="null" /> if no column is mapped to the given property.
         /// </summary>
-        new IColumn FindColumn([NotNull] IProperty property);
+        new IColumn? FindColumn([NotNull] IProperty property);
     }
 }

--- a/src/EFCore.Relational/Metadata/ITableBase.cs
+++ b/src/EFCore.Relational/Metadata/ITableBase.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the schema of the table in the database.
         /// </summary>
-        string Schema { get; }
+        string? Schema { get; }
 
         /// <summary>
         ///     Gets the database model.
@@ -45,22 +47,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the column with the given name. Returns <see langword="null" /> if no column with the given name is defined.
         /// </summary>
-        IColumnBase FindColumn([NotNull] string name);
+        IColumnBase? FindColumn([NotNull] string name);
 
         /// <summary>
         ///     Gets the column mapped to the given property. Returns <see langword="null" /> if no column is mapped to the given property.
         /// </summary>
-        IColumnBase FindColumn([NotNull] IProperty property);
+        IColumnBase? FindColumn([NotNull] IProperty property);
 
         /// <summary>
         ///     Gets the foreign keys for the given entity type that point to other entity types sharing this table.
         /// </summary>
-        IEnumerable<IForeignKey> GetRowInternalForeignKeys([NotNull] IEntityType entityType);
+        IEnumerable<IForeignKey>? GetRowInternalForeignKeys([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     Gets the foreign keys referencing the given entity type from other entity types sharing this table.
         /// </summary>
-        IEnumerable<IForeignKey> GetReferencingRowInternalForeignKeys([NotNull] IEntityType entityType);
+        IEnumerable<IForeignKey>? GetReferencingRowInternalForeignKeys([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     Gets the value indicating whether an entity of the given type might not be present in a row.

--- a/src/EFCore.Relational/Metadata/ITableBase.cs
+++ b/src/EFCore.Relational/Metadata/ITableBase.cs
@@ -57,12 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the foreign keys for the given entity type that point to other entity types sharing this table.
         /// </summary>
-        IEnumerable<IForeignKey>? GetRowInternalForeignKeys([NotNull] IEntityType entityType);
+        IEnumerable<IForeignKey> GetRowInternalForeignKeys([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     Gets the foreign keys referencing the given entity type from other entity types sharing this table.
         /// </summary>
-        IEnumerable<IForeignKey>? GetReferencingRowInternalForeignKeys([NotNull] IEntityType entityType);
+        IEnumerable<IForeignKey> GetReferencingRowInternalForeignKeys([NotNull] IEntityType entityType);
 
         /// <summary>
         ///     Gets the value indicating whether an entity of the given type might not be present in a row.

--- a/src/EFCore.Relational/Metadata/ITableIndex.cs
+++ b/src/EFCore.Relational/Metadata/ITableIndex.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -39,6 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the expression used as the index filter.
         /// </summary>
-        string Filter { get; }
+        string? Filter { get; }
     }
 }

--- a/src/EFCore.Relational/Metadata/ITableMapping.cs
+++ b/src/EFCore.Relational/Metadata/ITableMapping.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ITableMappingBase.cs
+++ b/src/EFCore.Relational/Metadata/ITableMappingBase.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IUniqueConstraint.cs
+++ b/src/EFCore.Relational/Metadata/IUniqueConstraint.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IView.cs
+++ b/src/EFCore.Relational/Metadata/IView.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -24,16 +26,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the column with the given name. Returns <see langword="null" /> if no column with the given name is defined.
         /// </summary>
-        new IViewColumn FindColumn([NotNull] string name);
+        new IViewColumn? FindColumn([NotNull] string name);
 
         /// <summary>
         ///     Gets the column mapped to the given property. Returns <see langword="null" /> if no column is mapped to the given property.
         /// </summary>
-        new IViewColumn FindColumn([NotNull] IProperty property);
+        new IViewColumn? FindColumn([NotNull] IProperty property);
 
         /// <summary>
         ///     Gets the view definition or <see langword="null" /> if this view is not managed by migrations.
         /// </summary>
-        public string ViewDefinitionSql { get; }
+        public string? ViewDefinitionSql { get; }
     }
 }

--- a/src/EFCore.Relational/Metadata/IViewColumn.cs
+++ b/src/EFCore.Relational/Metadata/IViewColumn.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IViewColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/IViewColumnMapping.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/IViewMapping.cs
+++ b/src/EFCore.Relational/Metadata/IViewMapping.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/CheckConstraint.cs
@@ -9,6 +9,8 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -76,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static ICheckConstraint FindCheckConstraint(
+        public static ICheckConstraint? FindCheckConstraint(
             [NotNull] IEntityType entityType,
             [NotNull] string name)
         {
@@ -95,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static CheckConstraint RemoveCheckConstraint(
+        public static CheckConstraint? RemoveCheckConstraint(
             [NotNull] IMutableEntityType entityType,
             [NotNull] string name)
         {
@@ -155,8 +157,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _configurationSource = configurationSource.Max(_configurationSource);
         }
 
-        private static Dictionary<string, CheckConstraint> GetConstraintsDictionary(IEntityType entityType)
-            => (Dictionary<string, CheckConstraint>)entityType[RelationalAnnotationNames.CheckConstraints];
+        private static Dictionary<string, CheckConstraint>? GetConstraintsDictionary(IEntityType entityType)
+            => (Dictionary<string, CheckConstraint>?)entityType[RelationalAnnotationNames.CheckConstraints];
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/Column.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Column.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Column([NotNull] string name, [CanBeNull] string type, [NotNull] Table table)
+        public Column([NotNull] string name, [CanBeNull] string? type, [NotNull] Table table)
             : base(name, type, table)
         {
         }

--- a/src/EFCore.Relational/Metadata/Internal/Column.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Column.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public Column([NotNull] string name, [CanBeNull] string? type, [NotNull] Table table)
             : base(name, type, table)
         {
+            // TODO-NULLABLE: Seems like an annotation mismatch. Is it really OK for type to be null, in which cases?
         }
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/Internal/Column.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Column.cs
@@ -25,10 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Column([NotNull] string name, [CanBeNull] string? type, [NotNull] Table table)
+        public Column([NotNull] string name, [NotNull] string type, [NotNull] Table table)
             : base(name, type, table)
         {
-            // TODO-NULLABLE: Seems like an annotation mismatch. Is it really OK for type to be null, in which cases?
         }
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/Internal/ColumnBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnBase.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ColumnListComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnListComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -33,8 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(IReadOnlyList<IColumn> x, IReadOnlyList<IColumn> y)
+        public int Compare(IReadOnlyList<IColumn>? x, IReadOnlyList<IColumn>? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = x.Count - y.Count;
             if (result != 0)
             {
@@ -58,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(IReadOnlyList<IColumn> x, IReadOnlyList<IColumn> y)
+        public bool Equals(IReadOnlyList<IColumn>? x, IReadOnlyList<IColumn>? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] TableMapping tableMapping)
             : base(property, column, typeMapping, tableMapping)
         {
+            // TODO-NULLABLE: As with type, nullability mismatch for typeMapping - what's the right annotation?
         }
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
@@ -27,11 +27,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public ColumnMapping(
             [NotNull] IProperty property,
             [NotNull] Column column,
-            [CanBeNull] RelationalTypeMapping? typeMapping,
+            [NotNull] RelationalTypeMapping typeMapping,
             [NotNull] TableMapping tableMapping)
             : base(property, column, typeMapping, tableMapping)
         {
-            // TODO-NULLABLE: As with type, nullability mismatch for typeMapping - what's the right annotation?
         }
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMapping.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public ColumnMapping(
             [NotNull] IProperty property,
             [NotNull] Column column,
-            [CanBeNull] RelationalTypeMapping typeMapping,
+            [CanBeNull] RelationalTypeMapping? typeMapping,
             [NotNull] TableMapping tableMapping)
             : base(property, column, typeMapping, tableMapping)
         {

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMappingBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMappingBase.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnMappingBaseComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -32,8 +34,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(IColumnMappingBase x, IColumnMappingBase y)
+        public int Compare(IColumnMappingBase? x, IColumnMappingBase? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = y.Property.IsPrimaryKey().CompareTo(x.Property.IsPrimaryKey());
             if (result != 0)
             {
@@ -73,9 +90,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(IColumnMappingBase x, IColumnMappingBase y)
-            => x.Property == y.Property
-                && x.Column == y.Column;
+        public bool Equals(IColumnMappingBase? x, IColumnMappingBase? y)
+            => ReferenceEquals(x, y) || x is not null && y is not null && x.Property == y.Property && x.Column == y.Column;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/ColumnNameComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ColumnNameComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(string x, string y)
+        public int Compare(string? x, string? y)
         {
             var xIndex = -1;
             var yIndex = -1;

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -15,6 +15,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -27,13 +30,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public class DbFunction : ConventionAnnotatable, IMutableDbFunction, IConventionDbFunction
     {
         private readonly List<DbFunctionParameter> _parameters;
-        private string _schema;
-        private string _name;
+        private string? _schema;
+        private string? _name;
         private bool _builtIn;
         private bool _nullable;
-        private string _storeType;
-        private RelationalTypeMapping _typeMapping;
-        private Func<IReadOnlyCollection<SqlExpression>, SqlExpression> _translation;
+        private string? _storeType;
+        private RelationalTypeMapping? _typeMapping;
+        private Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? _translation;
 
         private ConfigurationSource _configurationSource;
         private ConfigurationSource? _schemaConfigurationSource;
@@ -57,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             : this(
                 methodInfo.Name,
                 methodInfo.ReturnType,
-                methodInfo.GetParameters().Select(pi => (pi.Name, pi.ParameterType)),
+                methodInfo.GetParameters().Select(pi => (pi.Name!, pi.ParameterType)),
                 model,
                 configurationSource)
         {
@@ -89,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public DbFunction(
             [NotNull] string name,
             [NotNull] Type returnType,
-            [CanBeNull] IEnumerable<(string Name, Type Type)> parameters,
+            [CanBeNull] IEnumerable<(string Name, Type Type)>? parameters,
             [NotNull] IMutableModel model,
             ConfigurationSource configurationSource)
         {
@@ -99,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 || returnType == typeof(void))
             {
                 throw new ArgumentException(
-                    RelationalStrings.DbFunctionInvalidReturnType(name, returnType.ShortDisplayName()));
+                    RelationalStrings.DbFunctionInvalidReturnType(name, returnType?.ShortDisplayName()));
             }
 
             IsScalar = !returnType.IsGenericType
@@ -110,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ReturnType = returnType;
             Model = model;
             _configurationSource = configurationSource;
-            Builder = new InternalDbFunctionBuilder(this, ((IConventionModel)model).Builder);
+            Builder = new InternalDbFunctionBuilder(this, ((IConventionModel)model).Builder!);
             _parameters = parameters == null
                 ? new List<DbFunctionParameter>()
                 : parameters
@@ -124,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private static string GetFunctionName(MethodInfo methodInfo, ParameterInfo[] parameters)
-            => methodInfo.DeclaringType.FullName
+            => methodInfo.DeclaringType!.FullName
                 + "."
                 + methodInfo.Name
                 + "("
@@ -140,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalDbFunctionBuilder Builder { get; private set; }
+        public virtual InternalDbFunctionBuilder? Builder { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -149,7 +152,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static IEnumerable<DbFunction> GetDbFunctions([NotNull] IModel model)
-            => ((SortedDictionary<string, DbFunction>)model[RelationalAnnotationNames.DbFunctions])
+            => ((SortedDictionary<string, DbFunction>?)model[RelationalAnnotationNames.DbFunctions])
                 ?.Values
                 ?? Enumerable.Empty<DbFunction>();
 
@@ -159,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static DbFunction FindDbFunction([NotNull] IModel model, [NotNull] MethodInfo methodInfo)
+        public static DbFunction? FindDbFunction([NotNull] IModel model, [NotNull] MethodInfo methodInfo)
             => model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, DbFunction> functions
                 && functions.TryGetValue(GetFunctionName(methodInfo, methodInfo.GetParameters()), out var dbFunction)
                     ? dbFunction
@@ -171,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static DbFunction FindDbFunction([NotNull] IModel model, [NotNull] string name)
+        public static DbFunction? FindDbFunction([NotNull] IModel model, [NotNull] string name)
             => model[RelationalAnnotationNames.DbFunctions] is SortedDictionary<string, DbFunction> functions
                 && functions.TryGetValue(name, out var dbFunction)
                     ? dbFunction
@@ -222,7 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static DbFunction RemoveDbFunction(
+        public static DbFunction? RemoveDbFunction(
             [NotNull] IMutableModel model,
             [NotNull] MethodInfo methodInfo)
         {
@@ -247,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static DbFunction RemoveDbFunction(
+        public static DbFunction? RemoveDbFunction(
             [NotNull] IMutableModel model,
             [NotNull] string name)
         {
@@ -265,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual string ModelName { get; }
 
         /// <inheritdoc />
-        public virtual MethodInfo MethodInfo { get; }
+        public virtual MethodInfo? MethodInfo { get; }
 
         /// <inheritdoc />
         public virtual Type ReturnType { get; }
@@ -297,7 +300,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string Schema
+        public virtual string? Schema
         {
             get => _schema ?? Model.GetDefaultSchema();
             set => SetSchema(value, ConfigurationSource.Explicit);
@@ -309,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string SetSchema([CanBeNull] string schema, ConfigurationSource configurationSource)
+        public virtual string? SetSchema([CanBeNull] string? schema, ConfigurationSource configurationSource)
         {
             _schema = schema;
 
@@ -347,7 +350,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string SetName([CanBeNull] string name, ConfigurationSource configurationSource)
+        public virtual string? SetName([CanBeNull] string? name, ConfigurationSource configurationSource)
         {
             Check.NullButNotEmpty(name, nameof(name));
 
@@ -450,7 +453,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string StoreType
+        public virtual string? StoreType
         {
             get => _storeType ?? TypeMapping?.StoreType;
             set => SetStoreType(value, ConfigurationSource.Explicit);
@@ -462,7 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string SetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        public virtual string? SetStoreType([CanBeNull] string? storeType, ConfigurationSource configurationSource)
         {
             _storeType = storeType;
 
@@ -488,7 +491,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual RelationalTypeMapping TypeMapping
+        public virtual RelationalTypeMapping? TypeMapping
         {
             get => _typeMapping;
             set => SetTypeMapping(value, ConfigurationSource.Explicit);
@@ -500,8 +503,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual RelationalTypeMapping SetTypeMapping(
-            [CanBeNull] RelationalTypeMapping typeMapping,
+        public virtual RelationalTypeMapping? SetTypeMapping(
+            [CanBeNull] RelationalTypeMapping? typeMapping,
             ConfigurationSource configurationSource)
         {
             _typeMapping = typeMapping;
@@ -528,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Func<IReadOnlyCollection<SqlExpression>, SqlExpression> Translation
+        public virtual Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? Translation
         {
             get => _translation;
             set => SetTranslation(value, ConfigurationSource.Explicit);
@@ -540,14 +543,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Func<IReadOnlyCollection<SqlExpression>, SqlExpression> SetTranslation(
-            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
+        public virtual Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? SetTranslation(
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? translation,
             ConfigurationSource configurationSource)
         {
             if (translation != null
                 && (!IsScalar || IsAggregate))
             {
-                throw new InvalidOperationException(RelationalStrings.DbFunctionNonScalarCustomTranslation(MethodInfo.DisplayName()));
+                throw new InvalidOperationException(RelationalStrings.DbFunctionNonScalarCustomTranslation(MethodInfo?.DisplayName()));
             }
 
             _translation = translation;
@@ -574,7 +577,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IStoreFunction StoreFunction { get; [param: NotNull] set; }
+        public virtual IStoreFunction? StoreFunction { get; [param: NotNull] set; }
+
+        // Relational model creation ensures StoreFunction is populated
+        IStoreFunction IDbFunction.StoreFunction
+            => StoreFunction!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -586,7 +593,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
         /// <inheritdoc />
-        IConventionDbFunctionBuilder IConventionDbFunction.Builder
+        IConventionDbFunctionBuilder? IConventionDbFunction.Builder
         {
             [DebuggerStepThrough]
             get => Builder;
@@ -645,17 +652,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual DbFunctionParameter FindParameter([NotNull] string name)
+        public virtual DbFunctionParameter? FindParameter([NotNull] string name)
             => Parameters.SingleOrDefault(p => p.Name == name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        string IConventionDbFunction.SetName(string name, bool fromDataAnnotation)
+        string? IConventionDbFunction.SetName(string? name, bool fromDataAnnotation)
             => SetName(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        string IConventionDbFunction.SetSchema(string schema, bool fromDataAnnotation)
+        string? IConventionDbFunction.SetSchema(string? schema, bool fromDataAnnotation)
             => SetSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -670,18 +677,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        string IConventionDbFunction.SetStoreType(string storeType, bool fromDataAnnotation)
+        string? IConventionDbFunction.SetStoreType(string? storeType, bool fromDataAnnotation)
             => SetStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        RelationalTypeMapping IConventionDbFunction.SetTypeMapping(RelationalTypeMapping returnTypeMapping, bool fromDataAnnotation)
+        RelationalTypeMapping? IConventionDbFunction.SetTypeMapping(RelationalTypeMapping? returnTypeMapping, bool fromDataAnnotation)
             => SetTypeMapping(returnTypeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        Func<IReadOnlyCollection<SqlExpression>, SqlExpression> IConventionDbFunction.SetTranslation(
-            Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
+        Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? IConventionDbFunction.SetTranslation(
+            Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? translation,
             bool fromDataAnnotation)
             => SetTranslation(translation, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ReturnType = returnType;
             Model = model;
             _configurationSource = configurationSource;
-            Builder = new InternalDbFunctionBuilder(this, ((IConventionModel)model).Builder!);
+            Builder = new InternalDbFunctionBuilder(this, ((IConventionModel)model).Builder);
             _parameters = parameters == null
                 ? new List<DbFunctionParameter>()
                 : parameters

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
@@ -10,6 +10,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Builders.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -21,8 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class DbFunctionParameter : ConventionAnnotatable, IMutableDbFunctionParameter, IConventionDbFunctionParameter
     {
-        private string _storeType;
-        private RelationalTypeMapping _typeMapping;
+        private string? _storeType;
+        private RelationalTypeMapping? _typeMapping;
         private bool _propagatesNullability;
 
         private ConfigurationSource? _storeTypeConfigurationSource;
@@ -47,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Name = name;
             Function = function;
             ClrType = clrType;
-            Builder = new InternalDbFunctionParameterBuilder(this, function.Builder.ModelBuilder);
+            Builder = new InternalDbFunctionParameterBuilder(this, function.Builder!.ModelBuilder);
         }
 
         /// <summary>
@@ -56,10 +59,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalDbFunctionParameterBuilder Builder { get; }
+        public virtual InternalDbFunctionParameterBuilder? Builder { get; }
 
         /// <inheritdoc />
-        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameter.Builder
+        IConventionDbFunctionParameterBuilder? IConventionDbFunctionParameter.Builder
             => Builder;
 
         /// <summary>
@@ -108,11 +111,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string StoreType
+        public virtual string? StoreType
         {
             get => _storeType ?? TypeMapping?.StoreType;
             set => SetStoreType(value, ConfigurationSource.Explicit);
         }
+
+        // Model validation ensures all parameters have a type mapping
+        string IDbFunctionParameter.StoreType
+            => StoreType!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -120,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string SetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        public virtual string? SetStoreType([CanBeNull] string? storeType, ConfigurationSource configurationSource)
         {
             _storeType = storeType;
 
@@ -140,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        string IConventionDbFunctionParameter.SetStoreType(string storeType, bool fromDataAnnotation)
+        string? IConventionDbFunctionParameter.SetStoreType(string? storeType, bool fromDataAnnotation)
             => SetStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -149,11 +156,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual RelationalTypeMapping TypeMapping
+        public virtual RelationalTypeMapping? TypeMapping
         {
             get => _typeMapping;
             set => SetTypeMapping(value, ConfigurationSource.Explicit);
         }
+
+        // Model validation ensures all parameters have a type mapping
+        RelationalTypeMapping IDbFunctionParameter.TypeMapping
+            => _typeMapping!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -161,8 +172,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual RelationalTypeMapping SetTypeMapping(
-            [NotNull] RelationalTypeMapping typeMapping,
+        public virtual RelationalTypeMapping? SetTypeMapping(
+            [CanBeNull] RelationalTypeMapping? typeMapping,
             ConfigurationSource configurationSource)
         {
             _typeMapping = typeMapping;
@@ -223,11 +234,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        RelationalTypeMapping IConventionDbFunctionParameter.SetTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+        RelationalTypeMapping? IConventionDbFunctionParameter.SetTypeMapping(RelationalTypeMapping? typeMapping, bool fromDataAnnotation)
             => SetTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
-        public virtual IStoreFunctionParameter StoreFunctionParameter { get; [param: NotNull] set; }
+        public virtual IStoreFunctionParameter? StoreFunctionParameter { get; [param: NotNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunctionParameter.cs
@@ -117,10 +117,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             set => SetStoreType(value, ConfigurationSource.Explicit);
         }
 
-        // Model validation ensures all parameters have a type mapping
-        string IDbFunctionParameter.StoreType
-            => StoreType!;
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -233,12 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => _typeMappingConfigurationSource;
 
         /// <inheritdoc />
-        [DebuggerStepThrough]
-        RelationalTypeMapping? IConventionDbFunctionParameter.SetTypeMapping(RelationalTypeMapping? typeMapping, bool fromDataAnnotation)
-            => SetTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
-
-        /// <inheritdoc />
-        public virtual IStoreFunctionParameter? StoreFunctionParameter { get; [param: NotNull] set; }
+        public virtual IStoreFunctionParameter StoreFunctionParameter { get; [param: NotNull] set; } = default!;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -248,5 +239,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public override string ToString()
             => this.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
+
+        /// <inheritdoc />
+        [DebuggerStepThrough]
+        RelationalTypeMapping? IConventionDbFunctionParameter.SetTypeMapping(RelationalTypeMapping? typeMapping, bool fromDataAnnotation)
+            => SetTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <inheritdoc />
+        string IDbFunctionParameter.StoreType
+            => StoreType!; // Model validation ensures all parameters have a type mapping
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraint.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyConstraintComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -33,8 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(IForeignKeyConstraint x, IForeignKeyConstraint y)
+        public int Compare(IForeignKeyConstraint? x, IForeignKeyConstraint? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = StringComparer.Ordinal.Compare(x.Name, y.Name);
             if (result != 0)
             {
@@ -63,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(IForeignKeyConstraint x, IForeignKeyConstraint y)
+        public bool Equals(IForeignKeyConstraint? x, IForeignKeyConstraint? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/FunctionColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/FunctionColumn.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/FunctionColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/FunctionColumnMapping.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/FunctionMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/FunctionMapping.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionBuilder.cs
@@ -12,6 +12,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 {
     /// <summary>
@@ -39,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder HasName([CanBeNull] string name, ConfigurationSource configurationSource)
+        public virtual IConventionDbFunctionBuilder? HasName([CanBeNull] string? name, ConfigurationSource configurationSource)
         {
             if (CanSetName(name, configurationSource))
             {
@@ -56,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetName([CanBeNull] string name, ConfigurationSource configurationSource)
+        public virtual bool CanSetName([CanBeNull] string? name, ConfigurationSource configurationSource)
             => (name != "" || configurationSource == ConfigurationSource.Explicit)
                 && (configurationSource.Overrides(Metadata.GetNameConfigurationSource())
                     || Metadata.Name == name);
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder HasSchema([CanBeNull] string schema, ConfigurationSource configurationSource)
+        public virtual IConventionDbFunctionBuilder? HasSchema([CanBeNull] string? schema, ConfigurationSource configurationSource)
         {
             if (CanSetSchema(schema, configurationSource))
             {
@@ -84,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetSchema([CanBeNull] string schema, ConfigurationSource configurationSource)
+        public virtual bool CanSetSchema([CanBeNull] string? schema, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetSchemaConfigurationSource())
                 || Metadata.Schema == schema;
 
@@ -94,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder IsBuiltIn(bool builtIn, ConfigurationSource configurationSource)
+        public virtual IConventionDbFunctionBuilder? IsBuiltIn(bool builtIn, ConfigurationSource configurationSource)
         {
             if (CanSetIsBuiltIn(builtIn, configurationSource))
             {
@@ -121,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder IsNullable(bool nullable, ConfigurationSource configurationSource)
+        public virtual IConventionDbFunctionBuilder? IsNullable(bool nullable, ConfigurationSource configurationSource)
         {
             if (CanSetIsNullable(nullable, configurationSource))
             {
@@ -148,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder HasStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        public virtual IConventionDbFunctionBuilder? HasStoreType([CanBeNull] string? storeType, ConfigurationSource configurationSource)
         {
             if (CanSetStoreType(storeType, configurationSource))
             {
@@ -165,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        public virtual bool CanSetStoreType([CanBeNull] string? storeType, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetStoreTypeConfigurationSource())
                 || Metadata.StoreType == storeType;
 
@@ -175,8 +177,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder HasTypeMapping(
-            [CanBeNull] RelationalTypeMapping returnTypeMapping,
+        public virtual IConventionDbFunctionBuilder? HasTypeMapping(
+            [CanBeNull] RelationalTypeMapping? returnTypeMapping,
             ConfigurationSource configurationSource)
         {
             if (CanSetTypeMapping(returnTypeMapping, configurationSource))
@@ -194,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping returnTypeMapping, ConfigurationSource configurationSource)
+        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping? returnTypeMapping, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetTypeMappingConfigurationSource())
                 || Metadata.TypeMapping == returnTypeMapping;
 
@@ -204,8 +206,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionBuilder HasTranslation(
-            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
+        public virtual IConventionDbFunctionBuilder? HasTranslation(
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? translation,
             ConfigurationSource configurationSource)
         {
             if (CanSetTranslation(translation, configurationSource))
@@ -224,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CanSetTranslation(
-            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
+            [CanBeNull] Func<IReadOnlyCollection<SqlExpression>, SqlExpression>? translation,
             ConfigurationSource configurationSource)
             => (Metadata.IsScalar && !Metadata.IsAggregate || configurationSource == ConfigurationSource.Explicit)
                 && (configurationSource.Overrides(Metadata.GetTranslationConfigurationSource())
@@ -242,10 +244,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
             if (parameter == null)
             {
                 throw new ArgumentException(
-                    RelationalStrings.DbFunctionInvalidParameterName(Metadata.MethodInfo.DisplayName(), name));
+                    RelationalStrings.DbFunctionInvalidParameterName(Metadata.MethodInfo?.DisplayName(), name));
             }
 
-            return parameter.Builder;
+            return parameter.Builder!;
         }
 
         IConventionDbFunction IConventionDbFunctionBuilder.Metadata
@@ -256,7 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasName(string name, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.HasName(string name, bool fromDataAnnotation)
             => HasName(name, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -266,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasSchema(string schema, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.HasSchema(string schema, bool fromDataAnnotation)
             => HasSchema(schema, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -276,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.IsBuiltIn(bool builtIn, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.IsBuiltIn(bool builtIn, bool fromDataAnnotation)
             => IsBuiltIn(builtIn, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -286,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.IsNullable(bool nullable, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.IsNullable(bool nullable, bool fromDataAnnotation)
             => IsNullable(nullable, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -296,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
             => HasStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -306,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.HasTypeMapping(RelationalTypeMapping typeMapping, bool fromDataAnnotation)
             => HasTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -316,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionBuilder IConventionDbFunctionBuilder.HasTranslation(
+        IConventionDbFunctionBuilder? IConventionDbFunctionBuilder.HasTranslation(
             Func<IReadOnlyCollection<SqlExpression>, SqlExpression> translation,
             bool fromDataAnnotation)
             => HasTranslation(translation, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalDbFunctionParameterBuilder.cs
@@ -7,6 +7,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 {
     /// <summary>
@@ -39,8 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionParameterBuilder HasStoreType(
-            [CanBeNull] string storeType,
+        public virtual IConventionDbFunctionParameterBuilder? HasStoreType(
+            [CanBeNull] string? storeType,
             ConfigurationSource configurationSource)
         {
             if (CanSetStoreType(storeType, configurationSource))
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetStoreType([CanBeNull] string storeType, ConfigurationSource configurationSource)
+        public virtual bool CanSetStoreType([CanBeNull] string? storeType, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetStoreTypeConfigurationSource())
                 || Metadata.StoreType == storeType;
 
@@ -68,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionParameterBuilder HasTypeMapping(
-            [CanBeNull] RelationalTypeMapping typeMapping,
+        public virtual IConventionDbFunctionParameterBuilder? HasTypeMapping(
+            [CanBeNull] RelationalTypeMapping? typeMapping,
             ConfigurationSource configurationSource)
         {
             if (CanSetTypeMapping(typeMapping, configurationSource))
@@ -87,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping typeMapping, ConfigurationSource configurationSource)
+        public virtual bool CanSetTypeMapping([CanBeNull] RelationalTypeMapping? typeMapping, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetTypeMappingConfigurationSource())
                 || Metadata.TypeMapping == typeMapping;
 
@@ -97,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionDbFunctionParameterBuilder PropagatesNullability(
+        public virtual IConventionDbFunctionParameterBuilder? PropagatesNullability(
             bool propagatesNullability,
             ConfigurationSource configurationSource)
         {
@@ -129,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
+        IConventionDbFunctionParameterBuilder? IConventionDbFunctionParameterBuilder.HasStoreType(string storeType, bool fromDataAnnotation)
             => HasStoreType(storeType, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -139,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionDbFunctionParameterBuilder IConventionDbFunctionParameterBuilder.HasTypeMapping(
+        IConventionDbFunctionParameterBuilder? IConventionDbFunctionParameterBuilder.HasTypeMapping(
             RelationalTypeMapping typeMapping,
             bool fromDataAnnotation)
             => HasTypeMapping(typeMapping, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Internal/InternalSequenceBuilder.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 {
     /// <summary>
@@ -35,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder HasType([CanBeNull] Type type, ConfigurationSource configurationSource)
+        public virtual IConventionSequenceBuilder? HasType([CanBeNull] Type? type, ConfigurationSource configurationSource)
         {
             if (configurationSource.Overrides(Metadata.GetTypeConfigurationSource())
                 || Metadata.Type == type)
@@ -53,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetType([CanBeNull] Type type, ConfigurationSource configurationSource)
+        public virtual bool CanSetType([CanBeNull] Type? type, ConfigurationSource configurationSource)
             => (type == null || Sequence.SupportedTypes.Contains(type))
                 && (configurationSource.Overrides(Metadata.GetTypeConfigurationSource())
                     || Metadata.Type == type);
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder IncrementsBy(
+        public virtual IConventionSequenceBuilder? IncrementsBy(
             int? increment,
             ConfigurationSource configurationSource)
         {
@@ -93,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder StartsAt(long? startValue, ConfigurationSource configurationSource)
+        public virtual IConventionSequenceBuilder? StartsAt(long? startValue, ConfigurationSource configurationSource)
         {
             if (CanSetStartsAt(startValue, configurationSource))
             {
@@ -120,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder HasMax(long? maximum, ConfigurationSource configurationSource)
+        public virtual IConventionSequenceBuilder? HasMax(long? maximum, ConfigurationSource configurationSource)
         {
             if (CanSetMax(maximum, configurationSource))
             {
@@ -147,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder HasMin(long? minimum, ConfigurationSource configurationSource)
+        public virtual IConventionSequenceBuilder? HasMin(long? minimum, ConfigurationSource configurationSource)
         {
             if (CanSetMin(minimum, configurationSource))
             {
@@ -174,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IConventionSequenceBuilder IsCyclic(bool? cyclic, ConfigurationSource configurationSource)
+        public virtual IConventionSequenceBuilder? IsCyclic(bool? cyclic, ConfigurationSource configurationSource)
         {
             if (CanSetIsCyclic(cyclic, configurationSource))
             {
@@ -204,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasType(Type type, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.HasType(Type type, bool fromDataAnnotation)
             => HasType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -214,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.IncrementsBy(int? increment, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.IncrementsBy(int? increment, bool fromDataAnnotation)
             => IncrementsBy(increment, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -224,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.StartsAt(long? startValue, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.StartsAt(long? startValue, bool fromDataAnnotation)
             => StartsAt(startValue, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -234,7 +236,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasMax(long? maximum, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.HasMax(long? maximum, bool fromDataAnnotation)
             => HasMax(maximum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -244,7 +246,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.HasMin(long? minimum, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.HasMin(long? minimum, bool fromDataAnnotation)
             => HasMin(minimum, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />
@@ -254,7 +256,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IConventionSequenceBuilder IConventionSequenceBuilder.IsCyclic(bool? cyclic, bool fromDataAnnotation)
+        IConventionSequenceBuilder? IConventionSequenceBuilder.IsCyclic(bool? cyclic, bool fromDataAnnotation)
             => IsCyclic(cyclic, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/Internal/NamedListComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/NamedListComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -13,8 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     // Sealed for perf
-    public sealed class NamedListComparer : IComparer<(string, string, IReadOnlyList<string>)>,
-        IEqualityComparer<(string, string, IReadOnlyList<string>)>
+    public sealed class NamedListComparer : IComparer<(string, string?, IReadOnlyList<string>)>,
+        IEqualityComparer<(string, string?, IReadOnlyList<string>)>
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare((string, string, IReadOnlyList<string>) x, (string, string, IReadOnlyList<string>) y)
+        public int Compare((string, string?, IReadOnlyList<string>) x, (string, string?, IReadOnlyList<string>) y)
         {
             var result = StringComparer.Ordinal.Compare(x.Item1, y.Item1);
             if (result != 0)
@@ -71,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals((string, string, IReadOnlyList<string>) x, (string, string, IReadOnlyList<string>) y)
+        public bool Equals((string, string?, IReadOnlyList<string>) x, (string, string?, IReadOnlyList<string>) y)
             => Compare(x, y) == 0;
 
         /// <summary>
@@ -80,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int GetHashCode((string, string, IReadOnlyList<string>) obj)
+        public int GetHashCode((string, string?, IReadOnlyList<string>) obj)
         {
             var hash = new HashCode();
             hash.Add(obj.Item1);

--- a/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalEntityTypeExtensions.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static IEnumerable<ITableMappingBase> GetViewOrTableMappings([NotNull] this IEntityType entityType)
-            => (IEnumerable<ITableMappingBase>)(entityType[RelationalAnnotationNames.ViewMappings]
+            => (IEnumerable<ITableMappingBase>?)(entityType[RelationalAnnotationNames.ViewMappings]
                     ?? entityType[RelationalAnnotationNames.TableMappings])
                 ?? Enumerable.Empty<ITableMappingBase>();
 

--- a/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
@@ -34,17 +34,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var principalType = foreignKey.PrincipalKey.IsPrimaryKey()
                 ? foreignKey.PrincipalEntityType
                 : foreignKey.PrincipalKey.DeclaringEntityType;
-            var principalTable = StoreObjectIdentifier.Create(principalType, StoreObjectType.Table)!;
+            var principalTable = StoreObjectIdentifier.Create(principalType, storeObject.StoreObjectType);
 
             var duplicatePrincipalType = duplicateForeignKey.PrincipalKey.IsPrimaryKey()
                 ? duplicateForeignKey.PrincipalEntityType
                 : duplicateForeignKey.PrincipalKey.DeclaringEntityType;
-            var duplicatePrincipalTable = StoreObjectIdentifier.Create(duplicatePrincipalType, StoreObjectType.Table);
+            var duplicatePrincipalTable = StoreObjectIdentifier.Create(duplicatePrincipalType, storeObject.StoreObjectType);
 
             var columnNames = foreignKey.Properties.GetColumnNames(storeObject);
             var duplicateColumnNames = duplicateForeignKey.Properties.GetColumnNames(storeObject);
-            if (columnNames == null
-                || duplicateColumnNames == null)
+            if (columnNames is null
+                || duplicateColumnNames is null
+                || principalTable is null
+                || duplicatePrincipalTable is null)
             {
                 if (shouldThrow)
                 {
@@ -54,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             foreignKey.DeclaringEntityType.DisplayName(),
                             duplicateForeignKey.Properties.Format(),
                             duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            foreignKey.GetConstraintName(storeObject, principalTable.Value),
+                            principalTable.HasValue
+                                ? foreignKey.GetConstraintName(storeObject, principalTable.Value)
+                                : foreignKey.GetDefaultName(),
                             foreignKey.DeclaringEntityType.GetSchemaQualifiedTableName(),
                             duplicateForeignKey.DeclaringEntityType.GetSchemaQualifiedTableName()));
                 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyExtensions.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -32,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var principalType = foreignKey.PrincipalKey.IsPrimaryKey()
                 ? foreignKey.PrincipalEntityType
                 : foreignKey.PrincipalKey.DeclaringEntityType;
-            var principalTable = StoreObjectIdentifier.Create(principalType, StoreObjectType.Table);
+            var principalTable = StoreObjectIdentifier.Create(principalType, StoreObjectType.Table)!;
 
             var duplicatePrincipalType = duplicateForeignKey.PrincipalKey.IsPrimaryKey()
                 ? duplicateForeignKey.PrincipalEntityType

--- a/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalIndexExtensions.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalKeyExtensions.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -844,10 +844,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             break;
                         }
 
-                        // TODO-NULLABLE: Can there be a keyless entity here?
                         if (entityTypeMapping.IncludesDerivedTypes
                             && foreignKey.DeclaringEntityType != entityType
-                            && foreignKey.Properties.SequenceEqual(entityType.FindPrimaryKey().Properties))
+                            && entityType.FindPrimaryKey() is IConventionKey primaryKey
+                            && foreignKey.Properties.SequenceEqual(primaryKey.Properties))
                         {
                             // The identifying FK constraint is needed to be created only on the table that corresponds
                             // to the declaring entity type

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -522,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var mappedQuery = StoreObjectIdentifier.SqlQuery(definingType);
                 if (!databaseModel.Queries.TryGetValue(mappedQuery.Name, out var sqlQuery))
                 {
-                    sqlQuery = new SqlQuery(mappedQuery.Name, databaseModel) { Sql = mappedTypeSqlQuery };
+                    sqlQuery = new SqlQuery(mappedQuery.Name, databaseModel, mappedTypeSqlQuery);
                     databaseModel.Queries.Add(mappedQuery.Name, sqlQuery);
                 }
 

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -49,8 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedDictionary<(string, string), Table> Tables { get; }
-            = new SortedDictionary<(string, string), Table>();
+        public virtual SortedDictionary<(string, string?), Table> Tables { get; }
+            = new SortedDictionary<(string, string?), Table>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -58,8 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedDictionary<(string, string), View> Views { get; }
-            = new SortedDictionary<(string, string), View>();
+        public virtual SortedDictionary<(string, string?), View> Views { get; }
+            = new SortedDictionary<(string, string?), View>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -76,29 +78,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedDictionary<(string, string, IReadOnlyList<string>), StoreFunction> Functions { get; }
-            = new SortedDictionary<(string, string, IReadOnlyList<string>), StoreFunction>(NamedListComparer.Instance);
+        public virtual SortedDictionary<(string, string?, IReadOnlyList<string>), StoreFunction> Functions { get; }
+            = new SortedDictionary<(string, string?, IReadOnlyList<string>), StoreFunction>(NamedListComparer.Instance);
 
         /// <inheritdoc />
-        public virtual ITable FindTable(string name, string schema)
+        public virtual ITable? FindTable(string name, string? schema)
             => Tables.TryGetValue((name, schema), out var table)
                 ? table
                 : null;
 
         /// <inheritdoc />
-        public virtual IView FindView(string name, string schema)
+        public virtual IView? FindView(string name, string? schema)
             => Views.TryGetValue((name, schema), out var view)
                 ? view
                 : null;
 
         /// <inheritdoc />
-        public virtual ISqlQuery FindQuery(string name)
+        public virtual ISqlQuery? FindQuery(string name)
             => Queries.TryGetValue(name, out var query)
                 ? query
                 : null;
 
         /// <inheritdoc />
-        public virtual IStoreFunction FindFunction(string name, string schema, IReadOnlyList<string> parameters)
+        public virtual IStoreFunction? FindFunction(string name, string? schema, IReadOnlyList<string> parameters)
             => Functions.TryGetValue((name, schema, parameters), out var function)
                 ? function
                 : null;
@@ -248,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     continue;
                 }
 
-                var column = (ColumnBase)defaultTable.FindColumn(columnName);
+                var column = (ColumnBase?)defaultTable.FindColumn(columnName);
                 if (column == null)
                 {
                     column = new ColumnBase(columnName, property.GetColumnType(), defaultTable);
@@ -299,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 var schema = entityType.GetSchema();
                 var mappedType = entityType;
-                List<TableMapping> tableMappings = null;
+                List<TableMapping>? tableMappings = null;
                 while (mappedType != null)
                 {
                     var mappedTableName = mappedType.GetTableName();
@@ -342,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             continue;
                         }
 
-                        var column = (Column)table.FindColumn(columnName);
+                        var column = (Column?)table.FindColumn(columnName);
                         if (column == null)
                         {
                             column = new Column(columnName, property.GetColumnType(mappedTable), table);
@@ -386,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                 }
 
-                tableMappings.Reverse();
+                tableMappings?.Reverse();
             }
         }
 
@@ -399,7 +401,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var schema = entityType.GetViewSchema();
-            List<ViewMapping> viewMappings = null;
+            List<ViewMapping>? viewMappings = null;
             var mappedType = entityType;
             while (mappedType != null)
             {
@@ -433,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         continue;
                     }
 
-                    var column = (ViewColumn)view.FindColumn(columnName);
+                    var column = (ViewColumn?)view.FindColumn(columnName);
                     if (column == null)
                     {
                         column = new ViewColumn(columnName, property.GetColumnType(mappedView), view);
@@ -477,7 +479,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            viewMappings.Reverse();
+            viewMappings?.Reverse();
         }
 
         private static void AddSqlQueries(RelationalModel databaseModel, IConventionEntityType entityType)
@@ -488,7 +490,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return;
             }
 
-            List<SqlQueryMapping> queryMappings = null;
+            List<SqlQueryMapping>? queryMappings = null;
             var definingType = entityType;
             while (definingType != null)
             {
@@ -503,6 +505,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 definingType = definingType.BaseType;
             }
+
+            Check.DebugAssert(definingType is not null, $"Could not find defining type for {entityType}");
 
             var mappedType = entityType;
             while (mappedType != null)
@@ -537,7 +541,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         continue;
                     }
 
-                    var column = (SqlQueryColumn)sqlQuery.FindColumn(columnName);
+                    var column = (SqlQueryColumn?)sqlQuery.FindColumn(columnName);
                     if (column == null)
                     {
                         column = new SqlQueryColumn(columnName, property.GetColumnType(mappedQuery), sqlQuery);
@@ -581,7 +585,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            queryMappings.Reverse();
+            queryMappings?.Reverse();
         }
 
         private static void AddMappedFunctions(RelationalModel databaseModel, IConventionEntityType entityType)
@@ -593,7 +597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return;
             }
 
-            List<FunctionMapping> functionMappings = null;
+            List<FunctionMapping>? functionMappings = null;
             var mappedType = entityType;
             while (mappedType != null)
             {
@@ -605,7 +609,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     break;
                 }
 
-                var dbFunction = (DbFunction)model.FindDbFunction(mappedFunctionName);
+                var dbFunction = (DbFunction)model.FindDbFunction(mappedFunctionName)!;
                 var functionMapping = CreateFunctionMapping(entityType, mappedType, dbFunction, databaseModel, @default: true);
 
                 mappedType = mappedType.BaseType;
@@ -625,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            functionMappings.Reverse();
+            functionMappings?.Reverse();
         }
 
         private static void AddTVFs(RelationalModel relationalModel)
@@ -687,7 +691,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     continue;
                 }
 
-                var column = (FunctionColumn)storeFunction.FindColumn(columnName);
+                var column = (FunctionColumn?)storeFunction.FindColumn(columnName);
                 if (column == null)
                 {
                     column = new FunctionColumn(columnName, property.GetColumnType(mappedFunction), storeFunction);
@@ -719,11 +723,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private static StoreFunction GetOrCreateStoreFunction(DbFunction dbFunction, RelationalModel model)
         {
-            var storeFunction = (StoreFunction)dbFunction.StoreFunction;
+            var storeFunction = (StoreFunction?)dbFunction.StoreFunction;
             if (storeFunction == null)
             {
-                var parameterTypes = dbFunction.Parameters.Select(p => p.StoreType).ToArray();
-                storeFunction = (StoreFunction)model.FindFunction(dbFunction.Name, dbFunction.Schema, parameterTypes);
+                var parameterTypes = dbFunction.Parameters.Select(p => p.StoreType!).ToArray();
+                storeFunction = (StoreFunction?)model.FindFunction(dbFunction.Name, dbFunction.Schema, parameterTypes);
                 if (storeFunction == null)
                 {
                     storeFunction = new StoreFunction(dbFunction, model);
@@ -799,8 +803,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         var principalColumns = new Column[foreignKey.Properties.Count];
                         for (var i = 0; i < principalColumns.Length; i++)
                         {
-                            principalColumns[i] = (Column)principalTable.FindColumn(foreignKey.PrincipalKey.Properties[i]);
-                            if (principalColumns[i] == null)
+                            if (principalTable.FindColumn(foreignKey.PrincipalKey.Properties[i]) is Column principalColumn)
+                            {
+                                principalColumns[i] = principalColumn;
+                            }
+                            else
                             {
                                 principalColumns = null;
                                 break;
@@ -815,8 +822,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         var columns = new Column[foreignKey.Properties.Count];
                         for (var i = 0; i < columns.Length; i++)
                         {
-                            columns[i] = (Column)table.FindColumn(foreignKey.Properties[i]);
-                            if (columns[i] == null)
+                            if (table.FindColumn(foreignKey.Properties[i]) is Column foreignKeyColumn)
+                            {
+                                columns[i] = foreignKeyColumn;
+                            }
+                            else
                             {
                                 columns = null;
                                 break;
@@ -834,6 +844,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             break;
                         }
 
+                        // TODO-NULLABLE: Can there be a keyless entity here?
                         if (entityTypeMapping.IncludesDerivedTypes
                             && foreignKey.DeclaringEntityType != entityType
                             && foreignKey.Properties.SequenceEqual(entityType.FindPrimaryKey().Properties))
@@ -873,8 +884,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         var columns = new Column[key.Properties.Count];
                         for (var i = 0; i < columns.Length; i++)
                         {
-                            columns[i] = (Column)table.FindColumn(key.Properties[i]);
-                            if (columns[i] == null)
+                            if (table.FindColumn(key.Properties[i]) is Column uniqueConstraintColumn)
+                            {
+                                columns[i] = uniqueConstraintColumn;
+                            }
+                            else
                             {
                                 columns = null;
                                 break;
@@ -918,8 +932,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         var columns = new Column[index.Properties.Count];
                         for (var i = 0; i < columns.Length; i++)
                         {
-                            columns[i] = (Column)table.FindColumn(index.Properties[i]);
-                            if (columns[i] == null)
+                            if (table.FindColumn(index.Properties[i]) is Column indexColumn)
+                            {
+                                columns[i] = indexColumn;
+                            }
+                            else
                             {
                                 columns = null;
                                 break;
@@ -950,9 +967,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private static void PopulateRowInternalForeignKeys(TableBase table)
         {
-            SortedDictionary<IEntityType, IEnumerable<IForeignKey>> internalForeignKeyMap = null;
-            SortedDictionary<IEntityType, IEnumerable<IForeignKey>> referencingInternalForeignKeyMap = null;
-            TableMappingBase mainMapping = null;
+            SortedDictionary<IEntityType, IEnumerable<IForeignKey>>? internalForeignKeyMap = null;
+            SortedDictionary<IEntityType, IEnumerable<IForeignKey>>? referencingInternalForeignKeyMap = null;
+            TableMappingBase? mainMapping = null;
             var mappedEntityTypes = new HashSet<IEntityType>();
             foreach (TableMappingBase entityTypeMapping in ((ITableBase)table).EntityTypeMappings)
             {
@@ -970,7 +987,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     continue;
                 }
 
-                SortedSet<IForeignKey> rowInternalForeignKeys = null;
+                SortedSet<IForeignKey>? rowInternalForeignKeys = null;
                 foreach (var foreignKey in entityType.FindForeignKeys(primaryKey.Properties))
                 {
                     if (foreignKey.IsUnique
@@ -1033,12 +1050,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 mainMapping.IsSharedTablePrincipal = true;
                 ((Table)mainMapping.Table).EntityTypeMappings.Add(mainTableMapping);
             }
-            else
+            else if (mainMapping is ViewMapping mainViewMapping)
             {
-                ((View)mainMapping.Table).EntityTypeMappings.Remove((ViewMapping)mainMapping);
+                ((View)mainMapping.Table).EntityTypeMappings.Remove(mainViewMapping);
                 mainMapping.IsSharedTablePrincipal = true;
-                ((View)mainMapping.Table).EntityTypeMappings.Add((ViewMapping)mainMapping);
+                ((View)mainMapping.Table).EntityTypeMappings.Add(mainViewMapping);
             }
+
+            Check.DebugAssert(mainMapping is not null,
+                $"{nameof(mainMapping)} is neither a {nameof(TableMapping)} nor a {nameof(ViewMapping)}");
 
             if (referencingInternalForeignKeyMap != null)
             {

--- a/src/EFCore.Relational/Metadata/Internal/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalPropertyExtensions.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        public static string GetConfiguredColumnType([NotNull] this IProperty property)
-            => (string)property[RelationalAnnotationNames.ColumnType];
+        public static string? GetConfiguredColumnType([NotNull] this IProperty property)
+            => (string?)property[RelationalAnnotationNames.ColumnType];
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalPropertyOverrides.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalPropertyOverrides.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class RelationalPropertyOverrides : ConventionAnnotatable
     {
-        private string _columnName;
+        private string? _columnName;
 
         private ConfigurationSource? _columnNameConfigurationSource;
 
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string ColumnName
+        public virtual string? ColumnName
         {
             get => _columnName;
             [param: CanBeNull]
@@ -38,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string SetColumnName([CanBeNull] string columnName, ConfigurationSource configurationSource)
+        public virtual string? SetColumnName([CanBeNull] string? columnName, ConfigurationSource configurationSource)
         {
             _columnName = columnName;
             _columnNameConfigurationSource = configurationSource.Max(_columnNameConfigurationSource);
@@ -61,9 +63,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static RelationalPropertyOverrides Find([NotNull] IProperty property, in StoreObjectIdentifier storeObject)
+        public static RelationalPropertyOverrides? Find([NotNull] IProperty property, in StoreObjectIdentifier storeObject)
         {
-            var tableOverrides = (SortedDictionary<StoreObjectIdentifier, RelationalPropertyOverrides>)
+            var tableOverrides = (SortedDictionary<StoreObjectIdentifier, RelationalPropertyOverrides>?)
                 property[RelationalAnnotationNames.RelationalOverrides];
             return tableOverrides != null
                 && tableOverrides.TryGetValue(storeObject, out var overrides)
@@ -81,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] IMutableProperty property,
             in StoreObjectIdentifier storeObject)
         {
-            var tableOverrides = (SortedDictionary<StoreObjectIdentifier, RelationalPropertyOverrides>)
+            var tableOverrides = (SortedDictionary<StoreObjectIdentifier, RelationalPropertyOverrides>?)
                 property[RelationalAnnotationNames.RelationalOverrides];
             if (tableOverrides == null)
             {

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Name = name;
             _schema = schema;
             _configurationSource = configurationSource;
-            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder!);
+            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _maxValue = data.MaxValue;
             _type = data.ClrType;
             _isCyclic = data.IsCyclic;
-            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder!);
+            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -13,6 +13,8 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Builders.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -23,14 +25,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class Sequence : ConventionAnnotatable, IMutableSequence, IConventionSequence
     {
-        private readonly IModel _model;
-
-        private readonly string _schema;
+        private readonly string? _schema;
         private long? _startValue;
         private int? _incrementBy;
         private long? _minValue;
         private long? _maxValue;
-        private Type _type;
+        private Type? _type;
         private bool? _isCyclic;
 
         private ConfigurationSource _configurationSource;
@@ -97,14 +97,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public Sequence(
             [NotNull] string name,
-            [CanBeNull] string schema,
+            [CanBeNull] string? schema,
             [NotNull] IModel model,
             ConfigurationSource configurationSource)
         {
             Check.NotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
-            _model = model;
+            Model = model;
             Name = name;
             _schema = schema;
             _configurationSource = configurationSource;
@@ -123,10 +123,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(model, nameof(model));
             Check.NotEmpty(annotationName, nameof(annotationName));
 
-            _model = model;
+            Model = model;
             _configurationSource = ConfigurationSource.Explicit;
 
-            var data = SequenceData.Deserialize((string)model[annotationName]);
+            var data = SequenceData.Deserialize((string)model[annotationName]!);
             Name = data.Name;
             _schema = data.Schema;
             _startValue = data.StartValue;
@@ -135,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _maxValue = data.MaxValue;
             _type = data.ClrType;
             _isCyclic = data.IsCyclic;
-            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder);
+            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder!);
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static IEnumerable<Sequence> GetSequences([NotNull] IModel model)
-            => ((SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences])
+            => ((SortedDictionary<(string, string?), Sequence>?)model[RelationalAnnotationNames.Sequences])
                 ?.Values
                 ?? Enumerable.Empty<Sequence>();
 
@@ -155,9 +155,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static Sequence FindSequence([NotNull] IModel model, [NotNull] string name, [CanBeNull] string schema)
+        public static Sequence? FindSequence([NotNull] IModel model, [NotNull] string name, [CanBeNull] string? schema)
         {
-            var sequences = (SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences];
+            var sequences = (SortedDictionary<(string, string?), Sequence>?)model[RelationalAnnotationNames.Sequences];
             if (sequences == null
                 || !sequences.TryGetValue((name, schema), out var sequence))
             {
@@ -176,14 +176,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static Sequence AddSequence(
             [NotNull] IMutableModel model,
             [NotNull] string name,
-            [CanBeNull] string schema,
+            [CanBeNull] string? schema,
             ConfigurationSource configurationSource)
         {
             var sequence = new Sequence(name, schema, model, configurationSource);
-            var sequences = (SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences];
+            var sequences = (SortedDictionary<(string, string?), Sequence>?)model[RelationalAnnotationNames.Sequences];
             if (sequences == null)
             {
-                sequences = new SortedDictionary<(string, string), Sequence>();
+                sequences = new SortedDictionary<(string, string?), Sequence>();
                 model[RelationalAnnotationNames.Sequences] = sequences;
             }
 
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static Sequence SetName(
+        public static Sequence? SetName(
             [NotNull] IMutableModel model,
             [NotNull] Sequence sequence,
             [NotNull] string name)
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(sequence, nameof(sequence));
             Check.NotEmpty(name, nameof(name));
 
-            var sequences = (SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences];
+            var sequences = (SortedDictionary<(string, string?), Sequence>?)model[RelationalAnnotationNames.Sequences];
             var tuple = (sequence.Name, sequence.Schema);
             if (sequences == null
                 || !sequences.ContainsKey(tuple))
@@ -229,9 +229,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static Sequence RemoveSequence([NotNull] IMutableModel model, [NotNull] string name, [CanBeNull] string schema)
+        public static Sequence? RemoveSequence([NotNull] IMutableModel model, [NotNull] string name, [CanBeNull] string? schema)
         {
-            var sequences = (SortedDictionary<(string, string), Sequence>)model[RelationalAnnotationNames.Sequences];
+            var sequences = (SortedDictionary<(string, string?), Sequence>?)model[RelationalAnnotationNames.Sequences];
             if (sequences == null
                 || !sequences.TryGetValue((name, schema), out var sequence))
             {
@@ -250,7 +250,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual InternalSequenceBuilder Builder { get; private set; }
+        public virtual InternalSequenceBuilder? Builder { get; private set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -258,8 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IModel Model
-            => _model;
+        public virtual IModel Model { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -275,7 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual string Schema
+        public virtual string? Schema
             => _schema ?? Model.GetDefaultSchema();
 
         /// <summary>
@@ -475,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Type SetType([CanBeNull] Type type, ConfigurationSource configurationSource)
+        public virtual Type? SetType([CanBeNull] Type? type, ConfigurationSource configurationSource)
         {
             if (type != null
                 && !SupportedTypes.Contains(type))
@@ -521,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [Obsolete("Use SetType")]
-        public virtual Type SetClrType([CanBeNull] Type type, ConfigurationSource configurationSource)
+        public virtual Type? SetClrType([CanBeNull] Type? type, ConfigurationSource configurationSource)
             => SetType(type, configurationSource);
 
         /// <summary>
@@ -587,7 +586,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IConventionSequenceBuilder IConventionSequence.Builder
+        IConventionSequenceBuilder? IConventionSequence.Builder
             => Builder;
 
         /// <summary>
@@ -650,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        Type IConventionSequence.SetClrType(Type type, bool fromDataAnnotation)
+        Type? IConventionSequence.SetClrType(Type? type, bool fromDataAnnotation)
             => SetType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -659,7 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        Type IConventionSequence.SetType(Type type, bool fromDataAnnotation)
+        Type? IConventionSequence.SetType(Type? type, bool fromDataAnnotation)
             => SetType(type, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -674,9 +673,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Obsolete("Don't use this in any new code")]
         private sealed class SequenceData
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = default!;
 
-            public string Schema { get; set; }
+            public string? Schema { get; set; }
 
             public long StartValue { get; set; }
 
@@ -686,7 +685,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             public long? MaxValue { get; set; }
 
-            public Type ClrType { get; set; }
+            public Type ClrType { get; set; } = default!;
 
             public bool IsCyclic { get; set; }
 
@@ -700,13 +699,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     // ReSharper disable PossibleInvalidOperationException
                     var position = 0;
-                    data.Name = ExtractValue(value, ref position);
+                    data.Name = ExtractValue(value, ref position)!;
                     data.Schema = ExtractValue(value, ref position);
-                    data.StartValue = (long)AsLong(ExtractValue(value, ref position));
-                    data.IncrementBy = (int)AsLong(ExtractValue(value, ref position));
+                    data.StartValue = (long)AsLong(ExtractValue(value, ref position)!)!;
+                    data.IncrementBy = (int)AsLong(ExtractValue(value, ref position)!)!;
                     data.MinValue = AsLong(ExtractValue(value, ref position));
                     data.MaxValue = AsLong(ExtractValue(value, ref position));
-                    data.ClrType = AsType(ExtractValue(value, ref position));
+                    data.ClrType = AsType(ExtractValue(value, ref position)!);
                     data.IsCyclic = AsBool(ExtractValue(value, ref position));
                     // ReSharper restore PossibleInvalidOperationException
 
@@ -718,7 +717,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            private static string ExtractValue(string value, ref int position)
+            private static string? ExtractValue(string value, ref int position)
             {
                 position = value.IndexOf('\'', position) + 1;
 
@@ -736,7 +735,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return extracted.Length == 0 ? null : extracted;
             }
 
-            private static long? AsLong(string value)
+            private static long? AsLong(string? value)
                 => value == null ? null : (long?)long.Parse(value, CultureInfo.InvariantCulture);
 
             private static Type AsType(string value)
@@ -750,16 +749,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                 ? typeof(decimal)
                                 : typeof(byte);
 
-            private static bool AsBool(string value)
+            private static bool AsBool(string? value)
                 => value != null && bool.Parse(value);
 
-            private static void EscapeAndQuote(StringBuilder builder, object value)
+            private static void EscapeAndQuote(StringBuilder builder, object? value)
             {
                 builder.Append("'");
 
                 if (value != null)
                 {
-                    builder.Append(value.ToString().Replace("'", "''"));
+                    builder.Append(value.ToString()!.Replace("'", "''"));
                 }
 
                 builder.Append("'");

--- a/src/EFCore.Relational/Metadata/Internal/Sequence.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Sequence.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Name = name;
             _schema = schema;
             _configurationSource = configurationSource;
-            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder);
+            Builder = new InternalSequenceBuilder(this, ((IConventionModel)model).Builder!);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public static Sequence AddSequence(
+        public static Sequence? AddSequence(
             [NotNull] IMutableModel model,
             [NotNull] string name,
             [CanBeNull] string? schema,

--- a/src/EFCore.Relational/Metadata/Internal/SqlQuery.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SqlQuery.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -28,11 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
         }
 
+        // TODO-NULLABLE: isn't Sql required (and so belongs in the ctor)?
         /// <inheritdoc />
         public virtual string Sql { get; [param: NotNull] set; }
 
         /// <inheritdoc />
-        public override IColumnBase FindColumn(IProperty property)
+        public override IColumnBase? FindColumn(IProperty property)
             => property.GetSqlQueryColumnMappings()
                 .FirstOrDefault(cm => cm.TableMapping.Table == this)
                 ?.Column;
@@ -62,12 +65,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        ISqlQueryColumn ISqlQuery.FindColumn(string name)
-            => (ISqlQueryColumn)base.FindColumn(name);
+        ISqlQueryColumn? ISqlQuery.FindColumn(string name)
+            => (ISqlQueryColumn?)base.FindColumn(name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        ISqlQueryColumn ISqlQuery.FindColumn(IProperty property)
-            => (ISqlQueryColumn)FindColumn(property);
+        ISqlQueryColumn? ISqlQuery.FindColumn(IProperty property)
+            => (ISqlQueryColumn?)FindColumn(property);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/SqlQuery.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SqlQuery.cs
@@ -25,12 +25,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public SqlQuery([NotNull] string name, [NotNull] RelationalModel model)
+        public SqlQuery([NotNull] string name, [NotNull] RelationalModel model, [NotNull] string sql)
             : base(name, null, model)
         {
+            Sql = sql;
         }
 
-        // TODO-NULLABLE: isn't Sql required (and so belongs in the ctor)?
         /// <inheritdoc />
         public virtual string Sql { get; [param: NotNull] set; }
 

--- a/src/EFCore.Relational/Metadata/Internal/SqlQueryColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SqlQueryColumn.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/SqlQueryColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SqlQueryColumnMapping.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/SqlQueryMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/SqlQueryMapping.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/StoreFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/StoreFunction.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -51,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool IsBuiltIn { get; }
 
         /// <inheritdoc />
-        public virtual string ReturnType { get; }
+        public virtual string? ReturnType { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -62,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual StoreFunctionParameter[] Parameters { get; }
 
         /// <inheritdoc />
-        public override IColumnBase FindColumn(IProperty property)
+        public override IColumnBase? FindColumn(IProperty property)
             => property.GetFunctionColumnMappings()
                 .FirstOrDefault(cm => cm.TableMapping.Table == this)
                 ?.Column;
@@ -106,12 +108,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IFunctionColumn IStoreFunction.FindColumn(string name)
-            => (IFunctionColumn)base.FindColumn(name);
+        IFunctionColumn? IStoreFunction.FindColumn(string name)
+            => (IFunctionColumn?)base.FindColumn(name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IFunctionColumn IStoreFunction.FindColumn(IProperty property)
-            => (IFunctionColumn)FindColumn(property);
+        IFunctionColumn? IStoreFunction.FindColumn(IProperty property)
+            => (IFunctionColumn?)FindColumn(property);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/StoreFunctionParameter.cs
+++ b/src/EFCore.Relational/Metadata/Internal/StoreFunctionParameter.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Function = function;
             Name = parameter.Name;
-            Type = parameter.StoreType;
+            Type = parameter.StoreType!;
             DbFunctionParameters = new List<IDbFunctionParameter> { parameter };
             parameter.StoreFunctionParameter = this;
         }

--- a/src/EFCore.Relational/Metadata/Internal/Table.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Table.cs
@@ -6,6 +6,9 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -17,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class Table : TableBase, ITable
     {
-        private UniqueConstraint _primaryKey;
+        private UniqueConstraint? _primaryKey;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -25,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Table([NotNull] string name, [CanBeNull] string schema, [NotNull] RelationalModel model)
+        public Table([NotNull] string name, [CanBeNull] string? schema, [NotNull] RelationalModel model)
             : base(name, schema, model)
         {
             Columns = new SortedDictionary<string, IColumnBase>(new ColumnNameComparer(this));
@@ -46,10 +49,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual UniqueConstraint PrimaryKey
+        public virtual UniqueConstraint? PrimaryKey
         {
             get => _primaryKey;
-            [param: NotNull]
             set
             {
                 var oldPrimaryKey = _primaryKey;
@@ -104,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual UniqueConstraint FindUniqueConstraint([NotNull] string name)
+        public virtual UniqueConstraint? FindUniqueConstraint([NotNull] string name)
             => PrimaryKey != null && PrimaryKey.Name == name
                 ? PrimaryKey
                 : UniqueConstraints.TryGetValue(name, out var constraint)
@@ -124,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool IsExcludedFromMigrations { get; set; }
 
         /// <inheritdoc />
-        public override IColumnBase FindColumn(IProperty property)
+        public override IColumnBase? FindColumn(IProperty property)
             => property.GetTableColumnMappings()
                 .FirstOrDefault(cm => cm.TableMapping.Table == this)
                 ?.Column;
@@ -160,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <inheritdoc />
-        IPrimaryKeyConstraint ITable.PrimaryKey
+        IPrimaryKeyConstraint? ITable.PrimaryKey
         {
             [DebuggerStepThrough]
             get => PrimaryKey;
@@ -182,12 +184,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IColumn ITable.FindColumn(string name)
-            => (IColumn)base.FindColumn(name);
+        IColumn? ITable.FindColumn(string name)
+            => (IColumn?)base.FindColumn(name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IColumn ITable.FindColumn(IProperty property)
-            => (IColumn)FindColumn(property);
+        IColumn? ITable.FindColumn(IProperty property)
+            => (IColumn?)FindColumn(property);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/Table.cs
+++ b/src/EFCore.Relational/Metadata/Internal/Table.cs
@@ -52,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual UniqueConstraint? PrimaryKey
         {
             get => _primaryKey;
+            [param: CanBeNull]
             set
             {
                 var oldPrimaryKey = _primaryKey;

--- a/src/EFCore.Relational/Metadata/Internal/TableBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableBase.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -24,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public TableBase([NotNull] string name, [CanBeNull] string schema, [NotNull] RelationalModel model)
+        public TableBase([NotNull] string name, [CanBeNull] string? schema, [NotNull] RelationalModel model)
         {
             Schema = schema;
             Name = name;
@@ -32,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <inheritdoc />
-        public virtual string Schema { get; }
+        public virtual string? Schema { get; }
 
         /// <inheritdoc />
         public virtual string Name { get; }
@@ -67,13 +69,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             = new SortedDictionary<string, IColumnBase>(StringComparer.Ordinal);
 
         /// <inheritdoc />
-        public virtual IColumnBase FindColumn(string name)
+        public virtual IColumnBase? FindColumn(string name)
             => Columns.TryGetValue(name, out var column)
                 ? column
                 : null;
 
         /// <inheritdoc />
-        public virtual IColumnBase FindColumn(IProperty property)
+        public virtual IColumnBase? FindColumn(IProperty property)
             => property.GetDefaultColumnMappings()
                 .FirstOrDefault(cm => cm.TableMapping.Table == this)
                 ?.Column;
@@ -84,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedDictionary<IEntityType, IEnumerable<IForeignKey>> RowInternalForeignKeys { get; [param: NotNull] set; }
+        public virtual SortedDictionary<IEntityType, IEnumerable<IForeignKey>>? RowInternalForeignKeys { get; [param: NotNull] set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -92,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual SortedDictionary<IEntityType, IEnumerable<IForeignKey>> ReferencingRowInternalForeignKeys
+        public virtual SortedDictionary<IEntityType, IEnumerable<IForeignKey>>? ReferencingRowInternalForeignKeys
         {
             get;
             [param: NotNull] set;
@@ -104,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Dictionary<IEntityType, bool> OptionalEntityTypes { get; [param: NotNull] set; }
+        public virtual Dictionary<IEntityType, bool>? OptionalEntityTypes { get; [param: NotNull] set; }
 
         /// <inheritdoc />
         public virtual bool IsOptional(IEntityType entityType)
@@ -114,7 +116,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     ? throw new InvalidOperationException(RelationalStrings.TableNotMappedEntityType(entityType.DisplayName(), Name))
                     : optional;
 
-        private IEntityType GetMappedEntityType(IEntityType entityType)
+        // TODO-NULLABLE: Doesn't look like this can return null, but invocations check
+        private IEntityType? GetMappedEntityType(IEntityType entityType)
             => EntityTypeMappings.Any(m => m.EntityType == entityType)
                 ? entityType
                 : throw new InvalidOperationException(RelationalStrings.TableNotMappedEntityType(entityType.DisplayName(), Name));
@@ -132,7 +135,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => Columns.Values;
 
         /// <inheritdoc />
-        IEnumerable<IForeignKey> ITableBase.GetRowInternalForeignKeys(IEntityType entityType)
+        IEnumerable<IForeignKey>? ITableBase.GetRowInternalForeignKeys(IEntityType entityType)
             => RowInternalForeignKeys != null
                 && RowInternalForeignKeys.TryGetValue(entityType, out var foreignKeys)
                     ? foreignKeys
@@ -141,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         : Enumerable.Empty<IForeignKey>();
 
         /// <inheritdoc />
-        IEnumerable<IForeignKey> ITableBase.GetReferencingRowInternalForeignKeys(IEntityType entityType)
+        IEnumerable<IForeignKey>? ITableBase.GetReferencingRowInternalForeignKeys(IEntityType entityType)
             => ReferencingRowInternalForeignKeys != null
                 && ReferencingRowInternalForeignKeys.TryGetValue(entityType, out var foreignKeys)
                     ? foreignKeys

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] string name,
             [NotNull] Table table,
             [NotNull] IReadOnlyList<Column> columns,
-            [NotNull] string filter,
+            [CanBeNull] string filter,
             bool unique)
         {
             Name = name;
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool IsUnique { get; }
 
         /// <inheritdoc />
-        public virtual string Filter { get; }
+        public virtual string? Filter { get; }
 
         /// <inheritdoc />
         ITable ITableIndex.Table

--- a/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndex.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] string name,
             [NotNull] Table table,
             [NotNull] IReadOnlyList<Column> columns,
-            [CanBeNull] string filter,
+            [CanBeNull] string? filter,
             bool unique)
         {
             Name = name;

--- a/src/EFCore.Relational/Metadata/Internal/TableIndexComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableIndexComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -33,8 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(ITableIndex x, ITableIndex y)
+        public int Compare(ITableIndex? x, ITableIndex? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = StringComparer.Ordinal.Compare(x.Name, y.Name);
             if (result != 0)
             {
@@ -47,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return result;
             }
 
-            return result != 0 ? result : StringComparer.Ordinal.Compare(x.Table.Name, y.Table.Name);
+            return StringComparer.Ordinal.Compare(x.Table.Name, y.Table.Name);
         }
 
         /// <summary>
@@ -56,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(ITableIndex x, ITableIndex y)
+        public bool Equals(ITableIndex? x, ITableIndex? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/TableMappingBase.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMappingBase.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/TableMappingBaseComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMappingBaseComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -34,8 +36,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(ITableMappingBase x, ITableMappingBase y)
+        public int Compare(ITableMappingBase? x, ITableMappingBase? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = y.IsSharedTablePrincipal.CompareTo(x.IsSharedTablePrincipal);
             if (result != 0)
             {
@@ -93,11 +110,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(ITableMappingBase x, ITableMappingBase y)
-            => x.EntityType == y.EntityType
+        public bool Equals(ITableMappingBase? x, ITableMappingBase? y)
+            => ReferenceEquals(x, y) || x is not null && y is not null && (x.EntityType == y.EntityType
                 && x.Table == y.Table
                 && x.IncludesDerivedTypes == y.IncludesDerivedTypes
-                && x.ColumnMappings.SequenceEqual(y.ColumnMappings);
+                && x.ColumnMappings.SequenceEqual(y.ColumnMappings));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Metadata/Internal/UniqueConstraint.cs
+++ b/src/EFCore.Relational/Metadata/Internal/UniqueConstraint.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/UniqueConstraintComparer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/UniqueConstraintComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -33,8 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(IUniqueConstraint x, IUniqueConstraint y)
+        public int Compare(IUniqueConstraint? x, IUniqueConstraint? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = StringComparer.Ordinal.Compare(x.Name, y.Name);
             if (result != 0)
             {
@@ -52,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(IUniqueConstraint x, IUniqueConstraint y)
+        public bool Equals(IUniqueConstraint? x, IUniqueConstraint? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/View.cs
+++ b/src/EFCore.Relational/Metadata/Internal/View.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -29,12 +31,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         /// <inheritdoc />
-        public virtual string ViewDefinitionSql
-            => (string)EntityTypeMappings.Select(m => m.EntityType[RelationalAnnotationNames.ViewDefinitionSql])
+        public virtual string? ViewDefinitionSql
+            => (string?)EntityTypeMappings.Select(m => m.EntityType[RelationalAnnotationNames.ViewDefinitionSql])
                 .FirstOrDefault(d => d != null);
 
         /// <inheritdoc />
-        public override IColumnBase FindColumn(IProperty property)
+        public override IColumnBase? FindColumn(IProperty property)
             => property.GetViewColumnMappings()
                 .FirstOrDefault(cm => cm.TableMapping.Table == this)
                 ?.Column;
@@ -64,12 +66,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IViewColumn IView.FindColumn(string name)
-            => (IViewColumn)base.FindColumn(name);
+        IViewColumn? IView.FindColumn(string name)
+            => (IViewColumn?)base.FindColumn(name);
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        IViewColumn IView.FindColumn(IProperty property)
-            => (IViewColumn)FindColumn(property);
+        IViewColumn? IView.FindColumn(IProperty property)
+            => (IViewColumn?)FindColumn(property);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumn.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ViewColumnMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewColumnMapping.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/Internal/ViewMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ViewMapping.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationProvider.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationProvider.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationProviderDependencies.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationProviderDependencies.cs
@@ -4,6 +4,8 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/SequenceExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SequenceExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/SqlQueryColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SqlQueryColumnExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/SqlQueryColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SqlQueryColumnMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/SqlQueryExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SqlQueryExtensions.cs
@@ -6,6 +6,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/SqlQueryMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/SqlQueryMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/StoreFunctionExtensions.cs
+++ b/src/EFCore.Relational/Metadata/StoreFunctionExtensions.cs
@@ -6,6 +6,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/StoreFunctionParameterExtensions.cs
+++ b/src/EFCore.Relational/Metadata/StoreFunctionParameterExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/StoreObjectIdentifier.cs
+++ b/src/EFCore.Relational/Metadata/StoreObjectIdentifier.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -12,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     /// </summary>
     public readonly struct StoreObjectIdentifier : IComparable<StoreObjectIdentifier>, IEquatable<StoreObjectIdentifier>
     {
-        private StoreObjectIdentifier(StoreObjectType storeObjectType, string name, string schema = null)
+        private StoreObjectIdentifier(StoreObjectType storeObjectType, string name, string? schema = null)
         {
             StoreObjectType = storeObjectType;
             Name = name;
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The table name. </param>
         /// <param name="schema"> The table schema. </param>
         /// <returns> The table id. </returns>
-        public static StoreObjectIdentifier Table([NotNull] string name, [CanBeNull] string schema)
+        public static StoreObjectIdentifier Table([NotNull] string name, [CanBeNull] string? schema)
         {
             Check.NotNull(name, nameof(name));
 
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The view name. </param>
         /// <param name="schema"> The view schema. </param>
         /// <returns> The view id. </returns>
-        public static StoreObjectIdentifier View([NotNull] string name, [CanBeNull] string schema)
+        public static StoreObjectIdentifier View([NotNull] string name, [CanBeNull] string? schema)
         {
             Check.NotNull(name, nameof(name));
 
@@ -123,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the table-like store object schema.
         /// </summary>
-        public string Schema { get; }
+        public string? Schema { get; }
 
         /// <inheritdoc />
         public int CompareTo(StoreObjectIdentifier other)
@@ -154,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             => StoreObjectType + " " + DisplayName();
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is StoreObjectIdentifier identifier && Equals(identifier);
 
         /// <inheritdoc />

--- a/src/EFCore.Relational/Metadata/StoreObjectType.cs
+++ b/src/EFCore.Relational/Metadata/StoreObjectType.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/TableExtensions.cs
+++ b/src/EFCore.Relational/Metadata/TableExtensions.cs
@@ -6,6 +6,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/TableIndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/TableIndexExtensions.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/TableMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/TableMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/UniqueConstraintExtensions.cs
+++ b/src/EFCore.Relational/Metadata/UniqueConstraintExtensions.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ViewColumnExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ViewColumnExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ViewColumnMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ViewColumnMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ViewExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ViewExtensions.cs
@@ -6,6 +6,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Metadata/ViewMappingExtensions.cs
+++ b/src/EFCore.Relational/Metadata/ViewMappingExtensions.cs
@@ -5,6 +5,8 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     continue;
                 }
 
-                var propertyMappings = table.FindColumn(property).PropertyMappings;
+                var propertyMappings = table.FindColumn(property)!.PropertyMappings;
                 if (propertyMappings.Count() > 1
                     && propertyMappings.Any(pm => principalEntityTypes.Contains(pm.TableMapping.EntityType)))
                 {
@@ -203,6 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private void GetPrincipalEntityTypes(ITableBase table, IEntityType entityType, HashSet<IEntityType> entityTypes)
         {
+            // TODO-NULLABLE: GetMappedEntityType inside might not need to return nullable
             foreach (var linkingFk in table.GetRowInternalForeignKeys(entityType))
             {
                 entityTypes.Add(linkingFk.PrincipalEntityType);

--- a/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalEntityShaperExpression.cs
@@ -203,7 +203,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private void GetPrincipalEntityTypes(ITableBase table, IEntityType entityType, HashSet<IEntityType> entityTypes)
         {
-            // TODO-NULLABLE: GetMappedEntityType inside might not need to return nullable
             foreach (var linkingFk in table.GetRowInternalForeignKeys(entityType))
             {
                 entityTypes.Add(linkingFk.PrincipalEntityType);

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1333,9 +1333,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var navigation = member.MemberInfo != null
                     ? entityType.FindNavigation(member.MemberInfo)
-                    : member.Name is not null
-                        ? entityType.FindNavigation(member.Name)
-                        : null;
+                    : entityType.FindNavigation(member.Name!);
 
                 if (navigation == null)
                 {

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1333,7 +1333,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var navigation = member.MemberInfo != null
                     ? entityType.FindNavigation(member.MemberInfo)
-                    : entityType.FindNavigation(member.Name);
+                    : member.Name is not null
+                        ? entityType.FindNavigation(member.Name)
+                        : null;
 
                 if (navigation == null)
                 {
@@ -1510,7 +1512,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .SelectMany(EntityTypeExtensions.GetDeclaredProperties))
                     {
                         propertyExpressions[property] = new ColumnExpression(
-                            property, table.FindColumn(property), tableExpression, nullable || !property.IsPrimaryKey());
+                            property, table.FindColumn(property)!, tableExpression, nullable || !property.IsPrimaryKey());
                     }
 
                     return propertyExpressions;
@@ -1553,7 +1555,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive()).SelectMany(EntityTypeExtensions.GetDeclaredProperties))
                 {
                     propertyExpressions[property] = new ColumnExpression(
-                        property, table.FindColumn(property), tableExpression, nullable: true);
+                        property, table.FindColumn(property)!, tableExpression, nullable: true);
                 }
 
                 return propertyExpressions;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -912,7 +912,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Type entityType,
                 Type relatedEntityType,
                 INavigationBase navigation,
-                INavigationBase inverseNavigation)
+                INavigationBase? inverseNavigation)
             {
                 var entityParameter = Expression.Parameter(entityType);
                 var relatedEntityParameter = Expression.Parameter(relatedEntityType);

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1077,7 +1077,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             var entityType = entityReferenceExpression.EntityType;
             var property = member.MemberInfo != null
                 ? entityType.FindProperty(member.MemberInfo)
-                : entityType.FindProperty(member.Name);
+                : member.Name is not null
+                    ? entityType.FindProperty(member.Name)
+                    : null;
 
             if (property != null)
             {

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1414,6 +1414,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             switch (target)
             {
+                // TODO-NULLABLE: Smit, take a look
                 case SqlConstantExpression sqlConstantExpression:
                     return Expression.Constant(
                         property.GetGetter().GetClrValue(sqlConstantExpression.Value), property.ClrType.MakeNullable());

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1077,9 +1077,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var entityType = entityReferenceExpression.EntityType;
             var property = member.MemberInfo != null
                 ? entityType.FindProperty(member.MemberInfo)
-                : member.Name is not null
-                    ? entityType.FindProperty(member.Name)
-                    : null;
+                : entityType.FindProperty(member.Name!);
 
             if (property != null)
             {
@@ -1414,10 +1412,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             switch (target)
             {
-                // TODO-NULLABLE: Smit, take a look
                 case SqlConstantExpression sqlConstantExpression:
                     return Expression.Constant(
-                        property.GetGetter().GetClrValue(sqlConstantExpression.Value), property.ClrType.MakeNullable());
+                        sqlConstantExpression.Value is null
+                            ? null
+                            : property.GetGetter().GetClrValue(sqlConstantExpression.Value),
+                        property.ClrType.MakeNullable());
 
                 case SqlParameterExpression sqlParameterExpression
                     when sqlParameterExpression.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal):

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -858,7 +858,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             table ??= entityType.GetViewOrTableMappings().FirstOrDefault()?.Table;
             if (table != null)
             {
-                // TODO-NULLABLE: GetMappedEntityType inside might not need to return nullable
                 var linkingFks = table.GetRowInternalForeignKeys(entityType);
                 var first = true;
                 foreach (var foreignKey in linkingFks)

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -858,6 +858,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             table ??= entityType.GetViewOrTableMappings().FirstOrDefault()?.Table;
             if (table != null)
             {
+                // TODO-NULLABLE: GetMappedEntityType inside might not need to return nullable
                 var linkingFks = table.GetRowInternalForeignKeys(entityType);
                 var first = true;
                 foreach (var foreignKey in linkingFks)

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -317,7 +317,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             ITableBase table,
             TableExpressionBase tableExpression,
             bool nullable)
-            => new ColumnExpression(property, table.FindColumn(property), tableExpression, nullable);
+            => new ColumnExpression(property, table.FindColumn(property)!, tableExpression, nullable);
 
         /// <summary>
         ///     Checks whether this <see cref="SelectExpression" /> representes a <see cref="FromSqlExpression" /> which is not composed upon.

--- a/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/TableExpression.cs
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// <summary>
         ///     The schema of the table or view.
         /// </summary>
-        public string Schema { get; }
+        public string? Schema { get; }
 
         /// <summary>
         ///     The <see cref="ITableBase" /> associated with this table or view.

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationProvider.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexExtensions.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerKeyExtensions.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerKeyExtensions.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
@@ -3,6 +3,8 @@
 
 // ReSharper disable once CheckNamespace
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationNames.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationNames.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationProvider.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
 {
     /// <summary>

--- a/src/EFCore/Extensions/ConventionNavigationExtensions.cs
+++ b/src/EFCore/Extensions/ConventionNavigationExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The inverse navigation, or <see langword="null" /> if none is defined.
         /// </returns>
         [Obsolete("Use IConventionNavigation.Inverse")]
-        public static IConventionNavigation FindInverse([NotNull] this IConventionNavigation navigation)
+        public static IConventionNavigation? FindInverse([NotNull] this IConventionNavigation navigation)
             => navigation.Inverse;
 
         /// <summary>

--- a/src/EFCore/Extensions/MutableNavigationExtensions.cs
+++ b/src/EFCore/Extensions/MutableNavigationExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     The inverse navigation, or <see langword="null" /> if none is defined.
         /// </returns>
         [Obsolete("Use IMutableNavigation.Inverse")]
-        public static IMutableNavigation FindInverse([NotNull] this IMutableNavigation navigation)
+        public static IMutableNavigation? FindInverse([NotNull] this IMutableNavigation navigation)
             => navigation.Inverse;
 
         /// <summary>

--- a/src/EFCore/Extensions/NavigationExtensions.cs
+++ b/src/EFCore/Extensions/NavigationExtensions.cs
@@ -52,11 +52,11 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="navigation"> The navigation property to find the inverse of. </param>
         /// <returns>
-        ///     The inverse navigation, or null if none is defined.
+        ///     The inverse navigation, or <see langword="null" /> if none is defined.
         /// </returns>
         [DebuggerStepThrough]
         [Obsolete("Use INavigation.Inverse")]
-        public static INavigation FindInverse([NotNull] this INavigation navigation)
+        public static INavigation? FindInverse([NotNull] this INavigation navigation)
             => Check.NotNull(navigation, nameof(navigation)).Inverse;
 
         /// <summary>

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -964,7 +964,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         || property.IsForeignKey()
                         || property.IsUniqueIndex())
                     {
-                        var _ = property.GetCurrentValueComparer(); // Will throw if there is no way to compare
+                        _ = property.GetCurrentValueComparer(); // Will throw if there is no way to compare
                     }
                 }
             }

--- a/src/EFCore/Metadata/ConfigurationSource.cs
+++ b/src/EFCore/Metadata/ConfigurationSource.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/ConfigurationSourceExtensions.cs
+++ b/src/EFCore/Metadata/ConfigurationSourceExtensions.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -90,6 +92,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public static ConfigurationSource Max(this ConfigurationSource left, ConfigurationSource? right)
             => left.Overrides(right)
                 ? left
-                : right.Value;
+                : right!.Value;
     }
 }

--- a/src/EFCore/Metadata/ConstructorBinding.cs
+++ b/src/EFCore/Metadata/ConstructorBinding.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -51,6 +53,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The type that will be created from the expression tree created for this binding.
         /// </summary>
         public override Type RuntimeType
-            => Constructor.DeclaringType;
+            => Constructor.DeclaringType!;
     }
 }

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -19,10 +21,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Creates a new <see cref="ServiceParameterBinding" /> instance for the given service type.
         /// </summary>
         /// <param name="contextType"> The <see cref="DbContext" /> CLR type. </param>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
+        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or <see langword="null" />. </param>
         public ContextParameterBinding(
             [NotNull] Type contextType,
-            [CanBeNull] IPropertyBase serviceProperty = null)
+            [CanBeNull] IPropertyBase? serviceProperty = null)
             : base(contextType, contextType, serviceProperty)
         {
         }

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
             [NotNull] MethodInfo method,
-            [CanBeNull] IPropertyBase serviceProperty = null)
+            [CanBeNull] IPropertyBase? serviceProperty = null)
             : base(parameterType, serviceType, serviceProperty)
         {
             Check.NotNull(method, nameof(method));

--- a/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     public class DependencyInjectionParameterBinding : ServiceParameterBinding
     {
         private static readonly MethodInfo _getServiceMethod
-            = typeof(InfrastructureExtensions).GetMethod(nameof(InfrastructureExtensions.GetService));
+            = typeof(InfrastructureExtensions).GetMethod(nameof(InfrastructureExtensions.GetService))!;
 
         /// <summary>
         ///     Creates a new <see cref="DependencyInjectionParameterBinding" /> instance for the given service type.
@@ -31,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public DependencyInjectionParameterBinding(
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
-            [CanBeNull] IPropertyBase serviceProperty = null)
+            [CanBeNull] IPropertyBase? serviceProperty = null)
             : base(parameterType, serviceType, serviceProperty)
         {
         }

--- a/src/EFCore/Metadata/EntityTypeFullNameComparer.cs
+++ b/src/EFCore/Metadata/EntityTypeFullNameComparer.cs
@@ -110,15 +110,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             while (true)
             {
                 hash.Add(obj.Name, StringComparer.Ordinal);
-                var definingNavigationName = obj.DefiningNavigationName;
-                if (definingNavigationName == null)
+                if (!obj.HasDefiningNavigation())
                 {
                     return hash.ToHashCode();
                 }
 
-                hash.Add(definingNavigationName, StringComparer.Ordinal);
-                // TODO-NULLABLE: Put MemberNotNull on HasDefiningNavigation when we target net5.0
-                obj = obj.DefiningEntityType!;
+                hash.Add(obj.DefiningNavigationName, StringComparer.Ordinal);
+                obj = obj.DefiningEntityType;
             }
         }
     }

--- a/src/EFCore/Metadata/EntityTypeFullNameComparer.cs
+++ b/src/EFCore/Metadata/EntityTypeFullNameComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -33,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> A negative number if 'x' is less than 'y'; a positive number if 'x' is greater than 'y'; zero otherwise. </returns>
-        public int Compare(IEntityType x, IEntityType y)
+        public int Compare(IEntityType? x, IEntityType? y)
         {
             if (ReferenceEquals(x, y))
             {
@@ -83,8 +85,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     return result;
                 }
 
-                x = x.DefiningEntityType;
-                y = y.DefiningEntityType;
+                x = x.DefiningEntityType!;
+                y = y.DefiningEntityType!;
             }
         }
 
@@ -94,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> <see langword="true" /> if the specified objects are equal; otherwise, <see langword="false" />. </returns>
-        public bool Equals(IEntityType x, IEntityType y)
+        public bool Equals(IEntityType? x, IEntityType? y)
             => Compare(x, y) == 0;
 
         /// <summary>
@@ -115,7 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 }
 
                 hash.Add(definingNavigationName, StringComparer.Ordinal);
-                obj = obj.DefiningEntityType;
+                // TODO-NULLABLE: Put MemberNotNull on HasDefiningNavigation when we target net5.0
+                obj = obj.DefiningEntityType!;
             }
         }
     }

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -5,6 +5,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -17,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Creates a new <see cref="EntityTypeParameterBinding" /> instance for the given service type.
         /// </summary>
         /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
-        public EntityTypeParameterBinding([CanBeNull] IPropertyBase serviceProperty = null)
+        public EntityTypeParameterBinding([CanBeNull] IPropertyBase? serviceProperty = null)
             : base(typeof(IEntityType), typeof(IEntityType), serviceProperty)
         {
         }

--- a/src/EFCore/Metadata/FactoryMethodBinding.cs
+++ b/src/EFCore/Metadata/FactoryMethodBinding.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     /// </summary>
     public class FactoryMethodBinding : InstantiationBinding
     {
-        private readonly object _factoryInstance;
+        private readonly object? _factoryInstance;
         private readonly MethodInfo _factoryMethod;
 
         /// <summary>

--- a/src/EFCore/Metadata/ForeignKeyComparer.cs
+++ b/src/EFCore/Metadata/ForeignKeyComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -34,22 +36,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> A negative number if 'x' is less than 'y'; a positive number if 'x' is greater than 'y'; zero otherwise. </returns>
-        public int Compare(IForeignKey x, IForeignKey y)
+        public int Compare(IForeignKey? x, IForeignKey? y)
         {
-            var result = PropertyListComparer.Instance.Compare(x.Properties, y.Properties);
+            var result = PropertyListComparer.Instance.Compare(x?.Properties, y?.Properties);
             if (result != 0)
             {
                 return result;
             }
 
-            result = PropertyListComparer.Instance.Compare(x.PrincipalKey.Properties, y.PrincipalKey.Properties);
+            result = PropertyListComparer.Instance.Compare(x?.PrincipalKey.Properties, y?.PrincipalKey.Properties);
             if (result != 0)
             {
                 return result;
             }
 
-            result = EntityTypeFullNameComparer.Instance.Compare(x.PrincipalEntityType, y.PrincipalEntityType);
-            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x.DeclaringEntityType, y.DeclaringEntityType);
+            result = EntityTypeFullNameComparer.Instance.Compare(x?.PrincipalEntityType, y?.PrincipalEntityType);
+            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x?.DeclaringEntityType, y?.DeclaringEntityType);
         }
 
         /// <summary>
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> <see langword="true" /> if the specified objects are equal; otherwise, <see langword="false" />. </returns>
-        public bool Equals(IForeignKey x, IForeignKey y)
+        public bool Equals(IForeignKey? x, IForeignKey? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore/Metadata/IClrCollectionAccessor.cs
+++ b/src/EFCore/Metadata/IClrCollectionAccessor.cs
@@ -4,6 +4,8 @@
 using System;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IClrPropertyGetter.cs
+++ b/src/EFCore/Metadata/IClrPropertyGetter.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IClrPropertySetter.cs
+++ b/src/EFCore/Metadata/IClrPropertySetter.cs
@@ -3,6 +3,8 @@
 
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -16,6 +18,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="instance"> The entity instance. </param>
         /// <param name="value"> The value to set. </param>
-        void SetClrValue([NotNull] object instance, [CanBeNull] object value);
+        void SetClrValue([NotNull] object instance, [CanBeNull] object? value);
     }
 }

--- a/src/EFCore/Metadata/IConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/IConstructorBindingFactory.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -33,8 +35,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         bool TryBindConstructor(
             [NotNull] IConventionEntityType entityType,
             [NotNull] ConstructorInfo constructor,
-            [CanBeNull] out InstantiationBinding binding,
-            [CanBeNull] out IEnumerable<ParameterInfo> unboundParameters);
+            [CanBeNull] out InstantiationBinding? binding,
+            [CanBeNull] out IEnumerable<ParameterInfo>? unboundParameters);
 
         /// <summary>
         ///     Attempts to create a <see cref="InstantiationBinding" /> for the given <see cref="IEntityType" /> and
@@ -48,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         bool TryBindConstructor(
             [NotNull] IMutableEntityType entityType,
             [NotNull] ConstructorInfo constructor,
-            [CanBeNull] out InstantiationBinding binding,
-            [CanBeNull] out IEnumerable<ParameterInfo> unboundParameters);
+            [CanBeNull] out InstantiationBinding? binding,
+            [CanBeNull] out IEnumerable<ParameterInfo>? unboundParameters);
     }
 }

--- a/src/EFCore/Metadata/IConventionAnnotation.cs
+++ b/src/EFCore/Metadata/IConventionAnnotation.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this model.
         /// </summary>
-        new IConventionModelBuilder? Builder { get; }
+        new IConventionModelBuilder Builder { get; }
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/IConventionNavigation.cs
+++ b/src/EFCore/Metadata/IConventionNavigation.cs
@@ -65,10 +65,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
-        new IConventionNavigation Inverse
+        new IConventionNavigation? Inverse
         {
             [DebuggerStepThrough]
-            get => (IConventionNavigation)((INavigation)this).Inverse;
+            get => (IConventionNavigation?)((INavigation)this).Inverse;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/IConventionPropertyBase.cs
+++ b/src/EFCore/Metadata/IConventionPropertyBase.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -44,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fieldInfo"> The <see cref="FieldInfo" /> for the underlying CLR field to use. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new <see cref="FieldInfo" />. </returns>
-        FieldInfo SetFieldInfo([CanBeNull] FieldInfo fieldInfo, bool fromDataAnnotation = false);
+        FieldInfo? SetFieldInfo([CanBeNull] FieldInfo? fieldInfo, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     <para>
@@ -60,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fieldInfo"> The <see cref="FieldInfo" /> for the underlying CLR field to use. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         [Obsolete("Use SetFieldInfo")]
-        void SetField([CanBeNull] FieldInfo fieldInfo, bool fromDataAnnotation = false)
+        void SetField([CanBeNull] FieldInfo? fieldInfo, bool fromDataAnnotation = false)
             => SetFieldInfo(fieldInfo, fromDataAnnotation);
 
         /// <summary>
@@ -84,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="fieldName"> The name of the field to use. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The new <see cref="FieldInfo" />. </returns>
-        FieldInfo SetField([CanBeNull] string fieldName, bool fromDataAnnotation = false)
+        FieldInfo? SetField([CanBeNull] string? fieldName, bool fromDataAnnotation = false)
             => this.AsPropertyBase()
                 .SetField(fieldName, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 

--- a/src/EFCore/Metadata/IConventionServiceProperty.cs
+++ b/src/EFCore/Metadata/IConventionServiceProperty.cs
@@ -4,6 +4,8 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the builder that can be used to configure this service property.
         /// </summary>
-        new IConventionServicePropertyBuilder Builder { get; }
+        new IConventionServicePropertyBuilder? Builder { get; }
 
         /// <summary>
         ///     Gets the type that this property belongs to.
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="parameterBinding"> The parameter binding. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> The configured binding. </returns>
-        ServiceParameterBinding SetParameterBinding([CanBeNull] ServiceParameterBinding parameterBinding, bool fromDataAnnotation = false);
+        ServiceParameterBinding? SetParameterBinding([CanBeNull] ServiceParameterBinding? parameterBinding, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns the configuration source for <see cref="IServiceProperty.ParameterBinding" />.

--- a/src/EFCore/Metadata/IConventionTypeBase.cs
+++ b/src/EFCore/Metadata/IConventionTypeBase.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -36,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="memberName"> The name of the member to be removed. </param>
         /// <returns> The removed ignored member name. </returns>
-        string RemoveIgnored([NotNull] string memberName);
+        string? RemoveIgnored([NotNull] string memberName);
 
         /// <summary>
         ///     Indicates whether the given member name is ignored.

--- a/src/EFCore/Metadata/IMetadataReference.cs
+++ b/src/EFCore/Metadata/IMetadataReference.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
@@ -15,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     The referenced object.
         /// </summary>
+        [CA.MaybeNull]
         T Object { get; }
     }
 }

--- a/src/EFCore/Metadata/IMutableNavigation.cs
+++ b/src/EFCore/Metadata/IMutableNavigation.cs
@@ -50,10 +50,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
-        new IMutableNavigation Inverse
+        new IMutableNavigation? Inverse
         {
             [DebuggerStepThrough]
-            get => (IMutableNavigation)((INavigation)this).Inverse;
+            get => (IMutableNavigation?)((INavigation)this).Inverse;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/INavigation.cs
+++ b/src/EFCore/Metadata/INavigation.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -32,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
-        new INavigation Inverse
+        new INavigation? Inverse
         {
             [DebuggerStepThrough]
             get => IsOnDependent ? ForeignKey.PrincipalToDependent : ForeignKey.DependentToPrincipal;
@@ -91,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
-        INavigationBase INavigationBase.Inverse
+        INavigationBase? INavigationBase.Inverse
         {
             [DebuggerStepThrough]
             get => Inverse;

--- a/src/EFCore/Metadata/INavigationBase.cs
+++ b/src/EFCore/Metadata/INavigationBase.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Gets the inverse navigation.
         /// </summary>
-        INavigationBase Inverse { get; }
+        INavigationBase? Inverse { get; }
 
         /// <summary>
         ///     Gets a value indicating whether the navigation property is a collection property.

--- a/src/EFCore/Metadata/IParameterBindingFactories.cs
+++ b/src/EFCore/Metadata/IParameterBindingFactories.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/IParameterBindingFactory.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IProperty.cs
+++ b/src/EFCore/Metadata/IProperty.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IPropertyParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/IPropertyParameterBindingFactory.cs
@@ -5,6 +5,8 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/IServiceProperty.cs
+++ b/src/EFCore/Metadata/IServiceProperty.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -17,6 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     The <see cref="ServiceParameterBinding" /> for this property.
         /// </summary>
-        ServiceParameterBinding ParameterBinding { get; }
+        ServiceParameterBinding? ParameterBinding { get; }
     }
 }

--- a/src/EFCore/Metadata/IndexComparer.cs
+++ b/src/EFCore/Metadata/IndexComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -34,10 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> A negative number if 'x' is less than 'y'; a positive number if 'x' is greater than 'y'; zero otherwise. </returns>
-        public int Compare(IIndex x, IIndex y)
+        public int Compare(IIndex? x, IIndex? y)
         {
-            var result = PropertyListComparer.Instance.Compare(x.Properties, y.Properties);
-            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x.DeclaringEntityType, y.DeclaringEntityType);
+            var result = PropertyListComparer.Instance.Compare(x?.Properties, y?.Properties);
+            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x?.DeclaringEntityType, y?.DeclaringEntityType);
         }
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> <see langword="true" /> if the specified objects are equal; otherwise, <see langword="false" />. </returns>
-        public bool Equals(IIndex x, IIndex y)
+        public bool Equals(IIndex? x, IIndex? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore/Metadata/InstantiationBinding.cs
+++ b/src/EFCore/Metadata/InstantiationBinding.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1502,7 +1502,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private Navigation AddNavigation(MemberIdentity navigationMember, ForeignKey foreignKey, bool pointsToPrincipal)
         {
-            var name = navigationMember.Name;
+            var name = navigationMember.Name!;
             var duplicateNavigation = FindNavigationsInHierarchy(name).FirstOrDefault();
             if (duplicateNavigation != null)
             {

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -266,10 +266,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual Navigation Inverse
+        public virtual Navigation? Inverse
         {
             [DebuggerStepThrough]
-            get => (Navigation)((INavigationBase)this).Inverse;
+            get => (Navigation?)((INavigationBase)this).Inverse;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -467,7 +467,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [DebuggerStepThrough]
-        FieldInfo? IConventionPropertyBase.SetFieldInfo(FieldInfo fieldInfo, bool fromDataAnnotation)
+        FieldInfo? IConventionPropertyBase.SetFieldInfo(FieldInfo? fieldInfo, bool fromDataAnnotation)
             => SetFieldInfo(fieldInfo, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyListComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyListComparer.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -33,8 +35,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(IReadOnlyList<IProperty> x, IReadOnlyList<IProperty> y)
+        public int Compare(IReadOnlyList<IProperty>? x, IReadOnlyList<IProperty>? y)
         {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
             var result = x.Count - y.Count;
 
             if (result != 0)
@@ -59,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public bool Equals(IReadOnlyList<IProperty> x, IReadOnlyList<IProperty> y)
+        public bool Equals(IReadOnlyList<IProperty>? x, IReadOnlyList<IProperty>? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyNameComparer.cs
+++ b/src/EFCore/Metadata/Internal/PropertyNameComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
@@ -34,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public int Compare(string x, string y)
+        public int Compare(string? x, string? y)
         {
             var xIndex = -1;
             var yIndex = -1;

--- a/src/EFCore/Metadata/Internal/Reference.cs
+++ b/src/EFCore/Metadata/Internal/Reference.cs
@@ -16,8 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class Reference<T> : IMetadataReference<T>
     {
-        // TODO-NULLABLE: Use T? once we switch to C# 9, in this and IMetadataReference
-        [CA.AllowNull, CA.MaybeNull]
         private T _object;
         private readonly IReferenceRoot<T>? _root;
         private int _referenceCount = 1;
@@ -28,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Reference([CanBeNull] T @object)
+        public Reference([NotNull] T @object)
             : this(@object, null)
         {
         }
@@ -39,9 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Reference([CanBeNull, CA.AllowNull] T @object, [CanBeNull] IReferenceRoot<T>? root)
+        public Reference([NotNull] T @object, [CanBeNull] IReferenceRoot<T>? root)
         {
-            // TODO-NULLABLE: Object can be set to null from the ctor, but not from the property?
             _object = @object;
             _root = root;
         }
@@ -52,7 +49,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        [CA.MaybeNull]
         public virtual T Object
         {
             get => _object;
@@ -70,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (_referenceCount-- == 1)
             {
                 _root?.Release(this);
-                _object = default;
+                _object = default!;
             }
         }
 

--- a/src/EFCore/Metadata/Internal/Reference.cs
+++ b/src/EFCore/Metadata/Internal/Reference.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -13,7 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class Reference<T> : IMetadataReference<T>
     {
-        private readonly IReferenceRoot<T> _root;
+        // TODO-NULLABLE: Use T? once we switch to C# 9, in this and IMetadataReference
+        [CA.AllowNull, CA.MaybeNull]
+        private T _object;
+        private readonly IReferenceRoot<T>? _root;
         private int _referenceCount = 1;
 
         /// <summary>
@@ -33,9 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public Reference([CanBeNull] T @object, [CanBeNull] IReferenceRoot<T> root)
+        public Reference([CanBeNull, CA.AllowNull] T @object, [CanBeNull] IReferenceRoot<T>? root)
         {
-            Object = @object;
+            // TODO-NULLABLE: Object can be set to null from the ctor, but not from the property?
+            _object = @object;
             _root = root;
         }
 
@@ -45,7 +52,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual T Object { get; [param: NotNull]set; }
+        [CA.MaybeNull]
+        public virtual T Object
+        {
+            get => _object;
+            [param: NotNull] set => _object = value;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -58,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (_referenceCount-- == 1)
             {
                 _root?.Release(this);
-                Object = default;
+                _object = default;
             }
         }
 

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         ServiceParameterBinding? IConventionServiceProperty.SetParameterBinding(
-            ServiceParameterBinding parameterBinding,
+            ServiceParameterBinding? parameterBinding,
             bool fromDataAnnotation)
             => SetParameterBinding(
                 parameterBinding, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore/Metadata/KeyComparer.cs
+++ b/src/EFCore/Metadata/KeyComparer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -34,10 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> A negative number if 'x' is less than 'y'; a positive number if 'x' is greater than 'y'; zero otherwise. </returns>
-        public int Compare(IKey x, IKey y)
+        public int Compare(IKey? x, IKey? y)
         {
-            var result = PropertyListComparer.Instance.Compare(x.Properties, y.Properties);
-            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x.DeclaringEntityType, y.DeclaringEntityType);
+            var result = PropertyListComparer.Instance.Compare(x?.Properties, y?.Properties);
+            return result != 0 ? result : EntityTypeFullNameComparer.Instance.Compare(x?.DeclaringEntityType, y?.DeclaringEntityType);
         }
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="x"> The first object to compare. </param>
         /// <param name="y"> The second object to compare. </param>
         /// <returns> <see langword="true" /> if the specified objects are equal; otherwise, <see langword="false" />. </returns>
-        public bool Equals(IKey x, IKey y)
+        public bool Equals(IKey? x, IKey? y)
             => Compare(x, y) == 0;
 
         /// <summary>

--- a/src/EFCore/Metadata/LazyLoaderParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/LazyLoaderParameterBindingFactory.cs
@@ -11,6 +11,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -26,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     /// </summary>
     public class LazyLoaderParameterBindingFactory : ServiceParameterBindingFactory
     {
-        private static readonly MethodInfo _loadMethod = typeof(ILazyLoader).GetMethod(nameof(ILazyLoader.Load));
-        private static readonly MethodInfo _loadAsyncMethod = typeof(ILazyLoader).GetMethod(nameof(ILazyLoader.LoadAsync));
+        private static readonly MethodInfo _loadMethod = typeof(ILazyLoader).GetMethod(nameof(ILazyLoader.Load))!;
+        private static readonly MethodInfo _loadAsyncMethod = typeof(ILazyLoader).GetMethod(nameof(ILazyLoader.LoadAsync))!;
 
         /// <summary>
         ///     Creates a new <see cref="LazyLoaderParameterBindingFactory" /> instance.

--- a/src/EFCore/Metadata/LazyLoaderParameterBindingFactoryDependencies.cs
+++ b/src/EFCore/Metadata/LazyLoaderParameterBindingFactoryDependencies.cs
@@ -4,6 +4,8 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/MemberIdentity.cs
+++ b/src/EFCore/Metadata/MemberIdentity.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public readonly struct MemberIdentity : IEquatable<MemberIdentity>
     {
-        private readonly object _nameOrMember;
+        private readonly object? _nameOrMember;
 
         /// <summary>
         ///     Constructs a new <see cref="MemberIdentity" /> from the given member name.
@@ -38,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         [DebuggerStepThrough]
-        private MemberIdentity([CanBeNull] object nameOrMember)
+        private MemberIdentity([CanBeNull] object? nameOrMember)
         {
             _nameOrMember = nameOrMember;
         }
@@ -53,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     A <see cref="MemberIdentity" /> instance that does not represent any member.
         /// </summary>
-        public static readonly MemberIdentity None = new MemberIdentity((object)null);
+        public static readonly MemberIdentity None = new MemberIdentity((object?)null);
 
         /// <summary>
         ///     Creates a new <see cref="MemberIdentity" /> from the given member name.
@@ -61,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The member name. </param>
         /// <returns> The newly created identity, or <see cref="None" /> if the given name is <see langword="null" />. </returns>
         [DebuggerStepThrough]
-        public static MemberIdentity Create([CanBeNull] string name)
+        public static MemberIdentity Create([CanBeNull] string? name)
             => name == null ? None : new MemberIdentity(name);
 
         /// <summary>
@@ -70,21 +72,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="memberInfo"> The member. </param>
         /// <returns> The newly created identity, or <see cref="None" /> if the given name is <see langword="null" />. </returns>
         [DebuggerStepThrough]
-        public static MemberIdentity Create([CanBeNull] MemberInfo memberInfo)
+        public static MemberIdentity Create([CanBeNull] MemberInfo? memberInfo)
             => memberInfo == null ? None : new MemberIdentity(memberInfo);
 
         /// <summary>
         ///     The name of the member.
         /// </summary>
-        public string Name
+        public string? Name
         {
-            [DebuggerStepThrough] get => MemberInfo?.GetSimpleMemberName() ?? (string)_nameOrMember;
+            [DebuggerStepThrough] get => MemberInfo?.GetSimpleMemberName() ?? (string?)_nameOrMember;
         }
 
         /// <summary>
         ///     The <see cref="MemberInfo" /> representing the member, or <see langword="null" /> if not known.
         /// </summary>
-        public MemberInfo MemberInfo
+        public MemberInfo? MemberInfo
         {
             [DebuggerStepThrough] get => _nameOrMember as MemberInfo;
         }
@@ -93,12 +95,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             => Name ?? "NONE";
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is MemberIdentity identity && Equals(identity);
 
         /// <inheritdoc />
         public bool Equals(MemberIdentity other)
-            => EqualityComparer<object>.Default.Equals(_nameOrMember, other._nameOrMember);
+        // TODO-NULLABLE: Bangs can be removed when targeting net5.0
+            => EqualityComparer<object>.Default.Equals(_nameOrMember!, other._nameOrMember!);
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/src/EFCore/Metadata/MemberIdentity.cs
+++ b/src/EFCore/Metadata/MemberIdentity.cs
@@ -100,8 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <inheritdoc />
         public bool Equals(MemberIdentity other)
-        // TODO-NULLABLE: Bangs can be removed when targeting net5.0
-            => EqualityComparer<object>.Default.Equals(_nameOrMember!, other._nameOrMember!);
+            => EqualityComparer<object>.Default.Equals(_nameOrMember, other._nameOrMember);
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
+++ b/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/ParameterBinding.cs
+++ b/src/EFCore/Metadata/ParameterBinding.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/ParameterBindingInfo.cs
@@ -22,10 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="materializationContextExpression"> The expression tree from which the parameter value will come. </param>
         public ParameterBindingInfo(
             [NotNull] IEntityType entityType,
-            // TODO-NULLABLE: Shouldn't this be [NotNull]?
-            [CanBeNull] Expression materializationContextExpression)
+            [NotNull] Expression materializationContextExpression)
         {
             Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(entityType, nameof(materializationContextExpression));
 
             EntityType = entityType;
             MaterializationContextExpression = materializationContextExpression;

--- a/src/EFCore/Metadata/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/ParameterBindingInfo.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -20,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="materializationContextExpression"> The expression tree from which the parameter value will come. </param>
         public ParameterBindingInfo(
             [NotNull] IEntityType entityType,
+            // TODO-NULLABLE: Shouldn't this be [NotNull]?
             [CanBeNull] Expression materializationContextExpression)
         {
             Check.NotNull(entityType, nameof(entityType));

--- a/src/EFCore/Metadata/PropertyParameterBinding.cs
+++ b/src/EFCore/Metadata/PropertyParameterBinding.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/PropertySaveBehavior.cs
+++ b/src/EFCore/Metadata/PropertySaveBehavior.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -17,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     /// </summary>
     public abstract class ServiceParameterBinding : ParameterBinding
     {
-        private Func<MaterializationContext, IEntityType, object, object> _serviceDelegate;
+        private Func<MaterializationContext, IEntityType, object, object>? _serviceDelegate;
 
         /// <summary>
         ///     Creates a new <see cref="ServiceParameterBinding" /> instance for the given service type
@@ -29,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         protected ServiceParameterBinding(
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
-            [CanBeNull] IPropertyBase serviceProperty = null)
+            [CanBeNull] IPropertyBase? serviceProperty = null)
             : base(
                 parameterType, serviceProperty != null
                     ? new[] { serviceProperty }

--- a/src/EFCore/Metadata/ServiceParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/ServiceParameterBindingFactory.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Metadata/SimpleModelFactory.cs
+++ b/src/EFCore/Metadata/SimpleModelFactory.cs
@@ -3,12 +3,14 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
     ///     <para>
     ///         Creates instances of <see cref="IMutableModel" /> that have no conventions. This is useful when
-    ///         Exhaustively configuring a model based on some existing metadata.
+    ///         exhaustively configuring a model based on some existing metadata.
     ///     </para>
     ///     <para>
     ///         This is typically not used in application code since building a model by overriding

--- a/src/EFCore/Metadata/ValueGenerated.cs
+++ b/src/EFCore/Metadata/ValueGenerated.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -124,9 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     var navigation = memberIdentity.MemberInfo != null
                         ? entityType.FindNavigation(memberIdentity.MemberInfo)
-                        : memberIdentity.Name is not null
-                            ? entityType.FindNavigation(memberIdentity.Name)
-                            : null;
+                        : entityType.FindNavigation(memberIdentity.Name!);
                     if (navigation != null)
                     {
                         return ExpandNavigation(root, entityReference, navigation, convertedType != null);

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -124,7 +124,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     var navigation = memberIdentity.MemberInfo != null
                         ? entityType.FindNavigation(memberIdentity.MemberInfo)
-                        : entityType.FindNavigation(memberIdentity.Name);
+                        : memberIdentity.Name is not null
+                            ? entityType.FindNavigation(memberIdentity.Name)
+                            : null;
                     if (navigation != null)
                     {
                         return ExpandNavigation(root, entityReference, navigation, convertedType != null);
@@ -132,7 +134,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     var skipNavigation = memberIdentity.MemberInfo != null
                         ? entityType.FindSkipNavigation(memberIdentity.MemberInfo)
-                        : entityType.FindSkipNavigation(memberIdentity.Name);
+                        : memberIdentity.Name is not null
+                            ? entityType.FindSkipNavigation(memberIdentity.Name)
+                            : null;
                     if (skipNavigation != null)
                     {
                         return ExpandSkipNavigation(root, entityReference, skipNavigation, convertedType != null);


### PR DESCRIPTION
Here's another bucket of nullability. After this, all of metadata is annotated (core, relational, providers) except for builders, conventions and some remaining internal stuff (which I will do later). I've left some nullability warnings where I think a closer look is warranted.

Feel free to push commits directly to this branch, or I can do corrections if you tell me to.