### PR TITLE
[5.0.1] Migrations: Skip DbFunctionAttributeConvention when creating model for history repository

### DIFF
--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -98,6 +99,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                 // Use public API to remove the convention, issue #214
                 ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(DbSetFindingConvention));
+                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23312", out var enabled) && enabled))
+                {
+                    ConventionSet.Remove(conventionSet.ModelInitializedConventions, typeof(RelationalDbFunctionAttributeConvention));
+                }
+
                 var modelBuilder = new ModelBuilder(conventionSet);
                 modelBuilder.Entity<HistoryRow>(
                     x =>

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -157,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         }
 
         private static IHistoryRepository CreateHistoryRepository(string schema = null)
-            => new DbContext(
+            => new TestDbContext(
                     new DbContextOptionsBuilder()
                         .UseInternalServiceProvider(SqlServerTestHelpers.Instance.CreateServiceProvider())
                         .UseSqlServer(
@@ -165,5 +166,36 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, schema))
                         .Options)
                 .GetService<IHistoryRepository>();
+
+        private class TestDbContext : DbContext
+        {
+            public TestDbContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Blog> Blogs { get; set; }
+
+            [DbFunction("TableFunction")]
+            public IQueryable<TableFunction> TableFunction()
+                => FromExpression(() => TableFunction());
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+            }
+
+        }
+
+        private class Blog
+        {
+            public int Id { get; set; }
+        }
+
+        private class TableFunction
+        {
+            public int Id { get; set; }
+            public int BlogId { get; set; }
+            public Blog Blog { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Resolves #23312

**Description**

When generating the script to create migration history table, we use a model builder to generate the model. This model builder is decoupled from the application DbContext so that it won't include application entity types in the model. However, this decoupling is broken in 5.0 because we still discover methods on DbContext annotated with DbFunctionAttribute. If the DbFunction is targeting table valued function (TVF), then we add that as an entity type to the model. This causes an incorrect model to be built for the history table.

**Customer Impact**

Customers who have TVF declared using DbFunction attribute on their DbContext will get error when applying first migration or generating migration script from first migration. We create the migration history table in first migration if it does not exist.

**How found**

Reported by customer on 5.0 release.

**Test coverage**

Updated existing tests which were verifying the scripts for migration history table to use actual DbContext which would match customer scenarios.

**Regression?**

No. TVF is a new feature in 5.0. Earlier even though we would have added DbFunctions to the model, it wouldn't have added additional entity types.

**Risk**

Low. The model is not supposed to discover any entity types. By removing convention it would not remove something which is required. Also there is a quirk mode to revert to previous behavior.
