### PR TITLE
[5.0.3] Set skip navigations in delayed fixup

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,6 +30,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
     /// </summary>
     public class NavigationFixer : INavigationFixer
     {
+        private readonly bool _useOldBehaviorFor23659
+            = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23659", out var enabled) && enabled;
+
         private readonly IChangeDetector _changeDetector;
         private readonly IEntityGraphAttacher _attacher;
         private bool _inFixup;
@@ -663,19 +667,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                 }
 
-                foreach (var skipNavigation in foreignKey.GetReferencingSkipNavigations())
-                {
-                    var leftEntry = stateManager.FindPrincipal(entry, foreignKey);
-                    if (leftEntry != null)
-                    {
-                        var rightEntry = stateManager.FindPrincipal(entry, skipNavigation.Inverse.ForeignKey);
-                        if (rightEntry != null)
-                        {
-                            AddToCollection(leftEntry, skipNavigation, rightEntry, fromQuery);
-                            AddToCollection(rightEntry, skipNavigation.Inverse, leftEntry, fromQuery);
-                        }
-                    }
-                }
+                FixupSkipNavigations(entry, foreignKey, fromQuery);
             }
 
             foreach (var foreignKey in entityType.GetReferencingForeignKeys())
@@ -894,6 +886,28 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     else if (referencedEntry.Entity == navigationValue)
                     {
                         FixupToPrincipal(entry, referencedEntry, navigation.ForeignKey, setModified, fromQuery);
+
+                        if (!_useOldBehaviorFor23659)
+                        {
+                            FixupSkipNavigations(entry, navigation.ForeignKey, fromQuery);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void FixupSkipNavigations(InternalEntityEntry entry, IForeignKey foreignKey, bool fromQuery)
+        {
+            foreach (var skipNavigation in foreignKey.GetReferencingSkipNavigations())
+            {
+                var leftEntry = entry.StateManager.FindPrincipal(entry, foreignKey);
+                if (leftEntry != null)
+                {
+                    var rightEntry = entry.StateManager.FindPrincipal(entry, skipNavigation.Inverse.ForeignKey);
+                    if (rightEntry != null)
+                    {
+                        AddToCollection(leftEntry, skipNavigation, rightEntry, fromQuery);
+                        AddToCollection(rightEntry, skipNavigation.Inverse, leftEntry, fromQuery);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #23659

**Description**

If we encounter an un-mapped entity during graph discovery of Attach, etc., then that entity is put aside for delayed fixup when it later becomes tracked. In this delayed fixup we were not populating skip navigations. The fix is to do this, just like happens in non-delayed fixup.

**Customer Impact**

Many-to-many navigations that use store-generated keys are not populated correctly when a join entity is tracked. This makes it appear to the application as if the two objects are not related.

**How found**

Customer reported on 5.0.

**Test coverage**

This only happens when using store-generated keys, for which we were missing some many-to-many coverage. A previous PR added that coverage, and this PR contains a new test for this specific case.

**Regression?**

No; new feature in 5.0.

**Risk**

Low. The navigations are now fixed up when doing delayed fixup.
