### PR TITLE
Enable post-build-signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ variables:
     value: https://localhost:8081
   - name: _CosmosToken
     value: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+  - name: PostBuildSign
+    value: true
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - group: DotNet-HelixApi-Access
     - group: DotNet-MSRC-Storage


### PR DESCRIPTION
 Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.