### PR TITLE
Replace NotImplementedException with NotSupportedException

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -24,6 +24,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             = new ResourceManager("Microsoft.EntityFrameworkCore.Cosmos.Properties.CosmosStrings", typeof(CosmosStrings).Assembly);
 
         /// <summary>
+        ///     The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.
+        /// </summary>
+        public static string CanConnectNotSupported
+            => GetString("CanConnectNotSupported");
+
+        /// <summary>
         ///     Both the connection string and account key or account endpoint were specified. Specify only one set of connection details.
         /// </summary>
         public static string ConnectionStringConflictingConfiguration
@@ -246,6 +252,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         /// </summary>
         public static string ReverseAfterSkipTakeNotSupported
             => GetString("ReverseAfterSkipTakeNotSupported");
+
+        /// <summary>
+        ///     The Cosmos database provider does not support transactions.
+        /// </summary>
+        public static string TransactionsNotSupported
+            => GetString("TransactionsNotSupported");
 
         /// <summary>
         ///     Unable to bind '{memberType}' '{member}' to an entity projection of '{entityType}'.

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CanConnectNotSupported" xml:space="preserve">
+    <value>The Cosmos database does not support 'CanConnect' or 'CanConnectAsync'.</value>
+  </data>
   <data name="ConnectionStringConflictingConfiguration" xml:space="preserve">
     <value>Both the connection string and account key or account endpoint were specified. Specify only one set of connection details.</value>
   </data>
@@ -214,6 +217,9 @@
   </data>
   <data name="ReverseAfterSkipTakeNotSupported" xml:space="preserve">
     <value>Reversing the ordering is not supported when limit or offset are already applied.</value>
+  </data>
+  <data name="TransactionsNotSupported" xml:space="preserve">
+    <value>The Cosmos database provider does not support transactions.</value>
   </data>
   <data name="UnableToBindMemberToEntityProjection" xml:space="preserve">
     <value>Unable to bind '{memberType}' '{member}' to an entity projection of '{entityType}'.</value>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotImplementedException();
+                    => throw new NotSupportedException();
             }
 
             private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotSupportedException();
+                    => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
             }
 
             private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotImplementedException();
+                    => throw new NotSupportedException();
 
                 private bool ShapeResult()
                 {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.ReadItemQueryingEnumerable.cs
@@ -290,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotSupportedException();
+                    => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
 
                 private bool ShapeResult()
                 {

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                             QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution));
 
                 default:
-                    throw new NotImplementedException();
+                    throw new NotSupportedException();
             }
         }
     }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Newtonsoft.Json.Linq;
@@ -110,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                             QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution));
 
                 default:
-                    throw new NotSupportedException();
+                    throw new NotSupportedException(CoreStrings.UnhandledExpressionNode(shapedQueryExpression.QueryExpression));
             }
         }
     }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                 }
 
                 public void Reset()
-                    => throw new NotSupportedException();
+                    => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
             }
         }
 

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                 }
 
                 public void Reset()
-                    => throw new NotImplementedException();
+                    => throw new NotSupportedException();
             }
         }
 

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosDatabaseCreator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -167,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CanConnect()
-            => throw new NotImplementedException();
+            => throw new NotSupportedException(CosmosStrings.CanConnectNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -176,7 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual Task<bool> CanConnectAsync(CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException(CosmosStrings.CanConnectNotSupported);
 
         /// <summary>
         ///     Returns the store name of the property that is used to store the partition key.

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
@@ -24,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IDbContextTransaction BeginTransaction()
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -34,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         /// </summary>
         public virtual Task<IDbContextTransaction> BeginTransactionAsync(
             CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void CommitTransaction()
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -52,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual Task CommitTransactionAsync(CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -61,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void RollbackTransaction()
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -70,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -97,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual void EnlistTransaction(Transaction transaction)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CosmosStrings.TransactionsNotSupported);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -160,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotImplementedException();
+                    => throw new NotSupportedException();
             }
         }
     }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.QueryingEnumerable.cs
@@ -160,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 }
 
                 public void Reset()
-                    => throw new NotSupportedException();
+                    => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
             }
         }
     }

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -787,7 +787,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         break;
                     default:
-                        throw new NotImplementedException(storeObject.StoreObjectType.ToString());
+                        throw new NotSupportedException(storeObject.StoreObjectType.ToString());
                 }
             }
         }

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         break;
                     default:
