### PR TITLE
Microsoft.Data.Sqlite: Enable nullable reference types

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Extensions/SqliteConnectionExtensions.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Extensions/SqliteConnectionExtensions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Data.Sqlite
             this SqliteConnection connection,
             string commandText,
             params SqliteParameter[] parameters)
-            => (T)connection.ExecuteScalar(commandText, parameters);
+            => (T)connection.ExecuteScalar(commandText, parameters)!;
 
-        private static object ExecuteScalar(
+        private static object? ExecuteScalar(
             this SqliteConnection connection,
             string commandText,
             params SqliteParameter[] parameters)

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -15,12 +15,13 @@ Microsoft.Data.Sqlite.SqliteException
 Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <MinClientVersion>3.6</MinClientVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.Data.Sqlite.Core.ruleset</CodeAnalysisRuleSet>
     <PackageTags>SQLite;Data;ADO.NET</PackageTags>
     <PackageProjectUrl>https://docs.microsoft.com/dotnet/standard/data/sqlite/</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
@@ -3,6 +3,8 @@
 using System.Reflection;
 using System.Resources;
 
+#nullable enable
+
 namespace Microsoft.Data.Sqlite.Properties
 {
     internal static class Resources
@@ -16,14 +18,6 @@ namespace Microsoft.Data.Sqlite.Properties
         public static string CallRequiresOpenConnection(object methodName)
             => string.Format(
                 GetString("CallRequiresOpenConnection", nameof(methodName)),
-                methodName);
-
-        /// <summary>
-        /// CommandText must be set before {methodName} can be called.
-        /// </summary>
-        public static string CallRequiresSetCommandText(object methodName)
-            => string.Format(
-                GetString("CallRequiresSetCommandText", nameof(methodName)),
                 methodName);
 
         /// <summary>
@@ -85,12 +79,6 @@ namespace Microsoft.Data.Sqlite.Properties
         /// </summary>
         public static string NoData
             => GetString("NoData");
-
-        /// <summary>
-        /// ConnectionString must be set before Open can be called.
-        /// </summary>
-        public static string OpenRequiresSetConnectionString
-            => GetString("OpenRequiresSetConnectionString");
 
         /// <summary>
         /// SqliteConnection does not support nested transactions.
@@ -254,7 +242,7 @@ namespace Microsoft.Data.Sqlite.Properties
 
         private static string GetString(string name, params string[] formatterNames)
         {
-            var value = _resourceManager.GetString(name);
+            var value = _resourceManager.GetString(name)!;
             for (var i = 0; i < formatterNames.Length; i++)
             {
                 value = value.Replace("{" + formatterNames[i] + "}", "{" + i + "}");

--- a/src/Microsoft.Data.Sqlite.Core/Properties/Resources.resx
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Resources.resx
@@ -120,9 +120,6 @@
   <data name="CallRequiresOpenConnection" xml:space="preserve">
     <value>{methodName} can only be called when the connection is open.</value>
   </data>
-  <data name="CallRequiresSetCommandText" xml:space="preserve">
-    <value>CommandText must be set before {methodName} can be called.</value>
-  </data>
   <data name="ConnectionStringRequiresClosedConnection" xml:space="preserve">
     <value>ConnectionString cannot be set when the connection is open.</value>
   </data>
@@ -146,9 +143,6 @@
   </data>
   <data name="NoData" xml:space="preserve">
     <value>No data exists for the row/column.</value>
-  </data>
-  <data name="OpenRequiresSetConnectionString" xml:space="preserve">
-    <value>ConnectionString must be set before Open can be called.</value>
   </data>
   <data name="ParallelTransactionsNotSupported" xml:space="preserve">
     <value>SqliteConnection does not support nested transactions.</value>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Sqlite
     /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/blob-io">BLOB I/O</seealso>
     public class SqliteBlob : Stream
     {
-        private sqlite3_blob _blob;
+        private sqlite3_blob? _blob;
         private readonly sqlite3 _db;
         private long _position;
 
@@ -62,17 +62,17 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Resources.SqlBlobRequiresOpenConnection);
             }
 
-            if (string.IsNullOrEmpty(tableName))
+            if (tableName is null)
             {
                 throw new ArgumentNullException(nameof(tableName));
             }
 
-            if (string.IsNullOrEmpty(columnName))
+            if (columnName is null)
             {
                 throw new ArgumentNullException(nameof(columnName));
             }
 
-            _db = connection.Handle;
+            _db = connection.Handle!;
             CanWrite = !readOnly;
             var rc = sqlite3_blob_open(
                 _db,

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateAggregate.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateAggregate.cs
@@ -4,6 +4,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.Data.Sqlite
 {
     partial class SqliteConnection
@@ -17,8 +19,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate>(string name, Func<TAccumulate, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 0, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a)), a => a, isDeterministic);
+        public virtual void CreateAggregate<TAccumulate>(string name, Func<TAccumulate?, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 0, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -30,334 +32,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, TAccumulate>(string name, Func<TAccumulate, T1, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 1, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, TAccumulate>(string name, Func<TAccumulate, T1, T2, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 2, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 3, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 4, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 5, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 6, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 7, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 8, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 9, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 10, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 11, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
-        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 12, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
-        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
-        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 13, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
-        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
-        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
-        /// <typeparam name="T14">The type of the fourteenth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 14, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
-        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
-        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
-        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
-        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
-        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
-        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
-        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
-        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
-        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
-        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
-        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
-        /// <typeparam name="T14">The type of the fourteenth parameter of the function.</typeparam>
-        /// <typeparam name="T15">The type of the fifteenth parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>(string name, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 15, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate>(string name, Func<TAccumulate, object[], TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, -1, default, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, GetValues(r))), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 0, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a)), a => a, isDeterministic);
-
-        /// <summary>
-        ///     Creates or redefines an aggregate SQL function.
-        /// </summary>
-        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
-        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
-        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
-        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
-        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, TAccumulate>(string name, Func<TAccumulate?, T1, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 1, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -366,13 +42,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 2, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, TAccumulate>(string name, Func<TAccumulate?, T1, T2, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 2, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -382,13 +57,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 3, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 3, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -399,13 +73,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 4, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 4, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -417,13 +90,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 5, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 5, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -436,13 +108,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 6, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 6, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -456,13 +127,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 7, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 7, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -477,13 +147,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 8, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 8, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -499,13 +168,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 9, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 9, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -522,13 +190,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 10, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 10, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -546,13 +213,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 11, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 11, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -571,13 +237,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 12, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 12, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -597,13 +262,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 13, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 13, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -624,13 +288,12 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T14">The type of the fourteenth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 14, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 14, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!)), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -652,13 +315,24 @@ namespace Microsoft.Data.Sqlite
         /// <typeparam name="T15">The type of the fifteenth parameter of the function.</typeparam>
         /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
         /// <param name="name">The name of the SQL function.</param>
-        /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, 15, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14))), a => a, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>(string name, Func<TAccumulate?, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 15, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<TAccumulate>(string name, Func<TAccumulate?, object?[], TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, -1, default!, IfNotNull<TAccumulate?, TAccumulate>(func, (a, r) => func!(a, GetValues(r))), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -670,8 +344,336 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, object[], TAccumulate> func, bool isDeterministic = false)
-            => CreateAggregateCore(name, -1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, GetValues(r))), a => a, isDeterministic);
+        public virtual void CreateAggregate<TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 0, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 2, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 3, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 4, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 5, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 6, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 7, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 8, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 9, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 10, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 11, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 12, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 13, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 14, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter of the function.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter of the function.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter of the function.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter of the function.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter of the function.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter of the function.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter of the function.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter of the function.</typeparam>
+        /// <typeparam name="T9">The type of the ninth parameter of the function.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter of the function.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter of the function.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter of the function.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter of the function.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter of the function.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter of the function.</typeparam>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, 15, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!)), a => a, isDeterministic);
+
+        /// <summary>
+        ///     Creates or redefines an aggregate SQL function.
+        /// </summary>
+        /// <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+        /// <param name="name">The name of the SQL function.</param>
+        /// <param name="seed">The initial accumulator value.</param>
+        /// <param name="func">An accumulator function to be invoked on each element. Pass null to delete a function.</param>
+        /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
+        /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
+        public virtual void CreateAggregate<TAccumulate>(string name, TAccumulate seed, Func<TAccumulate, object?[], TAccumulate>? func, bool isDeterministic = false)
+            => CreateAggregateCore(name, -1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, GetValues(r))), a => a, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -688,8 +690,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 0, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a)), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 0, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -707,8 +709,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -727,8 +729,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 2, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 2, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -748,8 +750,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 3, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 3, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -770,8 +772,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 4, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 4, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -793,8 +795,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 5, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 5, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -817,8 +819,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 6, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 6, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -842,8 +844,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 7, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 7, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -868,8 +870,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 8, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 8, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -895,8 +897,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 9, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 9, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -923,8 +925,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 10, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 10, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -952,8 +954,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 11, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 11, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -982,8 +984,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 12, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 12, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -1013,8 +1015,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 13, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 13, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -1045,8 +1047,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 14, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 14, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -1078,8 +1080,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, 15, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, 15, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!)), resultSelector, isDeterministic);
 
         /// <summary>
         ///     Creates or redefines an aggregate SQL function.
