### PR TITLE
EntityTypeConfiguration annotation #23163

### DIFF
--- a/src/EFCore.Abstractions/EntityConfigurationAttribute.cs
+++ b/src/EFCore.Abstractions/EntityConfigurationAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///  Specifies an entity configuration to the entity.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class EntityConfigurationAttribute : Attribute
+    {
+        private readonly Type _entityConfigurationType;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="EntityConfigurationAttribute" /> class.
+        /// </summary>
+        /// <param name="entityConfigurationType"> The entity configuration type created for the entity. </param>
+        public EntityConfigurationAttribute(Type entityConfigurationType)
+        {
+            _entityConfigurationType = entityConfigurationType;
+        }   
+
+        /// <summary>
+        /// Type of entity type configuration
+        /// </summary>
+        public Type EntityConfigurationType
+        {
+            get
+            {
+                return _entityConfigurationType;
+            }
+        }        
+    }
+}

--- a/src/EFCore/Metadata/Conventions/EntityConfigurationEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/EntityConfigurationEntityTypeAttributeConvention.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             if(!IsEntityTypeConfigurationImplementation(entityTypeConfiguration))
             {
-                throw new InvalidOperationException(CoreStrings.InvalidEntityTypeConfiguration);
+                throw new InvalidOperationException(CoreStrings.InvalidEntityTypeConfiguration(entityTypeConfiguration, entityTypeBuilder.Metadata));
             }
 
             var entityTypeBuilderInstance = GetEntityBuilderInstance(entityTypeBuilder.Metadata, entityTypeConfiguration);