-                        throw new NotImplementedException(storeObject.StoreObjectType.ToString());
+                        throw new NotSupportedException(storeObject.StoreObjectType.ToString());
                 }
 
                 if (entityType == null)
@@ -456,7 +456,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     return null;
                 default:
-                    throw new NotImplementedException(storeObject.StoreObjectType.ToString());
+                    throw new NotSupportedException(storeObject.StoreObjectType.ToString());
             }
         }
 

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -1253,7 +1253,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                                 break;
                             default:
-                                throw new NotImplementedException(storeOverride.StoreObjectType.ToString());
+                                throw new NotSupportedException(storeOverride.StoreObjectType.ToString());
                         }
                     }
                 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -1128,7 +1128,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 case DeleteBehavior.ClientCascade:
                     return ReferentialAction.Restrict;
                 default:
-                    throw new NotImplementedException(deleteBehavior.ToString());
+                    throw new NotSupportedException(deleteBehavior.ToString());
             }
         }
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -874,7 +874,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 => x.IsSameAs(y);
 
             public int GetHashCode(PropertyInfo obj)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         #endregion

--- a/src/EFCore.Relational/Migrations/Migration.cs
+++ b/src/EFCore.Relational/Migrations/Migration.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
@@ -118,9 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="migrationBuilder"> The <see cref="MigrationBuilder" /> that will build the operations. </param>
         protected virtual void Down([NotNull] MigrationBuilder migrationBuilder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationDownMissing);
 
         private List<MigrationOperation> BuildOperations(Action<MigrationBuilder> buildAction)
         {

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -322,7 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -333,9 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] AlterColumnOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(AlterColumnOperation)));
 
         /// <summary>
         ///     <para>
@@ -363,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -374,9 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] RenameIndexOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(RenameIndexOperation)));
 
         /// <summary>
         ///     Builds commands for the given <see cref="AlterSequenceOperation" /> by making calls on the given
@@ -431,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -442,9 +438,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] RenameTableOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(RenameTableOperation)));
 
         /// <summary>
         ///     Builds commands for the given <see cref="CreateIndexOperation" /> by making calls on the given
@@ -496,7 +490,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -507,9 +501,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] EnsureSchemaOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(EnsureSchemaOperation)));
 
         /// <summary>
         ///     Builds commands for the given <see cref="CreateSequenceOperation" /> by making calls on the given
@@ -657,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -670,9 +662,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder,
             bool terminate = true)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(DropIndexOperation)));
 
         /// <summary>
         ///     Builds commands for the given <see cref="DropPrimaryKeyOperation" /> by making calls on the given
@@ -834,7 +824,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -845,9 +835,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] RenameColumnOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(RenameColumnOperation)));
 
         /// <summary>
         ///     <para>
@@ -855,7 +843,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///         by making calls on the given <see cref="MigrationCommandListBuilder" />.
         ///     </para>
         ///     <para>
-        ///         Note that the default implementation of this method throws <see cref="NotImplementedException" />. Providers
+        ///         Note that the default implementation of this method throws <see cref="NotSupportedException" />. Providers
         ///         must override if they are to support this kind of operation.
         ///     </para>
         /// </summary>
@@ -866,9 +854,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] RenameSequenceOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(RenameSequenceOperation)));
 
         /// <summary>
         ///     Builds commands for the given <see cref="RestartSequenceOperation" /> by making calls on the given
@@ -1466,9 +1452,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [NotNull] ColumnOperation operation,
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
-        {
-            throw new NotImplementedException();
-        }
+            => throw new NotSupportedException(RelationalStrings.MigrationSqlGenerationMissing(nameof(ColumnOperation)));
 
         /// <summary>
         ///     Gets the store/database type of a column given the provided metadata.

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -721,6 +721,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 method);
 
         /// <summary>
+        ///     The 'Down' method for this migration has not been implemented. Both the 'Up' abd 'Down' methods must be implemented to support reverting migrations.
+        /// </summary>
+        public static string MigrationDownMissing
+            => GetString("MigrationDownMissing");
+
+        /// <summary>
         ///     The entity type '{entityType}' is mapped to the DbFunction named '{functionName}', but no DbFunction with that name was found in the model. Ensure that the entity type mapping is configured using the model name of a function in the model.
         /// </summary>
         public static string MappedFunctionNotFound([CanBeNull] object? entityType, [CanBeNull] object? functionName)

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -745,6 +745,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 migrationName);
 
         /// <summary>
