### PR TITLE
Fix #23569 Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors

### DIFF
--- a/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
+++ b/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
@@ -88,7 +88,11 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
             => string.Format(
                 GetString("UpdateConcurrencyTokenExceptionSensitive", nameof(entityType), nameof(keyValue), nameof(conflictingValues), nameof(databaseValues)),
                 entityType, keyValue, conflictingValues, databaseValues);
-
+        /// <summary>
+        ///     Attempt to add a duplicate entity with key='{key}'.
+        /// </summary>
+        public static string DuplicateKeyException(object key)
+            =>string.Format("a key with the same value already esists ({0})",key);
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                 {
                     var entry = entries[i];
                     var entityType = entry.EntityType;
-
+                    
                     Check.DebugAssert(!entityType.IsAbstract(), "entityType is abstract");
 
                     var table = EnsureTable(entityType);

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
@@ -202,7 +202,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             {
                 ThrowNullabilityErrorException(entry, nullabilityErrors);
             }
-
+            var key = CreateKey(entry);
+            if(_rows.ContainsKey(key))
+                throw new DbUpdateConcurrencyException($"a key with the same value already esists ({key})");
             _rows.Add(CreateKey(entry), row);
 
             BumpValueGenerators(row);

--- a/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
+using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -31,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
-
+       
         [ConditionalFact(Skip = "Optimistic Offline Lock #2195")]
         public override Task Simple_concurrency_exception_can_be_resolved_with_store_values()
             => Task.FromResult(true);
@@ -78,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore
         public override Task Two_concurrency_issues_in_one_to_one_related_entities_can_be_handled_by_dealing_with_dependent_first()
             => Task.FromResult(true);
 
-        [Fact]
+        [ConditionalFact]
         public override async Task Adding_the_same_entity_twice_results_in_DbUpdateException()
         {
             using var c = CreateF1Context();
@@ -106,20 +107,61 @@ namespace Microsoft.EntityFrameworkCore
 
                     await innerContext.SaveChangesAsync();
 
-                    await Assert.ThrowsAnyAsync<DbUpdateException>(() => context.SaveChangesAsync());
+                    await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
                 });
-            
         }
-        [ConditionalFact(Skip = "Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors #23569")]
-        public override Task Deleting_the_same_entity_twice_results_in_DbUpdateConcurrencyException()
+        [ConditionalFact]
+        public override async Task Deleting_the_same_entity_twice_results_in_DbUpdateConcurrencyException()
         {
-            return Task.FromResult(true);
+            const string DRIVER="Fernando Alonso";
+            using var c = CreateF1Context();
+            await c.Database.CreateExecutionStrategy().ExecuteAsync(
+                c, async context =>
+                {
+                    using var prepareTransaction = BeginTransaction(context.Database);
+                    context.Drivers.Add(
+                        new Driver(){ Name=DRIVER}
+                    );
+                    await context.SaveChangesAsync();
+                    using var transaction = BeginTransaction(context.Database);
+                    context.Drivers.Remove(context.Drivers.Single(d => d.Name == DRIVER));
+                        
+
+                    using var innerContext = CreateF1Context();
+                    UseTransaction(innerContext.Database, transaction);
+                    context.Drivers.Remove(innerContext.Drivers.Single(d => d.Name == DRIVER));
+
+                    await innerContext.SaveChangesAsync();
+
+                    await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
+                });
         }
 
-        [ConditionalFact(Skip = "Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors #23569")]
-        public override Task Deleting_then_updating_the_same_entity_results_in_DbUpdateConcurrencyException()
+        [ConditionalFact]
+        public override async Task Deleting_then_updating_the_same_entity_results_in_DbUpdateConcurrencyException()
         {
-            return Task.FromResult(true);
+            const string DRIVER="Fernando Alonso";
+            using var c = CreateF1Context();
+            await c.Database.CreateExecutionStrategy().ExecuteAsync(
+                c, async context =>
+                {
+                    using var prepareTransaction = BeginTransaction(context.Database);
+                    context.Drivers.Add(
+                        new Driver(){ Name=DRIVER}
+                    );
+                    await context.SaveChangesAsync();
+                    using var transaction = BeginTransaction(context.Database);
+                    context.Drivers.Remove(context.Drivers.Single(d => d.Name == DRIVER));
+                        
+
+                    using var innerContext = CreateF1Context();
+                    UseTransaction(innerContext.Database, transaction);
+                    var driver = context.Drivers.Single(d => d.Name == DRIVER);
+                    driver.Name="Felix";
+                    await innerContext.SaveChangesAsync();
+
+                    await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
+                });
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
@@ -129,10 +129,10 @@ namespace Microsoft.EntityFrameworkCore
 
                     using var innerContext = CreateF1Context();
                     UseTransaction(innerContext.Database, transaction);
-                    context.Drivers.Remove(innerContext.Drivers.Single(d => d.Name == DRIVER));
-
+                    innerContext.Drivers.Remove(innerContext.Drivers.Single(d => d.Name == DRIVER));
+                    
                     await innerContext.SaveChangesAsync();
-
+                    
                     await Assert.ThrowsAnyAsync<DbUpdateConcurrencyException>(() => context.SaveChangesAsync());
                 });
         }
@@ -150,13 +150,14 @@ namespace Microsoft.EntityFrameworkCore
                         new Driver(){ Name=DRIVER}
                     );
                     await context.SaveChangesAsync();
+
                     using var transaction = BeginTransaction(context.Database);
                     context.Drivers.Remove(context.Drivers.Single(d => d.Name == DRIVER));
                         
 
                     using var innerContext = CreateF1Context();
                     UseTransaction(innerContext.Database, transaction);
-                    var driver = context.Drivers.Single(d => d.Name == DRIVER);
+                    var driver = innerContext.Drivers.Single(d => d.Name == DRIVER);
                     driver.Name="Felix";
                     await innerContext.SaveChangesAsync();
 

--- a/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/OptimisticConcurrencyInMemoryTest.cs
@@ -79,14 +79,19 @@ namespace Microsoft.EntityFrameworkCore
 
         [ConditionalFact(Skip = "Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors #23569")]
         public override Task Adding_the_same_entity_twice_results_in_DbUpdateException()
-            => Task.FromResult(true);
-
+        {
+            return Task.FromResult(true);
+        }
         [ConditionalFact(Skip = "Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors #23569")]
         public override Task Deleting_the_same_entity_twice_results_in_DbUpdateConcurrencyException()
-            => Task.FromResult(true);
+        {
+            return Task.FromResult(true);
+        }
 
         [ConditionalFact(Skip = "Throw DbUpdateException or DbUpdateConcurrencyException for in-memory database errors #23569")]
         public override Task Deleting_then_updating_the_same_entity_results_in_DbUpdateConcurrencyException()
-            => Task.FromResult(true);
+        {
+            return Task.FromResult(true);
+        }
     }
 }


### PR DESCRIPTION
Fixes #23569
Created unit tests in `OptimisticConcurrencyInMemoryTest.cs`
Modified `InMemoryTable.cs `to pass the tests
Added a string in I`nMemoryString.Designer.cs`




