### PR TITLE
Fix unexpected null in principal columns of foreign key

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -282,20 +282,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 builder
                     .AppendLine(",")
                     .Append("principalTable: ")
-                    .Append(Code.Literal(operation.PrincipalTable))
-                    .AppendLine(",");
+                    .Append(Code.Literal(operation.PrincipalTable));
 
-                if (operation.PrincipalColumns.Length == 1)
+                if (operation.PrincipalColumns != null)
                 {
-                    builder
-                        .Append("principalColumn: ")
-                        .Append(Code.Literal(operation.PrincipalColumns[0]));
-                }
-                else
-                {
-                    builder
-                        .Append("principalColumns: ")
-                        .Append(Code.Literal(operation.PrincipalColumns));
+                    if (operation.PrincipalColumns.Length == 1)
+                    {
+                        builder
+                            .AppendLine(",")
+                            .Append("principalColumn: ")
+                            .Append(Code.Literal(operation.PrincipalColumns[0]));
+                    }
+                    else
+                    {
+                        builder
+                            .AppendLine(",")
+                            .Append("principalColumns: ")
+                            .Append(Code.Literal(operation.PrincipalColumns));
+                    }
                 }
 
                 if (operation.OnUpdate != ReferentialAction.NoAction)

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 principalTable,
                 schema,
                 principalSchema,
-                new[] { principalColumn },
+                principalColumn != null ? new[] { principalColumn } : null,
                 onUpdate,
                 onDelete);
 
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </param>
         /// <param name="principalColumns">
         ///     The columns to which the foreign key columns are constrained, or <see langword="null" /> to constrain to the primary key
-        ///     column.
+        ///     columns.
         /// </param>
         /// <param name="onUpdate"> The action to take on updates. </param>
         /// <param name="onDelete"> The action to take on deletes. </param>

--- a/src/EFCore.Relational/Migrations/Operations/AddForeignKeyOperation.cs
+++ b/src/EFCore.Relational/Migrations/Operations/AddForeignKeyOperation.cs
@@ -47,9 +47,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations
         public virtual string PrincipalTable { get; [param: NotNull] set; }
 
         /// <summary>
-        ///     The ordered-list of column names for the columns to which the columns that make up this foreign key are constrained.
+        ///     The ordered-list of column names for the columns to which the columns that make up this foreign key are constrained, or
+        ///     <see langword="null" /> to constrain to the primary key columns.
         /// </summary>
-        public virtual string[] PrincipalColumns { get; [param: NotNull] set; }
+        public virtual string[] PrincipalColumns { get; [param: CanBeNull] set; }
 
         /// <summary>
         ///     The <see cref="ReferentialAction" /> to use for updates.

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -197,11 +197,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Test(
                 new AddForeignKeyOperation
                 {
-                    Table = "Post",
                     Name = "FK_Post_Blog_BlogId",
+                    Table = "Post",
                     Columns = new[] { "BlogId" },
-                    PrincipalTable = "Blog",
-                    PrincipalColumns = new[] { "Id" }
+                    PrincipalTable = "Blog"
                 },
                 "mb.AddForeignKey("
                 + _eol
@@ -211,15 +210,44 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + _eol
                 + "    column: \"BlogId\","
                 + _eol
-                + "    principalTable: \"Blog\","
-                + _eol
-                + "    principalColumn: \"Id\");",
+                + "    principalTable: \"Blog\");",
                 o =>
                 {
-                    Assert.Equal("Post", o.Table);
                     Assert.Equal("FK_Post_Blog_BlogId", o.Name);
+                    Assert.Equal("Post", o.Table);
                     Assert.Equal(new[] { "BlogId" }, o.Columns);
                     Assert.Equal("Blog", o.PrincipalTable);
+                    Assert.Null(o.PrincipalColumns);
+                });
+        }
+
+        [ConditionalFact]
+        public void AddForeignKeyOperation_required_args_composite()
+        {
+            Test(
+                new AddForeignKeyOperation
+                {
+                    Name = "FK_Post_Blog_BlogId1_BlogId2",
+                    Table = "Post",
+                    Columns = new[] { "BlogId1", "BlogId2" },
+                    PrincipalTable = "Blog"
+                },
+                "mb.AddForeignKey("
+                + _eol
+                + "    name: \"FK_Post_Blog_BlogId1_BlogId2\","
+                + _eol
+                + "    table: \"Post\","
+                + _eol
+                + "    columns: new[] { \"BlogId1\", \"BlogId2\" },"
+                + _eol
+                + "    principalTable: \"Blog\");",
+                o =>
+                {
+                    Assert.Equal("FK_Post_Blog_BlogId1_BlogId2", o.Name);
+                    Assert.Equal("Post", o.Table);
+                    Assert.Equal(new[] { "BlogId1", "BlogId2" }, o.Columns);
+                    Assert.Equal("Blog", o.PrincipalTable);
+                    Assert.Null(o.PrincipalColumns);
                 });
         }
 
