### PR TITLE
[5.0.3] InMemory: Decompose join condition which uses equals for comparison

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -660,6 +660,20 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 }
             }
 
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23593", out var enabled)
+                && enabled)
+                && joinCondition is MethodCallExpression methodCallExpression
+                && methodCallExpression.Method.IsStatic
+                && methodCallExpression.Method.DeclaringType == typeof(object)
+                && methodCallExpression.Method.Name == nameof(object.Equals)
+                && methodCallExpression.Arguments.Count == 2)
+            {
+                leftExpressions.Add(methodCallExpression.Arguments[0]);
+                rightExpressions.Add(methodCallExpression.Arguments[1]);
+
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Resolves #23593

**Description**

Using enums as key selector for joins throws exception. Same could happen for any other type which uses `object.Equals` for value comparison.

**Customer Impact**

In 5.0 EF Core started applying value converter to server side for InMemory database. Some of the scenario where value comparer is default (but not == operator) are broken which were working. There is no work-around.

**How found**

Customer reported issue on 5.0.0

**Test coverage**

Added test coverage for using enums as key in joins in different construct of key selectors.

**Regression?**

Yes, this query worked correctly in 3.1 since InMemory didn't handle value converters/comparers

**Risk**

Very low, It adds additional pattern matching for expression of shape `object.Equals` existing working scenario wouldn't hit that code path and any query hitting that code path should work since that is the default comparer. Also added quirk in order to revert to older behavior.