### PR TITLE
#12482 Fix batch inserts using with different types on a sql_variant column

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// </summary>
         public SqlServerSqlVariantTypeMapping(
             [NotNull] string storeType)
-            : base(storeType, typeof(object))
+            : base(storeType, typeof(object), System.Data.DbType.Object)
         {
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -696,8 +696,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32='-128'
 @p33='128' (Size = 1)
 @p34='79'
-@p35='887876'
-@p36='Bang!' (Nullable = false) (Size = 5)
+@p35='887876' (DbType = Object)
+@p36='Bang!' (Nullable = false) (Size = 5) (DbType = Object)
 @p37='Your' (Nullable = false) (Size = 8000) (DbType = AnsiString)
 @p38='strong' (Nullable = false) (Size = 8000) (DbType = AnsiString)
 @p39='help' (Nullable = false) (Size = 4000)
@@ -887,8 +887,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p26='-128'
 @p27='128' (Size = 1)
 @p28='79'
-@p29='887876'
-@p30='Bang!' (Nullable = false) (Size = 5)
+@p29='887876' (DbType = Object)
+@p30='Bang!' (Nullable = false) (Size = 5) (DbType = Object)
 @p31='Gumball Rules OK!' (Nullable = false) (Size = 4000)
 @p32='"
                 + entity.StringAsNvarcharMax
@@ -1056,8 +1056,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32='-128' (Nullable = true)
 @p33='128' (Nullable = true) (Size = 1)
 @p34='79' (Nullable = true)
-@p35='887876' (Nullable = true)
-@p36='Bang!' (Size = 5)
+@p35='887876' (Nullable = true) (DbType = Object)
+@p36='Bang!' (Size = 5) (DbType = Object)
 @p37='Your' (Size = 8000) (DbType = AnsiString)
 @p38='strong' (Size = 8000) (DbType = AnsiString)
 @p39='help' (Size = 4000)
@@ -1244,8 +1244,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32=NULL (DbType = Int16)
 @p33=NULL (DbType = Byte)
 @p34=NULL (DbType = Int16)
-@p35=NULL
-@p36=NULL
+@p35=NULL (DbType = Object)
+@p36=NULL (DbType = Object)
 @p37=NULL (Size = 8000) (DbType = AnsiString)
 @p38=NULL (Size = 8000) (DbType = AnsiString)
 @p39=NULL (Size = 4000)
@@ -1825,8 +1825,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32='-128'
 @p33='128' (Size = 1)
 @p34='79'
-@p35='887876'
-@p36='Bang!' (Nullable = false) (Size = 5)
+@p35='887876' (DbType = Object)
+@p36='Bang!' (Nullable = false) (Size = 5) (DbType = Object)
 @p37='Your' (Nullable = false) (Size = 8000) (DbType = AnsiString)
 @p38='strong' (Nullable = false) (Size = 8000) (DbType = AnsiString)
 @p39='help' (Nullable = false) (Size = 4000)
@@ -2013,8 +2013,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32='-128' (Nullable = true)
 @p33='128' (Nullable = true) (Size = 1)
 @p34='79' (Nullable = true)
-@p35='887876' (Nullable = true)
-@p36='Bang!' (Size = 5)
+@p35='887876' (Nullable = true) (DbType = Object)
+@p36='Bang!' (Size = 5) (DbType = Object)
 @p37='Your' (Size = 8000) (DbType = AnsiString)
 @p38='strong' (Size = 8000) (DbType = AnsiString)
 @p39='help' (Size = 4000)
@@ -2201,8 +2201,8 @@ WHERE DATEDIFF(nanosecond, [m].[TimeSpanAsTime], @__timeSpan_1) = 0");
 @p32=NULL (DbType = Int16)
 @p33=NULL (DbType = Byte)
 @p34=NULL (DbType = Int16)
-@p35=NULL
-@p36=NULL
+@p35=NULL (DbType = Object)
+@p36=NULL (DbType = Object)
 @p37=NULL (Size = 8000) (DbType = AnsiString)
 @p38=NULL (Size = 8000) (DbType = AnsiString)
 @p39=NULL (Size = 4000)


### PR DESCRIPTION
Regarding issue #12482 
Currently when batch inserting values into a sql_variant column each DbParameter will resolve its own SqlDbType. This results in invalid sql and will therefore throw an exception

This pull request passes DbType.Object for any parameter targeting a variant column so that each DbParameter will map into the SqlDbType sql_variant instead, making the batch insert possible.

This is my first time working with this repository so please let me know if something is missing or if more tests are required