### PR TITLE
[5.0.3] InMemory: Wrap composite key selector for owned type in AnonymousObject

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -1467,6 +1467,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                         .Select(p => p.ClrType)
                         .Any(t => t.IsNullableType());
 
+
                     var outerKey = entityShaperExpression.CreateKeyValuesExpression(
                         navigation.IsOnDependent
                             ? foreignKey.Properties
@@ -1477,6 +1478,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                             ? foreignKey.PrincipalKey.Properties
                             : foreignKey.Properties,
                         makeNullable);
+
+                    if (foreignKey.Properties.Count > 1
+                        && !(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore23687", out var enabled) && enabled))
+                    {
+                        outerKey = Expression.New(AnonymousObject.AnonymousObjectCtor, outerKey);
+                        innerKey = Expression.New(AnonymousObject.AnonymousObjectCtor, innerKey);
+                    }
 
                     var outerKeySelector = Expression.Lambda(_expressionTranslator.Translate(outerKey), _queryExpression.CurrentParameter);
                     var innerKeySelector = Expression.Lambda(


### PR DESCRIPTION
Resolves #23687

Composite key selector needs wrapper so that we compare them component-wise

**Description**

When generating server side join for InMemory, we need to use Join from enumerable which takes key selectors for outer/inner. For composite key we generate an array of object where each index contain the property value. In order to compare them correctly during key selector we need to wrap them in AnonymousObject so that we compare matching indexes in both arrays. When we removed Anonymous object from core, we removed automatic injection of it in key selector generation hence queries with composite keys for owned reference failed to compare correctly.

**Customer Impact**
Queries where owned reference has composite key to owner will fail to match during join causing incorrect results to be generated in InMemory provider.

**How found**

Customer reported on 5.0.1.

**Test coverage**

We have added test coverage in this PR.

**Regression?**

Yes, from 3.1

**Risk**

Low. Only affects the faulty code path. Also added quirk to revert to earlier behavior.