### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark/Directory.Build.props
+++ b/benchmark/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesVersion)" />

--- a/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
+++ b/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
@@ -20,33 +20,15 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
     {
         public static void Run(string[] args, Assembly assembly, IConfig config = null)
         {
-            if (config == null)
-            {
-                config = DefaultConfig.Instance;
-            }
+//             if (config == null)
+//             {
+//                 config = DefaultConfig.Instance;
+//             }
 
-            config = config.With(DefaultConfig.Instance.GetDiagnosers().Concat(new[] { MemoryDiagnoser.Default }).ToArray());
+//             config = config.With(DefaultConfig.Instance.GetDiagnosers().Concat(new[] { MemoryDiagnoser.Default }).ToArray());
 
-            var index = Array.FindIndex(args, s => s == "--perflab");
-            if (index >= 0)
-            {
-                var argList = args.ToList();
-                argList.RemoveAt(index);
-                args = argList.ToArray();
-
-                config = config
-                    .With(StatisticColumn.OperationsPerSecond, new ParamsSummaryColumn())
-                    .With(
-                        MarkdownExporter.GitHub, new CsvExporter(
-                            CsvSeparator.Comma,
-                            new SummaryStyle(
-                                printUnitsInHeader: true,
-                                SizeUnit.KB,
-                                TimeUnit.Microsecond,
-                                printUnitsInContent: false)));
-            }
-
-            BenchmarkSwitcher.FromAssembly(assembly).Run(args, config);
+//             BenchmarkSwitcher.FromAssembly(assembly).Run(args, config);
+            BenchmarkSwitcher.FromAssembly(assembly).Run(args);
         }
     }
 }

--- a/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
+++ b/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
@@ -1,17 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
 using System.Reflection;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Exporters;
-using BenchmarkDotNet.Exporters.Csv;
-using BenchmarkDotNet.Horology;
-using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks
@@ -20,14 +11,6 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
     {
         public static void Run(string[] args, Assembly assembly, IConfig config = null)
         {
-//             if (config == null)
-//             {
-//                 config = DefaultConfig.Instance;
-//             }
-
-//             config = config.With(DefaultConfig.Instance.GetDiagnosers().Concat(new[] { MemoryDiagnoser.Default }).ToArray());
-
-//             BenchmarkSwitcher.FromAssembly(assembly).Run(args, config);
             BenchmarkSwitcher.FromAssembly(assembly).Run(args);
         }
     }


### PR DESCRIPTION
Without the new BDN version the current benchmarks fail (on net5.0).
It's also removing all the extraneous configuration that is not necessary anymore.