### PR TITLE
[5.0.2] Don't stop ForeignKeyRequirednessChanged conventions prematurely

### DIFF
--- a/src/EFCore/Metadata/Conventions/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/CascadeDeleteConvention.cs
@@ -53,7 +53,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionContext<bool?> context)
         {
             var newRelationshipBuilder = relationshipBuilder.OnDelete(GetTargetDeleteBehavior(relationshipBuilder.Metadata));
-            context.StopProcessingIfChanged(newRelationshipBuilder?.Metadata.IsRequired);
+            if (newRelationshipBuilder != null)
+            {
+                context.StopProcessingIfChanged(newRelationshipBuilder.Metadata.IsRequired);
+            }
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/CascadeDeleteConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
@@ -56,6 +57,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (newRelationshipBuilder != null)
             {
                 context.StopProcessingIfChanged(newRelationshipBuilder.Metadata.IsRequired);
+            }
+            else if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23555", out var enabled) && enabled)
+            {
+                context.StopProcessing();
             }
         }
 

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -1130,7 +1129,54 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 expectedPrincipalProperties.Add(fk.PrincipalKey.Properties.Single());
                 AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
-                expectedDependentProperties.Add(fk.Properties.Single());
+                var fkProperty = fk.Properties.Single();
+                Assert.False(fkProperty.IsNullable);
+                expectedDependentProperties.Add(fkProperty);
+                AssertEqual(expectedDependentProperties, dependentType.GetProperties());
+                Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
+                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+                Assert.Empty(principalType.GetIndexes());
+            }
+
+            [ConditionalFact]
+            public virtual void Can_specify_requiredness_after_OnDelete()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+                modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Entity<Customer>();
+                modelBuilder.Entity<Order>();
+
+                var dependentType = model.FindEntityType(typeof(Order));
+                var principalType = model.FindEntityType(typeof(Customer));
+                var expectedPrincipalProperties = principalType.GetProperties().ToList();
+                var expectedDependentProperties = dependentType.GetProperties().ToList();
+
+                modelBuilder
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
+                    .HasForeignKey("CustomerAlternateKey")
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .IsRequired();
+
+                modelBuilder.FinalizeModel();
+
+                var fk = dependentType.GetForeignKeys().Single();
+
+                Assert.Equal("Customer", dependentType.GetNavigations().Single().Name);
+                Assert.Equal("Orders", principalType.GetNavigations().Single().Name);
+                Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
+                Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
+                Assert.Empty(principalType.GetForeignKeys());
+
+                var principalKey = principalType.FindPrimaryKey();
+                Assert.Same(principalKey, fk.PrincipalKey);
+
+                expectedPrincipalProperties.Add(fk.PrincipalKey.Properties.Single());
+                AssertEqual(expectedPrincipalProperties, principalType.GetProperties());
+                var fkProperty = fk.Properties.Single();
+                Assert.False(fkProperty.IsNullable);
+                expectedDependentProperties.Add(fkProperty);
                 AssertEqual(expectedDependentProperties, dependentType.GetProperties());
                 Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
                 Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);


### PR DESCRIPTION
Fixes #23555

**Description**

If the OnDelete behavior is configured explicitly `CascadeDeleteConvention` could stop other conventions that react to the requiredness changing from running.

**Customer Impact**

Calling `IsRequired` after `OnDelete` will produce a foreign key with nullable properties. The workaround is to flip the order of the calls. However, customers may miss that their model is building incorrectly, and hence get unexpected results which will be hard to track to this issue.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

Yes

**Risk**

Low. There's only one convention that would be affected by this.
