### PR TITLE
[small] Fix migration dependencies

### DIFF
--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -109,6 +109,6 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddTransient(_ => context.GetService<IMigrator>())
                 .AddTransient(_ => context.GetService<IRelationalTypeMappingSource>())
                 .AddTransient(_ => context.GetService<IModel>())
-                .AddTransient(_ => context.GetService<IConventionSetBuilder>());
+                .AddTransient(_ => context.GetService<IModelRuntimeInitializer>());
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -67,6 +69,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             AssertAnnotations(index);
 
             Assert.Empty(reporter.Messages);
+        }
+
+        [ConditionalFact]
+        public void Can_resolve_ISnapshotModelProcessor_from_DI()
+        {
+            var assembly = typeof(SnapshotModelProcessorTest).Assembly;
+            var snapshotModelProcessor = new DesignTimeServicesBuilder(assembly, assembly, new TestOperationReporter(), new string[0])
+                .Build(SqlServerTestHelpers.Instance.CreateContext())
+                .GetRequiredService<ISnapshotModelProcessor>();
+
+            Assert.NotNull(snapshotModelProcessor);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Correctly reflect that SnapshotModelProcessor now depends on IModelRuntimeInitializer instead of IConventionSetBuilder

This is blocking preview-1 branching