### PR TITLE
[5.0.3] Correctly distinguish between seeds for different owned types

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1898,6 +1898,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     principalSourceTable = mainSourceEntityType.GetTableMappings().First().Table;
                 }
 
+                var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23792", out var enabled) && enabled;
                 foreach (var sourceSeed in sourceEntityType.GetSeedData())
                 {
                     var sourceEntry = GetEntry(sourceSeed, sourceEntityType, _sourceUpdateAdapter);
@@ -1985,7 +1986,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             {
                                 if (targetProperty.GetAfterSaveBehavior() != PropertySaveBehavior.Save
                                     && (targetProperty.ValueGenerated & ValueGenerated.OnUpdate) == 0
-                                    && (targetKeyMap.Count == 1 || entry.EntityType.Name == sourceEntityType.Name))
+                                    && (useOldBehavior || targetKeyMap.Count == 1 || entry.EntityType.Name == sourceEntityType.Name))
                                 {
                                     entryMapping.RecreateRow = true;
                                     break;

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -1984,7 +1984,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                             if (sourceProperty == null)
                             {
                                 if (targetProperty.GetAfterSaveBehavior() != PropertySaveBehavior.Save
-                                    && (targetProperty.ValueGenerated & ValueGenerated.OnUpdate) == 0)
+                                    && (targetProperty.ValueGenerated & ValueGenerated.OnUpdate) == 0
+                                    && (targetKeyMap.Count == 1 || entry.EntityType.Name == sourceEntityType.Name))
                                 {
                                     entryMapping.RecreateRow = true;
                                     break;


### PR DESCRIPTION
Fixes #23792

**Description**

Migrations compared seed data based on the column information, meaning that data was matched as long as the values were mapped to the same columns and in the case of table sharing in some cases this caused data to be mismatched between different entity types. And if one of the types has a read-only property (an alternate key) this results in the row being deleted and inserted again unnecessarily.

**Customer Impact**

A migration for a model that matches the above condition will always contain operations even if the model hasn't changed. There is no workaround other than removing the read-only properties or manually fixing the migrations.

**How found**

Customer reported on 5.0.1.

**Test coverage**

We have added more test coverage in this PR.

**Regression?**

Yes.

**Risk**

Low. The fix only affects migrations for models with table sharing and read-only properties.