### PR TITLE
[5.0.2] Calculate correct nullability for required sharing dependents on derived types in TPH

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -996,7 +996,7 @@ namespace Microsoft.EntityFrameworkCore
                         || IsOptionalSharingDependent(linkingForeignKey.PrincipalEntityType, storeObject, recursionDepth));
             }
 
-            return optional ?? false;
+            return optional ?? (entityType.BaseType != null && entityType.GetDiscriminatorProperty() != null);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -996,7 +996,14 @@ namespace Microsoft.EntityFrameworkCore
                         || IsOptionalSharingDependent(linkingForeignKey.PrincipalEntityType, storeObject, recursionDepth));
             }
 
-            return optional ?? (entityType.BaseType != null && entityType.GetDiscriminatorProperty() != null);
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+
+            return AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23479", out var enabled) && enabled
+                ? false
+                : entityType.BaseType != null && entityType.GetDiscriminatorProperty() != null;
         }
 
         /// <summary>

--- a/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalModelTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var model = CreateTestModel(mapToTables: useExplicitMapping, mapping: mapping);
 
-            Assert.Equal(8, model.Model.GetEntityTypes().Count());
+            Assert.Equal(9, model.Model.GetEntityTypes().Count());
             Assert.Equal(mapping == Mapping.TPH || !useExplicitMapping ? 3 : 5, model.Tables.Count());
             Assert.Empty(model.Views);
             Assert.True(model.Model.GetEntityTypes().All(et => !et.GetViewMappings().Any()));
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var model = CreateTestModel(mapToTables: false, mapToViews: true, mapping);
 
-            Assert.Equal(8, model.Model.GetEntityTypes().Count());
+            Assert.Equal(9, model.Model.GetEntityTypes().Count());
             Assert.Equal(mapping == Mapping.TPH ? 3 : 5, model.Views.Count());
             Assert.Empty(model.Tables);
             Assert.True(model.Model.GetEntityTypes().All(et => !et.GetTableMappings().Any()));
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             var model = CreateTestModel(mapToTables: true, mapToViews: true, mapping);
 
-            Assert.Equal(8, model.Model.GetEntityTypes().Count());
+            Assert.Equal(9, model.Model.GetEntityTypes().Count());
             Assert.Equal(mapping == Mapping.TPH ? 3 : 5, model.Tables.Count());
             Assert.Equal(mapping == Mapping.TPH ? 3 : 5, model.Views.Count());
 
@@ -218,7 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 var specialCustomerView = specialCustomerType.GetViewMappings().Select(t => t.Table)
                     .First(t => t.Name == "SpecialCustomerView");
                 Assert.Null(specialCustomerView.Schema);
-                Assert.Equal(4, specialCustomerView.Columns.Count());
+                Assert.Equal(5, specialCustomerView.Columns.Count());
 
                 Assert.True(specialCustomerView.EntityTypeMappings.Single(m => m.EntityType == specialCustomerType).IsSharedTablePrincipal);
 
@@ -239,7 +239,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 var specialCustomerView = specialCustomerViewMapping.View;
                 Assert.Same(customerView, specialCustomerView);
 
-                Assert.Equal(3, specialCustomerView.EntityTypeMappings.Count());
+                Assert.Equal(4, specialCustomerView.EntityTypeMappings.Count());
                 Assert.True(specialCustomerView.EntityTypeMappings.First().IsSharedTablePrincipal);
                 Assert.False(specialCustomerView.EntityTypeMappings.Last().IsSharedTablePrincipal);
 
@@ -443,17 +443,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 var specialCustomerTable =
                     specialCustomerType.GetTableMappings().Select(t => t.Table).First(t => t.Name == "SpecialCustomer");
                 Assert.Equal("SpecialSchema", specialCustomerTable.Schema);
-                Assert.Equal(4, specialCustomerTable.Columns.Count());
+                Assert.Equal(5, specialCustomerTable.Columns.Count());
 
                 Assert.True(specialCustomerTable.EntityTypeMappings.Single(m => m.EntityType == specialCustomerType).IsSharedTablePrincipal);
 
                 var specialityColumn = specialCustomerTable.Columns.Single(c => c.Name == nameof(SpecialCustomer.Speciality));
                 Assert.False(specialityColumn.IsNullable);
 
