### PR TITLE
Fix capturing uses of NonCapturingLazyInitializer

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryShapedQueryCompilingExpressionVisitor.CustomShaperCompilingExpressionVisitor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             {
                 if (entity is TIncludingEntity includingEntity)
                 {
-                    var collectionAccessor = navigation.GetCollectionAccessor();
+                    var collectionAccessor = navigation.GetCollectionAccessor()!;
                     collectionAccessor.GetOrCreate(includingEntity, forMaterialization: true);
 
                     if (setLoaded)

--- a/src/EFCore.Relational/Update/ModificationCommand.cs
+++ b/src/EFCore.Relational/Update/ModificationCommand.cs
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// </summary>
         public virtual IReadOnlyList<ColumnModification> ColumnModifications
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _columnModifications, this, command => command.GenerateColumnModifications());
+                ref _columnModifications, this, static command => command.GenerateColumnModifications());
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> <see langword="true" /> if they are equal; <see langword="false" /> otherwise. </returns>
         public virtual bool Equals(T left, T right)
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _equals, this, c => c.EqualsExpression.Compile())(left, right);
+                ref _equals, this, static c => c.EqualsExpression.Compile())(left, right);
 
         /// <summary>
         ///     Returns the hash code for the given instance.
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> The hash code. </returns>
         public virtual int GetHashCode(T instance)
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _hashCode, this, c => c.HashCodeExpression.Compile())(instance);
+                ref _hashCode, this, static c => c.HashCodeExpression.Compile())(instance);
 
         /// <summary>
         ///     <para>
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> The snapshot. </returns>
         public virtual T Snapshot([CanBeNull] T instance)
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _snapshot, this, c => c.SnapshotExpression.Compile())(instance);
+                ref _snapshot, this, static c => c.SnapshotExpression.Compile())(instance);
 
         /// <summary>
         ///     The type.

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 return NonCapturingLazyInitializer.EnsureInitialized(
                     ref _entityQueryable,
                     this,
-                    internalSet => internalSet.CreateEntityQueryable());
+                    static internalSet => internalSet.CreateEntityQueryable());
             }
         }
 

--- a/src/EFCore/Metadata/INavigation.cs
+++ b/src/EFCore/Metadata/INavigation.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The accessor. </returns>
         [DebuggerStepThrough]
-        new IClrCollectionAccessor GetCollectionAccessor()
+        new IClrCollectionAccessor? GetCollectionAccessor()
             => ((Navigation)this).CollectionAccessor;
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The accessor. </returns>
         [DebuggerStepThrough]
-        IClrCollectionAccessor INavigationBase.GetCollectionAccessor()
+        IClrCollectionAccessor? INavigationBase.GetCollectionAccessor()
             => GetCollectionAccessor();
     }
 }

--- a/src/EFCore/Metadata/INavigationBase.cs
+++ b/src/EFCore/Metadata/INavigationBase.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     navigation.
         /// </summary>
         /// <returns> The accessor. </returns>
-        IClrCollectionAccessor GetCollectionAccessor();
+        IClrCollectionAccessor? GetCollectionAccessor();
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Metadata/ISkipNavigation.cs
+++ b/src/EFCore/Metadata/ISkipNavigation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     navigation.
         /// </summary>
         /// <returns> The accessor. </returns>
