### PR TITLE
[5.0.2] Avoid duplicate properties when discovering the PK on the join entity type

### DIFF
--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -132,15 +132,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
 
-            for (var i = keyProperties.Count - 1; i >= 0; i--)
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23476", out var enabledFor23476) && enabledFor23476;
+            if (!useOldBehavior)
             {
-                var property = keyProperties[i];
-                for (var j = i - 1; j >= 0; j--)
+                for (var i = keyProperties.Count - 1; i >= 0; i--)
                 {
-                    if (property == keyProperties[j])
+                    var property = keyProperties[i];
+                    for (var j = i - 1; j >= 0; j--)
                     {
-                        keyProperties.RemoveAt(j);
-                        i--;
+                        if (property == keyProperties[j])
+                        {
+                            keyProperties.RemoveAt(j);
+                            i--;
+                        }
                     }
                 }
             }

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -132,6 +132,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
 
+            for (var i = keyProperties.Count - 1; i >= 0; i--)
+            {
+                var property = keyProperties[i];
+                for (var j = i - 1; j >= 0; j--)
+                {
+                    if (property == keyProperties[j])
+                    {
+                        keyProperties.RemoveAt(j);
+                        i--;
+                    }
+                }
+            }
+
             ProcessKeyProperties(keyProperties, entityType);
 
             if (keyProperties.Count > 0)

--- a/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
+++ b/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosTestModelBuilderExtensions.cs
@@ -29,6 +29,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             return builder;
         }
 
+        public static ModelBuilderTest.TestEntityTypeBuilder<TEntity> HasPartitionKey<TEntity>(
+            this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder,
+            string name)
+            where TEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.HasPartitionKey(name);
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nonGenericBuilder:
+                    nonGenericBuilder.Instance.HasPartitionKey(name);
+                    break;
+            }
+
+            return builder;
+        }
+
         public static ModelBuilderTest.TestPropertyBuilder<TProperty> ToJsonProperty<TProperty>(
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder,
             string name)

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -154,9 +154,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Assert.Same(principalToJoinNav, principalEntityType.GetSkipNavigations().Single());
                 Assert.Same(dependentToJoinNav, dependentEntityType.GetSkipNavigations().Single());
-                Assert.Single(principalEntityType.GetDeclaredKeys());
-                Assert.Single(dependentEntityType.GetDeclaredKeys());
-                Assert.Single(joinEntityType.GetDeclaredKeys());
                 Assert.Equal(2, joinEntityType.GetForeignKeys().Count());
                 Assert.Same(principalToDependentFk, joinEntityType.GetForeignKeys().Last());
                 Assert.Same(dependentToPrincipalFk, joinEntityType.GetForeignKeys().First());
@@ -493,7 +490,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Can_use_shared_Type_as_join_entity()
+            public virtual void Can_use_shared_type_as_join_entity()
             {
                 var modelBuilder = CreateModelBuilder();
 
@@ -532,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         nameof(ManyToManyNavPrincipal.Dependents) + nameof(NavDependent.Id),
                         nameof(NavDependent.ManyToManyPrincipals) + nameof(ManyToManyNavPrincipal.Id)
                     },
-                    shared1.GetProperties().Select(p => p.Name));
+                    shared1.FindPrimaryKey().Properties.Select(p => p.Name));
                 Assert.True(shared1.HasSharedClrType);
                 Assert.Equal(typeof(Dictionary<string, object>), shared1.ClrType);
 
@@ -542,10 +539,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(new[]
                     {
                         nameof(ManyToManyPrincipalWithField.Dependents) + nameof(DependentWithField.DependentWithFieldId),
-                        nameof(DependentWithField.ManyToManyPrincipals) + nameof(ManyToManyPrincipalWithField.Id),
-                        "Payload"
+                        nameof(DependentWithField.ManyToManyPrincipals) + nameof(ManyToManyPrincipalWithField.Id)
                     },
-                    shared2.GetProperties().Select(p => p.Name));
+                    shared2.FindPrimaryKey().Properties.Select(p => p.Name));
+                Assert.NotNull(shared2.FindProperty("Payload"));
                 Assert.True(shared2.HasSharedClrType);
                 Assert.Equal(typeof(Dictionary<string, object>), shared2.ClrType);
 

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -2753,16 +2753,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     {
                         eb.Ignore(e => e.Nobs);
 
-                        var r = eb.HasOne(c => c.Nob)
+                        eb.HasOne(c => c.Nob)
                             .WithOne()
                             .HasForeignKey<Hob>("NobId");
 
-                        var req = r.Metadata.IsRequired;
-                        var t = r.Metadata.Properties.Single().ClrType;
-
                         eb.HasKey("NobId");
-
-                        req = r.Metadata.IsRequired;
 
                         eb.HasOne(c => c.Nob)
                             .WithOne()

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -887,7 +887,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
         }
 
-        private class OneToManyNavPrincipal
+        protected class OneToManyNavPrincipal
         {
             public int Id { get; set; }
             public string Name { get; set; }
@@ -895,7 +895,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public List<NavDependent> Dependents { get; set; }
         }
 
-        private class OneToOneNavPrincipal
+        protected class OneToOneNavPrincipal
         {
             public int Id { get; set; }
             public string Name { get; set; }
@@ -903,7 +903,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public NavDependent Dependent { get; set; }
         }
 
-        private class ManyToManyNavPrincipal
+        protected class ManyToManyNavPrincipal
         {
             private readonly List<NavDependent> _randomField;
 
@@ -919,7 +919,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public List<NavDependent> Dependents { get; set; }
         }
 
-        private class NavDependent
+        protected class NavDependent
         {
             public int Id { get; set; }
             public string Name { get; set; }
@@ -929,7 +929,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public List<ManyToManyNavPrincipal> ManyToManyPrincipals { get; set; }
         }
 
-        private class OneToManyNavPrincipalOwner
+        protected class OneToManyNavPrincipalOwner
         {
             public int Id { get; set; }
             public string Description { get; set; }
@@ -937,7 +937,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public List<OwnedOneToManyNavDependent> OwnedDependents { get; set; }
         }
 
-        private class OneToOneNavPrincipalOwner
+        protected class OneToOneNavPrincipalOwner
         {
             public int Id { get; set; }
             public string Description { get; set; }
@@ -945,7 +945,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public OwnedNavDependent OwnedDependent { get; set; }
         }
 
-        private class OwnedNavDependent
+        protected class OwnedNavDependent
         {
             public string FirstName { get; set; }
             public string LastName { get; set; }
@@ -953,7 +953,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public OneToOneNavPrincipalOwner OneToOneOwner { get; set; }
         }
 
-        private class OwnedOneToManyNavDependent
+        protected class OwnedOneToManyNavDependent
         {
             public string FirstName { get; set; }
             public string LastName { get; set; }


### PR DESCRIPTION
Fixes #23476

**Description**

The PK on the join entity type is usually created by a convention from the FKs to the related types. However composite FKs might be sharing a property resulting in an exception if it's specified twice for the PK.

**Customer Impact**

The users will get an exception when configuring many-to-many relationship in the case above and the workaround is awkward since the conventions run before user configuration.

**How found**

Customer reported on 5.0.0.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

No, this only affects many-to-many, which is new in 5.0

**Risk**

Low. Only affects a new feature in 5.0