### PR TITLE
[5.0.1] Fix collation scaffolding

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -194,6 +194,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 modelBuilder.Model.SetDatabaseName(databaseModel.DatabaseName);
             }
 
+            if (!string.IsNullOrEmpty(databaseModel.Collation))
+            {
+                modelBuilder.UseCollation(databaseModel.Collation);
+            }
+
             VisitSequences(modelBuilder, databaseModel.Sequences);
             VisitTables(modelBuilder, databaseModel.Tables);
             VisitForeignKeys(modelBuilder, databaseModel.Tables.SelectMany(table => table.ForeignKeys).ToList());
@@ -497,7 +502,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (column.Collation != null)
             {
-                property.HasComment(column.Collation);
+                property.UseCollation(column.Collation);
             }
 
             if (!(column.Table.PrimaryKey?.Columns.Contains(column) ?? false))

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1995,6 +1995,50 @@ namespace Microsoft.EntityFrameworkCore.Internal
             Assert.Equal("An int column", column.GetComment());
         }
 
+        [ConditionalFact]
+        public void Database_collation()
+        {
+            var database = new DatabaseModel
+            {
+                Collation = "SomeDatabaseCollation"
+            };
+
+            var model = _factory.Create(database, new ModelReverseEngineerOptions());
+            Assert.Equal("SomeDatabaseCollation", model.GetCollation());
+        }
+
+        [ConditionalFact]
+        public void Column_collation()
+        {
+            var database = new DatabaseModel
+            {
+                Tables =
+                {
+                    new DatabaseTable
+                    {
+                        Database = Database,
+                        Name = "Table",
+                        Columns =
+                        {
+                            IdColumn,
+                            new DatabaseColumn
+                            {
+                                Table = Table,
+                                Name = "Column",
+                                StoreType = "int",
+                                Collation = "SomeColumnCollation"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var model = _factory.Create(database, new ModelReverseEngineerOptions());
+
+            var column = model.FindEntityType("Table").GetProperty("Column");
+            Assert.Equal("SomeColumnCollation", column.GetCollation());
+        }
+
         [ConditionalTheory]
         [InlineData(false, false, false)]
         [InlineData(false, false, true)]


### PR DESCRIPTION
Fixes #23386

**Description**

EF Core 5.0 added support for database and column collations, but the scaffolding logic was faulty.

**Customer Impact**

When reverse engineering an existing database, column collations are mistakenly scaffolded as comments, and database collations aren't scaffolded at all.

**How found**

User-reported for 5.0.0

**Test coverage**

Added in this PR. In addition, we have identified scaffolding as an area where we are lacking sufficient test coverage and are beginning to address this.

**Regression?**

No, collations are new in 5.0.

**Risk**

Very low, minimal code changes, and only in the scaffolding code (no impact on runtime).