### PR TITLE
Refactor, Remove Duplication, and simplify some methods

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             HandleGroupByForAggregate(selectExpression, eraseProjection: true);
 
-            var translation = _sqlTranslator.TranslateCount(_sqlExpressionFactory.Fragment("*"));
+            var translation = _sqlTranslator.TranslateCount<int>(_sqlExpressionFactory.Fragment("*"));
             if (translation == null)
             {
                 return null;

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -193,36 +193,31 @@ namespace Microsoft.EntityFrameworkCore.Query
         ///     Translates Count over an expression to an equivalent SQL representation.
         /// </summary>
         /// <param name="sqlExpression"> An expression to translate Count over. </param>
+        /// <param name="functionName"> Name of function of count. </param>
         /// <returns> A SQL translation of Count over the given expression. </returns>
-        public virtual SqlExpression? TranslateCount([NotNull] SqlExpression sqlExpression)
+        public virtual SqlExpression? TranslateCount<T>([NotNull] SqlExpression sqlExpression, [NotNull] string functionName = "COUNT")
+            where T : struct
         {
             Check.NotNull(sqlExpression, nameof(sqlExpression));
 
             return _sqlExpressionFactory.ApplyDefaultTypeMapping(
                 _sqlExpressionFactory.Function(
-                    "COUNT",
+                    functionName,
                     new[] { sqlExpression },
                     nullable: false,
                     argumentsPropagateNullability: new[] { false },
-                    typeof(int)));
+                    typeof(T)));
         }
 
         /// <summary>
         ///     Translates LongCount over an expression to an equivalent SQL representation.
         /// </summary>
         /// <param name="sqlExpression"> An expression to translate LongCount over. </param>
+        /// <param name="functionName"> Name of function of count. </param>
         /// <returns> A SQL translation of LongCount over the given expression. </returns>
-        public virtual SqlExpression? TranslateLongCount([NotNull] SqlExpression sqlExpression)
+        public virtual SqlExpression? TranslateLongCount([NotNull] SqlExpression sqlExpression, [NotNull] string functionName = "COUNT")
         {
-            Check.NotNull(sqlExpression, nameof(sqlExpression));
-
-            return _sqlExpressionFactory.ApplyDefaultTypeMapping(
-                _sqlExpressionFactory.Function(
-                    "COUNT",
-                    new[] { sqlExpression },
-                    nullable: false,
-                    argumentsPropagateNullability: new[] { false },
-                    typeof(long)));
+            return TranslateCount<long>(sqlExpression, functionName);
         }
 
         /// <summary>
@@ -515,7 +510,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 groupingElementExpression = newGroupingElementExpression;
                             }
 
-                            result = TranslateCount(GetExpressionForAggregation(groupingElementExpression, starProjection: true)!);
+                            result = TranslateCount<int>(GetExpressionForAggregation(groupingElementExpression, starProjection: true)!);
                             break;
 
                         case nameof(Enumerable.Distinct):

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerSqlTranslatingExpressionVisitor.cs
@@ -139,17 +139,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override SqlExpression? TranslateLongCount(SqlExpression sqlExpression)
+        public override SqlExpression? TranslateLongCount(SqlExpression sqlExpression, [NotNull] string functionName = "COUNT_BIG")
         {
-            Check.NotNull(sqlExpression, nameof(sqlExpression));
-
-            return Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(
-                Dependencies.SqlExpressionFactory.Function(
-                    "COUNT_BIG",
-                    new[] { sqlExpression },
-                    nullable: false,
-                    argumentsPropagateNullability: new[] { false },
-                    typeof(long)));
+            return base.TranslateLongCount(sqlExpression, functionName);
         }
 
         private static string? GetProviderType(SqlExpression expression)


### PR DESCRIPTION
I'm trying to read codes of ef core to develop something or features, But I see a lot of codes in one class like 'RelationalSqlTranslatingExpressionVisitor.cs' so I'm trying to simplify and refactor some duplication codes and make it easier to read and changes.

In these changes we have:

- Removed duplication and Refactor Count And LongCount generics