+        ///     SQL generation for the operation '{operation}' is not supported by the current database provider. Database providers must implement the appropriate method in 'MigrationsSqlGenerator' to support this operation.
+        /// </summary>
+        public static string MigrationSqlGenerationMissing([CanBeNull] object operation)
+            => string.Format(
+                GetString("MigrationSqlGenerationMissing", nameof(operation)),
+                operation);
+
+        /// <summary>
         ///     Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' which is used by another entity type sharing the table '{table}'. Add a store-generated property to '{entityType}' which is mapped to the same column; it may be in shadow state.
         /// </summary>
         public static string MissingConcurrencyColumn([CanBeNull] object? entityType, [CanBeNull] object? missingColumn, [CanBeNull] object? table)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -611,6 +611,9 @@
   <data name="MigrationNotFound" xml:space="preserve">
     <value>The migration '{migrationName}' was not found.</value>
   </data>
+  <data name="MigrationSqlGenerationMissing" xml:space="preserve">
+    <value>SQL generation for the operation '{operation}' is not supported by the current database provider. Database providers must implement the appropriate method in 'MigrationsSqlGenerator' to support this operation.</value>
+  </data>
   <data name="MissingConcurrencyColumn" xml:space="preserve">
     <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' which is used by another entity type sharing the table '{table}'. Add a store-generated property to '{entityType}' which is mapped to the same column; it may be in shadow state.</value>
   </data>

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -608,6 +608,9 @@
   <data name="MethodOnNonTPHRootNotSupported" xml:space="preserve">
     <value>Using '{methodName}' on DbSet of '{entityType}' is not supported since '{entityType}' is part of hierarchy and does not contain a discriminator property.</value>
   </data>
+  <data name="MigrationDownMissing" xml:space="preserve">
+    <value>The 'Down' method for this migration has not been implemented. Both the 'Up' abd 'Down' methods must be implemented to support reverting migrations.</value>
+  </data>
   <data name="MigrationNotFound" xml:space="preserve">
     <value>The migration '{migrationName}' was not found.</value>
   </data>

--- a/src/EFCore.Relational/Query/EntityProjectionExpression.cs
+++ b/src/EFCore.Relational/Query/EntityProjectionExpression.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [Obsolete("Use the constructor which takes populated column expressions map.", error: true)]
         public EntityProjectionExpression([NotNull] IEntityType entityType, [NotNull] TableExpressionBase innerTable, bool nullable)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException("Obsolete: Use the constructor which takes populated column expressions map.");
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
+++ b/src/EFCore.Relational/Query/Internal/BufferedDataReader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly bool _detailedErrorsEnabled;
 
         private DbDataReader? _underlyingReader;
-        private List<BufferedDataRecord> _bufferedDataRecords = new List<BufferedDataRecord>();
+        private List<BufferedDataRecord> _bufferedDataRecords = new();
         private BufferedDataRecord _currentResultSet;
         private int _currentResultSetNumber;
         private int _recordsAffected;

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotSupportedException();
+                => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotSupportedException();
+                => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -235,7 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
 
             public void Reset()
-                => throw new NotSupportedException();
+                => throw new NotSupportedException(CoreStrings.EnumerableResetNotSupported);
         }
 
         private sealed class AsyncEnumerator : IAsyncEnumerator<T>

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -109,6 +109,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             RelationalCommandParameterObject parameterObject,
             Guid commandId,
             DbCommandMethod commandMethod)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -108,7 +108,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         DbCommand CreateDbCommand(
             RelationalCommandParameterObject parameterObject,
             Guid commandId,
-            DbCommandMethod commandMethod)
-            => throw new NotSupportedException();
+            DbCommandMethod commandMethod);
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/IRelationalConnection.cs
@@ -32,8 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         string ConnectionString
         {
-            get => throw new NotImplementedException();
-            [param: CanBeNull] set => throw new NotImplementedException();
+            get => throw new NotSupportedException();
+            [param: CanBeNull] set => throw new NotSupportedException();
         }
 
         /// <summary>
