### PR TITLE
RevEng: Warn for FK with same required facets exists and skip it

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -231,6 +231,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 foreignKeyName, columnNames);
 
         /// <summary>
+        ///     Could not scaffold the foreign key '{foreignKeyName}'. Foreign key '{existingForeignKey}' is defined on same columns targeting same key on principal table.
+        /// </summary>
+        public static string ForeignKeyWithSameFacetsExists([CanBeNull] object foreignKeyName, [CanBeNull] object existingForeignKey)
+            => string.Format(
+                GetString("ForeignKeyWithSameFacetsExists", nameof(foreignKeyName), nameof(existingForeignKey)),
+                foreignKeyName, existingForeignKey);
+
+        /// <summary>
         ///     The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommend to put migrations for different DbContext classes into different namespaces.
         /// </summary>
         public static string ForeignMigrations([CanBeNull] object migrationsNamespace)
@@ -383,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 columnName);
 
         /// <summary>
-        ///     The provider '{provider}' is not a Relational provider and therefore cannot be use with Migrations.
+        ///     The provider '{provider}' is not a Relational provider and therefore cannot be used with Migrations.
         /// </summary>
         public static string NonRelationalProvider([CanBeNull] object provider)
             => string.Format(
@@ -455,7 +463,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 providerTypeName);
 
         /// <summary>
-        ///     No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist and must be made writeable to continue: {readOnlyFiles}.
+        ///     No files were generated in directory '{outputDirectoryName}'. The following file(s) already exist(s) and must be made writeable to continue: {readOnlyFiles}.
         /// </summary>
         public static string ReadOnlyFiles([CanBeNull] object outputDirectoryName, [CanBeNull] object readOnlyFiles)
             => string.Format(

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -201,6 +201,9 @@
   <data name="ForeignKeyScaffoldErrorPropertyNotFound" xml:space="preserve">
     <value>Could not scaffold the foreign key '{foreignKeyName}'.  The following columns in the foreign key could not be scaffolded: {columnNames}.</value>
   </data>
+  <data name="ForeignKeyWithSameFacetsExists" xml:space="preserve">
+    <value>Could not scaffold the foreign key '{foreignKeyName}'. Foreign key '{existingForeignKey}' is defined on same columns targeting same key on principal table.</value>
+  </data>
   <data name="ForeignMigrations" xml:space="preserve">
     <value>The namespace '{migrationsNamespace}' contains migrations for a different DbContext. This can result in conflicting migration names. It's recommend to put migrations for different DbContext classes into different namespaces.</value>
   </data>

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -748,7 +748,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var dependentEntityType = modelBuilder.Model.FindEntityType(GetEntityTypeName(foreignKey.Table));
-
             if (dependentEntityType == null)
             {
                 return null;
@@ -824,9 +823,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                                 nullablePrincipalProperties.Select(tuple => tuple.column.DisplayName()).ToList()
                                     .Aggregate((a, b) => a + "," + b)));
 
-                        nullablePrincipalProperties
-                            .ToList()
-                            .ForEach(tuple => tuple.property.IsNullable = false);
+                        nullablePrincipalProperties.ForEach(tuple => tuple.property.IsNullable = false);
                     }
 
                     principalKey = principalEntityType.AddKey(principalProperties);
@@ -843,6 +840,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                     return null;
                 }
+            }
+
+            var existingForeignKey = dependentEntityType.FindForeignKey(dependentProperties, principalKey, principalEntityType);
+            if (existingForeignKey is not null)
+            {
+                _reporter.WriteWarning(
+                    DesignStrings.ForeignKeyWithSameFacetsExists(foreignKey.DisplayName(), existingForeignKey.GetConstraintName()));
+
+                return null;
             }
 
             var newForeignKey = dependentEntityType.AddForeignKey(


### PR DESCRIPTION
So model builder does not throw error.

Resolves #23405