-        IClrCollectionAccessor INavigationBase.GetCollectionAccessor()
+        IClrCollectionAccessor? INavigationBase.GetCollectionAccessor()
             => ((SkipNavigation)this).CollectionAccessor;
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2544,7 +2544,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual PropertyCounts Counts
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _counts, this, entityType => entityType.CalculateCounts());
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _counts, this, static entityType => entityType.CalculateCounts());
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2555,7 +2555,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<InternalEntityEntry, ISnapshot> RelationshipSnapshotFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _relationshipSnapshotFactory, this,
-                entityType => new RelationshipSnapshotFactoryFactory().Create(entityType));
+                static entityType => new RelationshipSnapshotFactoryFactory().Create(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2566,7 +2566,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<InternalEntityEntry, ISnapshot> OriginalValuesFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _originalValuesFactory, this,
-                entityType => new OriginalValuesFactoryFactory().Create(entityType));
+                static entityType => new OriginalValuesFactoryFactory().Create(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2577,7 +2577,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<InternalEntityEntry, ISnapshot> StoreGeneratedValuesFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _storeGeneratedValuesFactory, this,
-                entityType => new SidecarValuesFactoryFactory().Create(entityType));
+                static entityType => new SidecarValuesFactoryFactory().Create(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2588,7 +2588,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<InternalEntityEntry, ISnapshot> TemporaryValuesFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _temporaryValuesFactory, this,
-                entityType => new TemporaryValuesFactoryFactory().Create(entityType));
+                static entityType => new TemporaryValuesFactoryFactory().Create(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2599,7 +2599,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<ValueBuffer, ISnapshot> ShadowValuesFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _shadowValuesFactory, this,
-                entityType => new ShadowValuesFactoryFactory().Create(entityType));
+                static entityType => new ShadowValuesFactoryFactory().Create(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2610,7 +2610,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<ISnapshot> EmptyShadowValuesFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _emptyShadowValuesFactory, this,
-                entityType => new EmptyShadowValuesFactoryFactory().CreateEmpty(entityType));
+                static entityType => new EmptyShadowValuesFactoryFactory().CreateEmpty(entityType));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2621,7 +2621,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual Func<MaterializationContext, object> InstanceFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _instanceFactory, this,
-                entityType =>
+                static entityType =>
                 {
                     var binding = (InstantiationBinding?)entityType[CoreAnnotationNames.ServiceOnlyConstructorBinding];
                     if (binding == null)
@@ -2631,7 +2631,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     var contextParam = Expression.Parameter(typeof(MaterializationContext), "mc");
 
-                    _instanceFactory = Expression.Lambda<Func<MaterializationContext, object>>(
+                    entityType._instanceFactory = Expression.Lambda<Func<MaterializationContext, object>>(
                             binding.CreateConstructorExpression(
                                 new ParameterBindingInfo(entityType, contextParam)),
                             contextParam)

--- a/src/EFCore/Metadata/Internal/Index.cs
+++ b/src/EFCore/Metadata/Internal/Index.cs
@@ -201,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IDependentKeyValueFactory<TKey> GetNullableValueFactory<TKey>()
             => (IDependentKeyValueFactory<TKey>)NonCapturingLazyInitializer.EnsureInitialized(
-                ref _nullableValueFactory, this, i => new CompositeValueFactory(i.Properties));
+                ref _nullableValueFactory, this, static i => new CompositeValueFactory(i.Properties));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Key.cs
+++ b/src/EFCore/Metadata/Internal/Key.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual Func<bool, IIdentityMap> IdentityMapFactory
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _identityMapFactory, this, k => new IdentityMapFactoryFactory().Create(k));
+                ref _identityMapFactory, this, static k => new IdentityMapFactoryFactory().Create(k));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -147,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IPrincipalKeyValueFactory<TKey> GetPrincipalKeyValueFactory<TKey>()
             => (IPrincipalKeyValueFactory<TKey>)NonCapturingLazyInitializer.EnsureInitialized(
-                ref _principalKeyValueFactory, this, k => new KeyValueFactoryFactory().Create<TKey>(k));
+                ref _principalKeyValueFactory, this, static k => new KeyValueFactoryFactory().Create<TKey>(k));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrCollectionAccessor? _collectionAccessor;
+        private bool _collectionAccessorInitialized;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -271,9 +272,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IClrCollectionAccessor CollectionAccessor
+        public virtual IClrCollectionAccessor? CollectionAccessor
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _collectionAccessor, this, n => new ClrCollectionAccessorFactory().Create(n));
+                ref _collectionAccessor,
+                ref _collectionAccessorInitialized,
+                this,
+                static n => new ClrCollectionAccessorFactory().Create(n));
 
         /// <summary>
         ///     Runs the conventions when an annotation was set or removed.

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -294,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             get
                 => NonCapturingLazyInitializer.EnsureInitialized(
                     ref _indexes, this,
-                    property =>
+                    static property =>
                     {
                         var _ = (property.DeclaringType as EntityType)?.Counts;
                     });
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IClrPropertyGetter Getter
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
+                ref _getter, this, static p => new ClrPropertyGetterFactory().Create(p));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IClrPropertySetter Setter
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _setter, this, p => new ClrPropertySetterFactory().Create(p));
+                ref _setter, this, static p => new ClrPropertySetterFactory().Create(p));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -372,7 +372,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IClrPropertySetter MaterializationSetter
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _materializationSetter, this, p => new ClrPropertyMaterializationSetterFactory().Create(p));
+                ref _materializationSetter, this, static p => new ClrPropertyMaterializationSetterFactory().Create(p));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -381,7 +381,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual PropertyAccessors Accessors
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, p => new PropertyAccessorsFactory().Create(p));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, static p => new PropertyAccessorsFactory().Create(p));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -391,7 +391,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IComparer<IUpdateEntry> CurrentValueComparer
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _currentValueComparer, this, p => new CurrentValueComparerFactory().Create(p));
+                ref _currentValueComparer, this, static p => new CurrentValueComparerFactory().Create(p));
 
         private static readonly MethodInfo _containsKeyMethod =
             typeof(IDictionary<string, object>).GetRequiredMethod(nameof(IDictionary<string, object>.ContainsKey), new[] { typeof(string) });

