### PR TITLE
InMemory: Add translation for object.Equals when object is null

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -4207,6 +4208,18 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
         public override Task Skip_0_Take_0_works_when_constant(bool async)
         {
             return base.Skip_0_Take_0_works_when_constant(async);
+        }
+
+        public override Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+        }
+
+        public override Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Using_string_Equals_with_StringComparison_throws_informative_error(async),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1151,10 +1151,10 @@ ORDER BY c[""CustomerID""]");
             AssertSql(" ");
         }
 
-        public override Task Reverse_without_explicit_ordering_throws(bool async)
+        public override Task Reverse_without_explicit_ordering(bool async)
         {
             return AssertTranslationFailedWithDetails(
-                () => base.Reverse_without_explicit_ordering_throws(async), CosmosStrings.MissingOrderingInSelectExpression);
+                () => base.Reverse_without_explicit_ordering(async), CosmosStrings.MissingOrderingInSelectExpression);
         }
 
         [ConditionalTheory(Skip = "Cross collection join Issue#17246")]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -2141,6 +2141,11 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND c[""OrderID""] IN (10248, 10249))");
         }
 
+        public override Task Where_equals_method_string_with_ignore_case(bool async)
+        {
+            return AssertTranslationFailed(() => base.Where_equals_method_string_with_ignore_case(async));
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -15,12 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
-        {
-            return base.Complex_query_with_optional_navigations_and_client_side_evaluation(async);
-        }
-
         [ConditionalFact(Skip = "issue #18194")]
         public override void Member_pushdown_chain_3_levels_deep_entity()
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsWeakQueryInMemoryTest.cs
@@ -19,12 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
-        {
-            return base.Complex_query_with_optional_navigations_and_client_side_evaluation(async);
-        }
-
         [ConditionalTheory(Skip = "Issue#17539")]
         public override Task Join_navigations_in_inner_selector_translated_without_collision(bool async)
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,21 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
-            => base.Correlated_collection_order_by_constant_null_of_non_mapped_type(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Client_side_equality_with_parameter_works_with_optional_navigations(bool async)
-            => base.Client_side_equality_with_parameter_works_with_optional_navigations(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Where_coalesce_with_anonymous_types(bool async)
-            => base.Where_coalesce_with_anonymous_types(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task GetValueOrDefault_on_DateTimeOffset(bool async)
-            => base.GetValueOrDefault_on_DateTimeOffset(async);
+        public override Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Client_member_and_unsupported_string_Equals_in_the_same_query(async),
+                CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
 
         [ConditionalFact(Skip = "issue #17537")]
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()
@@ -52,14 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory(Skip = "issue #19683")]
         public override Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
             => base.Group_by_on_StartsWith_with_null_parameter_as_argument(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
-            => base.Client_member_and_unsupported_string_Equals_in_the_same_query(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
-            => base.Client_eval_followed_by_set_operation_throws_meaningful_exception(async);
 
         [ConditionalTheory(Skip = "issue #17537")]
         public override Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindAggregateOperatorsQueryInMemoryTest.cs
@@ -69,12 +69,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 () => base.Collection_Last_member_access_in_projection_translated(async));
         }
 
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Contains_with_local_tuple_array_closure(bool async)
-        {
-            return base.Contains_with_local_tuple_array_closure(async);
-        }
-
         [ConditionalFact(Skip = "Issue#20023")]
         public override void Contains_over_keyless_entity_throws()
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindCompiledQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindCompiledQueryInMemoryTest.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -13,14 +11,5 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
-
-        [ConditionalFact(Skip = "See issue #17386")]
-        public override void Query_with_array_parameter()
-        {
-        }
-
-        [ConditionalFact(Skip = "See issue #17386")]
-        public override Task Query_with_array_parameter_async()
-            => null;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -65,50 +64,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact(Skip = "Issue#17050")]
         public override void Client_code_using_instance_method_throws()
             => base.Client_code_using_instance_method_throws();
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task OrderBy_multiple_queries(bool async)
-            => base.OrderBy_multiple_queries(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_1(bool async)
-            => base.Random_next_is_not_funcletized_1(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_2(bool async)
-            => base.Random_next_is_not_funcletized_2(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_3(bool async)
-            => base.Random_next_is_not_funcletized_3(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_4(bool async)
-            => base.Random_next_is_not_funcletized_4(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_5(bool async)
-            => base.Random_next_is_not_funcletized_5(async);
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Random_next_is_not_funcletized_6(bool async)
-            => base.Random_next_is_not_funcletized_6(async);
-
-        [ConditionalTheory(Skip = "issue#17386")]
-        public override Task Where_query_composition5(bool async)
-            => base.Where_query_composition5(async);
-
-        [ConditionalTheory(Skip = "issue#17386")]
-        public override Task Where_query_composition6(bool async)
-            => base.Where_query_composition6(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
-            => base.Using_string_Equals_with_StringComparison_throws_informative_error(async);
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
-            => base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async);
 
         public override async Task Max_on_empty_sequence_throws(bool async)
         {

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindNavigationsQueryInMemoryTest.cs
@@ -18,11 +18,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Where_subquery_on_navigation_client_eval(bool async)
-        {
-            return base.Where_subquery_on_navigation_client_eval(async);
-        }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindSelectQueryInMemoryTest.cs
@@ -20,28 +20,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
-        {
-            return base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(async);
-        }
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Projection_when_arithmetic_mixed_subqueries(bool async)
-        {
-            return base.Projection_when_arithmetic_mixed_subqueries(async);
-        }
-
         [ConditionalTheory(Skip = "Issue#17536")]
         public override Task SelectMany_correlated_with_outer_3(bool async)
         {
             return base.SelectMany_correlated_with_outer_3(async);
-        }
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Reverse_without_explicit_ordering_throws(bool async)
-        {
-            return base.Reverse_without_explicit_ordering_throws(async);
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
@@ -21,24 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Where_bool_client_side_negated(bool async)
-        {
-            return base.Where_bool_client_side_negated(async);
-        }
-
-        [ConditionalTheory(Skip = "Issue#17386")]
-        public override Task Where_equals_method_string_with_ignore_case(bool async)
-        {
-            return base.Where_equals_method_string_with_ignore_case(async);
-        }
-
-        [ConditionalTheory(Skip = "issue #17386")]
-        public override Task Where_equals_on_null_nullable_int_types(bool async)
-        {
-            return base.Where_equals_on_null_nullable_int_types(async);
-        }
-
         public override async Task<string> Where_simple_closure(bool async)
         {
             var queryString = await base.Where_simple_closure(async);

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -21,12 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             protected override ITestStoreFactory TestStoreFactory
                 => InMemoryTestStoreFactory.Instance;
-        }
-
-        [ConditionalFact(Skip = "issue #17386")]
-        public override void DbContext_list_is_parameterized()
-        {
-            base.DbContext_list_is_parameterized();
         }
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
@@ -545,6 +545,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
+        public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
+        {
+            return AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));
+        }
+
         protected virtual bool CanExecuteQueryString
             => false;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsWeakQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsWeakQueryRelationalTestBase.cs
@@ -507,6 +507,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .AsSplitQuery()))).Message;
         }
 
+        public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
+        {
+            return AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));
+        }
+
         protected virtual bool CanExecuteQueryString
             => false;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -54,6 +54,57 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("s.MissionId"), message);
         }
 
