### PR TITLE
[5.0.3] Fix event counter issues and add test patterns for event source testing

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1114,6 +1114,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             using (_concurrencyDetector.EnterCriticalSection())
             {
+                EntityFrameworkEventSource.Log.SavingChanges();
+
                 return await _database.SaveChangesAsync(entriesToSave, cancellationToken)
                     .ConfigureAwait(false);
             }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -112,6 +112,8 @@ namespace Microsoft.EntityFrameworkCore
             ServiceProviderCache.Instance.GetOrAdd(options, providerRequired: false)
                 .GetRequiredService<IDbSetInitializer>()
                 .InitializeSets(this);
+
+            EntityFrameworkEventSource.Log.DbContextInitializing();
         }
 
         /// <summary>
@@ -346,8 +348,6 @@ namespace Microsoft.EntityFrameworkCore
                 try
                 {
                     _initializing = true;
-
-                    EntityFrameworkEventSource.Log.DbContextInitializing();
 
                     var optionsBuilder = new DbContextOptionsBuilder(_options);
 
@@ -642,6 +642,8 @@ namespace Microsoft.EntityFrameworkCore
             }
             catch (DbUpdateConcurrencyException exception)
             {
+                EntityFrameworkEventSource.Log.OptimisticConcurrencyFailure();
+
                 await DbContextDependencies.UpdateLogger.OptimisticConcurrencyExceptionAsync(this, exception, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/EFCore/Infrastructure/EntityFrameworkEventSource.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkEventSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using System.Threading;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -155,6 +156,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 };
             }
         }