+                var addressColumn = specialCustomerTable.Columns.Single(c =>
+                    c.Name == nameof(SpecialCustomer.Details) + "_" + nameof(CustomerDetails.Address));
+                Assert.False(addressColumn.IsNullable);
+
                 Assert.Equal(3, customerPk.GetMappedConstraints().Count());
                 var specialCustomerPkConstraint = specialCustomerTable.PrimaryKey;
                 Assert.Equal("PK_SpecialCustomer", specialCustomerPkConstraint.Name);
-                Assert.Same(specialCustomerPkConstraint.MappedKeys.Single(), customerPk);
+                Assert.Same(specialCustomerPkConstraint.MappedKeys.First(), customerPk);
 
                 var idProperty = customerPk.Properties.Single();
                 Assert.Equal(6, idProperty.GetTableColumnMappings().Count());
@@ -505,16 +509,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 var specialCustomerTable = specialCustomerTypeMapping.Table;
                 Assert.Same(customerTable, specialCustomerTable);
 
-                Assert.Equal(3, specialCustomerTable.EntityTypeMappings.Count());
+                Assert.Equal(4, specialCustomerTable.EntityTypeMappings.Count());
                 Assert.True(specialCustomerTable.EntityTypeMappings.First().IsSharedTablePrincipal);
                 Assert.False(specialCustomerTable.EntityTypeMappings.Last().IsSharedTablePrincipal);
 
                 var specialityColumn = specialCustomerTable.Columns.Single(c => c.Name == nameof(SpecialCustomer.Speciality));
                 Assert.True(specialityColumn.IsNullable);
 
+                var addressColumn = specialCustomerTable.Columns.Single(c =>
+                    c.Name == nameof(SpecialCustomer.Details) + "_" + nameof(CustomerDetails.Address));
+                Assert.True(addressColumn.IsNullable);
+
                 var specialCustomerPkConstraint = specialCustomerTable.PrimaryKey;
                 Assert.Equal("PK_Customer", specialCustomerPkConstraint.Name);
-                Assert.Same(specialCustomerPkConstraint.MappedKeys.Single(), customerPk);
+                Assert.Same(specialCustomerPkConstraint.MappedKeys.First(), customerPk);
 
                 var idProperty = customerPk.Properties.Single();
                 Assert.Equal(3, idProperty.GetTableColumnMappings().Count());
@@ -583,6 +591,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                     cb.HasOne<SpecialCustomer>().WithOne()
                         .HasForeignKey<SpecialCustomer>("AnotherRelatedCustomerId");
+
+                    cb.OwnsOne(c => c.Details).Property(d => d.Address).IsRequired();
+                    cb.Navigation(c => c.Details).IsRequired();
                 });
 
             modelBuilder.Entity<ExtraSpecialCustomer>(
@@ -677,6 +688,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             modelBuilder.Entity<SpecialCustomer>(
                 cb =>
                 {
+                    cb.Ignore(c => c.Details);
                     cb.Property(s => s.Speciality).IsRequired();
                 });
 
@@ -906,6 +918,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             public string Speciality { get; set; }
             public string RelatedCustomerSpeciality { get; set; }
             public SpecialCustomer RelatedCustomer { get; set; }
+            public CustomerDetails Details { get; set; }
+        }
+
+        private class CustomerDetails
+        {
+            public string Address { get; set; }
         }
 
         private class ExtraSpecialCustomer : SpecialCustomer


### PR DESCRIPTION
Fixes #23479

**Description**

The columns for required properties on required sharing dependents were assumed to be required, but this is incorrect when the owner is a derived type in TPH. All properties of derived types in TPH must be nullable (not required) since instances of other types do not have values for that column.

**Customer Impact**

The migrations created for such a model would need to be fixed manually each time they are generated.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

No, required sharing dependents are new in 5.0

**Risk**

Low. Only affects required sharing dependents