+        public override async Task Client_eval_followed_by_aggregate_operation(bool async)
+        {
+            await AssertTranslationFailed(
+                () => AssertSum(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertAverage(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertMin(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+
+            await AssertTranslationFailed(
+                () => AssertMax(
+                    async,
+                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+        }
+
+        public override Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Client_member_and_unsupported_string_Equals_in_the_same_query(async),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison
+                + Environment.NewLine
+                + CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+        }
+
+        public override Task Client_side_equality_with_parameter_works_with_optional_navigations(bool async)
+        {
+            return AssertTranslationFailed(() => base.Client_side_equality_with_parameter_works_with_optional_navigations(async));
+        }
+
+        public override Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
+        {
+            return AssertTranslationFailed(() => base.Correlated_collection_order_by_constant_null_of_non_mapped_type(async));
+        }
+
+        public override Task GetValueOrDefault_on_DateTimeOffset(bool async)
+        {
+            return AssertTranslationFailed(() => base.GetValueOrDefault_on_DateTimeOffset(async));
+        }
+
+        public override Task Where_coalesce_with_anonymous_types(bool async)
+        {
+            return AssertTranslationFailed(() => base.Where_coalesce_with_anonymous_types(async));
+        }
+
         protected virtual bool CanExecuteQueryString
             => false;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -34,6 +34,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     () => base.LastOrDefault_when_no_order_by(async))).Message);
         }
 
+        public override Task Contains_with_local_tuple_array_closure(bool async)
+        {
+            return AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+        }
+
         protected virtual bool CanExecuteQueryString
             => false;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindMiscellaneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindMiscellaneousQueryRelationalTestBase.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -44,6 +45,48 @@ namespace Microsoft.EntityFrameworkCore.Query
                     e, a,
                     elementAsserter: (eo, ao) => AssertInclude(eo, ao, new ExpectedInclude<Order>(o => o.OrderDetails))),
                 entryCount: 227);
