### PR TITLE
[5.0.1] Query: Don't terminate translation if indexer method does not bind to indexer property

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -465,7 +465,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             // EF Indexer property
             if (methodCallExpression.TryGetIndexerArguments(_model, out source, out propertyName))
             {
-                return TryBindMember(Visit(source), MemberIdentity.Create(propertyName));
+                var result = TryBindMember(Visit(source), MemberIdentity.Create(propertyName));
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23410", out var enabled) && enabled;
+                if (result != null
+                    || useOldBehavior)
+                {
+                    return result;
+                }
             }
 
             // GroupBy Aggregate case


### PR DESCRIPTION
Resolves #23410

**Description**

in EF Core 5.0, we added support for indexer properties. As a part of translating indexer properties, we intercepted them and tried to identify them in model. If not found, we would terminate translation. In earlier versions, this would actually go into further translation treating indexer access as just a normal method call. There are custom extensions/plugins out there that utilize this (it reported on the MySQL provider, PostgreSQL is also impacted) and provide support for JSON mapping to database as in JSON dictionary, tokens are accessed using indexer.

**Customer Impact**

Customers which were using indexer by custom mapping or through 3rd party libraries will start having errors in using indexers in their queries without any work-around. This was reported against the Pomelo MySQL provider and we believe it also impacts the PostgreSQL provider, both of which are popular, and JSON support is a popular feature of those providers.

**How found**

Reported by the author of the Pomelo MySQL provider, since it breaks their provider. (See #23410)

**Test coverage**

We have added a test to verify that we don't terminate the translation and evaluate the earlier method call translation pipeline. We have mimicked a behavior a library trying to add translation for JSONs by registering services and verified that it translates correctly. In addition, we have provided the fix to the author of the MySQL provider and he has verified that the this change fixes the issue--see https://github.com/dotnet/efcore/issues/23410#issuecomment-731705568

**Regression?**

Yes, in 3.1 indexers passed through method call translators. New feature in 5.0 skipped that.

**Risk**

Low. Currently we terminate right away. After this fix, we would go through the method call translators. If they don't handle indexers then they would return null anyway. The only place where this could cause error if an external method call translators is not identifying their method correctly and incorrectly ends up matching an indexer method. This is unlikely, and would be a bug in the calling code that would fail on 3.1. It currently silently passes on 5.0.0, but will go back to failing in 5.0.1, which was the 3.1 behavior. There is also quirk added in case to go back to 5.0.0 behavior.
