### PR TITLE
[5.0.2] Stop marking the inverse navigation as loaded when loading a many-to-many navigation

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -393,7 +393,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(inverseNavigation, typeof(INavigation)),
                         Expression.Constant(fixup),
                         Expression.Constant(initialize, typeof(Action<>).MakeGenericType(includingClrType)),
+#pragma warning disable EF1001 // Internal EF Core API usage.
                         Expression.Constant(includeExpression.SetLoaded)));
+#pragma warning restore EF1001 // Internal EF Core API usage.
             }
 
             private static readonly MethodInfo _includeReferenceMethodInfo

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.CosmosProjectionBindingRemovingExpressionVisitorBase.cs
@@ -392,7 +392,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(navigation),
                         Expression.Constant(inverseNavigation, typeof(INavigation)),
                         Expression.Constant(fixup),
-                        Expression.Constant(initialize, typeof(Action<>).MakeGenericType(includingClrType))));
+                        Expression.Constant(initialize, typeof(Action<>).MakeGenericType(includingClrType)),
+                        Expression.Constant(includeExpression.SetLoaded)));
             }
 
             private static readonly MethodInfo _includeReferenceMethodInfo
@@ -409,7 +410,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 INavigation navigation,
                 INavigation inverseNavigation,
                 Action<TIncludingEntity, TIncludedEntity> fixup,
-                Action<TIncludingEntity> _)
+                Action<TIncludingEntity> _,
+                bool __)
             {
                 if (entity == null
                     || !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
@@ -454,7 +456,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 INavigation navigation,
                 INavigation inverseNavigation,
                 Action<TIncludingEntity, TIncludedEntity> fixup,
-                Action<TIncludingEntity> initialize)
+                Action<TIncludingEntity> initialize,
+                bool setLoaded)
             {
                 if (entity == null
                     || !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
@@ -485,9 +488,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
                 else
                 {
+                    if (setLoaded)
+                    {
 #pragma warning disable EF1001 // Internal EF Core API usage.
-                    entry.SetIsLoaded(navigation);
+                        entry.SetIsLoaded(navigation);
 #pragma warning restore EF1001 // Internal EF Core API usage.
+                    }
+
                     if (relatedEntities != null)
                     {
                         using var enumerator = relatedEntities.GetEnumerator();

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -87,7 +87,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 INavigationBase navigation,
                 INavigationBase inverseNavigation,
                 Action<TIncludingEntity, TIncludedEntity> fixup,
-                bool trackingQuery)
+                bool trackingQuery,
+                bool setLoaded)
                 where TIncludingEntity : class, TEntity
                 where TEntity : class
                 where TIncludedEntity : class
@@ -97,13 +98,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                     var collectionAccessor = navigation.GetCollectionAccessor();
                     collectionAccessor.GetOrCreate(includingEntity, forMaterialization: true);
 
-                    if (trackingQuery)
+                    if (setLoaded)
                     {
-                        queryContext.SetNavigationIsLoaded(entity, navigation);
-                    }
-                    else
-                    {
-                        navigation.SetIsLoadedWhenNoTracking(entity);
+                        if (trackingQuery)
+                        {
+                            queryContext.SetNavigationIsLoaded(entity, navigation);
+                        }
+                        else
+                        {
+                            navigation.SetIsLoadedWhenNoTracking(entity);
+                        }
                     }
 
                     foreach (var valueBuffer in innerValueBuffers)
@@ -178,7 +182,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                             Expression.Constant(
                                 GenerateFixup(
                                     includingClrType, relatedEntityClrType, includeExpression.Navigation, inverseNavigation).Compile()),
-                            Expression.Constant(_tracking));
+                            Expression.Constant(_tracking),
+                            Expression.Constant(includeExpression.SetLoaded));
                     }
 
                     return Expression.Call(

--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -183,7 +183,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                                 GenerateFixup(
                                     includingClrType, relatedEntityClrType, includeExpression.Navigation, inverseNavigation).Compile()),
                             Expression.Constant(_tracking),
+#pragma warning disable EF1001 // Internal EF Core API usage.
                             Expression.Constant(includeExpression.SetLoaded));
+#pragma warning restore EF1001 // Internal EF Core API usage.
                     }
 
                     return Expression.Call(

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -547,7 +547,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     Expression.Constant(outerIdentifierLambda.Compile()),
                                     Expression.Constant(navigation),
                                     Expression.Constant(navigation.GetCollectionAccessor()),
-                                    Expression.Constant(_isTracking)));
+                                    Expression.Constant(_isTracking),
+                                    Expression.Constant(includeExpression.SetLoaded)));
 
                             var relatedEntityType = innerShaper.ReturnType;
                             var inverseNavigation = navigation.Inverse;
@@ -629,7 +630,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     Expression.Constant(parentIdentifierLambda.Compile()),
                                     Expression.Constant(navigation),
                                     Expression.Constant(navigation.GetCollectionAccessor()),
