### PR TITLE
Reenable/remove flaky tests

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -320,7 +320,7 @@ namespace Microsoft.EntityFrameworkCore
             AssertStoreInitialState();
         }
 
-        [ConditionalTheory(Skip = "Issue #17017")]
+        [ConditionalTheory]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -98,41 +98,6 @@ INNER JOIN (
 ORDER BY [t0].[CustomerID]");
         }
 
-        [ConditionalFact(Skip = "Issue #16006")]
-        public virtual void Cache_key_contexts_are_detached()
-        {
-            var weakRef = Scoper(
-                () =>
-                {
-                    var context = new NorthwindRelationalContext(Fixture.CreateOptions());
-
-                    var wr = new WeakReference(context);
-
-                    using (context)
-                    {
-                        var orderDetails = context.OrderDetails;
-
-                        Customer Query(NorthwindContext param)
-                            => (from c in context.Customers
-                                from o in context.Set<Order>()
-                                from od in orderDetails
-                                from e1 in param.Employees
-                                from e2 in param.Set<Order>()
-                                select c).First();
-
-                        Assert.NotNull(Query(context));
-
-                        Assert.True(wr.IsAlive);
-
-                        return wr;
-                    }
-                });
-
-            GC.Collect();
-
-            Assert.False(weakRef.IsAlive);
-        }
-
         private static T Scoper<T>(Func<T> getter)
         {
             return getter();


### PR DESCRIPTION
Fixes #17017 - Ran the test over _one million ~~dollars~~ times_ and it did not fail
Fixes #23505 - Removing based on Smit's analysis and Andriy's agreement