@@ -49,8 +49,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         DbConnection DbConnection
         {
-            get => throw new NotImplementedException();
-            [param: CanBeNull] set => throw new NotImplementedException();
+            get => throw new NotSupportedException();
+            [param: CanBeNull] set => throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/IRelationalConnection.cs
@@ -30,11 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets or sets the connection string for the database.
         /// </summary>
-        string ConnectionString
-        {
-            get => throw new NotSupportedException();
-            [param: CanBeNull] set => throw new NotSupportedException();
-        }
+        string ConnectionString { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     <para>
@@ -47,11 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///         Note that the connection must be disposed by application code since it was not created by Entity Framework.
         ///     </para>
         /// </summary>
-        DbConnection DbConnection
-        {
-            get => throw new NotSupportedException();
-            [param: CanBeNull] set => throw new NotSupportedException();
-        }
+        DbConnection DbConnection { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     The <see cref="DbContext" /> currently in use, or null if not known.

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -198,6 +198,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 property, entityType);
 
         /// <summary>
+        ///     SQL Server does not support releasing a savepoint.
+        /// </summary>
+        public static string NoSavepointRelease
+            => GetString("NoSavepointRelease");
+
+        /// <summary>
         ///     SQL Server sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.
         /// </summary>
         public static string SequenceBadType([CanBeNull] object? property, [CanBeNull] object? entityType, [CanBeNull] object? propertyType)

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -262,6 +262,9 @@
   <data name="NonKeyValueGeneration" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is configured to use 'SequenceHiLo' value generator, which is only intended for keys. If this was intentional, configure an alternate key on the property, otherwise call 'ValueGeneratedNever' or configure store generation for this property.</value>
   </data>
+  <data name="NoSavepointRelease" xml:space="preserve">
+    <value>SQL Server does not support releasing a savepoint.</value>
+  </data>
   <data name="SequenceBadType" xml:space="preserve">
     <value>SQL Server sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.</value>
   </data>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlGenerationHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -124,6 +125,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// <param name="name"> The name of the savepoint to be released. </param>
         /// <returns> An SQL string to release the savepoint. </returns>
         public override string GenerateReleaseSavepointStatement(string name)
-            => throw new NotSupportedException("SQL Server does not support releasing a savepoint");
+            => throw new NotSupportedException(SqlServerStrings.NoSavepointRelease);
     }
 }

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         public virtual LocalView<TEntity> Local
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or <see langword="null" />.</returns>
         public virtual TEntity Find([CanBeNull] params object[] keyValues)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="keyValues">The values of the primary key for the entity to be found.</param>
         /// <returns>The entity found, or <see langword="null" />.</returns>
         public virtual ValueTask<TEntity> FindAsync([CanBeNull] params object[] keyValues)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Finds an entity with the given primary key values. If an entity with the given primary key values
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>The entity found, or <see langword="null" />.</returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
         public virtual ValueTask<TEntity> FindAsync([CanBeNull] object[] keyValues, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     access to change tracking information and operations for the entity.
         /// </returns>
         public virtual EntityEntry<TEntity> Add([NotNull] TEntity entity)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual ValueTask<EntityEntry<TEntity>> AddAsync(
             [NotNull] TEntity entity,
             CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     access to change tracking information and operations for the entity.
         /// </returns>
         public virtual EntityEntry<TEntity> Attach([NotNull] TEntity entity)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Begins tracking the given entity in the <see cref="EntityState.Deleted" /> state such that it will
@@ -246,7 +246,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     access to change tracking information and operations for the entity.
         /// </returns>
         public virtual EntityEntry<TEntity> Remove([NotNull] TEntity entity)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     access to change tracking information and operations for the entity.
         /// </returns>
         public virtual EntityEntry<TEntity> Update([NotNull] TEntity entity)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Begins tracking the given entities, and any other reachable entities that are
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
         public virtual void AddRange([NotNull] params TEntity[] entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -309,7 +309,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entities"> The entities to add. </param>
         /// <returns> A task that represents the asynchronous operation. </returns>
         public virtual Task AddRangeAsync([NotNull] params TEntity[] entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -342,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to attach. </param>
         public virtual void AttachRange([NotNull] params TEntity[] entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </remarks>
         /// <param name="entities"> The entities to remove. </param>
         public virtual void RemoveRange([NotNull] params TEntity[] entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -395,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to update. </param>
         public virtual void UpdateRange([NotNull] params TEntity[] entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Begins tracking the given entities, and any other reachable entities that are
@@ -404,7 +404,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
         public virtual void AddRange([NotNull] IEnumerable<TEntity> entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -425,7 +425,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual Task AddRangeAsync(
             [NotNull] IEnumerable<TEntity> entities,
             CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -458,7 +458,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to attach. </param>
         public virtual void AttachRange([NotNull] IEnumerable<TEntity> entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will
@@ -478,7 +478,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </remarks>
         /// <param name="entities"> The entities to remove. </param>
         public virtual void RemoveRange([NotNull] IEnumerable<TEntity> entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -511,7 +511,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="entities"> The entities to update. </param>
         public virtual void UpdateRange([NotNull] IEnumerable<TEntity> entities)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Returns an <see cref="IEnumerator{T}" /> which when enumerated will execute a query against the database
@@ -519,7 +519,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> The query results. </returns>
         IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator()
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Returns an <see cref="IEnumerator" /> which when enumerated will execute a query against the database
@@ -527,7 +527,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> The query results. </returns>
         IEnumerator IEnumerable.GetEnumerator()
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Returns an <see cref="IAsyncEnumerator{T}" /> which when enumerated will asynchronously execute a query against
@@ -535,25 +535,25 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> The query results. </returns>
         IAsyncEnumerator<TEntity> IAsyncEnumerable<TEntity>.GetAsyncEnumerator(CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Gets the IQueryable element type.
         /// </summary>
         Type IQueryable.ElementType
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Gets the IQueryable LINQ Expression.
         /// </summary>
         Expression IQueryable.Expression
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Gets the IQueryable provider.
         /// </summary>
         IQueryProvider IQueryable.Provider
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -565,7 +565,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         IServiceProvider IInfrastructure<IServiceProvider>.Instance
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/EventDefinitionBase.cs
+++ b/src/EFCore/Diagnostics/EventDefinitionBase.cs
@@ -103,8 +103,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 LogLevel logLevel,
                 EventId eventId,
                 [CanBeNull] TState state,
-                [CanBeNull] Exception exception,
-                [NotNull] Func<TState, Exception, string> formatter)
+                Exception exception,
+                Func<TState, Exception, string> formatter)
             {
                 Message = formatter(state, exception);
             }
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 => true;
 
             IDisposable ILogger.BeginScope<TState>([CanBeNull] TState state)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
     }
 }

--- a/src/EFCore/Extensions/Internal/QueryableExtensions.cs
+++ b/src/EFCore/Extensions/Internal/QueryableExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] Expression<Func<TInner, TKey>> innerKeySelector,
             [NotNull] Expression<Func<TOuter, TInner, TResult>> resultSelector)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/EFCore/Infrastructure/ConventionAnnotatable.cs
+++ b/src/EFCore/Infrastructure/ConventionAnnotatable.cs
@@ -125,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <inheritdoc />
         IConventionAnnotatableBuilder IConventionAnnotatable.Builder
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <inheritdoc />
         [DebuggerStepThrough]

--- a/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
@@ -361,7 +361,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] Type targetClrType,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<IConventionEntityTypeBuilder> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called for every navigation property that has an attribute after an entity type is ignored.
@@ -379,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] Type targetClrType,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<string> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called for every navigation property that has an attribute after an entity type is removed.
@@ -397,7 +397,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] Type targetClrType,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<IConventionEntityType> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called for every navigation property that has an attribute after the base type for an entity type is changed.
@@ -417,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] Type targetClrType,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<IConventionEntityType> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called after a navigation property that has an attribute is added to an entity type.
@@ -429,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] IConventionNavigationBuilder navigationBuilder,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<IConventionNavigationBuilder> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called after a skip navigation property that has an attribute is added to an entity type.
@@ -441,7 +441,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] IConventionSkipNavigationBuilder skipNavigationBuilder,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<IConventionSkipNavigationBuilder> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called after a navigation property that has an attribute is ignored.
@@ -457,7 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [NotNull] Type targetClrType,
             [NotNull] TAttribute attribute,
             [NotNull] IConventionContext<string> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     Called after the principal end of a foreign key is changed.
