### PR TITLE
[5.0.3] Flow through the column types in MigrationBuilder.InsertData

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1333,6 +1333,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 Table = table,
                 Schema = schema,
                 Columns = columns,
+                ColumnTypes = columnTypes,
                 Values = values
             };
             Operations.Add(operation);

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1328,12 +1328,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(columns, nameof(columns));
             Check.NotNull(values, nameof(values));
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23503", out var enabled) && enabled;
             var operation = new InsertDataOperation
             {
                 Table = table,
                 Schema = schema,
                 Columns = columns,
-                ColumnTypes = columnTypes,
+                ColumnTypes = useOldBehavior ? null : columnTypes,
                 Values = values
             };
             Operations.Add(operation);

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -1069,9 +1069,8 @@ SELECT @@ROWCOUNT');
                     .InsertData(
                         table: "Table1",
                         column: "Id",
-                        value: 1)
-                    .GetInfrastructure()
-                    .ColumnTypes = new[] { "int" },
+                        columnType: "int",
+                        value: 1),
                 MigrationsSqlGenerationOptions.Idempotent);
 
             AssertSql(
@@ -1094,14 +1093,12 @@ IF EXISTS (SELECT * FROM [sys].[identity_columns] WHERE [name] IN (N'Id') AND [o
                     var operation = migrationBuilder
                         .UpdateData(
                             table: "Table1",
-                            keyColumn: "Id",
-                            keyValue: 1,
-                            column: "Column1",
-                            value: 2)
-                        .GetInfrastructure();
-
-                    operation.KeyColumnTypes = new[] { "int" };
-                    operation.ColumnTypes = new[] { "int" };
+                            keyColumnTypes: new[] { "int" },
+                            keyColumns: new[] { "Id" },
+                            keyValues: new object[] { 1 },
+                            columns: new[] { "Column1" },
+                            columnTypes: new[] { "int" },
+                            values: new object[] { 2 });
                 },
                 MigrationsSqlGenerationOptions.Idempotent);
 


### PR DESCRIPTION
Fixes #23503

**Note for Tactics**

This was rejected for 5.0.2 due to concerns that it might not impact many customers. We now have multiple customer reports (4+) so we're brining it back for 5.0.3.

**Description**

`MigrationBuilder.InsertData` was not passing through the column types parameter to the underlying method.

**Customer Impact**

Creating a migration that adds data to a table that is not mapped in the model will fail. The workaround would be to use internal API.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

No, this overload of `InsertData` is new in 5.0

**Risk**

Low. Only affects new API that is seldomly used.