### PR TITLE
Correctly set pool size when using AddPooledDbContextFactory

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -865,7 +865,11 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(optionsAction, nameof(optionsAction));
 
-            return AddPooledDbContextFactory<TContext>(serviceCollection, (_, ob) => optionsAction(ob));
+            var useOldBehavior = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23889", out var enabled) && enabled;
+
+            return useOldBehavior
+                ? AddPooledDbContextFactory<TContext>(serviceCollection, (_, ob) => optionsAction(ob))
+                : AddPooledDbContextFactory<TContext>(serviceCollection, (_, ob) => optionsAction(ob), poolSize);
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -26,7 +27,41 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
-        private static IServiceProvider BuildServiceProvider<TContextService, TContext>(int poolSize = 32)
+        private static IServiceProvider BuildServiceProvider<TContextService, TContext>()
+            where TContextService : class
+            where TContext : DbContext, TContextService
+            => new ServiceCollection()
+                .AddDbContextPool<TContextService, TContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).AddDbContextPool<ISecondContext, SecondContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).BuildServiceProvider();
+
+        private static IServiceProvider BuildServiceProvider<TContext>()
+            where TContext : DbContext
+            => new ServiceCollection()
+                .AddDbContextPool<TContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).AddDbContextPool<SecondContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).BuildServiceProvider();
+
+        private static IServiceProvider BuildServiceProviderWithFactory<TContext>()
+            where TContext : DbContext
+            => new ServiceCollection()
+                .AddPooledDbContextFactory<TContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).AddDbContextPool<SecondContext>(
+                    ob =>
+                        ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString)
+                            .EnableServiceProviderCaching(false)).BuildServiceProvider();
+
+        private static IServiceProvider BuildServiceProvider<TContextService, TContext>(int poolSize)
             where TContextService : class
             where TContext : DbContext, TContextService
             => new ServiceCollection()
@@ -41,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore
                             .EnableServiceProviderCaching(false),
                     poolSize).BuildServiceProvider();
 
-        private static IServiceProvider BuildServiceProvider<TContext>(int poolSize = 32)
+        private static IServiceProvider BuildServiceProvider<TContext>(int poolSize)
             where TContext : DbContext
             => new ServiceCollection()
                 .AddDbContextPool<TContext>(
@@ -56,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore
                     poolSize)
                 .BuildServiceProvider();
 
-        private static IServiceProvider BuildServiceProviderWithFactory<TContext>(int poolSize = 32)
+        private static IServiceProvider BuildServiceProviderWithFactory<TContext>(int poolSize)
             where TContext : DbContext
             => new ServiceCollection()
                 .AddPooledDbContextFactory<TContext>(
@@ -151,10 +186,102 @@ namespace Microsoft.EntityFrameworkCore
                 () => BuildServiceProvider<PooledContext>(poolSize: -1));
 
             Assert.Throws<ArgumentOutOfRangeException>(
+                () => BuildServiceProvider<IPooledContext, PooledContext>(poolSize: 0));
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => BuildServiceProvider<IPooledContext, PooledContext>(poolSize: -1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () => BuildServiceProviderWithFactory<PooledContext>(poolSize: 0));
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => BuildServiceProviderWithFactory<PooledContext>(poolSize: -1));
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size()
+        {
+            var serviceProvider = BuildServiceProvider<PooledContext>(poolSize: 64);
+
+            using var scope = serviceProvider.CreateScope();
+
+            Assert.Equal(
+                64,
+                scope.ServiceProvider
+                    .GetRequiredService<PooledContext>()
+                    .GetService<IDbContextOptions>()
+                    .FindExtension<CoreOptionsExtension>().MaxPoolSize);
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size_with_service_interface()
+        {
+            var serviceProvider = BuildServiceProvider<IPooledContext, PooledContext>(poolSize: 64);
+
+            using var scope = serviceProvider.CreateScope();
+
+            Assert.Equal(
+                64,
+                ((DbContext)scope.ServiceProvider
+                    .GetRequiredService<IPooledContext>())
+                .GetService<IDbContextOptions>()
+                .FindExtension<CoreOptionsExtension>().MaxPoolSize);
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size_with_factory()
+        {
+            var serviceProvider = BuildServiceProviderWithFactory<PooledContext>(poolSize: 64);
+
+            using var context = serviceProvider.GetRequiredService<IDbContextFactory<PooledContext>>().CreateDbContext();
+
+            Assert.Equal(
+                64,
+                context.GetService<IDbContextOptions>()
+                    .FindExtension<CoreOptionsExtension>().MaxPoolSize);
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size_default()
+        {
+            var serviceProvider = BuildServiceProvider<PooledContext>();
+
+            using var scope = serviceProvider.CreateScope();
+
+            Assert.Equal(
+                128,
+                scope.ServiceProvider
+                    .GetRequiredService<PooledContext>()
+                    .GetService<IDbContextOptions>()
+                    .FindExtension<CoreOptionsExtension>().MaxPoolSize);
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size_with_service_interface_default()
+        {
+            var serviceProvider = BuildServiceProvider<IPooledContext, PooledContext>();
+
+            using var scope = serviceProvider.CreateScope();
+
+            Assert.Equal(
+                128,
+                ((DbContext)scope.ServiceProvider
+                    .GetRequiredService<IPooledContext>())
+                .GetService<IDbContextOptions>()
+                .FindExtension<CoreOptionsExtension>().MaxPoolSize);
+        }
+
+        [ConditionalFact]
+        public void Validate_pool_size_with_factory_default()
+        {
+            var serviceProvider = BuildServiceProviderWithFactory<PooledContext>();
+
+            using var context = serviceProvider.GetRequiredService<IDbContextFactory<PooledContext>>().CreateDbContext();
+
+            Assert.Equal(
+                128,
+                context.GetService<IDbContextOptions>()
+                    .FindExtension<CoreOptionsExtension>().MaxPoolSize);
         }
 
         [ConditionalTheory]
@@ -619,6 +746,7 @@ namespace Microsoft.EntityFrameworkCore
             => typeof(DbContext)
                 .GetField(eventName, BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(context);
+
         private bool _changeTracker_OnTracked;
 
         private void ChangeTracker_OnTracked(object sender, EntityTrackedEventArgs e)


### PR DESCRIPTION
Fixes #23889

**Description**

AddPooledDbContextFactory (new in 5.0) has a parameter to set the pool size. This value was not being passed down to lower-level config and hence the default pool size is always used.

**Customer Impact**

The pool size cannot be changed when using the 'AddDbContext' for a factory and pooling.

**How found**

Customer reported on 5.0.

**Test coverage**

The test factoring did not test the defaults or overridden values for pool size; this has been added.

**Regression?**

No; new feature in 5.0.

**Risk**

Very low.
