### PR TITLE
[5.0.3] Add column name null checks in default FK and PK name calculation

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
@@ -90,6 +90,7 @@ namespace Microsoft.EntityFrameworkCore
                 return null;
             }
 
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23672", out var enabled) && enabled;
             var rootIndex = index;
 
             // Limit traversal to avoid getting stuck in a cycle (validation will throw for these later)
@@ -102,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore
                     .SelectMany(fk => fk.PrincipalEntityType.GetIndexes()))
                 {
                     var otherColumnNames = otherIndex.Properties.GetColumnNames(storeObject);
-                    if (otherColumnNames != null
+                    if ((otherColumnNames != null || useOldBehavior)
                         && otherColumnNames.SequenceEqual(columnNames))
                     {
                         linkedIndex = otherIndex;

--- a/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
@@ -84,8 +84,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The default name that would be used for this index. </returns>
         public static string GetDefaultDatabaseName([NotNull] this IIndex index, in StoreObjectIdentifier storeObject)
         {
-            var propertyNames = index.Properties.GetColumnNames(storeObject);
-            if (propertyNames == null)
+            var columnNames = index.Properties.GetColumnNames(storeObject);
+            if (columnNames == null)
             {
                 return null;
             }
@@ -101,7 +101,9 @@ namespace Microsoft.EntityFrameworkCore
                     .FindRowInternalForeignKeys(storeObject)
                     .SelectMany(fk => fk.PrincipalEntityType.GetIndexes()))
                 {
-                    if (otherIndex.Properties.GetColumnNames(storeObject).SequenceEqual(propertyNames))
+                    var otherColumnNames = otherIndex.Properties.GetColumnNames(storeObject);
+                    if (otherColumnNames != null
+                        && otherColumnNames.SequenceEqual(columnNames))
                     {
                         linkedIndex = otherIndex;
                         break;
@@ -125,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Append("IX_")
                 .Append(storeObject.Name)
                 .Append("_")
-                .AppendJoin(propertyNames, "_")
+                .AppendJoin(columnNames, "_")
                 .ToString();
 
             return Uniquifier.Truncate(baseName, index.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
@@ -97,8 +97,8 @@ namespace Microsoft.EntityFrameworkCore
             }
             else
             {
-                var propertyNames = key.Properties.GetColumnNames(storeObject);
-                if (propertyNames == null)
+                var columnNames = key.Properties.GetColumnNames(storeObject);
+                if (columnNames == null)
                 {
                     return null;
                 }
@@ -114,7 +114,9 @@ namespace Microsoft.EntityFrameworkCore
                         .FindRowInternalForeignKeys(storeObject)
                         .SelectMany(fk => fk.PrincipalEntityType.GetKeys()))
                     {
-                        if (otherKey.Properties.GetColumnNames(storeObject).SequenceEqual(propertyNames))
+                        var otherColumnNames = otherKey.Properties.GetColumnNames(storeObject);
+                        if (otherColumnNames != null
+                            && otherColumnNames.SequenceEqual(columnNames))
                         {
                             linkedKey = otherKey;
                             break;
@@ -138,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
                     .Append("AK_")
                     .Append(storeObject.Name)
                     .Append("_")
-                    .AppendJoin(propertyNames, "_")
+                    .AppendJoin(columnNames, "_")
                     .ToString();
             }
 

--- a/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -103,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore
                     return null;
                 }
 
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23672", out var enabled) && enabled;
                 var rootKey = key;
 
                 // Limit traversal to avoid getting stuck in a cycle (validation will throw for these later)
@@ -115,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore
                         .SelectMany(fk => fk.PrincipalEntityType.GetKeys()))
                     {
                         var otherColumnNames = otherKey.Properties.GetColumnNames(storeObject);
-                        if (otherColumnNames != null
+                        if ((otherColumnNames != null || useOldBehavior)
                             && otherColumnNames.SequenceEqual(columnNames))
                         {
                             linkedKey = otherKey;

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -1089,6 +1089,46 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
+        public virtual void Passes_for_indexes_on_related_types_mapped_to_different_tables()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<PropertyBase>();
+            modelBuilder.Entity<Property>();
+
+            Validate(modelBuilder.Model);
+        }
+
+        [Table("Objects")]
+        private abstract class PropertyBase
+        {
+            public int Id { get; set; }
+
+            public Organization Organization { get; set; }
+        }
+
+        private class Organization
+        {
+            public int Id { get; set; }
+        }
+
+        [Table("Properties")]
+        private class Property : PropertyBase
+        {
+            public PropertyDetails Details { get; set; } = null!;
+        }
+
+        [Owned]
+        private class PropertyDetails
+        {
+            public Address Address { get; set; }
+        }
+
+        private class Address
+        {
+            public int Id { get; set; }
+        }
+
+        [ConditionalFact]
         public virtual void Detects_missing_concurrency_token_on_the_base_type_without_convention()
         {
             var modelBuilder = CreateModelBuilderWithoutConvention<TableSharingConcurrencyTokenConvention>();


### PR DESCRIPTION
Fixes #23672

**Description**

`GetColumnNames(StoreObjectIdentifier)` returns `null` for properties that are not mapped to the specifier store object. However `GetDefaultName()` didn't account for this.

**Customer Impact**

User models that use table splitting and have FKs to other table will result in an unhelpful `ArgumentNullException`. A workaround would be to specify the key and index store names explicitly, but this would be unfeasible for large models as the exception doesn't provide information on which are the offending ones.

**How found**

Customer reported on 5.0.1.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

Yes

**Risk**

Low. This just adds two `null` checks.