### PR TITLE
Fix to #19994 - Query/Test: figure out how to represent shadow properties in expected result queries

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
@@ -1,12 +1,85 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class GearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase
     {
+        public override Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+        {
+            var discriminatorMapping = new Dictionary<(Type, string), Func<object, object>>
+            {
+                {
+                    (typeof(Gear), "Discriminator"),
+                    e =>
+                    {
+                        switch (((Gear)e)?.Nickname)
+                        {
+                            case "Baird":
+                            case "Marcus":
+                                return "Officer";
+
+                            case "Cole Train":
+                            case "Dom":
+                            case "Paduk":
+                                return "Gear";
+
+                            default:
+                                return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(Faction), "Discriminator"),
+                    e =>
+                    {
+                        switch (((Faction)e)?.Id)
+                        {
+                            case 1:
+                            case 2:
+                                return "LocustHorde";
+
+                            default:
+                                return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(LocustLeader), "Discriminator"),
+                    e =>
+                    {
+                        switch (((LocustLeader)e)?.Name)
+                        {
+                            case "General Karn":
+                            case "General RAAM":
+                            case "High Priest Skorge":
+                            case "The Speaker":
+                                return "LocustLeader";
+
+                            case "Queen Myrrah":
+                            case "Unknown":
+                                return "LocustCommander";
+
+                            default:
+                                return null;
+                        }
+                    }
+                },
+            };
+
+            foreach (var shadowPropertyMappingElement in base.GetShadowPropertyMappings())
+            {
+                discriminatorMapping.Add(shadowPropertyMappingElement.Key, shadowPropertyMappingElement.Value);
+            }
+
+            return discriminatorMapping;
+        }
+
         public new RelationalTestStore TestStore
             => (RelationalTestStore)base.TestStore;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -105,6 +105,41 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertTranslationFailed(() => base.Where_coalesce_with_anonymous_types(async));
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Project_discriminator_columns(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Gear>().Select(g => new { g.Nickname, Discriminator = EF.Property<string>(g, "Discriminator") }),
+                elementSorter: e => e.Nickname);
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Gear>().OfType<Officer>().Select(g => new { g.Nickname, Discriminator = EF.Property<string>(g, "Discriminator") }),
+                elementSorter: e => e.Nickname);
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Faction>().Select(f => new { f.Id, Discriminator = EF.Property<string>(f, "Discriminator") }),
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<Faction>().OfType<LocustHorde>().Select(lh => new { lh.Id, Discriminator = EF.Property<string>(lh, "Discriminator") }),
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<LocustLeader>().Select(ll => new { ll.Name, Discriminator = EF.Property<string>(ll, "Discriminator") }),
+                elementSorter: e => e.Name);
+
+            await AssertQuery(
+                async,
+                ss => ss.Set<LocustLeader>().OfType<LocustCommander>().Select(ll => new { ll.Name, Discriminator = EF.Property<string>(ll, "Discriminator") }),
+                elementSorter: e => e.Name);
+        }
+
         protected virtual bool CanExecuteQueryString
             => false;
 

--- a/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/TPTGearsOfWarQueryRelationalTestBase.cs
@@ -19,5 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await base.Cast_to_derived_followed_by_include_and_FirstOrDefault(async);
         }
