### PR TITLE
[5.0.1] Avoid stack overflow in negative many-to-many cases

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -153,8 +153,9 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23377", out var enabled) && enabled;
                 var skipReferencingTypes = entityType.GetForeignKeys().SelectMany(fk => fk.GetReferencingSkipNavigations())
-                    .Where(n => !n.IsOnDependent && n.DeclaringEntityType != entityType)
+                    .Where(n => !n.IsOnDependent && (n.DeclaringEntityType != entityType || useOldBehavior))
                     .ToList();
                 var skipNavigationSchema = skipReferencingTypes.FirstOrDefault()?.DeclaringEntityType.GetSchema();
                 if (skipNavigationSchema != null

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -153,12 +153,12 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
-                var skipNavigationSchema = entityType.GetForeignKeys().SelectMany(fk => fk.GetReferencingSkipNavigations())
-                    .FirstOrDefault(n => !n.IsOnDependent)
-                    ?.DeclaringEntityType.GetSchema();
+                var skipReferencingTypes = entityType.GetForeignKeys().SelectMany(fk => fk.GetReferencingSkipNavigations())
+                    .Where(n => !n.IsOnDependent && n.DeclaringEntityType != entityType)
+                    .ToList();
+                var skipNavigationSchema = skipReferencingTypes.FirstOrDefault()?.DeclaringEntityType.GetSchema();
                 if (skipNavigationSchema != null
-                    && entityType.GetForeignKeys().SelectMany(fk => fk.GetReferencingSkipNavigations())
-                        .Where(n => !n.IsOnDependent)
+                    && skipReferencingTypes.Skip(1)
                         .All(n => n.DeclaringEntityType.GetSchema() == skipNavigationSchema))
                 {
                     return skipNavigationSchema;

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -60,7 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             if (selfReferencingSkipNavigation
                 == selfReferencingSkipNavigation.DeclaringEntityType.GetDeclaredSkipNavigations()
-                    .First(s => s == selfReferencingSkipNavigation || s == selfReferencingSkipNavigation.Inverse))
+                    .First(s => s == selfReferencingSkipNavigation || s == selfReferencingSkipNavigation.Inverse)
+                && selfReferencingSkipNavigation != selfReferencingSkipNavigation.Inverse)
             {
                 selfReferencingSkipNavigation.Inverse.ForeignKey?.Builder.OnDelete(
                     GetTargetDeleteBehavior(selfReferencingSkipNavigation.Inverse.ForeignKey));

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerOnDeleteConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -58,10 +59,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return deleteBehavior;
             }
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23354", out var enabled) && enabled;
             if (selfReferencingSkipNavigation
                 == selfReferencingSkipNavigation.DeclaringEntityType.GetDeclaredSkipNavigations()
                     .First(s => s == selfReferencingSkipNavigation || s == selfReferencingSkipNavigation.Inverse)
-                && selfReferencingSkipNavigation != selfReferencingSkipNavigation.Inverse)
+                && (selfReferencingSkipNavigation != selfReferencingSkipNavigation.Inverse || useOldBehavior))
             {
                 selfReferencingSkipNavigation.Inverse.ForeignKey?.Builder.OnDelete(
                     GetTargetDeleteBehavior(selfReferencingSkipNavigation.Inverse.ForeignKey));

--- a/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -721,11 +721,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .SelectMany(t => t.GetDeclaredForeignKeys()).ToList();
             foreach (var foreignKey in foreignKeys)
             {
-                if ((!foreignKey.IsUnique
-                    || foreignKey.DeclaringEntityType.BaseType != null))
+                if ((foreignKey.IsUnique
+                    && foreignKey.DeclaringEntityType.BaseType == null)
+                    || foreignKey.Builder == null)
                 {
-                    DiscoverProperties(foreignKey.Builder, context);
+                    continue;
                 }
+
+                DiscoverProperties(foreignKey.Builder, context);
             }
         }
 

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -124,7 +124,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             {
                 var manyToManyForeignKeys = entityType.GetForeignKeys()
                     .Where(fk => fk.GetReferencingSkipNavigations().Any(n => n.IsCollection)).ToList();
-                if (manyToManyForeignKeys.Count == 2)
+                if (manyToManyForeignKeys.Count == 2
+                    && !manyToManyForeignKeys.Any(fk => fk.PrincipalEntityType == entityType))
                 {
                     keyProperties.AddRange(manyToManyForeignKeys.SelectMany(fk => fk.Properties));
                 }

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -125,7 +125,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 var manyToManyForeignKeys = entityType.GetForeignKeys()
                     .Where(fk => fk.GetReferencingSkipNavigations().Any(n => n.IsCollection)).ToList();
                 if (manyToManyForeignKeys.Count == 2
-                    && !manyToManyForeignKeys.Any(fk => fk.PrincipalEntityType == entityType))
+                    && (!manyToManyForeignKeys.Any(fk => fk.PrincipalEntityType == entityType)
+                        || (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23377", out var enabled) && enabled)))
                 {
                     keyProperties.AddRange(manyToManyForeignKeys.SelectMany(fk => fk.Properties));
                 }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -317,9 +317,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class SelfRefManyToOne
         {
             public int Id { get; set; }
+            public int SelfRefId { get; set; }
             public SelfRefManyToOne SelfRef1 { get; set; }
             public ICollection<SelfRefManyToOne> SelfRef2 { get; set; }
-            public int SelfRefId { get; set; }
+
+            [NotMapped]
+            public ManyToManyRelated Related { get; set; }
+
+            [NotMapped]
+            public ICollection<ManyToManyRelated> Relateds { get; set; }
+        }
+
+        protected class ManyToManyRelated
+        {
+            public int Id { get; set; }
+            public ICollection<SelfRefManyToOne> DirectlyRelatedSelfRefs { get; set; }
+            public ICollection<SelfRefManyToOne> RelatedSelfRefs { get; set; }
         }
 
         protected class User


### PR DESCRIPTION
Fixes #23377
Fixes #23354

**Description**

Some unsupported models cause `StackOverflowException` instead of a more useful exception.

**Customer Impact**

Using the same property for a self-referencing many-to-many or using the same entity type as the join entity type produces a  `StackOverflowException`.

**How found**

Multiple customers reported on 5.0.

**Test coverage**

Added tests for affected scenarios

**Regression?**

No, many-to-many is a new feature in 5.0

**Risk**

Low. This only affects many-to-many.