-                                    Expression.Constant(_isTracking)));
+                                    Expression.Constant(_isTracking),
+                                    Expression.Constant(includeExpression.SetLoaded)));
 
                             var relatedEntityType = innerShaper.ReturnType;
                             var inverseNavigation = navigation.Inverse;
@@ -1207,20 +1209,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Func<QueryContext, DbDataReader, object[]> outerIdentifier,
                 INavigationBase navigation,
                 IClrCollectionAccessor clrCollectionAccessor,
-                bool trackingQuery)
+                bool trackingQuery,
+                bool setLoaded)
                 where TParent : class
                 where TNavigationEntity : class, TParent
             {
                 object collection = null;
                 if (entity is TNavigationEntity)
                 {
-                    if (trackingQuery)
+                    if (setLoaded)
                     {
-                        queryContext.SetNavigationIsLoaded(entity, navigation);
-                    }
-                    else
-                    {
-                        navigation.SetIsLoadedWhenNoTracking(entity);
+                        if (trackingQuery)
+                        {
+                            queryContext.SetNavigationIsLoaded(entity, navigation);
+                        }
+                        else
+                        {
+                            navigation.SetIsLoadedWhenNoTracking(entity);
+                        }
                     }
 
                     collection = clrCollectionAccessor.GetOrCreate(entity, forMaterialization: true);
@@ -1361,20 +1367,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Func<QueryContext, DbDataReader, object[]> parentIdentifier,
                 INavigationBase navigation,
                 IClrCollectionAccessor clrCollectionAccessor,
-                bool trackingQuery)
+                bool trackingQuery,
+                bool setLoaded)
                 where TParent : class
                 where TNavigationEntity : class, TParent
             {
                 object collection = null;
                 if (entity is TNavigationEntity)
                 {
-                    if (trackingQuery)
+                    if (setLoaded)
                     {
-                        queryContext.SetNavigationIsLoaded(entity, navigation);
-                    }
-                    else
-                    {
-                        navigation.SetIsLoadedWhenNoTracking(entity);
+                        if (trackingQuery)
+                        {
+                            queryContext.SetNavigationIsLoaded(entity, navigation);
+                        }
+                        else
+                        {
+                            navigation.SetIsLoadedWhenNoTracking(entity);
+                        }
                     }
 
                     collection = clrCollectionAccessor.GetOrCreate(entity, forMaterialization: true);

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -548,7 +548,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     Expression.Constant(navigation),
                                     Expression.Constant(navigation.GetCollectionAccessor()),
                                     Expression.Constant(_isTracking),
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                     Expression.Constant(includeExpression.SetLoaded)));
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                             var relatedEntityType = innerShaper.ReturnType;
                             var inverseNavigation = navigation.Inverse;
@@ -631,7 +633,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     Expression.Constant(navigation),
                                     Expression.Constant(navigation.GetCollectionAccessor()),
                                     Expression.Constant(_isTracking),
+#pragma warning disable EF1001 // Internal EF Core API usage.
                                     Expression.Constant(includeExpression.SetLoaded)));
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
                             var relatedEntityType = innerShaper.ReturnType;
                             var inverseNavigation = navigation.Inverse;

--- a/src/EFCore/Internal/ManyToManyLoader.cs
+++ b/src/EFCore/Internal/ManyToManyLoader.cs
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             //        .AsTracking()
             //        .Where(e => e.Id == left.Id)
             //        .SelectMany(e => e.TwoSkip)
-            //        .Include(e => e.OneSkip.Where(e => e.Id == left.Id));
+            //        .NotQuiteInclude(e => e.OneSkip.Where(e => e.Id == left.Id));
 
             var queryRoot = _skipNavigation.DeclaringEntityType.HasSharedClrType
                 ? context.Set<TSourceEntity>(_skipNavigation.DeclaringEntityType.Name)
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 .AsTracking()
                 .Where(BuildWhereLambda(loadProperties, new ValueBuffer(keyValues)))
                 .SelectMany(BuildSelectManyLambda(_skipNavigation))
-                .Include(BuildIncludeLambda(_skipNavigation.Inverse, loadProperties, new ValueBuffer(keyValues)))
+                .NotQuiteInclude(BuildIncludeLambda(_skipNavigation.Inverse, loadProperties, new ValueBuffer(keyValues)))
                 .AsQueryable();
         }
 

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             NavigationExpression = navigationExpression;
             Navigation = navigation;
             Type = EntityExpression.Type;
