### PR TITLE
Microsoft.Data.Sqlite: Don't use bool? in connection string builder

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -268,10 +268,10 @@ namespace Microsoft.Data.Sqlite
                     }
                 }
 
-                if (ConnectionOptions.ForeignKeys.HasValue)
+                if (ConnectionOptions.ForeignKeys != SqliteForeignKeys.Default)
                 {
                     this.ExecuteNonQuery(
-                        "PRAGMA foreign_keys = " + (ConnectionOptions.ForeignKeys.Value ? "1" : "0") + ";");
+                        "PRAGMA foreign_keys = " + (ConnectionOptions.ForeignKeys == SqliteForeignKeys.On ? "1" : "0") + ";");
                 }
 
                 if (ConnectionOptions.RecursiveTriggers)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteForeignKeys.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteForeignKeys.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Sqlite
+{
+    /// <summary>
+    ///     Represents the foreign key constraint enforcement modes of SQLite.
+    /// </summary>
+    public enum SqliteForeignKeys
+    {
+        /// <summary>
+        ///     The database default.
+        /// </summary>
+        Default = -1,
+
+        /// <summary>
+        ///     Don't enforce foreign key constraints.
+        /// </summary>
+        Off,
+
+        /// <summary>
+        ///     Enforce foreign key constraints.
+        /// </summary>
+        On
+    }
+}

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/NotNullWhenAttribute.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/NotNullWhenAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !NET
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+            => ReturnValue = returnValue;
+
+        public bool ReturnValue { get; }
+    }
+}
+
+#endif

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -369,8 +369,8 @@ namespace Microsoft.Data.Sqlite
 #endif
 
         [Theory]
-        [InlineData("True", 1L)]
-        [InlineData("False", 0L)]
+        [InlineData("On", 1L)]
+        [InlineData("Off", 0L)]
         public void Open_works_when_foreign_keys(string foreignKeys, long expected)
         {
             using (var connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=" + foreignKeys))


### PR DESCRIPTION
Note, this is done in a way that won't break existing connection strings.

<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


