### PR TITLE
[5.0.3] Fixes to database collation migrations

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -724,20 +724,31 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             using (builder.Indent())
             {
+                var needComma = false;
+
                 if (operation.Collation != null)
                 {
                     builder
                         .AppendLine()
                         .Append("collation: ")
                         .Append(Code.Literal(operation.Collation));
+
+                    needComma = true;
                 }
 
                 if (operation.OldDatabase.Collation != null)
                 {
+                    if (needComma)
+                    {
+                        builder.Append(",");
+                    }
+
                     builder
-                        .AppendLine(",")
+                        .AppendLine()
                         .Append("oldCollation: ")
                         .Append(Code.Literal(operation.OldDatabase.Collation));
+
+                    needComma = true;
                 }
 
                 builder.Append(")");

--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -477,7 +477,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] string collation = null,
             [CanBeNull] string oldCollation = null)
         {
-            var operation = new AlterDatabaseOperation { Collation = collation };
+            var operation = new AlterDatabaseOperation
+            {
+                Collation = collation,
+                OldDatabase =
+                {
+                    Collation = oldCollation
+                }
+            };
             Operations.Add(operation);
 
             return new AlterOperationBuilder<AlterDatabaseOperation>(operation);

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -804,8 +804,43 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 + "    .OldAnnotation(\"bar\", \"foo\");",
                 o =>
                 {
+                    Assert.Equal("Some collation", o.Collation);
+                    Assert.Equal("Some other collation", o.OldDatabase.Collation);
                     Assert.Equal("bar", o["foo"]);
                     Assert.Equal("foo", o.OldDatabase["bar"]);
+                });
+        }
+
+        [ConditionalFact]
+        public void AlterDatabaseOperation_with_default_old_collation()
+        {
+            Test(
+                new AlterDatabaseOperation { Collation = "Some collation" },
+                "mb.AlterDatabase("
+                + _eol
+                + "    collation: \"Some collation\");",
+                o =>
+                {
+                    Assert.Equal("Some collation", o.Collation);
+                    Assert.Null(o.OldDatabase.Collation);
+                });
+        }
+
+        [ConditionalFact]
+        public void AlterDatabaseOperation_with_default_new_collation()
+        {
+            Test(
+                new AlterDatabaseOperation
+                {
+                    OldDatabase = { Collation = "Some collation" }
+                },
+                "mb.AlterDatabase("
+                + _eol
+                + "    oldCollation: \"Some collation\");",
+                o =>
+                {
+                    Assert.Null(o.Collation);
+                    Assert.Equal("Some collation", o.OldDatabase.Collation);
                 });
         }
 


### PR DESCRIPTION
Fixes #23794

**Description**

When generating migrations, if a database collation is configured and non was previously configured, a mangled migration is generated which does not compile.

**Customer Impact**

Any user trying to explicitly set a collation on an existing database will fail and would have to manually edit generated migration source code.

**How found**

Customer reported on 5.0.2.

**Test coverage**

We have added test coverage in this PR.

**Regression?**

No, collation support was only introduced in 5.0.

**Risk**

Low. Only affects the faulty code path, which is part of design-time migration generation (no runtime impact).