### PR TITLE
Αccount for new Queryable.ElementAt/Take overloads

### DIFF
--- a/src/EFCore/Query/QueryableMethods.cs
+++ b/src/EFCore/Query/QueryableMethods.cs
@@ -475,9 +475,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 mi => mi.Name == nameof(Queryable.Max) && mi.GetParameters().Length == 1);
 
             ElementAt = queryableMethods.Single(
-                mi => mi.Name == nameof(Queryable.ElementAt) && mi.GetParameters().Length == 2);
+                mi => mi.Name == nameof(Queryable.ElementAt)
+                    && mi.GetParameters().Length == 2
+                    && mi.GetParameters()[1].ParameterType == typeof(int));
             ElementAtOrDefault = queryableMethods.Single(
-                mi => mi.Name == nameof(Queryable.ElementAtOrDefault) && mi.GetParameters().Length == 2);
+                mi => mi.Name == nameof(Queryable.ElementAtOrDefault)
+                    && mi.GetParameters().Length == 2
+                    && mi.GetParameters()[1].ParameterType == typeof(int));
             FirstWithoutPredicate = queryableMethods.Single(
                 mi => mi.Name == nameof(Queryable.First) && mi.GetParameters().Length == 1);
             FirstWithPredicate = queryableMethods.Single(
@@ -530,7 +534,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             Skip = queryableMethods.Single(
                 mi => mi.Name == nameof(Queryable.Skip) && mi.GetParameters().Length == 2);
             Take = queryableMethods.Single(
-                mi => mi.Name == nameof(Queryable.Take) && mi.GetParameters().Length == 2);
+                mi => mi.Name == nameof(Queryable.Take)
+                    && mi.GetParameters().Length == 2
+                    && mi.GetParameters()[1].ParameterType == typeof(int));
             SkipWhile = queryableMethods.Single(
                 mi => mi.Name == nameof(Queryable.SkipWhile)
                     && mi.GetParameters().Length == 2


### PR DESCRIPTION
Updates the reflection code so that the newly added Queryable overloads in https://github.com/dotnet/runtime/issues/28776 are tolerated.