+        }
+
+        public override Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Using_static_string_Equals_with_StringComparison_throws_informative_error(async),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+        }
+
+        public override Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
+        {
+            return AssertTranslationFailedWithDetails(() => base.Using_string_Equals_with_StringComparison_throws_informative_error(async),
+                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+        }
+
+        public override Task Random_next_is_not_funcletized_1(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_1(async));
+        }
+
+        public override Task Random_next_is_not_funcletized_2(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_2(async));
+        }
+
+        public override Task Random_next_is_not_funcletized_3(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_3(async));
+        }
+
+        public override Task Random_next_is_not_funcletized_4(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_4(async));
+        }
+
+        public override Task Random_next_is_not_funcletized_5(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_5(async));
+        }
+
+        public override Task Random_next_is_not_funcletized_6(bool async)
+        {
+            return AssertTranslationFailed(() => base.Random_next_is_not_funcletized_6(async));
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindNavigationsQueryRelationalTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,6 +12,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected NorthwindNavigationsQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override Task Where_subquery_on_navigation_client_eval(bool async)
+        {
+            return AssertTranslationFailed(() => base.Where_subquery_on_navigation_client_eval(async));
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,6 +13,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected NorthwindSelectQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
+        {
+            return AssertTranslationFailed(() => base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(async));
+        }
+
+        public override Task Reverse_without_explicit_ordering(bool async)
+        {
+            return AssertTranslationFailedWithDetails(
+                () => base.Reverse_without_explicit_ordering(async), RelationalStrings.MissingOrderingInSelectExpression);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindWhereQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindWhereQueryRelationalTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,6 +12,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected NorthwindWhereQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override Task Where_bool_client_side_negated(bool async)
+        {
+            return AssertTranslationFailed(() => base.Where_bool_client_side_negated(async));
+        }
+
+        public override Task Where_equals_method_string_with_ignore_case(bool async)
+        {
+            return AssertTranslationFailed(() => base.Where_equals_method_string_with_ignore_case(async));
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2453,21 +2453,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
+        public virtual Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
         {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Level1>().Where(
-                        l1 => l1.Id < 3
-                            && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id)
-                                .All(l4 => ClientMethod(l4))),
-                    ss => ss.Set<Level1>().Where(
-                        l1 => l1.Id < 3
-                            && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.MaybeScalar(x => x.Id))
-                                .All(a => true))))).Message;
-
-            Assert.Contains("ClientMethod((Nullable<int>)", message);
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Where(
+                    l1 => l1.Id < 3
+                        && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id)
+                            .All(l4 => ClientMethod(l4))),
+                ss => ss.Set<Level1>().Where(
+                    l1 => l1.Id < 3
+                        && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.MaybeScalar(x => x.Id))
+                            .All(a => true)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1253,12 +1253,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_coalesce_with_anonymous_types(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => from g in ss.Set<Gear>()
-                          where (new { Name = g.LeaderNickname } ?? new { Name = g.FullName }) != null
-                          select g.Nickname));
+            return AssertQuery(
+                async,
+                ss => from g in ss.Set<Gear>()
+                        where (new { Name = g.LeaderNickname } ?? new { Name = g.FullName }) != null
+                        select g.Nickname);
         }
 
         [ConditionalTheory(Skip = "issue #8421")]