-            SetLoaded = setLoaded;
+
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23475", out var enabled) && enabled;
+            SetLoaded = useOldBehavior || setLoaded;
         }
 
         /// <summary>

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -36,12 +37,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
-        ///     Creates a new instance of the <see cref="IncludeExpression" /> class.
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        /// <param name="entityExpression"> An expression to get entity which is performing include. </param>
-        /// <param name="navigationExpression"> An expression to get included navigation element. </param>
-        /// <param name="navigation"> The navigation for this include operation. </param>
-        /// <param name="setLoaded"> True if the navigation will be marked as loaded. </param>
+        [EntityFrameworkInternal]
         public IncludeExpression(
             [NotNull] Expression entityExpression,
             [NotNull] Expression navigationExpression,
@@ -77,8 +78,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual INavigationBase Navigation { get; }
 
         /// <summary>
-        ///     True if the navigation will be marked as loaded.
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        [EntityFrameworkInternal]
         public virtual bool SetLoaded { get; }
 
         /// <inheritdoc />

--- a/src/EFCore/Query/IncludeExpression.cs
+++ b/src/EFCore/Query/IncludeExpression.cs
@@ -21,7 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Query
     public class IncludeExpression : Expression, IPrintableExpression
     {
         /// <summary>
-        ///     Creates a new instance of the <see cref="IncludeExpression" /> class.
+        ///     Creates a new instance of the <see cref="IncludeExpression" /> class. The navigation will be set
+        ///     as loaded after completing the Include.
         /// </summary>
         /// <param name="entityExpression"> An expression to get entity which is performing include. </param>
         /// <param name="navigationExpression"> An expression to get included navigation element. </param>
@@ -30,6 +31,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] Expression entityExpression,
             [NotNull] Expression navigationExpression,
             [NotNull] INavigationBase navigation)
+            : this(entityExpression, navigationExpression, navigation, setLoaded: true)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new instance of the <see cref="IncludeExpression" /> class.
+        /// </summary>
+        /// <param name="entityExpression"> An expression to get entity which is performing include. </param>
+        /// <param name="navigationExpression"> An expression to get included navigation element. </param>
+        /// <param name="navigation"> The navigation for this include operation. </param>
+        /// <param name="setLoaded"> True if the navigation will be marked as loaded. </param>
+        public IncludeExpression(
+            [NotNull] Expression entityExpression,
+            [NotNull] Expression navigationExpression,
+            [NotNull] INavigationBase navigation,
+            bool setLoaded)
         {
             Check.NotNull(entityExpression, nameof(entityExpression));
             Check.NotNull(navigationExpression, nameof(navigationExpression));
@@ -39,6 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             NavigationExpression = navigationExpression;
             Navigation = navigation;
             Type = EntityExpression.Type;
+            SetLoaded = setLoaded;
         }
 
         /// <summary>
@@ -55,6 +73,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     The navigation associated with this include operation.
         /// </summary>
         public virtual INavigationBase Navigation { get; }
+
+        /// <summary>
+        ///     True if the navigation will be marked as loaded.
+        /// </summary>
+        public virtual bool SetLoaded { get; }
 
         /// <inheritdoc />
         public sealed override ExpressionType NodeType
@@ -87,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(navigationExpression, nameof(navigationExpression));
 
             return entityExpression != EntityExpression || navigationExpression != NavigationExpression
-                ? new IncludeExpression(entityExpression, navigationExpression, Navigation)
+                ? new IncludeExpression(entityExpression, navigationExpression, Navigation, SetLoaded)
                 : this;
         }
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -825,7 +825,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
-                    result = new IncludeExpression(result, included, navigationBase, entityReference.SetLoaded);
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                    result = new IncludeExpression(result, included, navigationBase, kvp.Value.SetLoaded);
+#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 return result;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -825,7 +825,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
-                    result = new IncludeExpression(result, included, navigationBase);
+                    result = new IncludeExpression(result, included, navigationBase, entityReference.SetLoaded);
                 }
 
                 return result;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public bool IsOptional { get; private set; }
             public IncludeTreeNode IncludePaths { get; private set; }
             public IncludeTreeNode LastIncludeTreeNode { get; private set; }
+            public bool SetLoaded { get; private set; } = true;
 
             public override ExpressionType NodeType
                 => ExpressionType.Extension;
@@ -56,6 +57,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public void MarkAsOptional()
                 => IsOptional = true;
