### PR TITLE
[3.1.x] Query: Cosmos: Generate enum literal/parameter correctly

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/BuiltInDataTypesCosmosTest.cs
@@ -31,30 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type()
-        {
-            base.Can_query_using_any_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-            base.Can_query_using_any_data_type_nullable_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_shadow()
-        {
-            base.Can_query_using_any_data_type_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_nullable_data_type()
-        {
-            base.Can_query_using_any_nullable_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
         public override void Can_query_using_any_nullable_data_type_as_literal()
         {
             base.Can_query_using_any_nullable_data_type_as_literal();
@@ -66,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Can_query_with_null_parameters_using_any_nullable_data_type();
         }
 
-        [ConditionalFact(Skip = "Issue #16919")]
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_string_key()
         {
             base.Can_insert_and_read_back_with_string_key();

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -36,30 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
         }
 
         [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type()
-        {
-            base.Can_query_using_any_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_nullable_shadow()
-        {
-            base.Can_query_using_any_data_type_nullable_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_data_type_shadow()
-        {
-            base.Can_query_using_any_data_type_shadow();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
-        public override void Can_query_using_any_nullable_data_type()
-        {
-            base.Can_query_using_any_nullable_data_type();
-        }
-
-        [ConditionalFact(Skip = "Issue #16919")]
         public override void Can_query_using_any_nullable_data_type_as_literal()
         {
             base.Can_query_using_any_nullable_data_type_as_literal();
@@ -71,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
             base.Can_query_with_null_parameters_using_any_nullable_data_type();
         }
 
-        [ConditionalFact(Skip = "Issue #16919")]
+        [ConditionalFact(Skip = "Issue #16920")]
         public override void Can_insert_and_read_back_with_string_key()
         {
             base.Can_insert_and_read_back_with_string_key();

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -2015,6 +2015,31 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+        [ConditionalFact]
+        public virtual void Can_compare_enum_to_constant()
+        {
+            using var context = CreateContext();
+            var query = context.Set<AnimalIdentification>()
+                .Where(a => a.Method == IdentificationMethod.EarTag)
+                .ToList();
+
+            var result = Assert.Single(query);
+            Assert.Equal(IdentificationMethod.EarTag, result.Method);
+        }
+
+        [ConditionalFact]
+        public virtual void Can_compare_enum_to_parameter()
+        {
+            var method = IdentificationMethod.EarTag;
+            using var context = CreateContext();
+            var query = context.Set<AnimalIdentification>()
+                .Where(a => a.Method == method)
+                .ToList();
+
+            var result = Assert.Single(query);
+            Assert.Equal(IdentificationMethod.EarTag, result.Method);
+        }
+
         public abstract class BuiltInDataTypesFixtureBase : SharedStoreFixtureBase<PoolableDbContext>
         {
             protected override string StoreName { get; } = "BuiltInDataTypes";


### PR DESCRIPTION
Resolves #20404

**Description**

When using enum value in a Cosmos query, the query throws rather than giving results back.

**Customer Impact**

Customers are unable to run queries which need to use enum values. There is no work-around.

**How found**

Reported my multiple customers on 3.1. We made a similar patch fix for relational providers, and based on feedback we are now bringing this for Cosmos as well.

**Test coverage**

Added test specifically for queries similar to customer queries. Also enabled existing tests which were using enums but were failing earlier.

**Regression?**

Not that we know of.

**Risk**

Low. We are backporting existing fix which went in 5.0 release and has no reported issues with it so far.