@@ -2724,10 +2723,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var prm = "Marcus' Tag";
 
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Gear>().Where(g => ClientEquals(g.Tag.Note, prm))));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Where(g => ClientEquals(g.Tag.Note, prm)));
         }
 
         private static bool ClientEquals(string first, string second)
@@ -5307,17 +5305,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Gear>().OrderByDescending(s => (MyDTO)null).Select(
-                        g => new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() }),
-                    elementSorter: e => e.Nickname,
-                    elementAsserter: (e, a) =>
-                    {
-                        Assert.Equal(e.Nickname, a.Nickname);
-                        AssertCollection(e.Weapons, a.Weapons);
-                    }));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().OrderByDescending(s => (MyDTO)null).Select(
+                    g => new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() }),
+                elementSorter: e => e.Nickname,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Nickname, a.Nickname);
+                    AssertCollection(e.Weapons, a.Weapons);
+                });
         }
 
         [ConditionalTheory]
@@ -6003,10 +6000,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var defaultValue = default(DateTimeOffset);
 
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Mission>().Where(m => ((DateTimeOffset?)m.Timeline).GetValueOrDefault() == defaultValue)));
+        return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => ((DateTimeOffset?)m.Timeline).GetValueOrDefault() == defaultValue));
         }
 
         [ConditionalTheory]
@@ -7562,27 +7558,23 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Client_eval_followed_by_set_operation_throws_meaningful_exception(bool async)
+        public virtual async Task Client_eval_followed_by_aggregate_operation(bool async)
         {
-            await AssertTranslationFailed(
-                () => AssertSum(
-                    async,
-                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+            await AssertSum(
+                async,
+                ss => ss.Set<Mission>().Select(m => m.Duration.Ticks));
 
-            await AssertTranslationFailed(
-                () => AssertAverage(
-                    async,
-                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+            await AssertAverage(
+                async,
+                ss => ss.Set<Mission>().Select(m => m.Duration.Ticks));
 
-            await AssertTranslationFailed(
-                () => AssertMin(
-                    async,
-                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+            await AssertMin(
+                async,
+                ss => ss.Set<Mission>().Select(m => m.Duration.Ticks));
 
-            await AssertTranslationFailed(
-                () => AssertMax(
-                    async,
-                    ss => ss.Set<Mission>().Select(m => m.Duration.Ticks)));
+            await AssertMax(
+                async,
+                ss => ss.Set<Mission>().Select(m => m.Duration.Ticks));
         }
 
         [ConditionalTheory]
@@ -7657,13 +7649,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Client_member_and_unsupported_string_Equals_in_the_same_query(bool async)
         {
-            return AssertTranslationFailedWithDetails(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Gear>().Where(g => g.FullName.Equals(g.Nickname, StringComparison.InvariantCulture) || g.IsMarcus)),
-                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison
-                + Environment.NewLine
-                + CoreStrings.QueryUnableToTranslateMember(nameof(Gear.IsMarcus), nameof(Gear)));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Where(g => g.FullName.Equals(g.Nickname, StringComparison.InvariantCulture) || g.IsMarcus));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -1343,11 +1343,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var ids = new[] { Tuple.Create(1, 2), Tuple.Create(10248, 11) };
 
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))),
-                    entryCount: 1));
+            return AssertQuery(
+                async,
+                ss => ss.Set<OrderDetail>().Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))),
+                entryCount: 1);
         }
 
         [ConditionalTheory(Skip = "Issue #15937")]

