### PR TITLE
Microsoft.Data.Sqlite: Use multi-thread mode

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -175,6 +175,11 @@ namespace Microsoft.Data.Sqlite
 
             var filename = ConnectionOptions.DataSource;
             var flags = 0;
+            
+            if (sqlite3_threadsafe() != 0)
+            {
+                flags |= SQLITE_OPEN_NOMUTEX;
+            }
 
             if (filename.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
Previously, the default mode (usually Serialized) was used. Since ADO.NET connections are generally not thread safe, this caused unnecessary lock checking in SQLite.

~~Note, this will break compatibility with versions compiled with SQLITE_THREADSAFE=0. However, we plan to add a connection pool in this release which, I suspect, will also break compatibility with those versions anyway.~~ (Updated)

Resolves #22330

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


