### PR TITLE
[5.0.3] Use IUpdateEntry.EntityState instead of ModificationCommand.EntityState for entities using table splitting.

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -37,6 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         private readonly IKeyValueIndexFactorySource _keyValueIndexFactorySource;
         private readonly int _minBatchSize;
         private readonly bool _sensitiveLoggingEnabled;
+        private static readonly bool _useOldStateBehavior =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23668", out var enabled) && enabled;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -492,7 +494,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 .Where(c => c.PrincipalTable.Name == command.TableName && c.PrincipalTable.Schema == command.Schema);
 
                             if (!constraints.Any()
-                                || (entry.EntityState == EntityState.Modified
+                                || ((_useOldStateBehavior ? command.EntityState : entry.EntityState) == EntityState.Modified
                                     && !foreignKey.PrincipalKey.Properties.Any(p => entry.IsModified(p))))
                             {
                                 continue;
@@ -527,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 .Where(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema);
 
                             if (!constraints.Any()
-                                || (entry.EntityState == EntityState.Modified
+                                || ((_useOldStateBehavior ? command.EntityState : entry.EntityState) == EntityState.Modified
                                     && !foreignKey.Properties.Any(p => entry.IsModified(p))))
                             {
                                 continue;
@@ -573,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             {
                                 if (!foreignKey.GetMappedConstraints()
                                         .Any(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema)
-                                    || (entry.EntityState == EntityState.Modified
+                                    || ((_useOldStateBehavior ? command.EntityState : entry.EntityState) == EntityState.Modified
                                         && !foreignKey.Properties.Any(p => entry.IsModified(p))))
                                 {
                                     continue;
@@ -659,7 +661,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     var entry = command.Entries[entryIndex];
                     foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
                     {
-                        if (entry.EntityState == EntityState.Modified
+                        if ((_useOldStateBehavior ? command.EntityState : entry.EntityState) == EntityState.Modified
                             && !index.Properties.Any(p => entry.IsModified(p)))
                         {
                             continue;
@@ -720,7 +722,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     {
                         foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
                         {
-                            if (entry.EntityState == EntityState.Modified
+                            if ((_useOldStateBehavior ? command.EntityState : entry.EntityState) == EntityState.Modified
                                 && !index.Properties.Any(p => entry.IsModified(p)))
                             {
                                 continue;

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 .Where(c => c.PrincipalTable.Name == command.TableName && c.PrincipalTable.Schema == command.Schema);
 
                             if (!constraints.Any()
-                                || (command.EntityState == EntityState.Modified
+                                || (entry.EntityState == EntityState.Modified
                                     && !foreignKey.PrincipalKey.Properties.Any(p => entry.IsModified(p))))
                             {
                                 continue;
@@ -527,7 +527,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 .Where(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema);
 
                             if (!constraints.Any()
-                                || (command.EntityState == EntityState.Modified
+                                || (entry.EntityState == EntityState.Modified
                                     && !foreignKey.Properties.Any(p => entry.IsModified(p))))
                             {
                                 continue;
@@ -573,7 +573,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             {
                                 if (!foreignKey.GetMappedConstraints()
                                         .Any(c => c.Table.Name == command.TableName && c.Table.Schema == command.Schema)
-                                    || (command.EntityState == EntityState.Modified
+                                    || (entry.EntityState == EntityState.Modified
                                         && !foreignKey.Properties.Any(p => entry.IsModified(p))))
                                 {
                                     continue;
@@ -659,7 +659,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     var entry = command.Entries[entryIndex];
                     foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
                     {
-                        if (command.EntityState == EntityState.Modified
+                        if (entry.EntityState == EntityState.Modified
                             && !index.Properties.Any(p => entry.IsModified(p)))
                         {
                             continue;
@@ -720,7 +720,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                     {
                         foreach (var index in entry.EntityType.GetIndexes().Where(i => i.IsUnique && i.GetMappedTableIndexes().Any()))
                         {
-                            if (command.EntityState == EntityState.Modified
+                            if (entry.EntityState == EntityState.Modified
                                 && !index.Properties.Any(p => entry.IsModified(p)))
                             {
                                 continue;

--- a/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TPTTableSplittingSqlServerTest.cs
@@ -179,22 +179,22 @@ WHERE [c].[FuelType] IS NOT NULL AND [c].[Capacity] IS NOT NULL");
         {
             base.Can_change_dependent_instance_non_derived();
             AssertSql(
-                            @"@p0='Trek Pro Fit Madone 6 Series' (Nullable = false) (Size = 450)
-@p1='Repair' (Size = 4000)
-
-SET NOCOUNT ON;
-INSERT INTO [LicensedOperators] ([VehicleName], [LicenseType])
-VALUES (@p0, @p1);",
-                            //
-                            @"@p1='Trek Pro Fit Madone 6 Series' (Nullable = false) (Size = 450)
+                @"@p1='Trek Pro Fit Madone 6 Series' (Nullable = false) (Size = 450)
 @p0='repairman' (Size = 4000)
 
 SET NOCOUNT ON;
 UPDATE [Vehicles] SET [Operator_Name] = @p0
 WHERE [Name] = @p1;
 SELECT @@ROWCOUNT;",
-                            //
-                            @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], [c].[AttachedVehicleName], CASE
+                //
+                @"@p2='Trek Pro Fit Madone 6 Series' (Nullable = false) (Size = 450)
+@p3='Repair' (Size = 4000)
+
+SET NOCOUNT ON;
+INSERT INTO [LicensedOperators] ([VehicleName], [LicenseType])
+VALUES (@p2, @p3);",
+                //
+                @"SELECT TOP(2) [v].[Name], [v].[SeatingCapacity], [c].[AttachedVehicleName], CASE
     WHEN [c].[Name] IS NOT NULL THEN N'CompositeVehicle'
     WHEN [p].[Name] IS NOT NULL THEN N'PoweredVehicle'
 END AS [Discriminator], [t0].[Name], [t0].[Operator_Name], [t0].[LicenseType], [t0].[Discriminator]


### PR DESCRIPTION
Fixes #23668

**Description**

`ModificationCommand.EntityState` is used in many places throughout `CommandBatchPreparer` and in most cases it is the same as `IUpdateEntry.EntityState` for the corresponding entry, however when adding an optional dependent to an existing row `ModificationCommand.EntityState` is `Modified` while `IUpdateEntry.EntityState` is `Added`

**Customer Impact**

Adding an optional dependent that is referencing a newly added principal entity or deleting both of them can result in a SQL error as the operations aren't ordered correctly. A workaround would be to call `SaveChanges` immediately after the first operation that should be performed, but this isn't feasible in some scenarios.

**How found**

Customer reported on 5.0.1.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

Yes

**Risk**

Low. In most cases other cases `ModificationCommand.EntityState` and `IUpdateEntry.EntityState` are the same