+
+        [UsedImplicitly]
+        private void ResetCacheInfo()
+            => _compiledQueryCacheInfo = new CacheInfo();
 
         [StructLayout(LayoutKind.Explicit)]
         private struct CacheInfo

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -273,6 +273,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 catch (Exception ex)
                 {
                     Suspended = false;
+
+                    EntityFrameworkEventSource.Log.ExecutionStrategyOperationFailure();
+
                     if (verifySucceeded != null
                         && CallOnWrappedException(ex, ShouldVerifySuccessOn))
                     {

--- a/test/EFCore.Tests/EventSourceTest.cs
+++ b/test/EFCore.Tests/EventSourceTest.cs
@@ -1,0 +1,314 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    [Collection("EventSourceTest")]
+    public class EventSourceTest
+    {
+        private static readonly BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        public EventSourceTest(EventSourceFixture fixture)
+        {
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_when_query_is_executed(bool async)
+        {
+            TotalQueries = 0;
+
+            for (var i = 1; i <= 3; i++)
+            {
+                using (var context = new SomeDbContext())
+                {
+                    var _ = async
+                        ? await context.Foos.ToListAsync()
+                        : context.Foos.ToList();
+
+                    Assert.Equal(i, TotalQueries);
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_when_SaveChanges_is_called(bool async)
+        {
+            TotalSaveChanges = 0;
+
+            for (var i = 1; i <= 3; i++)
+            {
+                using (var context = new SomeDbContext())
+                {
+                    context.Add(new Foo());
+
+                    var _ = async
+                        ? await context.SaveChangesAsync()
+                        : context.SaveChanges();
+
+                    Assert.Equal(i, TotalSaveChanges);
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_when_context_is_constructed_and_disposed(bool async)
+        {
+            ActiveDbContexts = 0;
+            var contexts = new List<DbContext>();
+
+            for (var i = 1; i <= 3; i++)
+            {
+                contexts.Add(new SomeDbContext());
+                var _ = contexts[i - 1].Model;
+
+                Assert.Equal(i, ActiveDbContexts);
+            }
+
+            for (var i = 2; i >= 0; i--)
+            {
+                if (async)
+                {
+                    await ((IAsyncDisposable)contexts[i]).DisposeAsync();
+                }
+                else
+                {
+                    contexts[i].Dispose();
+                }
+
+                Assert.Equal(i, ActiveDbContexts);
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_query_cache_hits_and_misses(bool async)
+        {
+            ResetCacheInfo();
+
+            for (var i = 1; i <= 3; i++)
+            {
+                using (var context = new SomeDbContext())
+                {
+                    var query = context.Foos.Where(e => e.Id == new Guid("6898CFFC-3DCC-45A6-A472-A23057462EE6"));
+
+                    var _ = async
+                        ? await query.ToListAsync()
+                        : query.ToList();
+
+                    Assert.Equal(1, CompiledQueryCacheInfoMisses);
+                    Assert.Equal(i - 1, CompiledQueryCacheInfoHits);
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_when_DbUpdateConcurrencyException_is_thrown(bool async)
+        {
+            TotalOptimisticConcurrencyFailures = 0;
+
+            for (var i = 1; i <= 3; i++)
+            {
+                using (var context = new SomeDbContext())
+                {
+                    var entity = new Foo();
+                    context.Add(entity);
+                    context.SaveChanges();
+
+                    using (var innerContext = new SomeDbContext())
+                    {
+                        innerContext.Foos.Find(entity.Id).Token = 1;
+                        innerContext.SaveChanges();
+                    }
+
+                    entity.Token = 2;
+
+                    if (async)
+                    {
+                        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () => await context.SaveChangesAsync());
+                    }
+                    else
+                    {
+                        Assert.Throws<DbUpdateConcurrencyException>(() => context.SaveChanges());
+                    }
+
+                    Assert.Equal(i, TotalOptimisticConcurrencyFailures);
+                }
+            }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Counts_when_execution_strategy_retries(bool async)
+        {
+            TotalExecutionStrategyOperationFailures = 0;
+
+            for (var i = 1; i <= 3; i++)
+            {
+                using (var context = new SomeDbContext())
+                {
+                    var executionCount = 0;
+                    var executionStrategyMock = new ExecutionStrategyTest.TestExecutionStrategy(
+                        context,
+                        retryCount: 2,
+                        shouldRetryOn: e => e is ArgumentOutOfRangeException,
+                        getNextDelay: e => TimeSpan.FromTicks(0));
+
+                    if (async)
+                    {
+                        Assert.IsType<ArgumentOutOfRangeException>(
+                            (await Assert.ThrowsAsync<RetryLimitExceededException>(
+                                () =>
+                                    executionStrategyMock.ExecuteAsync(
+                                        () =>
+                                        {
+                                            if (executionCount++ < 3)
+                                            {
+                                                throw new ArgumentOutOfRangeException();
+                                            }
+
+                                            Assert.True(false);
+                                            return Task.FromResult(1);
+                                        }))).InnerException);
+                    }
+                    else
+                    {
+                        Assert.IsType<ArgumentOutOfRangeException>(
+                            Assert.Throws<RetryLimitExceededException>(
+                                () =>
+                                    executionStrategyMock.Execute(
+                                        () =>
+                                        {
+                                            if (executionCount++ < 3)
+                                            {
+                                                throw new ArgumentOutOfRangeException();
+                                            }
+
+                                            Assert.True(false);
+                                            return 0;
+                                        })).InnerException);
+                    }
+
+                    Assert.Equal(3, executionCount);
+                    Assert.Equal(i * 3, TotalExecutionStrategyOperationFailures);
+                }
+            }
+        }
+
+        private static readonly FieldInfo _activeDbContexts
+            = typeof(EntityFrameworkEventSource).GetField("_activeDbContexts", _bindingFlags);
+
+        private static long ActiveDbContexts
+        {
+            get => (long)_activeDbContexts.GetValue(EntityFrameworkEventSource.Log);
+            set => _activeDbContexts.SetValue(EntityFrameworkEventSource.Log, value);
+        }
+
+        private static readonly FieldInfo _totalQueries
+            = typeof(EntityFrameworkEventSource).GetField(nameof(_totalQueries), _bindingFlags);
+
+        private static long TotalQueries
+        {
+            get => (long)_totalQueries.GetValue(EntityFrameworkEventSource.Log);
+            set => _totalQueries.SetValue(EntityFrameworkEventSource.Log, value);
+        }
+
+        private static readonly FieldInfo _totalSaveChanges
+            = typeof(EntityFrameworkEventSource).GetField(nameof(_totalSaveChanges), _bindingFlags);
+
+        private static long TotalSaveChanges
+        {
+            get => (long)_totalSaveChanges.GetValue(EntityFrameworkEventSource.Log);
+            set => _totalSaveChanges.SetValue(EntityFrameworkEventSource.Log, value);
+        }
+
+        private static readonly FieldInfo _totalExecutionStrategyOperationFailures
+            = typeof(EntityFrameworkEventSource).GetField(nameof(_totalExecutionStrategyOperationFailures), _bindingFlags);
+
+        private static long TotalExecutionStrategyOperationFailures
+        {
+            get => (long)_totalExecutionStrategyOperationFailures.GetValue(EntityFrameworkEventSource.Log);
+            set => _totalExecutionStrategyOperationFailures.SetValue(EntityFrameworkEventSource.Log, value);
+        }
+
+        private static readonly FieldInfo _totalOptimisticConcurrencyFailures
+            = typeof(EntityFrameworkEventSource).GetField(nameof(_totalOptimisticConcurrencyFailures), _bindingFlags);
+
+        private static long TotalOptimisticConcurrencyFailures
+        {
+            get => (long)_totalOptimisticConcurrencyFailures.GetValue(EntityFrameworkEventSource.Log);
+            set => _totalOptimisticConcurrencyFailures.SetValue(EntityFrameworkEventSource.Log, value);
+        }
+
+        private static readonly FieldInfo _compiledQueryCacheInfo
+            = typeof(EntityFrameworkEventSource).GetField(nameof(_compiledQueryCacheInfo), _bindingFlags);
+
+        private static readonly MethodInfo _resetCacheInfo
+            = typeof(EntityFrameworkEventSource).GetMethod("ResetCacheInfo", _bindingFlags);
+
+        private static readonly FieldInfo _compiledQueryCacheInfoHits
+            = _compiledQueryCacheInfo.FieldType.GetField("Hits", _bindingFlags);
+
+        private static int CompiledQueryCacheInfoHits
+        {
+            get => (int)_compiledQueryCacheInfoHits.GetValue(_compiledQueryCacheInfo.GetValue(EntityFrameworkEventSource.Log));
+        }
+
+        private static readonly FieldInfo _compiledQueryCacheInfoMisses
+            = _compiledQueryCacheInfo.FieldType.GetField("Misses", _bindingFlags);
+
+        private static int CompiledQueryCacheInfoMisses
+        {
+            get => (int)_compiledQueryCacheInfoMisses.GetValue(_compiledQueryCacheInfo.GetValue(EntityFrameworkEventSource.Log));
+        }
+
+        private static void ResetCacheInfo()
+            => _resetCacheInfo.Invoke(EntityFrameworkEventSource.Log, null);
+
+        private class SomeDbContext : DbContext
+        {
+            public DbSet<Foo> Foos { get; set; }
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<Foo>().Property(e => e.Token).IsConcurrencyToken();
+
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInMemoryDatabase(nameof(EventSourceTest));
+        }
+
+        private class Foo
+        {
+            public Guid Id { get; set; }
+            public int Token { get; set; }
+        }
+    }
+
+    [CollectionDefinition("EventSourceTest", DisableParallelization = true)]
+    public class EventSourceTestCollection : ICollectionFixture<EventSourceFixture>
+    {
+
+    }
+
+    public class EventSourceFixture
+    {
+    }
+}

--- a/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
+++ b/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
@@ -649,7 +649,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         .AddScoped<IDbContextTransactionManager, TestInMemoryTransactionManager>()),
                 InMemoryTestHelpers.Instance.CreateOptions());
 
-        private class TestExecutionStrategy : ExecutionStrategy
+        public class TestExecutionStrategy : ExecutionStrategy
         {
             private readonly Func<Exception, bool> _shouldRetryOn;
             private readonly Func<Exception, TimeSpan?> _getNextDelay;


### PR DESCRIPTION
Fixes #23630

**Description**

Three event counters don't get updated when the async API is used (as opposed to the sync one). An additional event counter is incorrectly updated, and so show wrong results.

**Customer Impact**

Our newly-introduced event counters show incorrect data which does not take into account async calls.

**How found**

Customer reported an issue on 5.0.0 with one counter, the rest discovered via due diligence.

**Test coverage**

Test coverage added after investigation and discussion of the best way to do it. We settled on using reflection to access the counters and then configuring the tests to not run in parallel. These tests are both for detecting regressions, and so that going forward we can test new event counters to avoid mistakes like this in the future.

**Regression?**

No, event counters are new in 5.0.0.

**Risk**

Very low, add missing counter updates which are already in place and working for the sync versions, and move the location of another counter update. Only affects the new event counters feature.
