### PR TITLE
Fix to #23063 - Query/OData: add test support for models requiring non-standard routing (e.g. "Order Details" table in Northwind)

### DIFF
--- a/test/EFCore.OData.FunctionalTests/Query/NorthwindODataContext.cs
+++ b/test/EFCore.OData.FunctionalTests/Query/NorthwindODataContext.cs
@@ -93,6 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Property(od => od.UnitPrice)
                 .HasColumnType("money");
 
+            modelBuilder.Entity<OrderDetail>().ToTable("Order Details");
+
             modelBuilder.Entity<Product>(
                 b =>
                 {

--- a/test/EFCore.OData.FunctionalTests/Query/NorthwindODataQueryTests.cs
+++ b/test/EFCore.OData.FunctionalTests/Query/NorthwindODataQueryTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(830, orderDates.Count);
         }
 
-        [ConditionalFact(Skip = "Issue #23063")]
+        [ConditionalFact]
         public async Task Basic_query_order_details()
         {
             var requestUri = string.Format("{0}/odata/Order Details", BaseAddress);
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var result = await response.Content.ReadAsObject<JObject>();
 
-            Assert.Contains("$metadata#OrderDetails", result["@odata.context"].ToString());
+            Assert.Contains("$metadata#Order%20Details", result["@odata.context"].ToString());
         }
     }
 }


### PR DESCRIPTION
Adding custom routing for OrderDetailsController

Fixes #23063