@@ -229,9 +257,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Test(
                 new AddForeignKeyOperation
                 {
+                    Name = "FK_Post_Blog_BlogId",
                     Schema = "dbo",
                     Table = "Post",
-                    Name = "FK_Post_Blog_BlogId",
                     Columns = new[] { "BlogId" },
                     PrincipalSchema = "my",
                     PrincipalTable = "Blog",
@@ -260,47 +288,64 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + "    onDelete: ReferentialAction.Cascade);",
                 o =>
                 {
-                    Assert.Equal("Post", o.Table);
-                    Assert.Equal("dbo", o.Schema);
                     Assert.Equal("FK_Post_Blog_BlogId", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("Post", o.Table);
                     Assert.Equal(new[] { "BlogId" }, o.Columns);
-                    Assert.Equal("Blog", o.PrincipalTable);
                     Assert.Equal("my", o.PrincipalSchema);
+                    Assert.Equal("Blog", o.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, o.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Restrict, o.OnUpdate);
                     Assert.Equal(ReferentialAction.Cascade, o.OnDelete);
                 });
         }
 
         [ConditionalFact]
-        public void AddForeignKeyOperation_composite()
+        public void AddForeignKeyOperation_all_args_composite()
         {
             Test(
                 new AddForeignKeyOperation
                 {
                     Name = "FK_Post_Blog_BlogId1_BlogId2",
+                    Schema = "dbo",
                     Table = "Post",
                     Columns = new[] { "BlogId1", "BlogId2" },
+                    PrincipalSchema = "my",
                     PrincipalTable = "Blog",
-                    PrincipalColumns = new[] { "Id1", "Id2" }
+                    PrincipalColumns = new[] { "Id1", "Id2" },
+                    OnUpdate = ReferentialAction.Restrict,
+                    OnDelete = ReferentialAction.Cascade
                 },
                 "mb.AddForeignKey("
                 + _eol
                 + "    name: \"FK_Post_Blog_BlogId1_BlogId2\","
                 + _eol
+                + "    schema: \"dbo\","
+                + _eol
                 + "    table: \"Post\","
                 + _eol
                 + "    columns: new[] { \"BlogId1\", \"BlogId2\" },"
                 + _eol
+                + "    principalSchema: \"my\","
+                + _eol
                 + "    principalTable: \"Blog\","
                 + _eol
-                + "    principalColumns: new[] { \"Id1\", \"Id2\" });",
+                + "    principalColumns: new[] { \"Id1\", \"Id2\" },"
+                + _eol
+                + "    onUpdate: ReferentialAction.Restrict,"
+                + _eol
+                + "    onDelete: ReferentialAction.Cascade);",
                 o =>
                 {
                     Assert.Equal("FK_Post_Blog_BlogId1_BlogId2", o.Name);
+                    Assert.Equal("dbo", o.Schema);
                     Assert.Equal("Post", o.Table);
                     Assert.Equal(new[] { "BlogId1", "BlogId2" }, o.Columns);
+                    Assert.Equal("my", o.PrincipalSchema);
                     Assert.Equal("Blog", o.PrincipalTable);
                     Assert.Equal(new[] { "Id1", "Id2" }, o.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Restrict, o.OnUpdate);
+                    Assert.Equal(ReferentialAction.Cascade, o.OnDelete);
                 });
         }
 


### PR DESCRIPTION
`MigrationsSqlGenerator` expects `PrincipalColumns` to be `null`, not a `null` element.