@@ -471,6 +471,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             [CanBeNull] IEnumerable<TAttribute> dependentToPrincipalAttributes,
             [CanBeNull] IEnumerable<TAttribute> principalToDependentAttributes,
             [NotNull] IConventionContext<IConventionForeignKeyBuilder> context)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -824,6 +824,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 invalidDependentType, invalidPrincipalType, dependentType, principalType);
 
         /// <summary>
+        ///     This enumerator cannot be reset.
+        /// </summary>
+        public static string EnumerableResetNotSupported
+            => GetString("EnumerableResetNotSupported");
+
+        /// <summary>
         ///     Cannot use multiple context instances within a single query execution. Ensure the query uses a single context instance.
         /// </summary>
         public static string ErrorInvalidQueryable
@@ -2283,6 +2289,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string RuntimeParameterMissingParameter
             => GetString("RuntimeParameterMissingParameter");
+
+        /// <summary>
+        ///     Savepoints are not supported by the database provider in use.
+        /// </summary>
+        public static string SavepointsNotSupported
+            => GetString("SavepointsNotSupported");
 
         /// <summary>
         ///     The seed entity for entity type '{entityType}' cannot be added because a default value was provided for the required property '{property}'. Please provide a value different from '{defaultValue}'.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -423,6 +423,9 @@
   <data name="EntityTypesNotInRelationship" xml:space="preserve">
     <value>The provided entity types '{invalidDependentType}' and '{invalidPrincipalType}' are invalid. Specify '{dependentType}' and '{principalType}', or entity types in the same hierarchy.</value>
   </data>