--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -213,18 +214,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
-                    Assert.Throws<InvalidOperationException>(
-                        () => query(context, new[] { "ALFKI" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+                query(context, new[] { "ALFKI" });
             }
 
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
-                    Assert.Throws<InvalidOperationException>(
-                        () => query(context, new[] { "ANATR" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+                query(context, new[] { "ANATR" });
             }
         }
 
@@ -477,18 +472,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => query(context, new[] { "ALFKI" }).ToListAsync())).Message.Replace("\r", "").Replace("\n", ""));
+                await Enumerate(query(context, new[] { "ALFKI" }));
             }
 
             using (var context = CreateContext())
             {
-                Assert.Equal(
-                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
-                    (await Assert.ThrowsAsync<InvalidOperationException>(
-                        () => query(context, new[] { "ANATR" }).ToListAsync())).Message.Replace("\r", "").Replace("\n", ""));
+                await Enumerate(query(context, new[] { "ANATR" }));
             }
         }
 
@@ -870,6 +859,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             var result = query(context, new[] { "ALFKI" }).ToList();
 
             Assert.Single(result);
+        }
+
+        protected async Task Enumerate<T>(IAsyncEnumerable<T> source)
+        {
+            await foreach(var _ in source)
+            {
+            }
         }
 
         protected NorthwindContext CreateContext()

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -3610,60 +3610,58 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_1(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next())));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_2(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(5))));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(5)),
+                entryCount: 830);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_3(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(0, 10))));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(0, 10)),
+                entryCount: 830);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_4(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next())));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next()));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_5(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(5))));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(5)),
+                entryCount: 830);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Random_next_is_not_funcletized_6(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(0, 10))));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderID > new Random(15).Next(0, 10)),
+                entryCount: 830);
         }
 
         [ConditionalTheory]
@@ -6091,22 +6089,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
         {
-            return AssertTranslationFailedWithDetails(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.InvariantCulture))),
-                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.InvariantCulture)),
+                entryCount: 1);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
         {
-            return AssertTranslationFailedWithDetails(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.InvariantCulture))),
-                CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.InvariantCulture)),
+                entryCount: 1);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -973,15 +973,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_subquery_on_navigation_client_eval(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => from c in ss.Set<Customer>()
-                          orderby c.CustomerID
-                          where c.Orders.Select(o => o.OrderID).Contains(
-                              ss.Set<Order>().OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())
-                          select c,
-                    entryCount: 1));
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>()
+                        orderby c.CustomerID
+                        where c.Orders.Select(o => o.OrderID).Contains(
+                            ss.Set<Order>().OrderByDescending(o => ClientMethod(o.OrderID)).Select(o => o.OrderID).FirstOrDefault())
+                        select c,
+                entryCount: 1);
         }
 
         // ReSharper disable once MemberCanBeMadeStatic.Local

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -235,11 +235,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var boolean = false;
 
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Select(c => new { f = boolean }).OrderBy(e => (bool?)e.f),
-                    assertOrder: true));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Select(c => new { f = boolean }).OrderBy(e => (bool?)e.f),
+                assertOrder: true);
         }
 
         [ConditionalTheory]
@@ -891,7 +890,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Reverse_without_explicit_ordering_throws(bool async)
+        public virtual Task Reverse_without_explicit_ordering(bool async)
         {
             return AssertQueryScalar(
                 async,

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -689,11 +689,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_equals_method_string_with_ignore_case(bool async)
         {
-            return Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Customer>().Where(c => c.City.Equals("London", StringComparison.OrdinalIgnoreCase)),
-                    entryCount: 6));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.City.Equals("London", StringComparison.OrdinalIgnoreCase)),
+                entryCount: 6);
         }
 
         [ConditionalTheory]