--- a/src/EFCore/Metadata/Internal/SkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigation.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrCollectionAccessor? _collectionAccessor;
+        private bool _collectionAccessorInitialized;
         private ICollectionLoader? _manyToManyLoader;
 
         /// <summary>
@@ -323,9 +324,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IClrCollectionAccessor CollectionAccessor
+        public virtual IClrCollectionAccessor? CollectionAccessor
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _collectionAccessor, this, n => new ClrCollectionAccessorFactory().Create(n));
+                ref _collectionAccessor,
+                ref _collectionAccessorInitialized,
+                this,
+                static n => new ClrCollectionAccessorFactory().Create(n));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -335,7 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual ICollectionLoader ManyToManyLoader
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _manyToManyLoader, this, n => new ManyToManyLoaderFactory().Create(this));
+                ref _manyToManyLoader, this, static n => new ManyToManyLoaderFactory().Create(n));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         public virtual Func<MaterializationContext, IEntityType, object, object> ServiceDelegate
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _serviceDelegate, this, b =>
+                ref _serviceDelegate, this, static b =>
                 {
                     var materializationContextParam = Expression.Parameter(typeof(MaterializationContext));
                     var entityTypeParam = Expression.Parameter(typeof(IEntityType));

--- a/src/EFCore/Query/Internal/CompiledQueryBase.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryBase.cs
@@ -90,14 +90,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private Func<QueryContext, TResult> EnsureExecutor(TContext context)
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _executor,
+                this,
                 context,
                 _queryExpression,
-                (c, q) =>
+                static (t, c, q) =>
                 {
-                    var queryCompiler = context.GetService<IQueryCompiler>();
+                    var queryCompiler = c.GetService<IQueryCompiler>();
                     var expression = new QueryExpressionRewriter(c, q.Parameters).Visit(q.Body);
 
-                    return CreateCompiledQuery(queryCompiler, expression);
+                    return t.CreateCompiledQuery(queryCompiler, expression);
                 });
 
         private sealed class QueryExpressionRewriter : ExpressionVisitor

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -195,7 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _comparer,
                 this,
-                c => ValueComparer.CreateDefault(c.ClrType, favorStructuralComparisons: false));
+                static c => ValueComparer.CreateDefault(c.ClrType, favorStructuralComparisons: false));
 
         /// <summary>
         ///     A <see cref="ValueComparer" /> adds custom value comparison for use when
@@ -205,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => NonCapturingLazyInitializer.EnsureInitialized(
                 ref _keyComparer,
                 this,
-                c => ValueComparer.CreateDefault(c.ClrType, favorStructuralComparisons: true));
+                static c => ValueComparer.CreateDefault(c.ClrType, favorStructuralComparisons: true));
 
         /// <summary>
         ///     A <see cref="ValueComparer" /> adds custom value comparison for use when

--- a/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverter`.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         public override Func<object?, object?> ConvertToProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertToProvider, this, c => SanitizeConverter(c.ConvertToProviderExpression));
+                ref _convertToProvider, this, static c => SanitizeConverter(c.ConvertToProviderExpression));
 
         /// <summary>
         ///     Gets the function to convert objects when reading data from the store,
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         public override Func<object?, object?> ConvertFromProvider
             => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertFromProvider, this, c => SanitizeConverter(c.ConvertFromProviderExpression));
+                ref _convertFromProvider, this, static c => SanitizeConverter(c.ConvertFromProviderExpression));
 
         /// <summary>
         ///     Gets the expression to convert objects when writing data to the store,


### PR DESCRIPTION
* Fixed several cases where our initialization was capturing (so spurious memory allocations). Added C# 9 static everywhere to reduce the risk of this happening again.
* Fixed one case where a nullable value was being lazily generated, defeating the initialization mechanism (because NonCapturingLazyInitializer compares to null to see if a value has been generated). This meant every invocation would re-generate again and again. Discovered during NRT annotations - doing this won't compile any more after that's done.