+
+        public override Task Project_discriminator_columns(bool async)
+            => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -13,14 +13,207 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class ComplexNavigationsQueryFixtureBase : SharedStoreFixtureBase<ComplexNavigationsContext>, IQueryFixtureBase
     {
+        private ComplexNavigationsDefaultData _expectedData;
+
         protected override string StoreName { get; } = "ComplexNavigations";
 
         public Func<DbContext> GetContextCreator()
             => () => CreateContext();
 
         public virtual ISetSource GetExpectedData()
-            => new ComplexNavigationsDefaultData();
+        {
+            if (_expectedData == null)
+            {
+                _expectedData = new ComplexNavigationsDefaultData();
+            }
 
+            return _expectedData;
+        }
+
+        public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+        {
+            var l1s = GetExpectedData().Set<Level1>().ToList();
+            var l2s = GetExpectedData().Set<Level2>().ToList();
+            var l3s = GetExpectedData().Set<Level3>().ToList();
+            var l4s = GetExpectedData().Set<Level4>().ToList();
+
+            var ib1s = GetExpectedData().Set<InheritanceBase1>().ToList();
+            var ib2s = GetExpectedData().Set<InheritanceBase2>().ToList();
+            var il1s = GetExpectedData().Set<InheritanceLeaf1>().ToList();
+            var il2s = GetExpectedData().Set<InheritanceLeaf2>().ToList();
+
+            return new Dictionary<(Type, string), Func<object, object>>
+            {
+                {
+                    (typeof(Level1), "OneToOne_Optional_Self1Id"),
+                    e => l1s.SingleOrDefault(l => l.Id == ((Level1)e)?.Id)?.OneToOne_Optional_Self1?.Id
+                },
+                {
+                    (typeof(Level1), "OneToMany_Required_Self_Inverse1Id"),
+                    e => l1s.SingleOrDefault(l => l.Id == ((Level1)e)?.Id)?.OneToMany_Required_Self_Inverse1?.Id
+                },
+                {
+                    (typeof(Level1), "OneToMany_Optional_Self_Inverse1Id"),
+                    e => l1s.SingleOrDefault(l => l.Id == ((Level1)e)?.Id)?.OneToMany_Optional_Self_Inverse1?.Id
+                },
+
+                {
+                    (typeof(Level2), "OneToOne_Optional_PK_Inverse2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToOne_Optional_PK_Inverse2?.Id
+                },
+                {
+                    (typeof(Level2), "OneToMany_Required_Inverse2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToMany_Required_Inverse2?.Id
+                },
+                {
+                    (typeof(Level2), "OneToMany_Optional_Inverse2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToMany_Optional_Inverse2?.Id
+                },
+                {
+                    (typeof(Level2), "OneToOne_Optional_Self2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToOne_Optional_Self2?.Id
+                },
+                {
+                    (typeof(Level2), "OneToMany_Required_Self_Inverse2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToMany_Required_Self_Inverse2?.Id
+                },
+                {
+                    (typeof(Level2), "OneToMany_Optional_Self_Inverse2Id"),
+                    e => l2s.SingleOrDefault(l => l.Id == ((Level2)e)?.Id)?.OneToMany_Optional_Self_Inverse2?.Id
+                },
+
+                {
+                    (typeof(Level3), "OneToOne_Optional_PK_Inverse3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToOne_Optional_PK_Inverse3?.Id
+                },
+                {
+                    (typeof(Level3), "OneToMany_Required_Inverse3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToMany_Required_Inverse3?.Id
+                },
+                {
+                    (typeof(Level3), "OneToMany_Optional_Inverse3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToMany_Optional_Inverse3?.Id
+                },
+                {
+                    (typeof(Level3), "OneToOne_Optional_Self3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToOne_Optional_Self3?.Id
+                },
+                {
+                    (typeof(Level3), "OneToMany_Required_Self_Inverse3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToMany_Required_Self_Inverse3?.Id
+                },
+                {
+                    (typeof(Level3), "OneToMany_Optional_Self_Inverse3Id"),
+                    e => l3s.SingleOrDefault(l => l.Id == ((Level3)e)?.Id)?.OneToMany_Optional_Self_Inverse3?.Id
+                },
+
+                {
+                    (typeof(Level4), "OneToOne_Optional_PK_Inverse4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToOne_Optional_PK_Inverse4?.Id
+                },
+                {
+                    (typeof(Level4), "OneToMany_Required_Inverse4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToMany_Required_Inverse4?.Id
+                },
+                {
+                    (typeof(Level4), "OneToMany_Optional_Inverse4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToMany_Optional_Inverse4?.Id
+                },
+                {
+                    (typeof(Level4), "OneToOne_Optional_Self4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToOne_Optional_Self4?.Id
+                },
+                {
+                    (typeof(Level4), "OneToMany_Required_Self_Inverse4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToMany_Required_Self_Inverse4?.Id
+                },
+                {
+                    (typeof(Level4), "OneToMany_Optional_Self_Inverse4Id"),
+                    e => l4s.SingleOrDefault(l => l.Id == ((Level4)e)?.Id)?.OneToMany_Optional_Self_Inverse4?.Id
+                },
+
+                {
+                    (typeof(InheritanceBase1), "InheritanceBase2Id"),
+                    e => ((InheritanceBase1)e)?.Id == 1 ? 1 : null
+                },
+                {
+                    (typeof(InheritanceBase1), "InheritanceBase2Id1"),
+                    e => ((InheritanceBase1)e)?.Id == 1 ? null : 1
+                },
+
+                {
+                    (typeof(InheritanceBase2), "InheritanceLeaf2Id"),
+                    e => ((InheritanceBase2)e)?.Id == 1 ? 1 : null
+                },
+
+                {
+                    (typeof(InheritanceLeaf1), "DifferentTypeReference_InheritanceDerived1Id"),
+                    e =>
+                    {
+                        switch (((InheritanceLeaf1)e)?.Id)
+                        {
+                            case 1: return 1;
+                            case 2: return 2;
+                            default: return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(InheritanceLeaf1), "InheritanceDerived1Id"),
+                    e =>
+                    {
+                        switch (((InheritanceLeaf1)e)?.Id)
+                        {
+                            case 1: return 1;
+                            case 2: return 2;
+                            case 3: return 2;
+                            default: return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(InheritanceLeaf1), "InheritanceDerived1Id1"),
+                    e => ((InheritanceLeaf1)e)?.Id == 1 ? 1 : null
+                },
+                {
+                    (typeof(InheritanceLeaf1), "InheritanceDerived2Id"),
+                    e =>
+                    {
+                        switch (((InheritanceLeaf1)e)?.Id)
+                        {
+                            case 2: return 3;
+                            case 3: return 3;
+                            default: return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(InheritanceLeaf1), "SameTypeReference_InheritanceDerived1Id"),
+                    e =>
+                    {
+                        switch (((InheritanceLeaf1)e)?.Id)
+                        {
+                            case 1: return 1;
+                            case 2: return 2;
+                            default: return null;
+                        }
+                    }
+                },
+                {
+                    (typeof(InheritanceLeaf1), "SameTypeReference_InheritanceDerived2Id"),
+                    e => ((InheritanceLeaf1)e)?.Id == 3 ? 3 : null
+                },
+
+                {
+                    (typeof(InheritanceLeaf2), "DifferentTypeReference_InheritanceDerived2Id"),
+                    e => ((InheritanceLeaf2)e)?.Id == 1 ? 3 : null
+                },
+                {
+                    (typeof(InheritanceLeaf2), "InheritanceDerived2Id"),
+                    e => ((InheritanceLeaf2)e)?.Id == 1 ? 3 : null
+                },
+            };
+        }
         public IReadOnlyDictionary<Type, object> GetEntitySorters()
             => new Dictionary<Type, Func<object, object>>
             {
@@ -354,6 +547,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (typeof(TEntity) == typeof(InheritanceBase2))
                 {
                     return (IQueryable<TEntity>)InheritanceBaseTwos.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceLeaf1))
+                {
+                    return (IQueryable<TEntity>)InheritanceLeafOnes.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceLeaf2))
+                {
+                    return (IQueryable<TEntity>)InheritanceLeafTwos.AsQueryable();
                 }
 
                 throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -39,48 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
-            => CreateExpectedQueryRewritingVisitor().Visit(expectedQueryExpression);
+            => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);
 
         private MemberInfo GetMemberInfo(Type sourceType, string name)
             => sourceType.GetMember(name).Single();
-
-        private ExpectedQueryRewritingVisitor CreateExpectedQueryRewritingVisitor()
-            => new ExpectedQueryRewritingVisitor(
-                new Dictionary<(Type, string), MemberInfo[]>
-                {
-                    {
-                        (typeof(Level1), "OneToMany_Optional_Self_Inverse1Id"),
-                        new[] { GetMemberInfo(typeof(Level1), "OneToMany_Optional_Self_Inverse1"), GetMemberInfo(typeof(Level1), "Id") }
-                    },
-                    {
-                        (typeof(Level1), "OneToOne_Optional_Self1Id"),
-                        new[] { GetMemberInfo(typeof(Level1), "OneToOne_Optional_Self1"), GetMemberInfo(typeof(Level1), "Id") }
-                    },
-                    {
-                        (typeof(Level2), "OneToMany_Optional_Self_Inverse2Id"),
-                        new[] { GetMemberInfo(typeof(Level2), "OneToMany_Optional_Self_Inverse2"), GetMemberInfo(typeof(Level2), "Id") }
-                    },
-                    {
-                        (typeof(Level2), "OneToOne_Optional_Self2Id"),
-                        new[] { GetMemberInfo(typeof(Level2), "OneToOne_Optional_Self2"), GetMemberInfo(typeof(Level2), "Id") }
-                    },
-                    {
-                        (typeof(Level3), "OneToMany_Optional_Self_Inverse3Id"),
-                        new[] { GetMemberInfo(typeof(Level3), "OneToMany_Optional_Self_Inverse3"), GetMemberInfo(typeof(Level3), "Id") }
-                    },
-                    {
-                        (typeof(Level3), "OneToOne_Optional_Self3Id"),
-                        new[] { GetMemberInfo(typeof(Level3), "OneToOne_Optional_Self3"), GetMemberInfo(typeof(Level3), "Id") }
-                    },
-                    {
-                        (typeof(Level4), "OneToMany_Optional_Self_Inverse4Id"),
-                        new[] { GetMemberInfo(typeof(Level4), "OneToMany_Optional_Self_Inverse4"), GetMemberInfo(typeof(Level4), "Id") }
-                    },
-                    {
-                        (typeof(Level4), "OneToOne_Optional_Self4Id"),
-                        new[] { GetMemberInfo(typeof(Level4), "OneToOne_Optional_Self4"), GetMemberInfo(typeof(Level4), "Id") }
-                    },
-                });
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -5961,6 +5923,137 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select inner,
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Project_shadow_properties(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<Level1>()
+                      select new
+                      {
+                          Id = x.Id,
+                          OneToOne_Optional_Self1Id = EF.Property<int?>(x, "OneToOne_Optional_Self1Id"),
+                          OneToMany_Required_Self_Inverse1Id = EF.Property<int?>(x, "OneToMany_Required_Self_Inverse1Id"),
+                          OneToMany_Optional_Self_Inverse1Id = EF.Property<int?>(x, "OneToMany_Optional_Self_Inverse1Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<Level2>()
+                      select new
+                      {
+                          Id = x.Id,
+                          OneToOne_Optional_PK_Inverse2Id = EF.Property<int?>(x, "OneToOne_Optional_PK_Inverse2Id"),
+                          OneToMany_Required_Inverse2Id = EF.Property<int?>(x, "OneToMany_Required_Inverse2Id"),
+                          OneToMany_Optional_Inverse2Id = EF.Property<int?>(x, "OneToMany_Optional_Inverse2Id"),
+                          OneToOne_Optional_Self2Id = EF.Property<int?>(x, "OneToOne_Optional_Self2Id"),
+                          OneToMany_Required_Self_Inverse2Id = EF.Property<int?>(x, "OneToMany_Required_Self_Inverse2Id"),
+                          OneToMany_Optional_Self_Inverse2Id = EF.Property<int?>(x, "OneToMany_Optional_Self_Inverse2Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<Level3>()
+                      select new
+                      {
+                          Id = x.Id,
+                          OneToOne_Optional_PK_Inverse3Id = EF.Property<int?>(x, "OneToOne_Optional_PK_Inverse3Id"),
+                          OneToMany_Required_Inverse3Id = EF.Property<int?>(x, "OneToMany_Required_Inverse3Id"),
+                          OneToMany_Optional_Inverse3Id = EF.Property<int?>(x, "OneToMany_Optional_Inverse3Id"),
+                          OneToOne_Optional_Self3Id = EF.Property<int?>(x, "OneToOne_Optional_Self3Id"),
+                          OneToMany_Required_Self_Inverse3Id = EF.Property<int?>(x, "OneToMany_Required_Self_Inverse3Id"),
+                          OneToMany_Optional_Self_Inverse3Id = EF.Property<int?>(x, "OneToMany_Optional_Self_Inverse3Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<Level4>()
+                      select new
+                      {
+                          Id = x.Id,
+                          OneToOne_Optional_PK_Inverse4Id = EF.Property<int?>(x, "OneToOne_Optional_PK_Inverse4Id"),
+                          OneToMany_Required_Inverse4Id = EF.Property<int?>(x, "OneToMany_Required_Inverse4Id"),
+                          OneToMany_Optional_Inverse4Id = EF.Property<int?>(x, "OneToMany_Optional_Inverse4Id"),
+                          OneToOne_Optional_Self4Id = EF.Property<int?>(x, "OneToOne_Optional_Self4Id"),
+                          OneToMany_Required_Self_Inverse4Id = EF.Property<int?>(x, "OneToMany_Required_Self_Inverse4Id"),
+                          OneToMany_Optional_Self_Inverse4Id = EF.Property<int?>(x, "OneToMany_Optional_Self_Inverse4Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceBase1>()
+                      select new
+                      {
+                          Id = x.Id,
+                          InheritanceBase2Id = EF.Property<int?>(x, "InheritanceBase2Id"),
+                          InheritanceBase2Id1 = EF.Property<int?>(x, "InheritanceBase2Id1"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceBase1>().OfType<InheritanceDerived1>()
+                      select new
+                      {
+                          Id = x.Id,
+                          InheritanceBase2Id = EF.Property<int?>(x, "InheritanceBase2Id"),
+                          InheritanceBase2Id1 = EF.Property<int?>(x, "InheritanceBase2Id1"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceBase1>().OfType<InheritanceDerived2>()
+                      select new
+                      {
+                          Id = x.Id,
+                          InheritanceBase2Id = EF.Property<int?>(x, "InheritanceBase2Id"),
+                          InheritanceBase2Id1 = EF.Property<int?>(x, "InheritanceBase2Id1"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceBase2>()
+                      select new
+                      {
+                          Id = x.Id,
+                          InheritanceLeaf2Id = EF.Property<int?>(x, "InheritanceLeaf2Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceLeaf1>()
+                      select new
+                      {
+                          Id = x.Id,
+                          DifferentTypeReference_InheritanceDerived1Id = EF.Property<int?>(x, "DifferentTypeReference_InheritanceDerived1Id"),
+                          InheritanceDerived1Id = EF.Property<int?>(x, "InheritanceDerived1Id"),
+                          InheritanceDerived1Id1 = EF.Property<int?>(x, "InheritanceDerived1Id1"),
+                          InheritanceDerived2Id = EF.Property<int?>(x, "InheritanceDerived2Id"),
+                          SameTypeReference_InheritanceDerived1Id = EF.Property<int?>(x, "SameTypeReference_InheritanceDerived1Id"),
+                          SameTypeReference_InheritanceDerived2Id = EF.Property<int?>(x, "SameTypeReference_InheritanceDerived2Id"),
+                      },
+                elementSorter: e => e.Id);
+
+            await AssertQuery(
+                async,
+                ss => from x in ss.Set<InheritanceLeaf2>()
+                      select new
+                      {
+                          Id = x.Id,
+                          DifferentTypeReference_InheritanceDerived2Id = EF.Property<int?>(x, "DifferentTypeReference_InheritanceDerived2Id"),
+                          InheritanceDerived2Id = EF.Property<int?>(x, "InheritanceDerived2Id"),
+                      },
+                elementSorter: e => e.Id);
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
@@ -13,10 +13,19 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavigationsQueryFixtureBase, IQueryFixtureBase
     {
+        private ComplexNavigationsWeakData _expectedData;
+
         protected override string StoreName { get; } = "ComplexNavigationsOwned";
 
         public override ISetSource GetExpectedData()
-            => new ComplexNavigationsWeakData();
+        {
+            if (_expectedData == null)
+            {
+                _expectedData = new ComplexNavigationsWeakData();
+            }
+
+            return _expectedData;
+        }
 
         Func<DbContext, ISetSource> IQueryFixtureBase.GetSetSourceCreator()
             => context => new ComplexNavigationsWeakSetExtractor(context);
@@ -311,6 +320,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (typeof(TEntity) == typeof(InheritanceBase2))
                 {
                     return (IQueryable<TEntity>)InheritanceBaseTwos.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceLeaf1))
+                {
+                    return (IQueryable<TEntity>)InheritanceLeafOnes.AsQueryable();
+                }
+
+                if (typeof(TEntity) == typeof(InheritanceLeaf2))
+                {
+                    return (IQueryable<TEntity>)InheritanceLeafTwos.AsQueryable();
                 }
 
                 throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryTestBase.cs
@@ -160,5 +160,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Multiple_collection_FirstOrDefault_followed_by_member_access_in_projection(async);
         }
+
+        public override Task Project_shadow_properties(bool async)
+            => Task.CompletedTask;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -13,13 +13,31 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class GearsOfWarQueryFixtureBase : SharedStoreFixtureBase<GearsOfWarContext>, IQueryFixtureBase
     {
+        private GearsOfWarData _expectedData;
+
         protected override string StoreName { get; } = "GearsOfWarQueryTest";
 
         public Func<DbContext> GetContextCreator()
             => () => CreateContext();
 
         public virtual ISetSource GetExpectedData()
-            =>  new GearsOfWarData();
+        {
+            if (_expectedData == null)
+            {
+                _expectedData = new GearsOfWarData();
+            }
+
+            return _expectedData;
+        }
+
+        public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+            => new Dictionary<(Type, string), Func<object, object>>
+            {
+                {
+                    (typeof(Gear), "AssignedCityName"),
+                    e => GetExpectedData().Set<Gear>().AsEnumerable().SingleOrDefault(g => g.Nickname == ((Gear)e)?.Nickname)?.AssignedCity?.Name
+                },
+            };
 
         public IReadOnlyDictionary<Type, object> GetEntitySorters()
             => new Dictionary<Type, Func<object, object>>

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -37,6 +37,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
+            => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings())
+                .Visit(expectedQueryExpression);
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Negate_on_binary_expression(bool async)
@@ -7952,6 +7956,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery(
                 async,
                 ss => ss.Set<Squad>().Where(e => e.Banner5[2] == 0x06));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Project_shadow_properties(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => from g in ss.Set<Gear>()
+                      select new
+                      {
+                          g.Nickname,
+                          AssignedCityName = EF.Property<string>(g, "AssignedCityName")
+                      },
+                elementSorter: e => e.Nickname);
         }
 
         protected GearsOfWarContext CreateContext()

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsData.cs
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             return result;
         }
 
-        public static void WireUpInheritancePart1(
+        private static void WireUpInheritancePart1(
             IReadOnlyList<InheritanceBase1> ib1s,
             IReadOnlyList<InheritanceBase2> ib2s,
             IReadOnlyList<InheritanceLeaf1> il1s,
@@ -372,14 +372,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             ((InheritanceDerived2)ib1s[2]).CollectionDifferentType = new List<InheritanceLeaf2> { il2s[0] };
         }
 
-        public static void WireUpInheritancePart2(
+        private static void WireUpInheritancePart2(
             IReadOnlyList<InheritanceBase2> ib2s,
             IReadOnlyList<InheritanceLeaf2> il2s)
         {
             il2s[0].BaseCollection = new List<InheritanceBase2> { ib2s[0] };
         }
 
-        public static void WireUpPart1(
+        private static void WireUpPart1(
             IReadOnlyList<Level1> l1s,
             IReadOnlyList<Level2> l2s,
             IReadOnlyList<Level3> l3s,
@@ -622,7 +622,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             l4s[9].OneToMany_Required_Self4 = new List<Level4>();
         }
 
-        public static void WireUpInversePart1(
+        private static void WireUpInversePart1(
             IReadOnlyList<Level1> l1s,
             IReadOnlyList<Level2> l2s,
             IReadOnlyList<Level3> l3s,
@@ -908,7 +908,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             l4s[9].OneToMany_Required_Self_Inverse4 = l4s[8];
         }
 
-        public static void WireUpPart2(
+        private static void WireUpPart2(
             IReadOnlyList<Level1> l1s,
             IReadOnlyList<Level2> l2s,
             IReadOnlyList<Level3> l3s,
@@ -1020,7 +1020,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
             l4s[9].OneToMany_Optional_Self4 = new List<Level4> { l4s[8] };
         }
 
-        public static void WireUpInversePart2(
+        private static void WireUpInversePart2(
             IReadOnlyList<Level1> l1s,
             IReadOnlyList<Level2> l2s,
             IReadOnlyList<Level3> l3s,
@@ -1059,9 +1059,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel
 
             l3s[0].OneToOne_Optional_PK_Inverse3 = l2s[0];
             l3s[2].OneToOne_Optional_PK_Inverse3 = l2s[2];
-            l3s[5].OneToOne_Optional_PK_Inverse3 = l2s[4];
-            l3s[7].OneToOne_Optional_PK_Inverse3 = l2s[6];
-            l3s[9].OneToOne_Optional_PK_Inverse3 = l2s[8];
+            l3s[4].OneToOne_Optional_PK_Inverse3 = l2s[5];
+            l3s[6].OneToOne_Optional_PK_Inverse3 = l2s[7];
+            l3s[8].OneToOne_Optional_PK_Inverse3 = l2s[9];
 
             l3s[8].OneToOne_Optional_FK_Inverse3 = l2s[1];
             l3s[6].OneToOne_Optional_FK_Inverse3 = l2s[3];

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -6136,6 +6136,44 @@ OUTER APPLY (
 ORDER BY [l].[Id], [t0].[Id], [t1].[Id]");
         }
 
+        public override async Task Project_shadow_properties(bool async)
+        {
+            await base.Project_shadow_properties(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[OneToOne_Optional_Self1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToMany_Optional_Self_Inverse1Id]
+FROM [LevelOne] AS [l]",
+                //
+                @"SELECT [l].[Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id]
+FROM [LevelTwo] AS [l]",
+                //
+                @"SELECT [l].[Id], [l].[OneToOne_Optional_PK_Inverse3Id], [l].[OneToMany_Required_Inverse3Id], [l].[OneToMany_Optional_Inverse3Id], [l].[OneToOne_Optional_Self3Id], [l].[OneToMany_Required_Self_Inverse3Id], [l].[OneToMany_Optional_Self_Inverse3Id]
+FROM [LevelThree] AS [l]",
+                //
+                @"SELECT [l].[Id], [l].[OneToOne_Optional_PK_Inverse4Id], [l].[OneToMany_Required_Inverse4Id], [l].[OneToMany_Optional_Inverse4Id], [l].[OneToOne_Optional_Self4Id], [l].[OneToMany_Required_Self_Inverse4Id], [l].[OneToMany_Optional_Self_Inverse4Id]
+FROM [LevelFour] AS [l]",
+                //
+                @"SELECT [i].[Id], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1]
+FROM [InheritanceOne] AS [i]",
+                //
+                @"SELECT [i].[Id], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1]
+FROM [InheritanceOne] AS [i]
+WHERE [i].[Discriminator] = N'InheritanceDerived1'",
+                //
+                @"SELECT [i].[Id], [i].[InheritanceBase2Id], [i].[InheritanceBase2Id1]
+FROM [InheritanceOne] AS [i]
+WHERE [i].[Discriminator] = N'InheritanceDerived2'",
+                //
+                @"SELECT [i].[Id], [i].[InheritanceLeaf2Id]
+FROM [InheritanceTwo] AS [i]",
+                //
+                @"SELECT [i].[Id], [i].[DifferentTypeReference_InheritanceDerived1Id], [i].[InheritanceDerived1Id], [i].[InheritanceDerived1Id1], [i].[InheritanceDerived2Id], [i].[SameTypeReference_InheritanceDerived1Id], [i].[SameTypeReference_InheritanceDerived2Id]
+FROM [InheritanceLeafOne] AS [i]",
+                //
+                @"SELECT [i].[Id], [i].[DifferentTypeReference_InheritanceDerived2Id], [i].[InheritanceDerived2Id]
+FROM [InheritanceLeafTwo] AS [i]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7364,6 +7364,41 @@ FROM [Squads] AS [s]
 WHERE CAST(SUBSTRING([s].[Banner5], 2 + 1, 1) AS tinyint) = CAST(6 AS tinyint)");
         }
 
+        public override async Task Project_shadow_properties(bool async)
+        {
+            await base.Project_shadow_properties(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[AssignedCityName]
+FROM [Gears] AS [g]");
+        }
+
+        public override async Task Project_discriminator_columns(bool async)
+        {
+            await base.Project_discriminator_columns(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[Discriminator]
+FROM [Gears] AS [g]",
+                //
+                @"SELECT [g].[Nickname], [g].[Discriminator]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] = N'Officer'",
+                //
+                @"SELECT [f].[Id], [f].[Discriminator]
+FROM [Factions] AS [f]",
+                //
+                @"SELECT [f].[Id], [f].[Discriminator]
+FROM [Factions] AS [f]",
+                //
+                @"SELECT [l].[Name], [l].[Discriminator]
+FROM [LocustLeaders] AS [l]",
+                //
+                @"SELECT [l].[Name], [l].[Discriminator]
+FROM [LocustLeaders] AS [l]
+WHERE [l].[Discriminator] = N'LocustCommander'");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
Building the mapping when we generate the expected data, so we also have access to navigations and entities for shadow navigations in the future.
Discriminators are added at the test class level since we use same expected data setup for TPH and TPT.

Fixes #19994