### PR TITLE
Add support for three and four string argument versions of System.String.Concat

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -40,6 +40,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 m => m.Name == nameof(Enumerable.LastOrDefault)
                     && m.GetParameters().Length == 1).MakeGenericMethod(typeof(char));
 
+        private static readonly MethodInfo _stringConcatWithTwoArguments =
+            typeof(String).GetRequiredRuntimeMethod(nameof(string.Concat),
+                new[] { typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _stringConcatWithThreeArguments =
+            typeof(String).GetRequiredRuntimeMethod(nameof(string.Concat),
+                new[] { typeof(string), typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _stringConcatWithFourArguments =
+            typeof(String).GetRequiredRuntimeMethod(nameof(string.Concat),
+                new[] { typeof(string), typeof(string), typeof(string), typeof(string) });
+
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
         /// <summary>
@@ -95,6 +107,33 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             if (_lastOrDefaultMethodInfoWithoutArgs.Equals(method))
             {
                 return TranslateSystemFunction("RIGHT", arguments[0], _sqlExpressionFactory.Constant(1), typeof(char));
+            }
+
+            if(_stringConcatWithTwoArguments.Equals(method))
+            {
+                return _sqlExpressionFactory.Add(
+                    arguments[0],
+                    arguments[1]);
+            }
+
+            if(_stringConcatWithThreeArguments.Equals(method))
+            {
+                return _sqlExpressionFactory.Add(
+                    arguments[0],
+                    _sqlExpressionFactory.Add(
+                        arguments[1],
+                        arguments[2]));
+            }
+
+            if (_stringConcatWithFourArguments.Equals(method))
+            {
+                return _sqlExpressionFactory.Add(
+                    arguments[0],
+                    _sqlExpressionFactory.Add(
+                        arguments[1],
+                        _sqlExpressionFactory.Add(
+                            arguments[2],
+                            arguments[3])));
             }
 
             return null;

--- a/src/EFCore.Relational/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/StringMethodTranslator.cs
@@ -24,8 +24,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static readonly MethodInfo _isNullOrEmptyMethodInfo
             = typeof(string).GetRequiredRuntimeMethod(nameof(string.IsNullOrEmpty), new[] { typeof(string) });
 
-        private static readonly MethodInfo _concatMethodInfo
+        private static readonly MethodInfo _concatMethodInfoTwoArgs
             = typeof(string).GetRequiredRuntimeMethod(nameof(string.Concat), new[] { typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _concatMethodInfoThreeArgs
+            = typeof(string).GetRequiredRuntimeMethod(nameof(string.Concat), new[] { typeof(string), typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _concatMethodInfoFourArgs
+            = typeof(string).GetRequiredRuntimeMethod(nameof(string.Concat), new[] { typeof(string), typeof(string), typeof(string), typeof(string) });
 
         private readonly ISqlExpressionFactory _sqlExpressionFactory;
 
@@ -67,11 +73,31 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _sqlExpressionFactory.Constant(string.Empty)));
             }
 
-            if (Equals(method, _concatMethodInfo))
+            if (Equals(method, _concatMethodInfoTwoArgs))
             {
                 return _sqlExpressionFactory.Add(
                     arguments[0],
                     arguments[1]);
+            }
+
+            if (Equals(method, _concatMethodInfoThreeArgs))
+            {
+                return _sqlExpressionFactory.Add(
+                    arguments[0],
+                    _sqlExpressionFactory.Add(
+                        arguments[1],
+                        arguments[2]));
+            }
+
+            if(Equals(method, _concatMethodInfoFourArgs))
+            {
+                return _sqlExpressionFactory.Add(
+                    arguments[0],
+                    _sqlExpressionFactory.Add(
+                        arguments[1],
+                        _sqlExpressionFactory.Add(
+                            arguments[2],
+                            arguments[3])));
             }
 
             return null;

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1676,10 +1676,43 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((((@__p_0 + c[""CustomerID""])
             return base.Where_concat_string_int_comparison4(async);
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
-        public override Task Where_string_concat_method_comparison(bool async)
+        public override async Task Where_string_concat_method_comparison(bool async)
         {
-            return base.Where_string_concat_method_comparison(async);
+            await base.Where_string_concat_method_comparison(async);
+
+            AssertSql(
+                @"@__i_0='A'
+
+SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((@__i_0 || c[""CustomerID""]) = c[""CompanyName""]))");
+        }
+
+        public override async Task Where_string_concat_method_comparison_2(bool async)
+        {
+            await base.Where_string_concat_method_comparison_2(async);
+
+            AssertSql(
+                @"@__i_0='A'
+@__j_1='B'
+
+SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((@__i_0 || (@__j_1 || c[""CustomerID""])) = c[""CompanyName""]))");
+        }
+
+        public override async Task Where_string_concat_method_comparison_3(bool async)
+        {
+            await base.Where_string_concat_method_comparison_3(async);
+
+            AssertSql(
+                @"@__i_0='A'
+@__j_1='B'
+@__k_2='C'
+
+SELECT c[""CustomerID""]
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((@__i_0 || (@__j_1 || (@__k_2 || c[""CustomerID""]))) = c[""CompanyName""]))");
         }
 
         public override async Task Where_ternary_boolean_condition_true(bool async)

--- a/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
+++ b/test/EFCore.Relational.Tests/EFCore.Relational.Tests.csproj
@@ -26,8 +26,4 @@
     <Compile Update="TestUtilities\FakeProvider\FakeDbConnection.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Query" />
-  </ItemGroup>
-
 </Project>

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -1622,6 +1622,31 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_string_concat_method_comparison_2(bool async)
+        {
+            var i = "A";
+            var j = "B";
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_string_concat_method_comparison_3(bool async)
+        {
+            var i = "A";
+            var j = "B";
+            var k = "C";
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Concat(i, j, k, c.CustomerID) == c.CompanyName).Select(c => c.CustomerID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_ternary_boolean_condition_true(bool async)
         {
             var flag = true;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1368,6 +1368,33 @@ FROM [Customers] AS [c]
 WHERE (@__i_0 + [c].[CustomerID]) = [c].[CompanyName]");
         }
 
+        public override async Task Where_string_concat_method_comparison_2(bool async)
+        {
+            await base.Where_string_concat_method_comparison_2(async);
+
+            AssertSql(
+                @"@__i_0='A' (Size = 5)
+@__j_1='B' (Size = 5)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE (@__i_0 + (@__j_1 + [c].[CustomerID])) = [c].[CompanyName]");
+        }
+
+        public override async Task Where_string_concat_method_comparison_3(bool async)
+        {
+            await base.Where_string_concat_method_comparison_3(async);
+
+            AssertSql(
+                @"@__i_0='A' (Size = 5)
+@__j_1='B' (Size = 5)
+@__k_2='C' (Size = 5)
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE (@__i_0 + (@__j_1 + (@__k_2 + [c].[CustomerID]))) = [c].[CompanyName]");
+        }
+
         public override async Task Where_ternary_boolean_condition_true(bool async)
         {
             await base.Where_ternary_boolean_condition_true(async);


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->

This PR fixes #23859 by adding support for three and four string argument versions of [String.Concat](https://docs.microsoft.com/en-us/dotnet/api/system.string.concat?view=net-5.0).


