### PR TITLE
[5.0.2] Delay conventions when creating the properties to use for the foreign key

### DIFF
--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -396,28 +396,36 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .WithMany(e => e.Categories)
                     .UsingEntity<Dictionary<string, object>>(
                         "ProductCategory",
-                        e => e.HasOne<ProductWithAttribute>().WithMany().HasForeignKey("ProductKey"),
-                        e => e.HasOne<CategoryWithAttribute>().WithMany().HasForeignKey("CategoryKey"));
+                        e => e.HasOne<ProductWithAttribute>().WithMany().HasForeignKey("ProductWithAttributeId"),
+                        e => e.HasOne<CategoryWithAttribute>().WithMany().HasForeignKey("CategoryWithAttributeId"));
 
                 var model = modelBuilder.FinalizeModel();
 
                 var category = model.FindEntityType(typeof(CategoryWithAttribute));
                 var productsNavigation = category.GetSkipNavigations().Single();
                 var categoryFk = productsNavigation.ForeignKey;
-                Assert.Equal("CategoryKey", categoryFk.Properties.Single().Name);
+                Assert.Equal("CategoryWithAttributeId", categoryFk.Properties.Single().Name);
+
+                var categoryNavigation = productsNavigation.TargetEntityType.GetSkipNavigations().Single();
+                var productFk = categoryNavigation.ForeignKey;
+                Assert.Equal("ProductWithAttributeId", productFk.Properties.Single().Name);
+
+                var joinEntityType = categoryFk.DeclaringEntityType;
+                Assert.Equal(2, joinEntityType.GetForeignKeys().Count());
+                Assert.Equal(2, joinEntityType.GetProperties().Count());
             }
 
             protected class ProductWithAttribute
             {
-                public int Id { get; set; }
+                public int ID { get; set; }
 
-                [ForeignKey("ProductId")]
+                [ForeignKey("ProductKey")]
                 public virtual ICollection<CategoryWithAttribute> Categories { get; set; }
             }
 
             protected class CategoryWithAttribute
             {
-                public int Id { get; set; }
+                public int ID { get; set; }
                 public virtual ICollection<ProductWithAttribute> Products { get; set; }
             }
 


### PR DESCRIPTION
Fixes #23516

**Description**

When creating the properties to use for the foreign key the conventions could use them to configure the current foreign key before the explicit configuration is applied. However this removes the foreign key currently being configured from the model resulting in an extra foreign key created to compensate this.

**Customer Impact**

This only manifests itself when using a property not already present on an entity type. This situation is common when configuring the join entity type for the new 5.0 feature - many-to-many. There's no straightforward workaround for this.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

No, this existed in 3.1.x, but it's more likely to be hit in 5.0 when using many-to-many

**Risk**

Low. The fix is just delaying the conventions, so there should be no behavior changes.