### PR TITLE
Allow schema-less UDFs to not be built-in

### DIFF
--- a/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/ISqlExpressionFactory.cs
@@ -445,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="typeMapping"> The <see cref="RelationalTypeMapping" /> associated with the expression. </param>
         /// <returns> An expression representing a function call in a SQL tree. </returns>
         SqlFunctionExpression Function(
-            [NotNull] string schema,
+            [CanBeNull] string? schema,
             [NotNull] string name,
             [NotNull] IEnumerable<SqlExpression> arguments,
             bool nullable,

--- a/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Relational/Query/RelationalMethodCallTranslatorProvider.cs
@@ -88,17 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var argumentsPropagateNullability = dbFunction.Parameters.Select(p => p.PropagatesNullability);
 
-                if (dbFunction.IsBuiltIn)
-                {
-                    return _sqlExpressionFactory.Function(
-                        dbFunction.Name,
-                        arguments,
-                        dbFunction.IsNullable,
-                        argumentsPropagateNullability,
-                        method.ReturnType.UnwrapNullableType());
-                }
-
-                return dbFunction.Schema is null
+                return dbFunction.IsBuiltIn
                     ? _sqlExpressionFactory.Function(
                         dbFunction.Name,
                         arguments,

--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -636,7 +636,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         /// <inheritdoc />
         public virtual SqlFunctionExpression Function(
-            string schema,
+            string? schema,
             string name,
             IEnumerable<SqlExpression> arguments,
             bool nullable,
@@ -644,7 +644,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Type returnType,
             RelationalTypeMapping? typeMapping = null)
         {
-            Check.NotNull(schema, nameof(schema));
+            Check.NullButNotEmpty(schema, nameof(schema));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(arguments, nameof(arguments));
             Check.NotNull(argumentsPropagateNullability, nameof(argumentsPropagateNullability));


### PR DESCRIPTION
Since #23381, UDFs which have a null schema cause a SqlFunctionExpression with BuiltIn=true to be created. This causes incorrect SQL generation.

(SqlServer isn't affected because of SqlServerDbFunctionConvention, which sets the schema of all non-builtin UDFs with a null schema to dbo)