+  <data name="EnumerableResetNotSupported" xml:space="preserve">
+    <value>This enumerator cannot be reset.</value>
+  </data>
   <data name="ErrorInvalidQueryable" xml:space="preserve">
     <value>Cannot use multiple context instances within a single query execution. Ensure the query uses a single context instance.</value>
   </data>
@@ -1287,6 +1290,9 @@
   </data>
   <data name="RuntimeParameterMissingParameter" xml:space="preserve">
     <value>While registering a runtime parameter, the lambda expression must have only one parameter which must be same as 'QueryCompilationContext.QueryContextParameter' expression.</value>
+  </data>
+  <data name="SavepointsNotSupported" xml:space="preserve">
+    <value>Savepoints are not supported by the database provider in use.</value>
   </data>
   <data name="SeedDatumDefaultValue" xml:space="preserve">
     <value>The seed entity for entity type '{entityType}' cannot be added because a default value was provided for the required property '{property}'. Please provide a value different from '{defaultValue}'.</value>

--- a/src/EFCore/Query/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/ExpressionEqualityComparer.cs
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             break;
                         }
 
-                        throw new NotImplementedException(CoreStrings.UnhandledExpressionNode(obj.NodeType));
+                        throw new NotSupportedException(CoreStrings.UnhandledExpressionNode(obj.NodeType));
                 }
 
                 return hash.ToHashCode();

--- a/src/EFCore/Query/Internal/NullAsyncQueryProvider.cs
+++ b/src/EFCore/Query/Internal/NullAsyncQueryProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IQueryable IQueryProvider.CreateQuery(Expression expression)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         IQueryable<TElement> IQueryProvider.CreateQuery<TElement>(Expression expression)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         object IQueryProvider.Execute(Expression expression)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         TResult IQueryProvider.Execute<TResult>(Expression expression)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -82,6 +82,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         TResult IAsyncQueryProvider.ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException();
     }
 }

--- a/src/EFCore/Storage/IDbContextTransaction.cs
+++ b/src/EFCore/Storage/IDbContextTransaction.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -58,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="name"> The name of the savepoint to be created. </param>
         void CreateSavepoint([NotNull] string name)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CoreStrings.SavepointsNotSupported);
 
         /// <summary>
         ///     Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint
@@ -70,14 +71,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
         Task CreateSavepointAsync([NotNull] string name, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CoreStrings.SavepointsNotSupported);
 
         /// <summary>
         ///     Rolls back all commands that were executed after the specified savepoint was established.
         /// </summary>
         /// <param name="name"> The name of the savepoint to roll back to. </param>
         void RollbackToSavepoint([NotNull] string name)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CoreStrings.SavepointsNotSupported);
 
         /// <summary>
         ///     Rolls back all commands that were executed after the specified savepoint was established.
