### PR TITLE
Query: Throw error for translating Lambda right away

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -325,7 +325,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected override Expression VisitLambda<T>(Expression<T> lambdaExpression)
-            => null;
+            => throw new InvalidOperationException(CoreStrings.TranslationFailed(lambdaExpression.Print()));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         protected override Expression VisitLambda<T>(Expression<T> lambdaExpression)
-            => QueryCompilationContext.NotTranslatedExpression;
+            => throw new InvalidOperationException(CoreStrings.TranslationFailed(lambdaExpression.Print()));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -432,7 +432,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         /// <inheritdoc />
         protected override Expression VisitLambda<T>(Expression<T> lambdaExpression)
-            => QueryCompilationContext.NotTranslatedExpression;
+            => throw new InvalidOperationException(CoreStrings.TranslationFailed(lambdaExpression.Print()));
 
         /// <inheritdoc />
         protected override Expression VisitListInit(ListInitExpression listInitExpression)

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -2001,26 +2001,52 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Ternary_in_client_eval_assigns_correct_types(bool async)
-        {     return AssertQuery(
-                async,
-                ss => ss.Set<Order>()
+        {
+            return AssertQuery(
+              async,
+              ss => ss.Set<Order>()
 
-                    .Where(o => o.OrderID < 10300)
-                    .OrderBy(e => e.OrderID)
-                    .Select(
-                        o => new
-                        {
-                            CustomerID = ClientMethod(o.CustomerID),
-                            OrderDate = o.OrderDate.HasValue ? o.OrderDate.Value : new DateTime(o.OrderID - 10000, 1, 1),
-                            OrderDate2 = o.OrderDate.HasValue == false ? new DateTime(o.OrderID - 10000, 1, 1) : o.OrderDate.Value
-                        }),
-                assertOrder: true,
-                elementAsserter: (e, a) =>
-                {
-                    AssertEqual(e.CustomerID, a.CustomerID);
-                    AssertEqual(e.OrderDate, a.OrderDate);
-                    AssertEqual(e.OrderDate2, a.OrderDate2);
-                });
+                  .Where(o => o.OrderID < 10300)
+                  .OrderBy(e => e.OrderID)
+                  .Select(
+                      o => new
+                      {
+                          CustomerID = ClientMethod(o.CustomerID),
+                          OrderDate = o.OrderDate.HasValue ? o.OrderDate.Value : new DateTime(o.OrderID - 10000, 1, 1),
+                          OrderDate2 = o.OrderDate.HasValue == false ? new DateTime(o.OrderID - 10000, 1, 1) : o.OrderDate.Value
+                      }),
+              assertOrder: true,
+              elementAsserter: (e, a) =>
+              {
+                  AssertEqual(e.CustomerID, a.CustomerID);
+                  AssertEqual(e.OrderDate, a.OrderDate);
+                  AssertEqual(e.OrderDate2, a.OrderDate2);
+              });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task VisitLambda_should_not_be_visited_trivially(bool async)
+        {
+            return AssertTranslationFailed(() => AssertQuery(
+              async,
+              ss =>
+              {
+                  var orders = ss.Set<Order>().Where(o => o.CustomerID.StartsWith("A")).ToList();
+
+                  return ss.Set<Customer>()
+                    .Select(c => new
+                    {
+                        Customer = c,
+                        HasOrder = orders.Any(o => o.CustomerID == c.CustomerID)
+                    });
+              },
+              elementSorter: e => e.Customer.CustomerID,
+              elementAsserter: (e, a) =>
+              {
+                  AssertEqual(e.Customer, a.Customer);
+                  AssertEqual(e.HasOrder, a.HasOrder);
+              }));
         }
 
         private static string ClientMethod(string s) => s;


### PR DESCRIPTION
LambdaExpression can never be translated. The only time when returning null has effect in translation is projection where we would visit the base to client eval.
But lambda cannot be client evaluated either so right thing to do is just throw exception so that user know which lambda is throwing error.

Resolves #18179