+
+            public void SuppressSettingLoaded()
+                => SetLoaded = false;
 
             void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
             {

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public EntityReference(IEntityType entityType)
             {
                 EntityType = entityType;
-                IncludePaths = new IncludeTreeNode(entityType, this);
+                IncludePaths = new IncludeTreeNode(entityType, this, setLoaded: true);
             }
 
             public IEntityType EntityType { get; }
@@ -29,7 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             public bool IsOptional { get; private set; }
             public IncludeTreeNode IncludePaths { get; private set; }
             public IncludeTreeNode LastIncludeTreeNode { get; private set; }
-            public bool SetLoaded { get; private set; } = true;
 
             public override ExpressionType NodeType
                 => ExpressionType.Extension;
@@ -57,9 +56,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public void MarkAsOptional()
                 => IsOptional = true;
-
-            public void SuppressSettingLoaded()
-                => SetLoaded = false;
 
             void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
             {
@@ -90,23 +86,30 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private EntityReference _entityReference;
 
             public IncludeTreeNode(IEntityType entityType)
+                : this(entityType, null, setLoaded: true)
             {
-                EntityType = entityType;
             }
 
-            public IncludeTreeNode(IEntityType entityType, EntityReference entityReference)
+            public IncludeTreeNode(IEntityType entityType, EntityReference entityReference, bool setLoaded)
             {
                 EntityType = entityType;
                 _entityReference = entityReference;
+                SetLoaded = setLoaded;
             }
 
             public IEntityType EntityType { get; }
             public LambdaExpression FilterExpression { get; private set; }
+            public bool SetLoaded { get; private set; }
 
-            public IncludeTreeNode AddNavigation(INavigationBase navigation)
+            public IncludeTreeNode AddNavigation(INavigationBase navigation, bool setLoaded)
             {
                 if (TryGetValue(navigation, out var existingValue))
                 {
+                    if (setLoaded && !existingValue.SetLoaded)
+                    {
+                        existingValue.SetLoaded = true;
+                    }
+
                     return existingValue;
                 }
 
@@ -131,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (nodeToAdd == null)
                 {
-                    nodeToAdd = new IncludeTreeNode(navigation.TargetEntityType, null);
+                    nodeToAdd = new IncludeTreeNode(navigation.TargetEntityType, null, setLoaded);
                 }
 
                 this[navigation] = nodeToAdd;
@@ -141,7 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public IncludeTreeNode Snapshot(EntityReference entityReference)
             {
-                var result = new IncludeTreeNode(EntityType, entityReference) { FilterExpression = FilterExpression };
+                var result = new IncludeTreeNode(EntityType, entityReference, SetLoaded) { FilterExpression = FilterExpression };
 
                 foreach (var kvp in this)
                 {
@@ -157,7 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 FilterExpression = includeTreeNode.FilterExpression;
                 foreach (var item in includeTreeNode)
                 {
-                    AddNavigation(item.Key).Merge(item.Value);
+                    AddNavigation(item.Key, item.Value.SetLoaded).Merge(item.Value);
                 }
             }
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -865,7 +865,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             var currentNode = includeTreeNodes.Dequeue();
                             foreach (var navigation in FindNavigations(currentNode.EntityType, navigationName))
                             {
-                                var addedNode = currentNode.AddNavigation(navigation);
+                                var addedNode = currentNode.AddNavigation(navigation, setLoaded);
 
                                 // This is to add eager Loaded navigations when owner type is included.
                                 PopulateEagerLoadedNavigations(addedNode);
@@ -887,7 +887,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var includeLambda = expression.UnwrapLambdaFromQuote();
 
                     var (result, filterExpression) = ExtractIncludeFilter(includeLambda.Body, includeLambda.Body);
-                    var lastIncludeTree = PopulateIncludeTree(currentIncludeTreeNode, result);
+                    var lastIncludeTree = PopulateIncludeTree(currentIncludeTreeNode, result, setLoaded);
                     if (filterExpression != null)
                     {
                         if (lastIncludeTree.FilterExpression != null
@@ -903,11 +903,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
 
                     entityReference.SetLastInclude(lastIncludeTree);
-
-                    if (!setLoaded)
-                    {
-                        entityReference.SuppressSettingLoaded();
-                    }
                 }
 
                 return source;
@@ -1747,7 +1742,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             foreach (var navigation in outboundNavigations)
             {
-                includeTreeNode.AddNavigation(navigation);
+                includeTreeNode.AddNavigation(navigation, includeTreeNode.SetLoaded);
             }
         }
 
@@ -1794,7 +1789,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .Concat(entityType.GetDerivedSkipNavigations())
                 .Where(n => n.IsEagerLoaded);
 
-        private IncludeTreeNode PopulateIncludeTree(IncludeTreeNode includeTreeNode, Expression expression)
+        private IncludeTreeNode PopulateIncludeTree(IncludeTreeNode includeTreeNode, Expression expression, bool setLoaded)
         {
             switch (expression)
             {
@@ -1803,7 +1798,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 case MemberExpression memberExpression:
                     var innerExpression = memberExpression.Expression.UnwrapTypeConversion(out var convertedType);
-                    var innerIncludeTreeNode = PopulateIncludeTree(includeTreeNode, innerExpression);
+                    var innerIncludeTreeNode = PopulateIncludeTree(includeTreeNode, innerExpression, setLoaded);
                     var entityType = innerIncludeTreeNode.EntityType;
                     if (convertedType != null)
                     {
@@ -1819,7 +1814,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var navigation = entityType.FindNavigation(memberExpression.Member);
                     if (navigation != null)
                     {
-                        var addedNode = innerIncludeTreeNode.AddNavigation(navigation);
+                        var addedNode = innerIncludeTreeNode.AddNavigation(navigation, setLoaded);
 
                         // This is to add eager Loaded navigations when owner type is included.
                         PopulateEagerLoadedNavigations(addedNode);
@@ -1830,7 +1825,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var skipNavigation = entityType.FindSkipNavigation(memberExpression.Member);
                     if (skipNavigation != null)
                     {
-                        var addedNode = innerIncludeTreeNode.AddNavigation(skipNavigation);
+                        var addedNode = innerIncludeTreeNode.AddNavigation(skipNavigation, setLoaded);
 
                         // This is to add eager Loaded navigations when owner type is included.
                         PopulateEagerLoadedNavigations(addedNode);

--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -80,7 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && method.GetGenericMethodDefinition() is MethodInfo genericMethod
                 && (genericMethod == EntityFrameworkQueryableExtensions.IncludeMethodInfo
                     || genericMethod == EntityFrameworkQueryableExtensions.ThenIncludeAfterEnumerableMethodInfo
-                    || genericMethod == EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo))
+                    || genericMethod == EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo
+                    || genericMethod == EntityFrameworkQueryableExtensions.NotQuiteIncludeMethodInfo))
             {
                 var includeLambda = methodCallExpression.Arguments[1].UnwrapLambdaFromQuote();
                 if (includeLambda.ReturnType.IsGenericType

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -74,6 +74,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -113,6 +117,10 @@ namespace Microsoft.EntityFrameworkCore
                 : collectionEntry.Query().ToList();
 
             Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -234,6 +242,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.ThreeSkipPayloadFull)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipPayloadFull).IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -276,6 +288,10 @@ namespace Microsoft.EntityFrameworkCore
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
+            }
 
             Assert.Equal(7, left.TwoSkip.Count);
             foreach (var right in left.TwoSkip)
@@ -326,6 +342,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             Assert.True(navigationEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -365,6 +385,10 @@ namespace Microsoft.EntityFrameworkCore
                 : collectionEntry.Query().ToList<object>();
 
             Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.False(context.Entry((object)entityTwo).Collection("OneSkipShared").IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -514,6 +538,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             Assert.True(navigationEntry.IsLoaded);
+            foreach (var entityTwo in left.ThreeSkipPayloadFull)
+            {
+                Assert.False(context.Entry((object)entityTwo).Collection("OneSkipPayloadFull").IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -565,6 +593,10 @@ namespace Microsoft.EntityFrameworkCore
                 : navigationEntry.Query().ToList<object>();
 
             Assert.True(navigationEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkip)
+            {
+                Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -618,6 +650,10 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.ThreeSkipFull)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;
@@ -657,6 +693,10 @@ namespace Microsoft.EntityFrameworkCore
                 : collectionEntry.Query().ToList();
 
             Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.ThreeSkipFull)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
+            }
 
             RecordLog();
             context.ChangeTracker.LazyLoadingEnabled = false;

--- a/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyLoadTestBase.cs
@@ -770,6 +770,317 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Throws<InvalidOperationException>(() => collectionEntry.Query()).Message);
         }
 
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_Include(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var children = async
+                ? await collectionEntry.Query().Include(e => e.ThreeSkipFull).ToListAsync()
+                : collectionEntry.Query().Include(e => e.ThreeSkipFull).ToList();
+
+            Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
+                Assert.True(context.Entry(entityTwo).Collection(e => e.ThreeSkipFull).IsLoaded);
+
+                foreach (var entityThree in entityTwo.ThreeSkipFull)
+                {
+                    Assert.False(context.Entry(entityThree).Collection(e => e.TwoSkipFull).IsLoaded);
+                }
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+                foreach (var three in right.ThreeSkipFull)
+                {
+                    Assert.Contains(right, three.TwoSkipFull);
+                }
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
+
+            Assert.Equal(21, context.ChangeTracker.Entries().Count());
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_Include_for_inverse(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var queryable = collectionEntry.Query().Include(e => e.OneSkipShared);
+            var children = async
+                ? await queryable.ToListAsync()
+                : queryable.ToList();
+
+            Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.True(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
+            Assert.Equal(7, context.ChangeTracker.Entries().Count());
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_Include_for_same_collection(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var queryable = collectionEntry.Query().Include(e => e.OneSkipShared).ThenInclude(e => e.TwoSkipShared);
+            var children = async
+                ? await queryable.ToListAsync()
+                : queryable.ToList();
+
+            Assert.True(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.True(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
+            Assert.Equal(7, context.ChangeTracker.Entries().Count());
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_filtered_Include(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var children = async
+                ? await collectionEntry.Query().Include(e => e.ThreeSkipFull.Where(e => e.Id == 13 || e.Id == 11)).ToListAsync()
+                : collectionEntry.Query().Include(e => e.ThreeSkipFull.Where(e => e.Id == 13 || e.Id == 11)).ToList();
+
+            Assert.False(collectionEntry.IsLoaded);
+            foreach (var entityTwo in left.TwoSkipShared)
+            {
+                Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
+                Assert.True(context.Entry(entityTwo).Collection(e => e.ThreeSkipFull).IsLoaded);
+
+                foreach (var entityThree in entityTwo.ThreeSkipFull)
+                {
+                    Assert.False(context.Entry(entityThree).Collection(e => e.TwoSkipFull).IsLoaded);
+                }
+            }
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(3, left.TwoSkipShared.Count);
+            foreach (var right in left.TwoSkipShared)
+            {
+                Assert.Contains(left, right.OneSkipShared);
+                foreach (var three in right.ThreeSkipFull)
+                {
+                    Assert.True(three.Id == 11 || three.Id == 13);
+                    Assert.Contains(right, three.TwoSkipFull);
+                }
+            }
+
+            Assert.Equal(children, left.TwoSkipShared.ToList());
+
+            Assert.Equal(9, context.ChangeTracker.Entries().Count());
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_filtered_Include_and_projection(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var queryable = collectionEntry
+                .Query()
+                .Include(e => e.ThreeSkipFull.Where(e => e.Id == 13 || e.Id == 11))
+                .Select(e => new { e.Id, e.Name, Count1 = e.OneSkipShared.Count, Count3 = e.ThreeSkipFull.Count });
+
+            var projected = async
+                ? await queryable.ToListAsync()
+                : queryable.ToList();
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+            Assert.False(collectionEntry.IsLoaded);
+            Assert.Empty(left.TwoSkipShared);
+            Assert.Equal(1, context.ChangeTracker.Entries().Count());
+
+            Assert.Equal(3, projected.Count);
+
+            Assert.Equal(10, projected[0].Id);
+            Assert.Equal("EntityTwo 10", projected[0].Name);
+            Assert.Equal(3, projected[0].Count1);
+            Assert.Equal(1, projected[0].Count3);
+
+            Assert.Equal(11, projected[1].Id);
+            Assert.Equal("EntityTwo 11", projected[1].Name);
+            Assert.Equal(2, projected[1].Count1);
+            Assert.Equal(4, projected[1].Count3);
+
+            Assert.Equal(16, projected[2].Id);
+            Assert.Equal("EntityTwo 16", projected[2].Name);
+            Assert.Equal(3, projected[2].Count1);
+            Assert.Equal(2, projected[2].Count3);
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Load_collection_using_Query_with_join(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var left = context.Set<EntityOne>().Find(3);
+
+            ClearLog();
+
+            var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            var queryable = from t in collectionEntry.Query()
+                            join s in context.Set<EntityOne>().SelectMany(e => e.TwoSkipShared)
+                                on t.Id equals s.Id
+                            select new { t, s };
+
+            var projected = async
+                ? await queryable.ToListAsync()
+                : queryable.ToList();
+
+            Assert.False(collectionEntry.IsLoaded);
+
+            RecordLog();
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(7, context.ChangeTracker.Entries().Count());
+            Assert.Equal(8, projected.Count);
+
+            foreach (var pair in projected)
+            {
+                Assert.Same(pair.s, pair.t);
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Query_with_Include_marks_only_left_as_loaded(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var queryable = context.EntityOnes.Include(e => e.TwoSkip);
+            var left = async
+                ? await queryable.SingleAsync(e => e.Id == 1)
+                : queryable.Single(e => e.Id == 1);
+
+            Assert.True(context.Entry(left).Collection(e => e.TwoSkip).IsLoaded);
+
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(20, left.TwoSkip.Count);
+            foreach (var right in left.TwoSkip)
+            {
+                Assert.False(context.Entry(right).Collection(e => e.OneSkip).IsLoaded);
+                Assert.Same(left, right.OneSkip.Single());
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public virtual async Task Query_with_filtered_Include_marks_only_left_as_loaded(bool async)
+        {
+            using var context = Fixture.CreateContext();
+
+            var queryable = context.EntityOnes.Include(e => e.TwoSkip.Where(e => e.Id == 1 || e.Id == 2));
+            var left = async
+                ? await queryable.SingleAsync(e => e.Id == 1)
+                : queryable.Single(e => e.Id == 1);
+
+            Assert.True(context.Entry(left).Collection(e => e.TwoSkip).IsLoaded);
+
+            context.ChangeTracker.LazyLoadingEnabled = false;
+
+            Assert.Equal(2, left.TwoSkip.Count);
+            foreach (var right in left.TwoSkip)
+            {
+                Assert.False(context.Entry(right).Collection(e => e.OneSkip).IsLoaded);
+                Assert.Same(left, right.OneSkip.Single());
+            }
+        }
+
         protected virtual void ClearLog()
         {
         }

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -42,6 +42,177 @@ WHERE [e].[Id] = @__p_0
 ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id]");
         }
 
+
+        public override async Task Load_collection_using_Query_with_Include_for_inverse(bool async)
+        {
+            await base.Load_collection_using_Query_with_Include_for_inverse(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[Name]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityOneId], [e0].[EntityTwoId]
+    FROM [EntityOneEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[EntityTwoId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[EntityOneId]
+LEFT JOIN (
+    SELECT [e2].[EntityOneId], [e2].[EntityTwoId], [e3].[Id], [e3].[Name]
+    FROM [EntityOneEntityTwo] AS [e2]
+    INNER JOIN [EntityOnes] AS [e3] ON [e2].[EntityOneId] = [e3].[Id]
+    WHERE [e3].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id]");
+        }
+
+        public override async Task Load_collection_using_Query_with_Include_for_same_collection(bool async)
+        {
+            await base.Load_collection_using_Query_with_Include_for_same_collection(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t1].[EntityOneId], [t1].[EntityTwoId], [t1].[Id], [t1].[Name], [t1].[EntityOneId0], [t1].[EntityTwoId0], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityOneId], [e0].[EntityTwoId]
+    FROM [EntityOneEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[EntityTwoId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[EntityOneId]
+LEFT JOIN (
+    SELECT [e2].[EntityOneId], [e2].[EntityTwoId], [e3].[Id], [e3].[Name], [t0].[EntityOneId] AS [EntityOneId0], [t0].[EntityTwoId] AS [EntityTwoId0], [t0].[Id] AS [Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId]
+    FROM [EntityOneEntityTwo] AS [e2]
+    INNER JOIN [EntityOnes] AS [e3] ON [e2].[EntityOneId] = [e3].[Id]
+    LEFT JOIN (
+        SELECT [e4].[EntityOneId], [e4].[EntityTwoId], [e5].[Id], [e5].[CollectionInverseId], [e5].[Name], [e5].[ReferenceInverseId]
+        FROM [EntityOneEntityTwo] AS [e4]
+        INNER JOIN [EntityTwos] AS [e5] ON [e4].[EntityTwoId] = [e5].[Id]
+    ) AS [t0] ON [e3].[Id] = [t0].[EntityOneId]
+    WHERE [e3].[Id] = @__p_0
+) AS [t1] ON [t].[Id] = [t1].[EntityTwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t1].[EntityOneId], [t1].[EntityTwoId], [t1].[Id], [t1].[EntityOneId0], [t1].[EntityTwoId0], [t1].[Id0]");
+        }
+
+        public override async Task Load_collection_using_Query_with_Include(bool async)
+        {
+            await base.Load_collection_using_Query_with_Include(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[Name], [t1].[ThreeId], [t1].[TwoId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityOneId], [e0].[EntityTwoId]
+    FROM [EntityOneEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[EntityTwoId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[EntityOneId]
+LEFT JOIN (
+    SELECT [e2].[EntityOneId], [e2].[EntityTwoId], [e3].[Id], [e3].[Name]
+    FROM [EntityOneEntityTwo] AS [e2]
+    INNER JOIN [EntityOnes] AS [e3] ON [e2].[EntityOneId] = [e3].[Id]
+    WHERE [e3].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
+LEFT JOIN (
+    SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
+) AS [t1] ON [t].[Id] = [t1].[TwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+        }
+
+        public override async Task Load_collection_using_Query_with_filtered_Include(bool async)
+        {
+            await base.Load_collection_using_Query_with_filtered_Include(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[Name], [t1].[ThreeId], [t1].[TwoId], [t1].[Id], [t1].[CollectionInverseId], [t1].[Name], [t1].[ReferenceInverseId]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityOneId], [e0].[EntityTwoId]
+    FROM [EntityOneEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[EntityTwoId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[EntityOneId]
+LEFT JOIN (
+    SELECT [e2].[EntityOneId], [e2].[EntityTwoId], [e3].[Id], [e3].[Name]
+    FROM [EntityOneEntityTwo] AS [e2]
+    INNER JOIN [EntityOnes] AS [e3] ON [e2].[EntityOneId] = [e3].[Id]
+    WHERE [e3].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
+LEFT JOIN (
+    SELECT [j].[ThreeId], [j].[TwoId], [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId]
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
+    WHERE [e4].[Id] IN (13, 11)
+) AS [t1] ON [t].[Id] = [t1].[TwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+        }
+
+        public override async Task Load_collection_using_Query_with_filtered_Include_and_projection(bool async)
+        {
+            await base.Load_collection_using_Query_with_filtered_Include_and_projection(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[Name], (
+    SELECT COUNT(*)
+    FROM [EntityOneEntityTwo] AS [e]
+    INNER JOIN [EntityOnes] AS [e0] ON [e].[EntityOneId] = [e0].[Id]
+    WHERE [t].[Id] = [e].[EntityTwoId]) AS [Count1], (
+    SELECT COUNT(*)
+    FROM [JoinTwoToThree] AS [j]
+    INNER JOIN [EntityThrees] AS [e1] ON [j].[ThreeId] = [e1].[Id]
+    WHERE [t].[Id] = [j].[TwoId]) AS [Count3]
+FROM [EntityOnes] AS [e2]
+INNER JOIN (
+    SELECT [e4].[Id], [e4].[Name], [e3].[EntityOneId]
+    FROM [EntityOneEntityTwo] AS [e3]
+    INNER JOIN [EntityTwos] AS [e4] ON [e3].[EntityTwoId] = [e4].[Id]
+) AS [t] ON [e2].[Id] = [t].[EntityOneId]
+WHERE [e2].[Id] = @__p_0");
+        }
+
+        public override async Task Load_collection_using_Query_with_join(bool async)
+        {
+            await base.Load_collection_using_Query_with_join(async);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[Id], [t].[CollectionInverseId], [t].[Name], [t].[ReferenceInverseId], [t1].[Id0], [t1].[CollectionInverseId], [t1].[Name0], [t1].[ReferenceInverseId], [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t1].[Id], [t1].[EntityOneId], [t1].[EntityTwoId], [t2].[EntityOneId], [t2].[EntityTwoId], [t2].[Id], [t2].[Name]
+FROM [EntityOnes] AS [e]
+INNER JOIN (
+    SELECT [e1].[Id], [e1].[CollectionInverseId], [e1].[Name], [e1].[ReferenceInverseId], [e0].[EntityOneId], [e0].[EntityTwoId]
+    FROM [EntityOneEntityTwo] AS [e0]
+    INNER JOIN [EntityTwos] AS [e1] ON [e0].[EntityTwoId] = [e1].[Id]
+) AS [t] ON [e].[Id] = [t].[EntityOneId]
+INNER JOIN (
+    SELECT [e2].[Id], [t0].[Id] AS [Id0], [t0].[CollectionInverseId], [t0].[Name] AS [Name0], [t0].[ReferenceInverseId], [t0].[EntityOneId], [t0].[EntityTwoId]
+    FROM [EntityOnes] AS [e2]
+    INNER JOIN (
+        SELECT [e4].[Id], [e4].[CollectionInverseId], [e4].[Name], [e4].[ReferenceInverseId], [e3].[EntityOneId], [e3].[EntityTwoId]
+        FROM [EntityOneEntityTwo] AS [e3]
+        INNER JOIN [EntityTwos] AS [e4] ON [e3].[EntityTwoId] = [e4].[Id]
+    ) AS [t0] ON [e2].[Id] = [t0].[EntityOneId]
+) AS [t1] ON [t].[Id] = [t1].[Id0]
+LEFT JOIN (
+    SELECT [e5].[EntityOneId], [e5].[EntityTwoId], [e6].[Id], [e6].[Name]
+    FROM [EntityOneEntityTwo] AS [e5]
+    INNER JOIN [EntityOnes] AS [e6] ON [e5].[EntityOneId] = [e6].[Id]
+    WHERE [e6].[Id] = @__p_0
+) AS [t2] ON [t].[Id] = [t2].[EntityTwoId]
+WHERE [e].[Id] = @__p_0
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t1].[Id], [t1].[EntityOneId], [t1].[EntityTwoId], [t1].[Id0], [t2].[EntityOneId], [t2].[EntityTwoId], [t2].[Id]");
+        }
+
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();
 


### PR DESCRIPTION
Fixes #23475

This is a targeted patch fix which special cases many-to-many loading. I will file an issue for a more general solution using an appropriate general update to query. See #22022.

**Description**

This is a bug in many-to-many relationships, a major new feature in EF Core 5.0. When loading a collection navigation property, the inverse navigation property is marked as loaded. This is not correct, since only entities related to the source entity are loaded. This means that attempting to load the inverse is a no-op because it is already marked as loaded, and hence data is missing in the context.

**Customer Impact**

Related entities are not loaded from the database when they should be, leading to possible data corruption in an application that assumes this is working correctly. This will kind of problem is often hard to find since there is no error, just incorrect data.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We did not have test coverage for this case. However, this isn't why we didn't catch this, since I didn't think about the consequences for the IsLoaded flag here, and only investigation of this issue made me realize the mistake. We have added more test coverage in this PR.

**Regression?**

No; new feature in 5.0.

**Risk**

Medium. The underlying problem is that we ere using `Include` in the generated query to do lazy loading. The behavior of Include is to set the collection as loaded, even if filtered, which means we can't change the default behavior of Include. Therefore, we have introduced a new internal `NotQuiteInclude` method that is processed the same as `Include` in the query pipeline, but then changes the final materialization delegate to indicate that the collection should not be loaded. This is new code path has been done in a way that it is only used for this case, and can be disabled with a quirk switch. It has also been reviewed in detail by the team and we have added more testing.
