### PR TITLE
[5.0.3] InMemory: Skip over AsSingleQuery method

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryableMethodTranslatingExpressionVisitor.cs
@@ -83,7 +83,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             if (methodCallExpression.Method.IsGenericMethod
                 && methodCallExpression.Arguments.Count == 1
                 && methodCallExpression.Arguments[0].Type.TryGetSequenceType() != null
-                && string.Equals(methodCallExpression.Method.Name, "AsSplitQuery", StringComparison.Ordinal))
+                && (string.Equals(methodCallExpression.Method.Name, "AsSplitQuery", StringComparison.Ordinal)
+                    || string.Equals(methodCallExpression.Method.Name, "AsSingleQuery", StringComparison.Ordinal)))
             {
                 return Visit(methodCallExpression.Arguments[0]);
             }


### PR DESCRIPTION
Resolves #23759

**Description**

Relational providers have `AsSingleQuery` operator to evaluate query in single SQL scenario. The queryable method only exist for relational providers but when using InMemory provider for testing (multiple providers in same app scenario), the method throws translation error since InMemory provider doesn't understand the method. In 5.0, we added code to skip `AsSplitQuery` this is similar method on the flipside.

**Customer Impact**

Customers who are using `AsSingleQuery` in their production code and using InMemory provider for testing will see test failures.

**How found**

Customer reported on 5.0.1.

**Test coverage**

Manually verified. No test projects contains relational and inmemory provider together.

**Regression?**

No, AsSingleQuery is operator introduced in 5.0 only. The query fails on 5.0.0 too.

**Risk**

"Low", we would skip over a method which would fail anyway. The fuzzy string match is by-design since we don't have access to actual method which is defined in a different assembly. Plus, InMemory is supposed to be used for testing only.