### PR TITLE
[release/5.0] InMemory: Allow UnaryExpression.Operand to be converted to nullable for LeftJoin

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -1191,6 +1191,14 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
                 return Condition(test, ifTrue, ifFalse);
             }
+
+            protected override Expression VisitUnary(UnaryExpression unaryExpression)
+            {
+                return AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23926", out var enabled)
+                    && enabled
+                    ? base.VisitUnary(unaryExpression)
+                    : unaryExpression.Update(Visit(unaryExpression.Operand));
+            }
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -1252,6 +1252,75 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #endregion
 
+        #region Issue23926
+
+        [ConditionalFact]
+        public virtual void Left_join_with_entity_with_enum_discriminator()
+        {
+            using (CreateScratch<MyContext23926>(Seed23926, "23926"))
+            {
+                using var context = new MyContext23926();
+
+                var query = context.History.Select(e => e.User.Name).ToList();
+
+                Assert.Equal(query, new string[] { "UserA", "DerivedUserB", null });
+            }
+        }
+
+        private static void Seed23926(MyContext23926 context)
+        {
+            context.Add(new History23926 { User = new User23926 { Name = "UserA" } });
+            context.Add(new History23926 { User = new DerivedUser23926 { Name = "DerivedUserB" } });
+            context.Add(new History23926 { User = null });
+
+            context.SaveChanges();
+        }
+
+        private class History23926
+        {
+            public int Id { get; set; }
+            public int? UserId { get; set; }
+            public User23926 User { get; set; }
+        }
+
+        private class User23926
+        {
+            public int Id { get; set; }
+            public UserTypes23926 Type { get; set; }
+            public string Name { get; set; }
+        }
+        private enum UserTypes23926
+        {
+            User,
+            DerivedUser
+        }
+
+        private class DerivedUser23926 : User23926
+        {
+            public string Value { get; set; }
+        }
+
+        private class MyContext23926 : DbContext
+        {
+            public DbSet<History23926> History { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder
+                    .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
+                    .UseInMemoryDatabase("23926");
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<User23926>().HasDiscriminator(e => e.Type)
+                    .HasValue<User23926>(UserTypes23926.User)
+                    .HasValue<DerivedUser23926>(UserTypes23926.DerivedUser);
+            }
+        }
+
+        #endregion
+
         #region SharedHelper
 
         private static InMemoryTestStore CreateScratch<TContext>(Action<TContext> seed, string databaseName)


### PR DESCRIPTION
Resolves #23926

Issue:
- For TPH hierarchy, we generate conditional value read expression for derived property using ConditionalExpression
- To check the right derived type we use value comparer on discriminator column in ConditionalExpression.Test
- For enum discriminator the value comparer uses `object.Equals` methods which requires converting all args to object using UnaryExpression. (This could happen for non-enums too in some cases)
- When reading right side of properties in left join we convert all of those read access to nullable which causes operand of unary to be nullable type. The base visitor does not allow this type change

Hence we need to override the method and allow for conversion to happen since we expect it.

**Description**

Doing left join with entity hierarchy on right side which has enum discriminator, query throws exception for InMemory provider.

**Customer Impact**

Unable to run most of the queries with enum discriminator in InMemory.

**How found**

Customer reported on 5.0.

**Test coverage**

Added test coverage for the issue

**Regression?**

Yes, regression from 3.1

**Risk**

Very low. Code just bypass type check from base expression visitor which is valid. Also added quirk to go back to previous behavior.
