### PR TITLE
Remove QueryFailed

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosProjectionBindingExpressionVisitor.cs
@@ -271,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     return newIncludeExpression;
 
                 default:
-                    throw new InvalidOperationException(CoreStrings.QueryFailed(extensionExpression.Print(), GetType().Name));
+                    throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
             }
         }
 
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     break;
 
                 default:
-                    throw new InvalidOperationException(CoreStrings.QueryFailed(memberExpression.Print(), GetType().Name));
+                    throw new InvalidOperationException(CoreStrings.TranslationFailed(memberExpression.Print()));
             }
 
             var navigationProjection = innerEntityProjection.BindMember(
@@ -372,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 default:
-                    throw new InvalidOperationException(CoreStrings.QueryFailed(memberExpression.Print(), GetType().Name));
+                    throw new InvalidOperationException(CoreStrings.TranslationFailed(memberExpression.Print()));
             }
 
             Expression NullSafeUpdate(Expression expression)
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         break;
 
                     default:
-                        throw new InvalidOperationException(CoreStrings.QueryFailed(methodCallExpression.Print(), GetType().Name));
+                        throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
                 }
 
                 Expression navigationProjection;
@@ -576,7 +576,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     }
 
                     default:
-                        throw new InvalidOperationException(CoreStrings.QueryFailed(methodCallExpression.Print(), GetType().Name));
+                        throw new InvalidOperationException(CoreStrings.TranslationFailed(methodCallExpression.Print()));
                 }
             }
 
@@ -725,7 +725,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             if (projectionBindingExpression.QueryExpression != _selectExpression)
             {
-                throw new InvalidOperationException(CoreStrings.QueryFailed(projectionBindingExpression.Print(), GetType().Name));
+                throw new InvalidOperationException(CoreStrings.TranslationFailed(projectionBindingExpression.Print()));
             }
         }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 => projectionBindingExpression.ProjectionMember != null
                     ? _selectExpression.GetMappedProjection(projectionBindingExpression.ProjectionMember).GetConstantValue<int>()
                     : projectionBindingExpression.Index
-                    ?? throw new InvalidOperationException(CoreStrings.QueryFailed(projectionBindingExpression.Print(), GetType().Name));
+                    ?? throw new InvalidOperationException(CoreStrings.TranslationFailed(projectionBindingExpression.Print()));
         }
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                                         break;
                                     default:
                                         throw new InvalidOperationException(
-                                            CoreStrings.QueryFailed(binaryExpression.Print(), GetType().Name));
+                                            CoreStrings.TranslationFailed(binaryExpression.Print()));
                                 }
                             }
 
@@ -260,7 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                                 objectArrayProjection = objectArrayProjectionExpression;
                                 break;
                             default:
-                                throw new InvalidOperationException(CoreStrings.QueryFailed(extensionExpression.Print(), GetType().Name));
+                                throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
                         }
 
                         var jArray = _projectionBindings[objectArrayProjection];

--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     : QueryCompilationContext.NotTranslatedExpression;
             }
 
-            throw new InvalidOperationException(CoreStrings.QueryFailed(extensionExpression.Print(), GetType().Name));
+            throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -355,7 +355,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     return _clientEval ? extensionExpression : QueryCompilationContext.NotTranslatedExpression;
 
                 default:
-                    throw new InvalidOperationException(CoreStrings.QueryFailed(extensionExpression.Print(), GetType().Name));
+                    throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
             }
         }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2158,14 +2158,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     Processing of the LINQ expression '{expression}' by '{visitor}' failed. This may indicate either a bug or a limitation in Entity Framework. See https://go.microsoft.com/fwlink/?linkid=2101433 for more detailed information.
-        /// </summary>
-        public static string QueryFailed([CanBeNull] object expression, [CanBeNull] object visitor)
-            => string.Format(
-                GetString("QueryFailed", nameof(expression), nameof(visitor)),
-                expression, visitor);
-
-        /// <summary>
         ///     The query contains a projection '{projection}' of type '{queryableType}'. Collections in the final projection must be an 'IEnumerable&lt;T&gt;' type such as 'List&lt;T&gt;'. Consider using 'ToList' or some other mechanism to convert the 'IQueryable&lt;T&gt;' or 'IOrderedEnumerable&lt;T&gt;' into an 'IEnumerable&lt;T&gt;'.
         /// </summary>
         public static string QueryInvalidMaterializationType([CanBeNull] object projection, [CanBeNull] object queryableType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1233,9 +1233,6 @@
   <data name="QueryEntityMaterializationConditionWrongShape" xml:space="preserve">
     <value>The materialization condition passed for entity shaper of entity type '{entityType}' is not of the correct shape. A materialization condition must be a 'LambdaExpression' of 'Func&lt;ValueBuffer, IEntityType&gt;'.</value>
   </data>
-  <data name="QueryFailed" xml:space="preserve">
-    <value>Processing of the LINQ expression '{expression}' by '{visitor}' failed. This may indicate either a bug or a limitation in Entity Framework. See https://go.microsoft.com/fwlink/?linkid=2101433 for more detailed information.</value>
-  </data>
   <data name="QueryInvalidMaterializationType" xml:space="preserve">
     <value>The query contains a projection '{projection}' of type '{queryableType}'. Collections in the final projection must be an 'IEnumerable&lt;T&gt;' type such as 'List&lt;T&gt;'. Consider using 'ToList' or some other mechanism to convert the 'IQueryable&lt;T&gt;' or 'IOrderedEnumerable&lt;T&gt;' into an 'IEnumerable&lt;T&gt;'.</value>
   </data>


### PR DESCRIPTION
Mainly error in projection binding expression visitor, when we have an unknown extension expression which is hit when client evaluating, (non-client eval we wouldn't reach this code).
Translation failure seems most appropriate error.
Returning NoTranslationExpression will actually provide lesser value in what failed exactly.

Cosmos has a lot of places where it used but those are supposed to invariants and shouldn't exist after Cosmos Query pipeline is updated.

Resolves #22508
