### PR TITLE
Skip SqlServer functional tests

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <SkipTests Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''">True</SkipTests>
+    <!-- Skipping tests pending investigation in https://github.com/dotnet/efcore/issues/23776 -->
+    <SkipTests>True</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While someone investigates https://github.com/dotnet/efcore/issues/23776, we can disable the tests to unblock dependency updates with this as a temporary measure.