@@ -87,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> A <see cref="Task" /> representing the asynchronous operation. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
         Task RollbackToSavepointAsync([NotNull] string name, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => throw new NotSupportedException(CoreStrings.SavepointsNotSupported);
 
         /// <summary>
         ///     <para>

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosTransactionManagerTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosTransactionManagerTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Cosmos.Internal;
+using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    public class CosmosTransactionManagerTest
+    {
+        [ConditionalFact]
+        public virtual async Task CosmosTransactionManager_does_not_support_transactions()
+        {
+            var transactionManager = new CosmosTransactionManager();
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                Assert.Throws<NotSupportedException>(() => transactionManager.BeginTransaction()).Message);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                (await Assert.ThrowsAsync<NotSupportedException>(async () => await transactionManager.BeginTransactionAsync())).Message);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                Assert.Throws<NotSupportedException>(() => transactionManager.CommitTransaction()).Message);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                (await Assert.ThrowsAsync<NotSupportedException>(async () => await transactionManager.CommitTransactionAsync())).Message);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                Assert.Throws<NotSupportedException>(() => transactionManager.RollbackTransaction()).Message);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                (await Assert.ThrowsAsync<NotSupportedException>(async () => await transactionManager.RollbackTransactionAsync())).Message);
+
+            Assert.Null(transactionManager.CurrentTransaction);
+            Assert.Null(transactionManager.EnlistedTransaction);
+
+            Assert.Equal(
+                CosmosStrings.TransactionsNotSupported,
+                Assert.Throws<NotSupportedException>(() => transactionManager.EnlistTransaction(null)).Message);
+
+            transactionManager.ResetState();
+            await transactionManager.ResetStateAsync();
+
+            Assert.Null(transactionManager.CurrentTransaction);
+            Assert.Null(transactionManager.EnlistedTransaction);
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -172,11 +172,9 @@ namespace Microsoft.EntityFrameworkCore
 
         private class FakeRelationalConnection : IRelationalConnection
         {
-            public string ConnectionString
-                => throw new NotImplementedException();
+            public string ConnectionString { get; set; }
 
-            public DbConnection DbConnection
-                => new FakeDbConnection();
+            public DbConnection DbConnection { get; set; } = new FakeDbConnection();
 
             public DbContext Context
                 => null;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -1,9 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -202,6 +205,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 return result;
             }
+
+            public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
+                => throw new NotImplementedException();
 
             private int? PreExecution(IRelationalConnection connection)
             {

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -265,9 +267,7 @@ namespace Microsoft.EntityFrameworkCore
                 => throw new NotImplementedException();
 
             public int ExecuteNonQuery(RelationalCommandParameterObject parameterObject)
-            {
-                return 0;
-            }
+                => 0;
 
             public Task<int> ExecuteNonQueryAsync(
                 RelationalCommandParameterObject parameterObject,
@@ -275,28 +275,23 @@ namespace Microsoft.EntityFrameworkCore
                 => Task.FromResult(0);
 
             public RelationalDataReader ExecuteReader(RelationalCommandParameterObject parameterObject)
-            {
-                throw new NotImplementedException();
-            }
+                => throw new NotImplementedException();
 
             public Task<RelationalDataReader> ExecuteReaderAsync(
                 RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
-            {
-                throw new NotImplementedException();
-            }
+                => throw new NotImplementedException();
+
+            public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
+                => throw new NotImplementedException();
 
             public object ExecuteScalar(RelationalCommandParameterObject parameterObject)
-            {
-                throw new NotImplementedException();
-            }
+                => throw new NotImplementedException();
 
             public Task<object> ExecuteScalarAsync(
                 RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
-            {
-                throw new NotImplementedException();
-            }
+                => throw new NotImplementedException();
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
@@ -277,6 +279,9 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     throw new NotImplementedException();
                 }
+
+                public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
+                    => throw new NotImplementedException();
             }
         }
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -376,8 +376,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public SemaphoreSlim Semaphore { get; }
 
-            public string ConnectionString { get; }
-            public DbConnection DbConnection { get; }
+            public string ConnectionString { get; set; }
+            public DbConnection DbConnection { get; set; }
 
             public DbContext Context
                 => null;


### PR DESCRIPTION
Fixes #20961

> You might choose to throw a NotImplementedException exception in properties or methods in your own types when the that member is still in development and will only later be implemented in production code. In other words, a NotImplementedException exception should be synonymous with "still in development."

I left one NotImplementedException in Migration.cs, because it really is there for when the application hasn't implemented Down yet, but tries to do a Down.