@@ -1255,10 +1254,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_bool_client_side_negated(bool async)
         {
-            return AssertTranslationFailed(
-                () => AssertQuery(
-                    async,
-                    ss => ss.Set<Product>().Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8));
+            return AssertQuery(
+                async,
+                ss => ss.Set<Product>().Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8);
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter

--- a/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -69,11 +69,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void DbContext_list_is_parameterized()
         {
             using var context = CreateContext();
-            // This throws because the default value of TenantIds is null which is NRE
-            Assert.Throws<NullReferenceException>(() => context.Set<ListFilter>().ToList());
+            // Default value of TenantIds is null
+            var query = context.Set<ListFilter>().ToList();
+            Assert.Empty(query);
 
             context.TenantIds = new List<int>();
-            var query = context.Set<ListFilter>().ToList();
+            query = context.Set<ListFilter>().ToList();
             Assert.Empty(query);
 
             context.TenantIds = new List<int> { 1 };

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -338,6 +340,52 @@ WHERE ((((((((((((([c].[CustomerID] = @__s1) OR ([c].[CustomerID] = @__s2)) OR (
                 CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
+        }
+
+        public override void Query_with_array_parameter()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context, string[] args)
+                    => context.Customers.Where(c => c.CustomerID == args[0]));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => query(context, new[] { "ALFKI" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => query(context, new[] { "ANATR" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+            }
+        }
+
+        public override async Task Query_with_array_parameter_async()
+        {
+            var query = EF.CompileAsyncQuery(
+                            (NorthwindContext context, string[] args)
+                                => context.Customers.Where(c => c.CustomerID == args[0]));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => Enumerate(query(context, new[] { "ALFKI" })))).Message.Replace("\r", "").Replace("\n", ""));
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => Enumerate(query(context, new[] { "ANATR" })))).Message.Replace("\r", "").Replace("\n", ""));
+            }
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1434,12 +1434,6 @@ ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
             Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
-        public override Task Reverse_without_explicit_ordering_throws(bool async)
-        {
-            return AssertTranslationFailedWithDetails(
-                () => base.Reverse_without_explicit_ordering_throws(async), RelationalStrings.MissingOrderingInSelectExpression);
-        }
-
         public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
         {
             await base.Custom_projection_reference_navigation_PK_to_FK_optimization(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindCompiledQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindCompiledQuerySqliteTest.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -21,6 +24,52 @@ namespace Microsoft.EntityFrameworkCore.Query
                 CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == (string)(__parameters[0]))"),
                 Assert.Throws<InvalidOperationException>(
                     () => base.MakeBinary_does_not_throw_for_unsupported_operator()).Message.Replace("\r", "").Replace("\n", ""));
+        }
+
+        public override void Query_with_array_parameter()
+        {
+            var query = EF.CompileQuery(
+                (NorthwindContext context, string[] args)
+                    => context.Customers.Where(c => c.CustomerID == args[0]));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => query(context, new[] { "ALFKI" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => query(context, new[] { "ANATR" }).First().CustomerID).Message.Replace("\r", "").Replace("\n", ""));
+            }
+        }
+
+        public override async Task Query_with_array_parameter_async()
+        {
+            var query = EF.CompileAsyncQuery(
+                            (NorthwindContext context, string[] args)
+                                => context.Customers.Where(c => c.CustomerID == args[0]));
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => Enumerate(query(context, new[] { "ALFKI" })))).Message.Replace("\r", "").Replace("\n", ""));
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.TranslationFailed("DbSet<Customer>()    .Where(c => c.CustomerID == __args[0])"),
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => Enumerate(query(context, new[] { "ANATR" })))).Message.Replace("\r", "").Replace("\n", ""));
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -211,12 +211,6 @@ FROM ""Orders"" AS ""o""");
             return base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async);
         }
 
-        public override Task Reverse_without_explicit_ordering_throws(bool async)
-        {
-            return AssertTranslationFailedWithDetails(
-                () => base.Reverse_without_explicit_ordering_throws(async), RelationalStrings.MissingOrderingInSelectExpression);
-        }
-
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -16,6 +20,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void DbContext_list_is_parameterized()
+        {
+            using var context = CreateContext();
+            // Default value of TenantIds is null InExpression over null values throws
+            Assert.Throws<NullReferenceException>(() => context.Set<ListFilter>().ToList());
+
+            context.TenantIds = new List<int>();
+            var query = context.Set<ListFilter>().ToList();
+            Assert.Empty(query);
+
+            context.TenantIds = new List<int> { 1 };
+            query = context.Set<ListFilter>().ToList();
+            Assert.Single(query);
+
+            context.TenantIds = new List<int> { 2, 3 };
+            query = context.Set<ListFilter>().ToList();
+            Assert.Equal(2, query.Count);
         }
 
         public class QueryFilterFuncletizationSqliteFixture : QueryFilterFuncletizationRelationalFixture


### PR DESCRIPTION
Selectively assert exception in tests for other providers which works for InMemory