@@ -1096,7 +1098,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, object[], TAccumulate> func, Func<TAccumulate, TResult> resultSelector, bool isDeterministic = false)
-            => CreateAggregateCore(name, -1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, GetValues(r))), resultSelector, isDeterministic);
+        public virtual void CreateAggregate<TAccumulate, TResult>(string name, TAccumulate seed, Func<TAccumulate, object?[], TAccumulate>? func, Func<TAccumulate, TResult>? resultSelector, bool isDeterministic = false)
+            => CreateAggregateCore(name, -1, seed, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func!(a, GetValues(r))), resultSelector, isDeterministic);
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateAggregate.tt
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateAggregate.tt
@@ -7,6 +7,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.Data.Sqlite
 {
     partial class SqliteConnection
@@ -22,7 +24,7 @@ namespace Microsoft.Data.Sqlite
             : "";
 
         var resultSelectorParameter = resultSelector
-            ? ", Func<TAccumulate, TResult> resultSelector"
+            ? ", Func<TAccumulate, TResult>? resultSelector"
             : "";
 
         var resultSelectorArgument = resultSelector
@@ -42,7 +44,7 @@ namespace Microsoft.Data.Sqlite
 
             var seedArgument = seed
                 ? "seed"
-                : "default";
+                : "default!";
 
             for (var arity = 0; arity <= 15; arity++)
             {
@@ -60,7 +62,7 @@ namespace Microsoft.Data.Sqlite
                 var typeArguments = String.Join(", ", typeArgumentsList);
 
                 var lambdaTypeArgumentList = new List<string>();
-                lambdaTypeArgumentList.Add("TAccumulate");
+                lambdaTypeArgumentList.Add("TAccumulate" + (seed ? "" : "?"));
                 lambdaTypeArgumentList.AddRange(parameterTypeArgumentList);
                 lambdaTypeArgumentList.Add("TAccumulate");
 
@@ -72,7 +74,7 @@ namespace Microsoft.Data.Sqlite
 
                 for (var i = 0; i < parameterTypeArgumentList.Count; i++)
                 {
-                    lambdaArgumentsList.Add("r.GetFieldValue<" + parameterTypeArgumentList[i] + ">(" + i + ")");
+                    lambdaArgumentsList.Add("r.GetFieldValue<" + parameterTypeArgumentList[i] + ">(" + i + ")!");
                 }
 
                 var lambdaArguments = string.Join(", ", lambdaArgumentsList);
@@ -110,8 +112,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<<#= typeArguments #>>(string name<#= seedParameter #>, Func<<#= lambdaTypeArguments #>> func<#= resultSelectorParameter #>, bool isDeterministic = false)
-            => CreateAggregateCore(name, <#= arity #>, <#= seedArgument #>, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(<#= lambdaArguments #>)), <#= resultSelectorArgument #>, isDeterministic);
+        public virtual void CreateAggregate<<#= typeArguments #>>(string name<#= seedParameter #>, Func<<#= lambdaTypeArguments #>>? func<#= resultSelectorParameter #>, bool isDeterministic = false)
+            => CreateAggregateCore(name, <#= arity #>, <#= seedArgument #>, IfNotNull<TAccumulate<#= seed ? "" : "?" #>, TAccumulate>(func, (a, r) => func!(<#= lambdaArguments #>)), <#= resultSelectorArgument #>, isDeterministic);
 <#
             }
 #>
@@ -137,8 +139,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the aggregate is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateAggregate<TAccumulate<#= resultTypeArgument #>>(string name<#= seedParameter #>, Func<TAccumulate, object[], TAccumulate> func<#= resultSelectorParameter #>, bool isDeterministic = false)
-            => CreateAggregateCore(name, -1, <#= seedArgument #>, IfNotNull<TAccumulate, TAccumulate>(func, (a, r) => func(a, GetValues(r))), <#= resultSelectorArgument #>, isDeterministic);
+        public virtual void CreateAggregate<TAccumulate<#= resultTypeArgument #>>(string name<#= seedParameter #>, Func<TAccumulate<#= seed ? "" : "?" #>, object?[], TAccumulate>? func<#= resultSelectorParameter #>, bool isDeterministic = false)
+            => CreateAggregateCore(name, -1, <#= seedArgument #>, IfNotNull<TAccumulate<#= seed ? "" : "?" #>, TAccumulate>(func, (a, r) => func!(a, GetValues(r))), <#= resultSelectorArgument #>, isDeterministic);
 <#
         }
     }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateFunction.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateFunction.cs
@@ -4,6 +4,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.Data.Sqlite
 {
     partial class SqliteConnection
@@ -17,8 +19,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TResult>(string name, Func<TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 0, null, IfNotNull<object, TResult>(function, (s, r) => function()), isDeterministic);
+        public virtual void CreateFunction<TResult>(string name, Func<TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 0, null, IfNotNull<object?, TResult>(function, (s, r) => function!()), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -30,8 +32,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, TResult>(string name, Func<T1, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 1, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0))), isDeterministic);
+        public virtual void CreateFunction<T1, TResult>(string name, Func<T1, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 1, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -44,8 +46,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, TResult>(string name, Func<T1, T2, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 2, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, TResult>(string name, Func<T1, T2, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 2, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -59,8 +61,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, TResult>(string name, Func<T1, T2, T3, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 3, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, TResult>(string name, Func<T1, T2, T3, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 3, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -75,8 +77,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, TResult>(string name, Func<T1, T2, T3, T4, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 4, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, TResult>(string name, Func<T1, T2, T3, T4, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 4, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -92,8 +94,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, TResult>(string name, Func<T1, T2, T3, T4, T5, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 5, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, TResult>(string name, Func<T1, T2, T3, T4, T5, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 5, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -110,8 +112,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 6, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 6, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -129,8 +131,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 7, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 7, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -149,8 +151,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 8, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 8, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -170,8 +172,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 9, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 9, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -192,8 +194,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 10, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 10, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -215,8 +217,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 11, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 11, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -239,8 +241,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 12, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 12, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -264,8 +266,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 13, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 13, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -290,8 +292,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 14, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 14, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -317,8 +319,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 15, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 15, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -345,8 +347,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 16, null, IfNotNull<object, TResult>(function, (s, r) => function(r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14), r.GetFieldValue<T16>(15))), isDeterministic);
+        public virtual void CreateFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(string name, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 16, null, IfNotNull<object?, TResult>(function, (s, r) => function!(r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!, r.GetFieldValue<T16>(15)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -357,8 +359,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TResult>(string name, Func<object[], TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, -1, null, IfNotNull<object, TResult>(function, (s, r) => function(GetValues(r))), isDeterministic);
+        public virtual void CreateFunction<TResult>(string name, Func<object?[], TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, -1, null, IfNotNull<object?, TResult>(function, (s, r) => function!(GetValues(r))), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -371,8 +373,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, TResult>(string name, TState state, Func<TState, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 0, state, IfNotNull<TState, TResult>(function, (s, r) => function(s)), isDeterministic);
+        public virtual void CreateFunction<TState, TResult>(string name, TState state, Func<TState, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 0, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -386,8 +388,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, TResult>(string name, TState state, Func<TState, T1, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 1, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, TResult>(string name, TState state, Func<TState, T1, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 1, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -402,8 +404,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, TResult>(string name, TState state, Func<TState, T1, T2, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 2, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, TResult>(string name, TState state, Func<TState, T1, T2, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 2, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -419,8 +421,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, TResult>(string name, TState state, Func<TState, T1, T2, T3, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 3, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, TResult>(string name, TState state, Func<TState, T1, T2, T3, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 3, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -437,8 +439,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 4, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 4, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -456,8 +458,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 5, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 5, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -476,8 +478,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 6, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 6, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -497,8 +499,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 7, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 7, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -519,8 +521,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 8, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 8, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -542,8 +544,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 9, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 9, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -566,8 +568,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 10, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 10, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -591,8 +593,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 11, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 11, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -617,8 +619,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 12, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 12, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -644,8 +646,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 13, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 13, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -672,8 +674,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 14, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 14, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -701,8 +703,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, 15, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, r.GetFieldValue<T1>(0), r.GetFieldValue<T2>(1), r.GetFieldValue<T3>(2), r.GetFieldValue<T4>(3), r.GetFieldValue<T5>(4), r.GetFieldValue<T6>(5), r.GetFieldValue<T7>(6), r.GetFieldValue<T8>(7), r.GetFieldValue<T9>(8), r.GetFieldValue<T10>(9), r.GetFieldValue<T11>(10), r.GetFieldValue<T12>(11), r.GetFieldValue<T13>(12), r.GetFieldValue<T14>(13), r.GetFieldValue<T15>(14))), isDeterministic);
+        public virtual void CreateFunction<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(string name, TState state, Func<TState, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, 15, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, r.GetFieldValue<T1>(0)!, r.GetFieldValue<T2>(1)!, r.GetFieldValue<T3>(2)!, r.GetFieldValue<T4>(3)!, r.GetFieldValue<T5>(4)!, r.GetFieldValue<T6>(5)!, r.GetFieldValue<T7>(6)!, r.GetFieldValue<T8>(7)!, r.GetFieldValue<T9>(8)!, r.GetFieldValue<T10>(9)!, r.GetFieldValue<T11>(10)!, r.GetFieldValue<T12>(11)!, r.GetFieldValue<T13>(12)!, r.GetFieldValue<T14>(13)!, r.GetFieldValue<T15>(14)!)), isDeterministic);
 
         /// <summary>
         ///     Creates or redefines a SQL function.
@@ -715,7 +717,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<TState, TResult>(string name, TState state, Func<TState, object[], TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, -1, state, IfNotNull<TState, TResult>(function, (s, r) => function(s, GetValues(r))), isDeterministic);
+        public virtual void CreateFunction<TState, TResult>(string name, TState state, Func<TState, object?[], TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, -1, state, IfNotNull<TState, TResult>(function, (s, r) => function!(s, GetValues(r))), isDeterministic);
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateFunction.tt
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.CreateFunction.tt
@@ -7,6 +7,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.Data.Sqlite
 {
     partial class SqliteConnection
@@ -35,7 +37,7 @@ namespace Microsoft.Data.Sqlite
 
         var stateParameterType = state
             ? "TState"
-            : "object";
+            : "object?";
 
         var lambdaStateArgument = state
             ? "s, "
@@ -66,7 +68,7 @@ namespace Microsoft.Data.Sqlite
 
             for (var i = 0; i < parameterTypeArgumentList.Count; i++)
             {
-                lambdaArgumentsList.Add("r.GetFieldValue<" + parameterTypeArgumentList[i] + ">(" + i + ")");
+                lambdaArgumentsList.Add("r.GetFieldValue<" + parameterTypeArgumentList[i] + ">(" + i + ")!");
             }
 
             var lambdaArguments = string.Join(", ", lambdaArgumentsList);
@@ -98,8 +100,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<<#= typeArguments #>>(string name, <#= stateParameter #>Func<<#= typeArguments #>> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, <#= arity #>, <#= stateArgument #>, IfNotNull<<#= stateParameterType #>, TResult>(function, (s, r) => function(<#= lambdaArguments #>)), isDeterministic);
+        public virtual void CreateFunction<<#= typeArguments #>>(string name, <#= stateParameter #>Func<<#= typeArguments #>>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, <#= arity #>, <#= stateArgument #>, IfNotNull<<#= stateParameterType #>, TResult>(function, (s, r) => function!(<#= lambdaArguments #>)), isDeterministic);
 <#
         }
 
@@ -120,8 +122,8 @@ namespace Microsoft.Data.Sqlite
         /// <param name="isDeterministic">Flag indicating whether the function is deterministic.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/user-defined-functions">User-Defined Functions</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual void CreateFunction<<#= stateTypeArgument #>TResult>(string name, <#= stateParameter #>Func<<#= stateTypeArgument #>object[], TResult> function, bool isDeterministic = false)
-            => CreateFunctionCore(name, -1, <#= stateArgument #>, IfNotNull<<#= stateParameterType #>, TResult>(function, (s, r) => function(<#= lambdaStateArgument #>GetValues(r))), isDeterministic);
+        public virtual void CreateFunction<<#= stateTypeArgument #>TResult>(string name, <#= stateParameter #>Func<<#= stateTypeArgument #>object?[], TResult>? function, bool isDeterministic = false)
+            => CreateFunctionCore(name, -1, <#= stateArgument #>, IfNotNull<<#= stateParameterType #>, TResult>(function, (s, r) => function!(<#= lambdaStateArgument #>GetValues(r))), isDeterministic);
 <#
     }
 #>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Data.Sqlite.Properties;
 using Microsoft.Data.Sqlite.Utilities;
@@ -27,19 +28,21 @@ namespace Microsoft.Data.Sqlite
 
         private readonly List<WeakReference<SqliteCommand>> _commands = new List<WeakReference<SqliteCommand>>();
 
-        private Dictionary<string, (object state, strdelegate_collation collation)> _collations;
+        private Dictionary<string, (object? state, strdelegate_collation? collation)>? _collations;
 
-        private Dictionary<(string name, int arity), (int flags, object state, delegate_function_scalar func)> _functions;
+        private Dictionary<(string name, int arity), (int flags, object? state, delegate_function_scalar? func)>? _functions;
 
-        private Dictionary<(string name, int arity), (int flags, object state, delegate_function_aggregate_step func_step,
-            delegate_function_aggregate_final func_final)> _aggregates;
+        private Dictionary<(string name, int arity), (int flags, object? state, delegate_function_aggregate_step? func_step,
+            delegate_function_aggregate_final? func_final)>? _aggregates;
 
-        private HashSet<(string file, string proc)> _extensions;
+        private HashSet<(string file, string? proc)>? _extensions;
 
         private string _connectionString = string.Empty;
+        private SqliteConnectionStringBuilder? _connectionOptions;
         private ConnectionState _state;
-        private sqlite3 _db;
+        private sqlite3? _db;
         private bool _extensionsEnabled;
+        private int? _defaultTimeout;
 
         static SqliteConnection()
             => BundleInitializer.Initialize();
@@ -57,7 +60,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="connectionString">The string used to open the connection.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/connection-strings">Connection Strings</seealso>
         /// <seealso cref="SqliteConnectionStringBuilder" />
-        public SqliteConnection(string connectionString)
+        public SqliteConnection(string? connectionString)
             => ConnectionString = connectionString;
 
         /// <summary>
@@ -65,7 +68,7 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <value>A handle to underlying database connection.</value>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/interop">Interoperability</seealso>
-        public virtual sqlite3 Handle
+        public virtual sqlite3? Handle
             => _db;
 
         /// <summary>
@@ -74,6 +77,7 @@ namespace Microsoft.Data.Sqlite
         /// <value>A string used to open the connection.</value>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/connection-strings">Connection Strings</seealso>
         /// <seealso cref="SqliteConnectionStringBuilder" />
+        [AllowNull]
         public override string ConnectionString
         {
             get => _connectionString;
@@ -85,11 +89,12 @@ namespace Microsoft.Data.Sqlite
                 }
 
                 _connectionString = value ?? string.Empty;
-                ConnectionOptions = new SqliteConnectionStringBuilder(value);
+                _connectionOptions = null;
             }
         }
 
-        internal SqliteConnectionStringBuilder ConnectionOptions { get; set; }
+        internal SqliteConnectionStringBuilder ConnectionOptions
+            => _connectionOptions ??= new SqliteConnectionStringBuilder(ConnectionString);
 
         /// <summary>
         ///     Gets the name of the current database. Always 'main'.
@@ -106,7 +111,7 @@ namespace Microsoft.Data.Sqlite
         {
             get
             {
-                string dataSource = null;
+                string? dataSource = null;
                 if (State == ConnectionState.Open)
                 {
                     dataSource = sqlite3_db_filename(_db, MainDatabaseName).utf8_to_string();
@@ -123,7 +128,11 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <value>The default <see cref="SqliteCommand.CommandTimeout" /> value.</value>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/database-errors">Database Errors</seealso>
-        public virtual int DefaultTimeout { get; set; } = 30;
+        public virtual int DefaultTimeout
+        {
+            get => _defaultTimeout ?? 30;
+            set => _defaultTimeout = value;
+        }
 
         /// <summary>
         ///     Gets the version of SQLite used by the connection.
@@ -150,7 +159,7 @@ namespace Microsoft.Data.Sqlite
         ///     Gets or sets the transaction currently being used by the connection, or null if none.
         /// </summary>
         /// <value>The transaction currently being used by the connection.</value>
-        protected internal virtual SqliteTransaction Transaction { get; set; }
+        protected internal virtual SqliteTransaction? Transaction { get; set; }
 
         /// <summary>
         ///     Opens a connection to the database using the value of <see cref="ConnectionString" />. If
@@ -162,11 +171,6 @@ namespace Microsoft.Data.Sqlite
             if (State == ConnectionState.Open)
             {
                 return;
-            }
-
-            if (string.IsNullOrEmpty(ConnectionString))
-            {
-                throw new InvalidOperationException(Resources.OpenRequiresSetConnectionString);
             }
 
             var filename = ConnectionOptions.DataSource;
@@ -243,7 +247,7 @@ namespace Microsoft.Data.Sqlite
             _state = ConnectionState.Open;
             try
             {
-                if (!string.IsNullOrEmpty(ConnectionOptions.Password))
+                if (ConnectionOptions.Password.Length != 0)
                 {
                     if (SQLitePCLExtensions.EncryptionSupported(out var libraryName) == false)
                     {
@@ -364,7 +368,7 @@ namespace Microsoft.Data.Sqlite
 
             Debug.Assert(_commands.Count == 0);
 
-            _db.Dispose();
+            _db!.Dispose();
             _db = null;
 
             _state = ConnectionState.Closed;
@@ -432,9 +436,9 @@ namespace Microsoft.Data.Sqlite
         /// <param name="name">Name of the collation.</param>
         /// <param name="comparison">Method that compares two strings.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/collation">Collation</seealso>
-        public virtual void CreateCollation(string name, Comparison<string> comparison)
+        public virtual void CreateCollation(string name, Comparison<string>? comparison)
             => CreateCollation(
-                name, null, comparison != null ? (_, s1, s2) => comparison(s1, s2) : (Func<object, string, string, int>)null);
+                name, null, comparison != null ? (_, s1, s2) => comparison(s1, s2) : (Func<object?, string, string, int>?)null);
 
         /// <summary>
         ///     Create custom collation.
@@ -444,14 +448,14 @@ namespace Microsoft.Data.Sqlite
         /// <param name="state">State object passed to each invocation of the collation.</param>
         /// <param name="comparison">Method that compares two strings, using additional state.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/collation">Collation</seealso>
-        public virtual void CreateCollation<T>(string name, T state, Func<T, string, string, int> comparison)
+        public virtual void CreateCollation<T>(string name, T state, Func<T, string, string, int>? comparison)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var collation = comparison != null ? (v, s1, s2) => comparison((T)v, s1, s2) : (strdelegate_collation)null;
+            var collation = comparison != null ? (v, s1, s2) => comparison((T)v, s1, s2) : (strdelegate_collation?)null;
 
             if (State == ConnectionState.Open)
             {
@@ -459,7 +463,7 @@ namespace Microsoft.Data.Sqlite
                 SqliteException.ThrowExceptionForRC(rc, _db);
             }
 
-            _collations ??= new Dictionary<string, (object, strdelegate_collation)>(StringComparer.OrdinalIgnoreCase);
+            _collations ??= new Dictionary<string, (object?, strdelegate_collation?)>(StringComparer.OrdinalIgnoreCase);
             _collations[name] = (state, collation);
         }
 
@@ -575,7 +579,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="file">The shared library containing the extension.</param>
         /// <param name="proc">The entry point. If null, the default entry point is used.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/extensions">Extensions</seealso>
-        public virtual void LoadExtension(string file, string proc = null)
+        public virtual void LoadExtension(string file, string? proc = null)
         {
             if (State == ConnectionState.Open)
             {
@@ -598,11 +602,11 @@ namespace Microsoft.Data.Sqlite
                 }
             }
 
-            _extensions ??= new HashSet<(string, string)>();
+            _extensions ??= new HashSet<(string, string?)>();
             _extensions.Add((file, proc));
         }
 
-        private void LoadExtensionCore(string file, string proc)
+        private void LoadExtensionCore(string file, string? proc)
         {
             if (proc == null)
             {
@@ -680,15 +684,15 @@ namespace Microsoft.Data.Sqlite
             string name,
             int arity,
             TState state,
-            Func<TState, SqliteValueReader, TResult> function,
+            Func<TState, SqliteValueReader, TResult>? function,
             bool isDeterministic)
         {
-            if (string.IsNullOrEmpty(name))
+            if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-            delegate_function_scalar func = null;
+            delegate_function_scalar? func = null;
             if (function != null)
             {
                 func = (ctx, user_data, args) =>
@@ -730,7 +734,7 @@ namespace Microsoft.Data.Sqlite
                 SqliteException.ThrowExceptionForRC(rc, _db);
             }
 
-            _functions ??= new Dictionary<(string, int), (int, object, delegate_function_scalar)>(FunctionsKeyComparer.Instance);
+            _functions ??= new Dictionary<(string, int), (int, object?, delegate_function_scalar?)>(FunctionsKeyComparer.Instance);
             _functions[(name, arity)] = (flags, state, func);
         }
 
@@ -738,16 +742,16 @@ namespace Microsoft.Data.Sqlite
             string name,
             int arity,
             TAccumulate seed,
-            Func<TAccumulate, SqliteValueReader, TAccumulate> func,
-            Func<TAccumulate, TResult> resultSelector,
+            Func<TAccumulate, SqliteValueReader, TAccumulate>? func,
+            Func<TAccumulate, TResult>? resultSelector,
             bool isDeterministic)
         {
-            if (string.IsNullOrEmpty(name))
+            if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-            delegate_function_aggregate_step func_step = null;
+            delegate_function_aggregate_step? func_step = null;
             if (func != null)
             {
                 func_step = (ctx, user_data, args) =>
@@ -774,7 +778,7 @@ namespace Microsoft.Data.Sqlite
                 };
             }
 
-            delegate_function_aggregate_final func_final = null;
+            delegate_function_aggregate_final? func_final = null;
             if (resultSelector != null)
             {
                 func_final = (ctx, user_data) =>
@@ -826,19 +830,19 @@ namespace Microsoft.Data.Sqlite
             }
 
             _aggregates ??=
-                new Dictionary<(string, int), (int, object, delegate_function_aggregate_step, delegate_function_aggregate_final)>(
+                new Dictionary<(string, int), (int, object?, delegate_function_aggregate_step?, delegate_function_aggregate_final?)>(
                     FunctionsKeyComparer.Instance);
             _aggregates[(name, arity)] = (flags, state, func_step, func_final);
         }
 
-        private static Func<TState, SqliteValueReader, TResult> IfNotNull<TState, TResult>(
-            object x,
+        private static Func<TState, SqliteValueReader, TResult>? IfNotNull<TState, TResult>(
+            object? x,
             Func<TState, SqliteValueReader, TResult> value)
             => x != null ? value : null;
 
-        private static object[] GetValues(SqliteValueReader reader)
+        private static object?[] GetValues(SqliteValueReader reader)
         {
-            var values = new object[reader.FieldCount];
+            var values = new object?[reader.FieldCount];
             reader.GetValues(values);
 
             return values;
@@ -850,7 +854,7 @@ namespace Microsoft.Data.Sqlite
                 => Accumulate = seed;
 
             public T Accumulate { get; set; }
-            public Exception Exception { get; set; }
+            public Exception? Exception { get; set; }
         }
 
         private sealed class FunctionsKeyComparer : IEqualityComparer<(string name, int arity)>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Data.Sqlite.Properties;
 
@@ -87,17 +88,18 @@ namespace Microsoft.Data.Sqlite
         /// <param name="connectionString">
         ///     The initial connection string the builder will represent. Can be null.
         /// </param>
-        public SqliteConnectionStringBuilder(string connectionString)
+        public SqliteConnectionStringBuilder(string? connectionString)
             => ConnectionString = connectionString;
 
         /// <summary>
         ///     Gets or sets the database file.
         /// </summary>
         /// <value>The database file.</value>
+        [AllowNull]
         public virtual string DataSource
         {
             get => _dataSource;
-            set => base[DataSourceKeyword] = _dataSource = value;
+            set => base[DataSourceKeyword] = _dataSource = value ?? string.Empty;
         }
 
         /// <summary>
@@ -125,13 +127,13 @@ namespace Microsoft.Data.Sqlite
         {
             get
             {
-                var values = new object[_validKeywords.Count];
+                var values = new object?[_validKeywords.Count];
                 for (var i = 0; i < _validKeywords.Count; i++)
                 {
                     values[i] = GetAt((Keywords)i);
                 }
 
-                return new ReadOnlyCollection<object>(values);
+                return new ReadOnlyCollection<object?>(values);
             }
         }
 
@@ -151,10 +153,11 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <value>The encryption key.</value>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/encryption">Encryption</seealso>
+        [AllowNull]
         public string Password
         {
             get => _password;
-            set => base[PasswordKeyword] = _password = value;
+            set => base[PasswordKeyword] = _password = value ?? string.Empty;
         }
 
         /// <summary>
@@ -187,9 +190,11 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <param name="keyword">The key.</param>
         /// <returns>The value.</returns>
-        public override object this[string keyword]
+        public override object? this[string keyword]
         {
+#pragma warning disable CS8764 // NB: this["Foreign Keys"] may return null
             get => GetAt(GetIndex(keyword));
+#pragma warning restore CS8764
             set
             {
                 if (value == null)
@@ -329,7 +334,9 @@ namespace Microsoft.Data.Sqlite
         /// <param name="keyword">The key.</param>
         /// <param name="value">The value.</param>
         /// <returns><see langword="true" /> if the key was used; otherwise, <see langword="false" />. </returns>
-        public override bool TryGetValue(string keyword, out object value)
+#pragma warning disable CS8765 // NB: TryGetValue("Foreign Keys", out value) returns true, but value may be null
+        public override bool TryGetValue(string keyword, out object? value)
+#pragma warning restore CS8765
         {
             if (!_keywords.TryGetValue(keyword, out var index))
             {
@@ -343,7 +350,7 @@ namespace Microsoft.Data.Sqlite
             return true;
         }
 
-        private object GetAt(Keywords index)
+        private object? GetAt(Keywords index)
         {
             switch (index)
             {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Data.Sqlite
         private readonly SqliteCommand _command;
         private readonly bool _closeConnection;
         private readonly Stopwatch _timer;
-        private IEnumerator<sqlite3_stmt> _stmtEnumerator;
-        private SqliteDataRecord _record;
+        private IEnumerator<sqlite3_stmt>? _stmtEnumerator;
+        private SqliteDataRecord? _record;
         private bool _closed;
         private int _recordsAffected = -1;
 
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <value>A handle to underlying prepared statement.</value>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/interop">Interoperability</seealso>
-        public virtual sqlite3_stmt Handle
+        public virtual sqlite3_stmt? Handle
             => _record?.Handle;
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Sqlite
             sqlite3_stmt stmt;
             int rc;
 
-            while (_stmtEnumerator.MoveNext())
+            while (_stmtEnumerator!.MoveNext())
             {
                 try
                 {
@@ -172,7 +172,7 @@ namespace Microsoft.Data.Sqlite
 
                     _timer.Stop();
 
-                    SqliteException.ThrowExceptionForRC(rc, _command.Connection.Handle);
+                    SqliteException.ThrowExceptionForRC(rc, _command.Connection!.Handle);
 
                     // It's a SELECT statement
                     if (sqlite3_column_count(stmt) != 0)
@@ -249,7 +249,7 @@ namespace Microsoft.Data.Sqlite
                 {
                     while (NextResult())
                     {
-                        _record.Dispose();
+                        _record!.Dispose();
                     }
                 }
                 catch
@@ -263,7 +263,7 @@ namespace Microsoft.Data.Sqlite
 
             if (_closeConnection)
             {
-                _command.Connection.Close();
+                _command.Connection!.Close();
             }
         }
 
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="bufferOffset">The index to which the data will be copied.</param>
         /// <param name="length">The maximum number of bytes to read.</param>
         /// <returns>The actual number of bytes read.</returns>
-        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
             => _closed
                 ? throw new InvalidOperationException(Resources.DataReaderClosed(nameof(GetBytes)))
                 : _record == null
@@ -523,7 +523,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="bufferOffset">The index to which the data will be copied.</param>
         /// <param name="length">The maximum number of characters to read.</param>
         /// <returns>The actual number of characters read.</returns>
-        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
             => _closed
                 ? throw new InvalidOperationException(Resources.DataReaderClosed(nameof(GetChars)))
                 : _record == null
@@ -588,7 +588,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="values">An array into which the values are copied.</param>
         /// <returns>The number of values copied into the array.</returns>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public override int GetValues(object[] values)
+        public override int GetValues(object?[] values)
             => _closed
                 ? throw new InvalidOperationException(Resources.DataReaderClosed(nameof(GetValues)))
                 : _record == null
@@ -669,7 +669,7 @@ namespace Microsoft.Data.Sqlite
                 schemaRow[ColumnSize] = -1;
                 schemaRow[NumericPrecision] = DBNull.Value;
                 schemaRow[NumericScale] = DBNull.Value;
-                schemaRow[BaseServerName] = _command.Connection.DataSource;
+                schemaRow[BaseServerName] = _command.Connection!.DataSource;
                 var databaseName = sqlite3_column_database_name(_record.Handle, i).utf8_to_string();
                 schemaRow[BaseCatalogName] = databaseName;
                 var columnName = sqlite3_column_origin_name(_record.Handle, i).utf8_to_string();
@@ -684,8 +684,8 @@ namespace Microsoft.Data.Sqlite
                 schemaRow[IsExpression] = columnName == null;
                 schemaRow[IsLong] = DBNull.Value;
 
-                if (!string.IsNullOrEmpty(tableName)
-                    && !string.IsNullOrEmpty(columnName))
+                if (tableName != null
+                    && columnName != null)
                 {
                     using (var command = _command.Connection.CreateCommand())
                     {
@@ -697,7 +697,7 @@ namespace Microsoft.Data.Sqlite
                         command.Parameters.AddWithValue("$table", tableName);
                         command.Parameters.AddWithValue("$column", columnName);
 
-                        var cnt = (long)command.ExecuteScalar();
+                        var cnt = (long)command.ExecuteScalar()!;
                         schemaRow[IsUnique] = cnt != 0;
 
                         command.Parameters.Clear();
@@ -710,7 +710,7 @@ namespace Microsoft.Data.Sqlite
                             .AppendLine("ORDER BY count() DESC")
                             .AppendLine("LIMIT 1;").ToString();
 
-                        var type = (string)command.ExecuteScalar();
+                        var type = (string)command.ExecuteScalar()!;
                         schemaRow[DataType] =
                             (type != null)
                                 ? SqliteDataRecord.GetFieldType(type)
@@ -718,7 +718,7 @@ namespace Microsoft.Data.Sqlite
                                     SqliteDataRecord.Sqlite3AffinityType(dataTypeName));
                     }
 
-                    if (!string.IsNullOrEmpty(databaseName))
+                    if (databaseName != null)
                     {
                         var rc = sqlite3_table_column_metadata(
                             _command.Connection.Handle, databaseName, tableName, columnName, out var dataType, out var collSeq,

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Data.Sqlite
     internal class SqliteDataRecord : SqliteValueReader, IDisposable
     {
         private readonly SqliteConnection _connection;
-        private byte[][] _blobCache;
-        private int?[] _typeCache;
+        private byte[][]? _blobCache;
+        private int?[]? _typeCache;
         private bool _stepped;
         private int? _rowidOrdinal;
 
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Sqlite
         public override object GetValue(int ordinal)
             => !_stepped || sqlite3_data_count(Handle) == 0
                 ? throw new InvalidOperationException(Resources.NoData)
-                : base.GetValue(ordinal);
+                : base.GetValue(ordinal)!;
 
         protected override double GetDoubleCore(int ordinal)
             => sqlite3_column_double(Handle, ordinal);
@@ -58,6 +58,12 @@ namespace Microsoft.Data.Sqlite
 
         protected override string GetStringCore(int ordinal)
             => sqlite3_column_text(Handle, ordinal).utf8_to_string();
+
+        public override T GetFieldValue<T>(int ordinal)
+            => base.GetFieldValue<T>(ordinal)!;
+
+        protected override byte[] GetBlob(int ordinal)
+            => base.GetBlob(ordinal)!;
 
         protected override byte[] GetBlobCore(int ordinal)
             => sqlite3_column_blob(Handle, ordinal).ToArray();
@@ -90,7 +96,7 @@ namespace Microsoft.Data.Sqlite
                 throw new ArgumentOutOfRangeException(nameof(ordinal), ordinal, message: null);
             }
 
-            return name;
+            return name!;
         }
 
         public virtual int GetOrdinal(string name)
@@ -195,13 +201,13 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
-        public virtual long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        public virtual long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
         {
             using var stream = GetStream(ordinal);
 
             if (buffer == null)
             {
-                return stream.Length - dataOffset;
+                return stream.Length;
             }
 
             stream.Position = dataOffset;
@@ -209,9 +215,21 @@ namespace Microsoft.Data.Sqlite
             return stream.Read(buffer, bufferOffset, length);
         }
 
-        public virtual long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        public virtual long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
         {
             using var reader = new StreamReader(GetStream(ordinal), Encoding.UTF8);
+
+            if (buffer == null)
+            {
+                // TODO: Consider using a stackalloc buffer and reading blocks instead
+                var charCount = 0;
+                while (reader.Read() != -1)
+                {
+                    charCount++;
+                }
+
+                return charCount;
+            }
 
             for (var position = 0; position < dataOffset; position++)
             {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <param name="message">The message to display for the exception. Can be null.</param>
         /// <param name="errorCode">The SQLite error code.</param>
-        public SqliteException(string message, int errorCode)
+        public SqliteException(string? message, int errorCode)
             : this(message, errorCode, errorCode)
         {
         }
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="message">The message to display for the exception. Can be null.</param>
         /// <param name="errorCode">The SQLite error code.</param>
         /// <param name="extendedErrorCode">The extended SQLite error code.</param>
-        public SqliteException(string message, int errorCode, int extendedErrorCode)
+        public SqliteException(string? message, int errorCode, int extendedErrorCode)
             : base(message)
         {
             SqliteErrorCode = errorCode;
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Sqlite
         /// <remarks>
         ///     No exception is thrown for non-error result codes.
         /// </remarks>
-        public static void ThrowExceptionForRC(int rc, sqlite3 db)
+        public static void ThrowExceptionForRC(int rc, sqlite3? db)
         {
             if (rc == SQLITE_OK
                 || rc == SQLITE_ROW

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Data.Sqlite.Properties;
 using SQLitePCL;
 using static SQLitePCL.raw;
@@ -19,7 +20,7 @@ namespace Microsoft.Data.Sqlite
     public class SqliteParameter : DbParameter
     {
         private string _parameterName = string.Empty;
-        private object _value;
+        private object? _value;
         private int? _size;
         private SqliteType? _sqliteType;
         private string _sourceColumn = string.Empty;
@@ -39,7 +40,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="value">The value of the parameter. Can be null.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public SqliteParameter(string name, object value)
+        public SqliteParameter(string? name, object? value)
         {
             ParameterName = name;
             Value = value;
@@ -51,7 +52,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="name">The name of the parameter.</param>
         /// <param name="type">The type of the parameter.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public SqliteParameter(string name, SqliteType type)
+        public SqliteParameter(string? name, SqliteType type)
         {
             ParameterName = name;
             SqliteType = type;
@@ -64,7 +65,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="type">The type of the parameter.</param>
         /// <param name="size">The maximum size, in bytes, of the parameter.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public SqliteParameter(string name, SqliteType type, int size)
+        public SqliteParameter(string? name, SqliteType type, int size)
             : this(name, type)
             => Size = size;
 
@@ -76,7 +77,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="size">The maximum size, in bytes, of the parameter.</param>
         /// <param name="sourceColumn">The source column used for loading the value. Can be null.</param>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public SqliteParameter(string name, SqliteType type, int size, string sourceColumn)
+        public SqliteParameter(string? name, SqliteType type, int size, string? sourceColumn)
             : this(name, type, size)
             => SourceColumn = sourceColumn;
 
@@ -124,6 +125,7 @@ namespace Microsoft.Data.Sqlite
         ///     Gets or sets the name of the parameter.
         /// </summary>
         /// <value>The name of the parameter.</value>
+        [AllowNull]
         public override string ParameterName
         {
             get => _parameterName;
@@ -161,6 +163,7 @@ namespace Microsoft.Data.Sqlite
         ///     Gets or sets the source column used for loading the value.
         /// </summary>
         /// <value>The source column used for loading the value.</value>
+        [AllowNull]
         public override string SourceColumn
         {
             get => _sourceColumn;
@@ -179,7 +182,7 @@ namespace Microsoft.Data.Sqlite
         /// <value>The value of the parameter.</value>
         /// <remarks>Due to SQLite's dynamic type system, parameter values are not converted.</remarks>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public override object Value
+        public override object? Value
         {
             get => _value;
             set { _value = value; }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Sqlite
             var blob = value;
             if (ShouldTruncate(value.Length))
             {
-                blob = new byte[_size.Value];
+                blob = new byte[_size!.Value];
                 Array.Copy(value, blob, _size.Value);
             }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Sqlite
                 _stmt,
                 _index,
                 ShouldTruncate(value.Length)
-                    ? value.Substring(0, _size.Value)
+                    ? value.Substring(0, _size!.Value)
                     : value);
 
         private bool ShouldTruncate(int length)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="type">The SQLite type of the parameter.</param>
         /// <returns>The parameter that was added.</returns>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public virtual SqliteParameter Add(string parameterName, SqliteType type)
+        public virtual SqliteParameter Add(string? parameterName, SqliteType type)
             => Add(new SqliteParameter(parameterName, type));
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="size">The maximum size, in bytes, of the parameter.</param>
         /// <returns>The parameter that was added.</returns>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public virtual SqliteParameter Add(string parameterName, SqliteType type, int size)
+        public virtual SqliteParameter Add(string? parameterName, SqliteType type, int size)
             => Add(new SqliteParameter(parameterName, type, size));
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Microsoft.Data.Sqlite
         /// </param>
         /// <returns>The parameter that was added.</returns>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
-        public virtual SqliteParameter Add(string parameterName, SqliteType type, int size, string sourceColumn)
+        public virtual SqliteParameter Add(string? parameterName, SqliteType type, int size, string? sourceColumn)
             => Add(new SqliteParameter(parameterName, type, size, sourceColumn));
 
         /// <summary>
@@ -157,13 +157,8 @@ namespace Microsoft.Data.Sqlite
         /// <returns>The parameter that was added.</returns>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/parameters">Parameters</seealso>
         /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/types">Data Types</seealso>
-        public virtual SqliteParameter AddWithValue(string parameterName, object value)
-        {
-            var parameter = new SqliteParameter(parameterName, value);
-            Add(parameter);
-
-            return parameter;
-        }
+        public virtual SqliteParameter AddWithValue(string? parameterName, object? value)
+            => Add(new SqliteParameter(parameterName, value));
 
         /// <summary>
         ///     Removes all parameters from the collection.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteResultBinder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Sqlite
     {
         private readonly sqlite3_context _ctx;
 
-        public SqliteResultBinder(sqlite3_context ctx, object value)
+        public SqliteResultBinder(sqlite3_context ctx, object? value)
             : base(value)
         {
             _ctx = ctx;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteTransaction.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteTransaction.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Data.Sqlite
     /// <seealso href="https://docs.microsoft.com/dotnet/standard/data/sqlite/transactions">Transactions</seealso>
     public class SqliteTransaction : DbTransaction
     {
-        private SqliteConnection _connection;
+        private SqliteConnection? _connection;
         private readonly IsolationLevel _isolationLevel;
         private bool _completed;
 
         internal SqliteTransaction(SqliteConnection connection, IsolationLevel isolationLevel, bool deferred)
         {
             if ((isolationLevel == IsolationLevel.ReadUncommitted
-                    && ((connection.ConnectionOptions.Cache != SqliteCacheMode.Shared) || !deferred))
+                    && ((connection.ConnectionOptions!.Cache != SqliteCacheMode.Shared) || !deferred))
                 || isolationLevel == IsolationLevel.ReadCommitted
                 || isolationLevel == IsolationLevel.RepeatableRead)
             {
@@ -57,14 +57,14 @@ namespace Microsoft.Data.Sqlite
         ///     Gets the connection associated with the transaction.
         /// </summary>
         /// <value>The connection associated with the transaction.</value>
-        public new virtual SqliteConnection Connection
+        public new virtual SqliteConnection? Connection
             => _connection;
 
         /// <summary>
         ///     Gets the connection associated with the transaction.
         /// </summary>
         /// <value>The connection associated with the transaction.</value>
-        protected override DbConnection DbConnection
+        protected override DbConnection? DbConnection
             => Connection;
 
         internal bool ExternalRollback { get; private set; }
@@ -75,11 +75,11 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <value>The isolation level for the transaction.</value>
         public override IsolationLevel IsolationLevel
-            => _completed || _connection.State != ConnectionState.Open
+            => _completed || _connection!.State != ConnectionState.Open
                 ? throw new InvalidOperationException(Resources.TransactionCompleted)
                 : _isolationLevel != IsolationLevel.Unspecified
                     ? _isolationLevel
-                    : (_connection.ConnectionOptions.Cache == SqliteCacheMode.Shared
+                    : (_connection.ConnectionOptions!.Cache == SqliteCacheMode.Shared
                         && _connection.ExecuteScalar<long>("PRAGMA read_uncommitted;") != 0)
                         ? IsolationLevel.ReadUncommitted
                         : IsolationLevel.Serializable;
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Sqlite
         {
             if (ExternalRollback
                 || _completed
-                || _connection.State != ConnectionState.Open)
+                || _connection!.State != ConnectionState.Open)
             {
                 throw new InvalidOperationException(Resources.TransactionCompleted);
             }
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         public override void Rollback()
         {
-            if (_completed || _connection.State != ConnectionState.Open)
+            if (_completed || _connection!.State != ConnectionState.Open)
             {
                 throw new InvalidOperationException(Resources.TransactionCompleted);
             }
@@ -114,28 +114,22 @@ namespace Microsoft.Data.Sqlite
             RollbackInternal();
         }
 
-#if NET
         /// <inheritdoc />
         public override bool SupportsSavepoints => true;
-#endif
 
         /// <summary>
         /// Creates a savepoint in the transaction. This allows all commands that are executed after the savepoint was
         /// established to be rolled back, restoring the transaction state to what it was at the time of the savepoint.
         /// </summary>
         /// <param name="savepointName">The name of the savepoint to be created.</param>
-#if NET
         public override void Save(string savepointName)
-#else
-        public void Save(string savepointName)
-#endif
         {
             if (savepointName is null)
             {
                 throw new ArgumentNullException(nameof(savepointName));
             }
 
-            if (_completed || _connection.State != ConnectionState.Open)
+            if (_completed || _connection!.State != ConnectionState.Open)
             {
                 throw new InvalidOperationException(Resources.TransactionCompleted);
             }
@@ -152,18 +146,14 @@ namespace Microsoft.Data.Sqlite
         /// Rolls back all commands that were executed after the specified savepoint was established.
         /// </summary>
         /// <param name="savepointName">The name of the savepoint to roll back to.</param>
-#if NET
         public override void Rollback(string savepointName)
-#else
-        public void Rollback(string savepointName)
-#endif
         {
             if (savepointName is null)
             {
                 throw new ArgumentNullException(nameof(savepointName));
             }
 
-            if (_completed || _connection.State != ConnectionState.Open)
+            if (_completed || _connection!.State != ConnectionState.Open)
             {
                 throw new InvalidOperationException(Resources.TransactionCompleted);
             }
@@ -181,18 +171,14 @@ namespace Microsoft.Data.Sqlite
         /// reclaim some resources before the transaction ends.
         /// </summary>
         /// <param name="savepointName">The name of the savepoint to release.</param>
-#if NET
         public override void Release(string savepointName)
-#else
-        public void Release(string savepointName)
-#endif
         {
             if (savepointName is null)
             {
                 throw new ArgumentNullException(nameof(savepointName));
             }
 
-            if (_completed || _connection.State != ConnectionState.Open)
+            if (_completed || _connection!.State != ConnectionState.Open)
             {
                 throw new InvalidOperationException(Resources.TransactionCompleted);
             }
@@ -216,7 +202,7 @@ namespace Microsoft.Data.Sqlite
         {
             if (disposing
                 && !_completed
-                && _connection.State == ConnectionState.Open)
+                && _connection!.State == ConnectionState.Open)
             {
                 RollbackInternal();
             }
@@ -224,7 +210,7 @@ namespace Microsoft.Data.Sqlite
 
         private void Complete()
         {
-            _connection.Transaction = null;
+            _connection!.Transaction = null;
             _connection = null;
             _completed = true;
         }
@@ -233,7 +219,7 @@ namespace Microsoft.Data.Sqlite
         {
             if (!ExternalRollback)
             {
-                sqlite3_rollback_hook(_connection.Handle, null, null);
+                sqlite3_rollback_hook(_connection!.Handle, null, null);
                 _connection.ExecuteNonQuery("ROLLBACK;");
             }
 
@@ -242,7 +228,7 @@ namespace Microsoft.Data.Sqlite
 
         private void RollbackExternal(object userData)
         {
-            sqlite3_rollback_hook(_connection.Handle, null, null);
+            sqlite3_rollback_hook(_connection!.Handle, null, null);
             ExternalRollback = true;
         }
     }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Data.Sqlite
     // TODO: Make generic
     internal abstract class SqliteValueBinder
     {
-        private readonly object _value;
+        private readonly object? _value;
         private readonly SqliteType? _sqliteType;
 
-        protected SqliteValueBinder(object value)
+        protected SqliteValueBinder(object? value)
             : this(value, null)
         {
         }
 
-        protected SqliteValueBinder(object value, SqliteType? sqliteType)
+        protected SqliteValueBinder(object? value, SqliteType? sqliteType)
         {
             _value = value;
             _sqliteType = sqliteType;
@@ -230,7 +230,7 @@ namespace Microsoft.Data.Sqlite
                 { typeof(ushort), SqliteType.Integer }
             };
 
-        internal static SqliteType GetSqliteType(object value)
+        internal static SqliteType GetSqliteType(object? value)
         {
             if (value == null)
             {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Sqlite
             switch (sqliteType)
             {
                 case SQLITE_BLOB:
-                    var bytes = GetBlob(ordinal);
+                    var bytes = GetBlob(ordinal)!;
                     return bytes.Length == 16
                         ? new Guid(bytes)
                         : new Guid(Encoding.UTF8.GetString(bytes, 0, bytes.Length));
@@ -130,7 +130,7 @@ namespace Microsoft.Data.Sqlite
 
         protected abstract string GetStringCore(int ordinal);
 
-        public virtual T GetFieldValue<T>(int ordinal)
+        public virtual T? GetFieldValue<T>(int ordinal)
         {
             if (IsDBNull(ordinal)
                 && typeof(T).IsNullable())
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Sqlite
 
             if (type == typeof(byte[]))
             {
-                return (T)(object)GetBlob(ordinal);
+                return (T)(object)GetBlob(ordinal)!;
             }
 
             if (type == typeof(char))
@@ -243,7 +243,7 @@ namespace Microsoft.Data.Sqlite
             return (T)GetValue(ordinal);
         }
 
-        public virtual object GetValue(int ordinal)
+        public virtual object? GetValue(int ordinal)
         {
             var sqliteType = GetSqliteType(ordinal);
             switch (sqliteType)
@@ -266,7 +266,7 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
-        public virtual int GetValues(object[] values)
+        public virtual int GetValues(object?[] values)
         {
             int i;
             for (i = 0; i < FieldCount; i++)
@@ -277,14 +277,14 @@ namespace Microsoft.Data.Sqlite
             return i;
         }
 
-        protected byte[] GetBlob(int ordinal)
+        protected virtual byte[]? GetBlob(int ordinal)
             => IsDBNull(ordinal)
                 ? GetNull<byte[]>(ordinal)
                 : GetBlobCore(ordinal) ?? Array.Empty<byte>();
 
         protected abstract byte[] GetBlobCore(int ordinal);
 
-        protected virtual T GetNull<T>(int ordinal)
+        protected virtual T? GetNull<T>(int ordinal)
             => typeof(T) == typeof(DBNull)
                 ? (T)(object)DBNull.Value
                 : default;

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/ApplicationDataHelper.cs
@@ -8,25 +8,25 @@ namespace Microsoft.Data.Sqlite.Utilities
 {
     internal class ApplicationDataHelper
     {
-        private static object _appData;
-        private static string _localFolder;
-        private static string _tempFolder;
+        private static object? _appData;
+        private static string? _localFolder;
+        private static string? _tempFolder;
 
-        public static object CurrentApplicationData
+        public static object? CurrentApplicationData
             => _appData ??= LoadAppData();
 
-        public static string TemporaryFolderPath
+        public static string? TemporaryFolderPath
             => _tempFolder ??= GetFolderPath("TemporaryFolder");
 
-        public static string LocalFolderPath
+        public static string? LocalFolderPath
             => _localFolder ??= GetFolderPath("LocalFolder");
 
-        private static object LoadAppData()
+        private static object? LoadAppData()
         {
             try
             {
                 return Type.GetType("Windows.Storage.ApplicationData, Windows, ContentType=WindowsRuntime")
-                    ?.GetRuntimeProperty("Current").GetValue(null);
+                    ?.GetRuntimeProperty("Current")!.GetValue(null);
             }
             catch
             {
@@ -35,12 +35,12 @@ namespace Microsoft.Data.Sqlite.Utilities
             }
         }
 
-        private static string GetFolderPath(string propertyName)
+        private static string? GetFolderPath(string propertyName)
         {
             var appDataType = CurrentApplicationData?.GetType();
-            var temporaryFolder = appDataType?.GetRuntimeProperty(propertyName).GetValue(CurrentApplicationData);
+            var temporaryFolder = appDataType?.GetRuntimeProperty(propertyName)!.GetValue(CurrentApplicationData);
 
-            return temporaryFolder?.GetType().GetRuntimeProperty("Path").GetValue(temporaryFolder) as string;
+            return temporaryFolder?.GetType().GetRuntimeProperty("Path")!.GetValue(temporaryFolder) as string;
         }
     }
 }

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/BundleInitializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Reflection;
 using static SQLitePCL.raw;
 
@@ -13,7 +14,7 @@ namespace Microsoft.Data.Sqlite.Utilities
 
         public static void Initialize()
         {
-            Assembly assembly = null;
+            Assembly? assembly = null;
             try
             {
                 assembly = Assembly.Load(new AssemblyName("SQLitePCLRaw.batteries_v2"));
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Sqlite.Utilities
 
             if (assembly != null)
             {
-                assembly.GetType("SQLitePCL.Batteries_V2").GetTypeInfo().GetDeclaredMethod("Init")
+                assembly.GetType("SQLitePCL.Batteries_V2", throwOnError: true)!.GetMethod("Init", Type.EmptyTypes)!
                     .Invoke(null, null);
             }
 

--- a/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
+++ b/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
@@ -15,7 +15,7 @@ Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <MinClientVersion>3.6</MinClientVersion>
     <PackageTags>SQLite;Data;ADO.NET</PackageTags>
     <IncludeSymbols>false</IncludeSymbols>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>$(DefineConstants);E_SQLITE3</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.e_sqlcipher.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.e_sqlcipher.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>$(DefineConstants);E_SQLCIPHER</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>$(DefineConstants);SQLITE3</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <DefineConstants>$(DefineConstants);WINSQLITE3</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteBlobTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteBlobTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Sqlite
         public void Ctor_throws_when_table_null()
         {
             var ex = Assert.Throws<ArgumentNullException>(
-                () => new SqliteBlob(_connection, null, Column, Rowid));
+                () => new SqliteBlob(_connection, null!, Column, Rowid));
             Assert.Equal("tableName", ex.ParamName);
         }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Sqlite
         public void Ctor_throws_when_column_null()
         {
             var ex = Assert.Throws<ArgumentNullException>(
-                () => new SqliteBlob(_connection, Table, null, Rowid));
+                () => new SqliteBlob(_connection, Table, null!, Rowid));
             Assert.Equal("columnName", ex.ParamName);
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.Data.Sqlite
             using (var stream = CreateStream())
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => stream.Read(null, 0, 1));
+                    () => stream.Read(null!, 0, 1));
 
                 Assert.Equal("buffer", ex.ParamName);
             }
@@ -335,7 +335,7 @@ namespace Microsoft.Data.Sqlite
             using (var stream = CreateStream())
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => stream.Write(null, 0, 0));
+                    () => stream.Write(null!, 0, 0));
                 Assert.Equal("buffer", ex.ParamName);
             }
         }
@@ -419,6 +419,22 @@ namespace Microsoft.Data.Sqlite
 
             var ex = Assert.Throws<ObjectDisposedException>(
                 () => stream.Write(new byte[] { 3 }, 0, 1));
+        }
+
+        [Fact]
+        public void Empty_works()
+        {
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+
+            connection.ExecuteNonQuery(
+            @"
+                CREATE TABLE """" ("""" BLOB);
+                INSERT INTO """" (rowid, """") VALUES(1, X'02');
+            ");
+
+            using var stream = new SqliteBlob(connection, "", "", 1);
+            Assert.Equal(2, stream.ReadByte());
         }
 
         protected Stream CreateStream(bool readOnly = false)

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -165,15 +165,13 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
-        public void Prepare_throws_when_no_command_text()
+        public void Prepare_works_when_no_command_text()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.CreateCommand().Prepare());
-
-                Assert.Equal(Resources.CallRequiresSetCommandText("Prepare"), ex.Message);
+                connection.CreateCommand().Prepare();
             }
         }
 
@@ -255,15 +253,16 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
-        public void ExecuteReader_throws_when_no_command_text()
+        public void ExecuteReader_works_when_no_command_text()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.CreateCommand().ExecuteReader());
+                using var reader = connection.CreateCommand().ExecuteReader();
 
-                Assert.Equal(Resources.CallRequiresSetCommandText("ExecuteReader"), ex.Message);
+                Assert.False(reader.HasRows);
+                Assert.Equal(-1, reader.RecordsAffected);
             }
         }
 
@@ -326,9 +325,9 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.CreateCommand().ExecuteScalar());
+                var result = connection.CreateCommand().ExecuteScalar();
 
-                Assert.Equal(Resources.CallRequiresSetCommandText("ExecuteScalar"), ex.Message);
+                Assert.Null(result);
             }
         }
 
@@ -541,15 +540,15 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
-        public void ExecuteNonQuery_throws_when_no_command_text()
+        public void ExecuteNonQuery_works_when_no_command_text()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
 
-                var ex = Assert.Throws<InvalidOperationException>(() => connection.CreateCommand().ExecuteNonQuery());
+                var result = connection.CreateCommand().ExecuteNonQuery();
 
-                Assert.Equal(Resources.CallRequiresSetCommandText("ExecuteNonQuery"), ex.Message);
+                Assert.Equal(-1, result);
             }
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -134,13 +134,11 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
-        public void Open_throws_when_no_connection_string()
+        public void Open_works_when_no_connection_string()
         {
-            var connection = new SqliteConnection();
+            using var connection = new SqliteConnection();
 
-            var ex = Assert.Throws<InvalidOperationException>(() => connection.Open());
-
-            Assert.Equal(Resources.OpenRequiresSetConnectionString, ex.Message);
+            connection.Open();
         }
 
         [Fact]
@@ -436,7 +434,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.BackupDatabase(null));
+                var ex = Assert.Throws<ArgumentNullException>(() => connection.BackupDatabase(null!));
 
                 Assert.Equal("destination", ex.ParamName);
             }
@@ -611,7 +609,7 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateCollation(null, null));
+                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateCollation(null!, null));
 
                 Assert.Equal("name", ex.ParamName);
             }
@@ -659,7 +657,7 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateFunction(null, () => 1L));
+                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateFunction(null!, () => 1L));
 
                 Assert.Equal("name", ex.ParamName);
             }
@@ -744,7 +742,7 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
-                connection.CreateFunction<object>("test", () => null);
+                connection.CreateFunction<object?>("test", () => null);
 
                 var result = connection.ExecuteScalar<object>("SELECT test();");
 
@@ -819,7 +817,7 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
-                connection.CreateFunction("test", (string x) => x == null);
+                connection.CreateFunction("test", (string? x) => x == null);
 
                 var result = connection.ExecuteScalar<long>("SELECT test(NULL);");
 
@@ -913,7 +911,7 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
-                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateAggregate(null, (string a) => "A"));
+                var ex = Assert.Throws<ArgumentNullException>(() => connection.CreateAggregate(null!, (string? a) => "A"));
 
                 Assert.Equal("name", ex.ParamName);
             }
@@ -945,7 +943,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
                 connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string a, object[] args) => a + string.Join(", ", args) + "; ");
+                connection.CreateAggregate("test", (string? a, object?[] args) => a + string.Join(", ", args) + "; ");
 
                 var result = connection.ExecuteScalar<string>("SELECT test(dummy) FROM dual;");
 
@@ -960,7 +958,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
                 connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string a) => throw new Exception("Test"));
+                connection.CreateAggregate("test", (string? a) => throw new Exception("Test"));
 
                 var ex = Assert.Throws<SqliteException>(
                     () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
@@ -992,7 +990,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
                 connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string a) => throw new SqliteException("Test", 200));
+                connection.CreateAggregate("test", (string? a) => throw new SqliteException("Test", 200));
 
                 var ex = Assert.Throws<SqliteException>(
                     () => connection.ExecuteScalar<string>("SELECT test() FROM dual;"));
@@ -1008,8 +1006,8 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
                 connection.ExecuteNonQuery("CREATE TABLE dual (dummy); INSERT INTO dual (dummy) VALUES ('X');");
-                connection.CreateAggregate("test", (string a) => "A");
-                connection.CreateAggregate("test", default(Func<string, string>));
+                connection.CreateAggregate("test", (string? a) => "A");
+                connection.CreateAggregate("test", default(Func<string?, string>));
 
                 var ex = Assert.Throws<SqliteException>(
                     () => connection.ExecuteScalar<long>("SELECT test() FROM dual;"));

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -160,12 +160,9 @@ namespace Microsoft.Data.Sqlite
                     var hasData = reader.Read();
                     Assert.True(hasData);
 
-                    byte[] buffer = null;
-                    long bytesRead = reader.GetBytes(0, 1, buffer, 0, 3);
+                    long bytesRead = reader.GetBytes(0, 1, null, 0, 3);
 
-                    // Expecting to return the length of the field in bytes,
-                    // which can be simply be blob length minus the offset.
-                    Assert.Equal(3, bytesRead);
+                    Assert.Equal(4, bytesRead);
                 }
             }
         }
@@ -236,14 +233,33 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                using (var reader = connection.ExecuteReader("SELECT 'test';"))
+                using (var reader = connection.ExecuteReader("SELECT 'têst';"))
                 {
                     var hasData = reader.Read();
                     Assert.True(hasData);
 
                     var buffer = new char[2];
                     reader.GetChars(0, 1, buffer, 0, buffer.Length);
-                    Assert.Equal(new char[2] { 'e', 's' }, buffer);
+                    Assert.Equal(new char[2] { 'ê', 's' }, buffer);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetChars_works_when_buffer_null()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                using (var reader = connection.ExecuteReader("SELECT 'têst';"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    long bytesRead = reader.GetChars(0, 1, null, 0, 3);
+
+                    Assert.Equal(4, bytesRead);
                 }
             }
         }
@@ -255,7 +271,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                using (var reader = connection.ExecuteReader("SELECT 'test';"))
+                using (var reader = connection.ExecuteReader("SELECT 'têst';"))
                 {
                     var hasData = reader.Read();
                     Assert.True(hasData);
@@ -264,7 +280,7 @@ namespace Microsoft.Data.Sqlite
                     long charsRead = reader.GetChars(0, 1, hugeBuffer, 0, hugeBuffer.Length);
                     Assert.Equal(3, charsRead);
 
-                    var correctBytes = new char[3] { 'e', 's', 't' };
+                    var correctBytes = new char[3] { 'ê', 's', 't' };
                     for (int i = 0; i < charsRead; i++)
                     {
                         Assert.Equal(correctBytes[i], hugeBuffer[i]);
@@ -280,7 +296,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                using (var reader = connection.ExecuteReader("SELECT 'test';"))
+                using (var reader = connection.ExecuteReader("SELECT 'têst';"))
                 {
                     var hasData = reader.Read();
                     Assert.True(hasData);
@@ -296,12 +312,12 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetChars_throws_when_closed()
         {
-            X_throws_when_closed(r => r.GetChars(0, 0, null, 0, 0), nameof(SqliteDataReader.GetChars));
+            X_throws_when_closed(r => r.GetChars(0, 0, null!, 0, 0), nameof(SqliteDataReader.GetChars));
         }
 
         [Fact]
         public void GetChars_throws_when_non_query()
-            => X_throws_when_non_query(r => r.GetChars(0, 0, null, 0, 0));
+            => X_throws_when_non_query(r => r.GetChars(0, 0, null!, 0, 0));
 
         [Fact]
         public void GetChars_works_streaming()
@@ -310,7 +326,7 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES ('test');");
+                connection.ExecuteNonQuery("CREATE TABLE Data (Value); INSERT INTO Data VALUES ('têst');");
 
                 using (var reader = connection.ExecuteReader("SELECT rowid, Value FROM Data;"))
                 {
@@ -319,7 +335,7 @@ namespace Microsoft.Data.Sqlite
 
                     var buffer = new char[2];
                     reader.GetChars(1, 1, buffer, 0, buffer.Length);
-                    Assert.Equal(new[] { 'e', 's' }, buffer);
+                    Assert.Equal(new[] { 'ê', 's' }, buffer);
                 }
             }
         }
@@ -1179,7 +1195,7 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetOrdinal_throws_when_closed()
         {
-            X_throws_when_closed(r => r.GetOrdinal(null), nameof(SqliteDataReader.GetOrdinal));
+            X_throws_when_closed(r => r.GetOrdinal(null!), nameof(SqliteDataReader.GetOrdinal));
         }
 
         [Fact]
@@ -1320,12 +1336,12 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetValues_throws_when_closed()
         {
-            X_throws_when_closed(r => r.GetValues(null), nameof(SqliteDataReader.GetValues));
+            X_throws_when_closed(r => r.GetValues(null!), nameof(SqliteDataReader.GetValues));
         }
 
         [Fact]
         public void GetValues_throws_when_non_query()
-            => X_throws_when_non_query(r => r.GetValues(null));
+            => X_throws_when_non_query(r => r.GetValues(null!));
 
         [Fact]
         public void HasRows_returns_true_when_rows()

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Data.Sqlite
                 Assert.Equal(1, command.ExecuteNonQuery());
 
                 command.CommandText = "SELECT DateOfBirth FROM Person;";
-                var result = command.ExecuteScalar();
+                var result = command.ExecuteScalar()!;
                 Assert.Equal("2018-03-25 00:00:00", (string)result);
 
                 using (var reader = command.ExecuteReader())
@@ -495,7 +495,7 @@ namespace Microsoft.Data.Sqlite
                 Assert.Equal(1, command.ExecuteNonQuery());
 
                 command.CommandText = "SELECT date FROM Test;";
-                var result = command.ExecuteScalar();
+                var result = command.ExecuteScalar()!;
                 Assert.Equal("2018-03-25 00:00:00+00:00", (string)result);
 
                 using (var reader = command.ExecuteReader())

--- a/test/Microsoft.Data.Sqlite.Tests/TestUtilities/UseCultureAttribute.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/TestUtilities/UseCultureAttribute.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Data.Sqlite.TestUtilities
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public sealed class UseCultureAttribute : BeforeAfterTestAttribute
     {
-        private CultureInfo _originalCulture;
-        private CultureInfo _originalUICulture;
+        private CultureInfo? _originalCulture;
+        private CultureInfo? _originalUICulture;
 
         public UseCultureAttribute(string culture)
             : this(culture, culture)
@@ -39,8 +39,8 @@ namespace Microsoft.Data.Sqlite.TestUtilities
 
         public override void After(MethodInfo methodUnderTest)
         {
-            CultureInfo.CurrentCulture = _originalCulture;
-            CultureInfo.CurrentUICulture = _originalUICulture;
+            CultureInfo.CurrentCulture = _originalCulture!;
+            CultureInfo.CurrentUICulture = _originalUICulture!;
         }
     }
 }

--- a/tools/SqliteResources.tt
+++ b/tools/SqliteResources.tt
@@ -17,6 +17,8 @@
 using System.Reflection;
 using System.Resources;
 
+#nullable enable
+
 namespace <#= model.Namespace #>
 {
     internal static class <#= model.Class #>
@@ -60,7 +62,7 @@ namespace <#= model.Namespace #>
 
         private static string GetString(string name, params string[] formatterNames)
         {
-            var value = _resourceManager.GetString(name);
+            var value = _resourceManager.GetString(name)!;
             for (var i = 0; i < formatterNames.Length; i++)
             {
                 value = value.Replace("{" + formatterNames[i] + "}", "{" + i + "}");


### PR DESCRIPTION
Part of #19007

Also updates the behavior of SqliteDataReader.GetChars when buffer is null and GetBytes when dataOffset is specified.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


