### PR TITLE
[5.0.2] Diff FKs to excluded tables correctly

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -597,6 +597,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             if (source.IsExcludedFromMigrations
                 && target.IsExcludedFromMigrations)
             {
+                // Populate column mapping
+                foreach(var _ in Diff(source.Columns, target.Columns, diffContext))
+                { }
+                
                 yield break;
             }
 

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -597,9 +597,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             if (source.IsExcludedFromMigrations
                 && target.IsExcludedFromMigrations)
             {
-                // Populate column mapping
-                foreach(var _ in Diff(source.Columns, target.Columns, diffContext))
-                { }
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23639", out var enabled) && enabled;
+                if (!useOldBehavior)
+                {
+                    // Populate column mapping
+                    foreach (var _ in Diff(source.Columns, target.Columns, diffContext))
+                    { }
+                }
                 
                 yield break;
             }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -90,6 +90,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 var operationsDown = modelDiffer.GetDifferences(targetModel.GetRelationalModel(), sourceModel.GetRelationalModel());
                 assertActionDown(operationsDown);
             }
+
+            var noopOperations = modelDiffer.GetDifferences(sourceModel.GetRelationalModel(), sourceModel.GetRelationalModel());
+            Assert.Empty(noopOperations);
+
+            noopOperations = modelDiffer.GetDifferences(targetModel.GetRelationalModel(), targetModel.GetRelationalModel());
+            Assert.Empty(noopOperations);
         }
 
         protected void AssertMultidimensionalArray<T>(T[,] values, params Action<T>[] assertions)


### PR DESCRIPTION
Fixes #23639
Fixes #23641
 
**Description**

When diffing foreign keys we compare make sure that the principal columns haven't changed, but for excluded principal tables we didn't have this information since they were never diffed.

**Customer Impact**

Users witch excluded principal tables in the model will always get redundant changes when adding a migration, even if the model hasn't changes

**How found**

Customer reported on 5.0.1

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

No, this only affects excluded tables, which is new in 5.0

**Risk**

Low. Only affects a new feature in 5.0