### PR TITLE
Fixes generation of broken SQL on multiple skip/take calls

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -603,5 +603,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <returns> An expression representing a SELECT in a SQL tree. </returns>
         [Obsolete("Use overload which takes TableExpressionBase by passing FromSqlExpression directly.")]
         SelectExpression Select([NotNull] IEntityType entityType, [NotNull] string sql, [NotNull] Expression sqlArguments);
+
+        /// <summary/>
+        AliasFactory AliasFactory { get; }
     }
 }

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -16,11 +16,27 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
+    /// <summary/>
+    public sealed class AliasFactory
+    {
+        private int _counter = -2;
+
+        /// <summary/>
+        public string GetUniqueAlias()
+        {
+            _counter++;
+            return _counter == -1 ? "t" : "t" + _counter;
+        }
+    }
+
     /// <inheritdoc />
     public class SqlExpressionFactory : ISqlExpressionFactory
     {
         private readonly IRelationalTypeMappingSource _typeMappingSource;
         private readonly RelationalTypeMapping _boolTypeMapping;
+
+        /// <summary/>
+        public AliasFactory AliasFactory { get; } = new AliasFactory();
 
         /// <summary>
         ///     Creates a new instance of the <see cref="SqlExpressionFactory" /> class.
@@ -784,7 +800,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         /// <inheritdoc />
         public virtual SelectExpression Select(SqlExpression projection)
-            => new SelectExpression(projection);
+            => new SelectExpression(projection, AliasFactory);
 
         /// <inheritdoc />
         public virtual SelectExpression Select(IEntityType entityType)
@@ -803,7 +819,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(tableExpressionBase, nameof(tableExpressionBase));
 
-            var selectExpression = new SelectExpression(entityType, tableExpressionBase);
+            var selectExpression = new SelectExpression(entityType, tableExpressionBase, AliasFactory);
             AddConditions(selectExpression, entityType);
 
             return selectExpression;
@@ -818,7 +834,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             var tableExpression = new FromSqlExpression(
                 entityType.GetDefaultMappings().SingleOrDefault().Table.Name.Substring(0, 1).ToLower(), sql, sqlArguments);
-            var selectExpression = new SelectExpression(entityType, tableExpression);
+            var selectExpression = new SelectExpression(entityType, tableExpression, AliasFactory);
             AddConditions(selectExpression, entityType);
 
             return selectExpression;


### PR DESCRIPTION
I've spent some time investigating how to fix #21026, because our users keep hitting this bug over and over again.
To make analysis easier, I've simplified the repoduction scenario a bit.

The next query:
```c#
var query = dbContext.Blogs
    .OrderBy(blog => blog.Id)
    .Skip(2).Take(3) // <--- causes crash when BOTH lines are uncommented
    .Select(blog => new Blog
    {
        Posts = blog.Posts
            .OrderBy(post => post.Id)
            .Skip(1).Take(5) // <--- causes crash when BOTH lines are uncommented
            .Select(post => new Post
            {
                Author = post.Author
            })
            .ToList()
    });
```

produces the following when using SQL Server:
```sql
DECLARE @__p_0 int = 2;
DECLARE @__p_1 int = 3;

SELECT [t].[Id], [t1].[Id], [t1].[LastName], [t1].[Id0]
FROM (
    SELECT [b].[Id]
    FROM [Blogs] AS [b]
    ORDER BY [b].[Id]
    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
) AS [t]
OUTER APPLY (
    SELECT [a].[Id], [a].[LastName], [t].[Id] AS [Id0]    -- [t].[Id] should be: [t0].[Id]
    FROM (
        SELECT [p].[Id], [p].[AuthorId], [p].[BlogId], [p].[Title]
        FROM [Post] AS [p]
        WHERE [t].[Id] = [p].[BlogId]
        ORDER BY [p].[Id]
        OFFSET 1 ROWS FETCH NEXT 5 ROWS ONLY
    ) AS [t0]
    LEFT JOIN [Author] AS [a] ON [t].[AuthorId] = [a].[Id]    -- [t].[AuthorId] should be: [t0].[AuthorId]
) AS [t1]
ORDER BY [t].[Id], [t1].[Id0], [t1].[Id]
```

This fails with the below error when sent to SQL Server LocalDb:
```
Invalid column name 'AuthorId'.
```

Looking at the EF Core source code, I found that `SelectExpression.PushdownIntoSubquery` always uses the hardcoded alias 't' ([here](https://github.com/dotnet/efcore/blob/0e91fa166dfdb72b3da33af130aafccac217c093/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs#L1046-L1047)), which is called multiple times. This makes it impossible for the LEFT JOIN generator to distinguish between [t] and what is later renamed to [t0] by `TableAliasUniquifyingExpressionVisitor`.

I believe I've fixed this bug by assigning a unique alias each time `SelectExpression.PushdownIntoSubquery` executes.
The downside is that this changes the generated names in SQL, breaking lots of other tests (queries are built from the inside out).

When applying the changes from this PR, the next SQL is generated, which looks correct to me:
```sql
@__p_0='2'
@__p_1='3'

SELECT [t1].[Id], [t00].[Id], [t00].[LastName], [t00].[Id0]
FROM (
    SELECT [b].[Id]
    FROM [Blogs] AS [b]
    ORDER BY [b].[Id]
    OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
) AS [t1]
OUTER APPLY (
    SELECT [a].[Id], [a].[LastName], [t0].[Id] AS [Id0]
    FROM (
        SELECT [p].[Id], [p].[AuthorId]
        FROM [Post21026] AS [p]
        WHERE [t1].[Id] = [p].[Blog21026Id]
        ORDER BY [p].[Id]
        OFFSET 1 ROWS FETCH NEXT 5 ROWS ONLY
    ) AS [t0]
    LEFT JOIN [Author21026] AS [a] ON [t0].[AuthorId] = [a].[Id]
) AS [t00]
ORDER BY [t1].[Id], [t00].[Id0], [t00].[Id]
```

An interesting side effect of my change is that the deepest SELECT no longer selects BlogId and Title, which were not needed anyway.

I also noticed my test succeeds when run in isolation, but fails when running all tests in the file. The alias numbers change. I'm probably generating them at the wrong scope.

As I'm fairly new to this codebase, I'm sure there must a better way to solve this. Any pointers are highly appreciated! I'll add doc-comments etc. once I know I'm on the right track.

Closes #21026.