--- a/src/EFCore/Metadata/Conventions/EntityConfigurationEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/EntityConfigurationEntityTypeAttributeConvention.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    /// A convention that apply specified enity type configuration <see cref="EntityConfigurationAttribute" />.
+    /// </summary>
+    public class EntityConfigurationEntityTypeAttributeConvention : EntityTypeAttributeConventionBase<EntityConfigurationAttribute>
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="EntityConfigurationEntityTypeAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public EntityConfigurationEntityTypeAttributeConvention([NotNull] ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Called after an entity type is added to the model if it has an attribute.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="attribute"> The attribute. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        protected override void ProcessEntityTypeAdded(IConventionEntityTypeBuilder entityTypeBuilder,
+            EntityConfigurationAttribute attribute,
+            IConventionContext<IConventionEntityTypeBuilder> context)
+        {
+            var entityTypeConfiguration = attribute.EntityConfigurationType;
+
+            var entityTypeBuilderInstance = GetEntityBuilderInstance(entityTypeBuilder.Metadata, entityTypeConfiguration);
+
+            var instance = Activator.CreateInstance(entityTypeConfiguration);
+
+            MethodInfo method = entityTypeConfiguration.GetMethod("Configure");
+            method.Invoke(instance, new object[] { entityTypeBuilderInstance });
+        }
+
+        private Type[] GetEntityTypeArgs(Type entityTypeConfiguration)
+        {
+            var interfaces = entityTypeConfiguration.GetInterfaces()
+                .ToList()
+                .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEntityTypeConfiguration<>));
+
+            var types = interfaces
+                .Select(x => x.GetGenericArguments().First())
+                .ToArray();
+
+            return types;
+        }
+
+        private object GetEntityBuilderInstance(IConventionEntityType conventionEntityType, Type entityTypeConfiguration)
+        {
+            Type[] entityTypeArgs = GetEntityTypeArgs(entityTypeConfiguration);
+
+            var entityTypeBuilder = typeof(EntityTypeBuilder<>);
+
+            Type constructed = entityTypeBuilder.MakeGenericType(entityTypeArgs);
+
+            var entityTypeBuilderInstance = Activator.CreateInstance(constructed, new object[] { conventionEntityType });
+
+            return entityTypeBuilderInstance;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -67,6 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new KeylessEntityTypeAttributeConvention(Dependencies));
+            conventionSet.EntityTypeAddedConventions.Add(new EntityConfigurationEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(baseTypeDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1151,10 +1151,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
-        ///     Entity Type Configuration is invalid. The configuration have to implement IEntityTypeConfiguration&lt;&gt; Interface.
+        ///     Entity Type Configuration of type {entityTypeConfigurationType} is invalid. The configuration have to implement IEntityTypeConfiguration&lt;{entityType}&gt; Interface.
         /// </summary>
-        public static string InvalidEntityTypeConfiguration
-            => GetString("InvalidEntityTypeConfiguration");
+        public static string InvalidEntityTypeConfiguration([CanBeNull] object entityTypeConfigurationType, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("InvalidEntityTypeConfiguration", nameof(entityTypeConfigurationType), nameof(entityType)),
+                entityTypeConfigurationType, entityType);
 
         /// <summary>
         ///     The value '{value}' provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1151,6 +1151,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 type);
 
         /// <summary>
+        ///     Entity Type Configuration is invalid. The configuration have to implement IEntityTypeConfiguration&lt;&gt; Interface.
+        /// </summary>
+        public static string InvalidEntityTypeConfiguration
+            => GetString("InvalidEntityTypeConfiguration");
+
+        /// <summary>
         ///     The value '{value}' provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.
         /// </summary>
         public static string InvalidEnumValue([CanBeNull] object value, [CanBeNull] object argumentName, [CanBeNull] object enumType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -550,6 +550,9 @@
   <data name="InvalidEntityType" xml:space="preserve">
     <value>The specified type '{type}' must be a non-interface reference type to be used as an entity type.</value>
   </data>
+  <data name="InvalidEntityTypeConfiguration" xml:space="preserve">
+    <value>Entity Type Configuration is invalid. The configuration have to implement IEntityTypeConfiguration&lt;&gt; Interface.</value>
+  </data>
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value '{value}' provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
   </data>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -551,7 +551,7 @@
     <value>The specified type '{type}' must be a non-interface reference type to be used as an entity type.</value>
   </data>
   <data name="InvalidEntityTypeConfiguration" xml:space="preserve">
-    <value>Entity Type Configuration is invalid. The configuration have to implement IEntityTypeConfiguration&lt;&gt; Interface.</value>
+    <value>Entity Type Configuration of type {entityTypeConfigurationType} is invalid. The configuration have to implement IEntityTypeConfiguration&lt;{entityType}&gt; Interface.</value>
   </data>
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value '{value}' provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>

--- a/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -20,6 +22,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
         }
 
+        [ConditionalFact]
+        public void EntityConfigurationAttribute_Should_ThrowInvalidOperationException_WhenConfiguration_IsInvalid()
+        {
+            var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            Assert.Equal(CoreStrings.InvalidEntityTypeConfiguration,
+                Assert.Throws<InvalidOperationException>(() => builder.Entity<User>()).Message);
+        }
+
+        private class UserConfiguration
+        {
+        }
+
+        [EntityConfiguration(typeof(UserConfiguration))]
+        protected class User
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
         private class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         {
             public void Configure(EntityTypeBuilder<Customer> builder)
@@ -34,6 +57,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public int Id { get; set; }
 
             public string Name { get; set; }
-        }      
+        }
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    public class EntityConfigurationAttributeConventionTest
+    {
+        [ConditionalFact]
+        public void EntityConfigurationAttribute_Should_AppliConfiguration_ToEntityType()
+        {
+            var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<Customer>();
+
+            var entityType = builder.Model.FindEntityType(typeof(Customer));
+            Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
+        }
+
+        private class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+        {
+            public void Configure(EntityTypeBuilder<Customer> builder)
+            {
+                builder.Property(c => c.Name).HasMaxLength(1000);
+            }
+        }
+
+        [EntityConfiguration(typeof(CustomerConfiguration))]
+        protected class Customer
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }      
+    }
+}

--- a/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityConfigurationAttributeConventionTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -27,9 +28,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
 
-            Assert.Equal(CoreStrings.InvalidEntityTypeConfiguration,
+            var entityType = (IConventionEntityType)CreateModel().AddEntityType(typeof(User));
+
+            Assert.Equal(CoreStrings.InvalidEntityTypeConfiguration(typeof(UserConfiguration), entityType),
                 Assert.Throws<InvalidOperationException>(() => builder.Entity<User>()).Message);
         }
+
+         private static IMutableModel CreateModel()
+            => new Model();
 
         private class UserConfiguration
         {


### PR DESCRIPTION
Fixes #23163 

I am not sure how I have to handle the case when in the attribute a wrong Configuration type is given


