### PR TITLE
[5.0.1] RevEng: Ignore column store index

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -1023,7 +1023,12 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
                         index.Columns.Add(column);
                     }
 
-                    table.Indexes.Add(index);
+                    var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23378", out var enabled) && enabled;
+                    if (index.Columns.Count > 0
+                        || useOldBehavior)
+                    {
+                        table.Indexes.Add(index);
+                    }
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -1912,6 +1912,26 @@ CREATE INDEX ixHypo ON HypotheticalIndexTable ( Id1 ) WITH STATISTICS_ONLY = -1;
         }
 
         [ConditionalFact]
+        public void Ignore_columnstore_index()
+        {
+            Test(
+                @"
+CREATE TABLE ColumnStoreIndexTable (
+    Id1 int,
+    Id2 int NULL,
+);
+
+CREATE NONCLUSTERED COLUMNSTORE INDEX ixColumnStore ON ColumnStoreIndexTable ( Id1, Id2 )",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    Assert.Empty(dbModel.Tables.Single().Indexes);
+                },
+                "DROP TABLE ColumnStoreIndexTable;");
+        }
+
+        [ConditionalFact]
         public void Set_include_for_index()
         {
             Test(


### PR DESCRIPTION
Since all the columns are considered included columns

Resolves #23378

**Description**

All the columns in the columnstore index in SqlServer appears as included columns for the index. When we started identifying included columns as separate and started skipping them over, the columnstore indexes were left without any columns in the index causing error when generating model out of it.

**Customer Impact**

Customer will see an exception when scaffolding a database which has a columnstore index without any details why it failed. It has only been reported by a single customer so far, but we believe more people will hit this given that it also reproduces when scaffolding from the WideWorldImporters sample database, which is commonly used in SQL Server samples.

**How found**

Customer reported on 5.0.

**Test coverage**

Added test to skip column store index. As I mentioned in another issue, we have identified scaffolding (a.k.a. reverse engineering) as an area where we are lacking test coverage and are beginning to address this. One of the things we have already done is to reverse engineer four standard sample databases (Northwind, Pubs, AdventureWorks, and WideWorldImporters) which together cover many SQL Server features. This issue is reproduced on WideWorldImporters; we have not found any further issues from these databases.

**Regression?**

Yes, in 3.1 these indexes were scaffolded as regular index, which was wrong but not harmful. In 5.0 RTM it throws exception. With this fix they will be ignored. Ignoring them will allow us to add support for them fully in future.

**Risk**

Low. We would skip an index only if it does not have any columns. And indexes without any columns will throw later anyway. Also added quirk to go back to previous behavior.
