### PR TITLE
Add Caching to SqliteDataRecord for Ordinal and Name 

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -17,6 +18,8 @@ namespace Microsoft.Data.Sqlite
         private readonly SqliteConnection _connection;
         private byte[][]? _blobCache;
         private int?[]? _typeCache;
+        private Dictionary<string, int>? _columnNameOrdinalCache;
+        private string?[]? _columnNameCache;
         private bool _stepped;
         private int? _rowidOrdinal;
 
@@ -100,7 +103,7 @@ namespace Microsoft.Data.Sqlite
 
         public virtual string GetName(int ordinal)
         {
-            var name = sqlite3_column_name(Handle, ordinal).utf8_to_string();
+            var name = _columnNameCache?[ordinal] ?? sqlite3_column_name(Handle, ordinal).utf8_to_string();
             if (name == null
                 && (ordinal < 0 || ordinal >= FieldCount))
             {
@@ -108,17 +111,26 @@ namespace Microsoft.Data.Sqlite
                 throw new ArgumentOutOfRangeException(nameof(ordinal), ordinal, message: null);
             }
 
+            _columnNameCache ??= new string[FieldCount];
+            _columnNameCache[ordinal] = name;
+
             return name!;
         }
 
         public virtual int GetOrdinal(string name)
         {
-            for (var i = 0; i < FieldCount; i++)
+            if (_columnNameOrdinalCache == null)
             {
-                if (GetName(i) == name)
+                _columnNameOrdinalCache = new Dictionary<string, int>();
+                for (var i = 0; i < FieldCount; i++)
                 {
-                    return i;
+                    _columnNameOrdinalCache[GetName(i)] = i;
                 }
+            }
+            
+            if (_columnNameOrdinalCache.TryGetValue(name, out var ordinal))
+            {
+                return ordinal;
             }
 
             // NB: Message is provided by framework

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Sqlite
         private byte[][]? _blobCache;
         private int?[]? _typeCache;
         private Dictionary<string, int>? _columnNameOrdinalCache;
-        private string?[]? _columnNameCache;
+        private string[]? _columnNameCache;
         private bool _stepped;
         private int? _rowidOrdinal;
 
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Sqlite
             }
 
             _columnNameCache ??= new string[FieldCount];
-            _columnNameCache[ordinal] = name;
+            _columnNameCache[ordinal] = name!;
 
             return name!;
         }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -1227,7 +1227,8 @@ namespace Microsoft.Data.Sqlite
                 using (var reader = connection.ExecuteReader("SELECT 1 AS Id;"))
                 {
                     Assert.Equal("Id", reader.GetName(0));
-                    // Repeated access might use caching.
+
+                    // NB: Repeated to use caching
                     Assert.Equal("Id", reader.GetName(0));
                 }
             }
@@ -1265,12 +1266,12 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                using (var reader = connection.ExecuteReader("SELECT 1 as Id, 'ÆØÅ' AS Value"))
+                using (var reader = connection.ExecuteReader("SELECT 1 AS Id;"))
                 {
                     Assert.Equal(0, reader.GetOrdinal("Id"));
-                    Assert.Equal(1, reader.GetOrdinal("Value"));
-                    // Repeated access may use caching
-                    Assert.Equal(1, reader.GetOrdinal("Value"));
+
+                    // NB: Repeated to use caching
+                    Assert.Equal(0, reader.GetOrdinal("Id"));
                 }
             }
         }
@@ -1301,7 +1302,6 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetOrdinal_throws_when_non_query()
             => X_throws_when_non_query(r => r.GetOrdinal("dummy"));
-
 
         [Fact]
         public void GetString_works_utf8()

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -1227,6 +1227,8 @@ namespace Microsoft.Data.Sqlite
                 using (var reader = connection.ExecuteReader("SELECT 1 AS Id;"))
                 {
                     Assert.Equal("Id", reader.GetName(0));
+                    // Repeated access might use caching.
+                    Assert.Equal("Id", reader.GetName(0));
                 }
             }
         }
@@ -1263,9 +1265,12 @@ namespace Microsoft.Data.Sqlite
             {
                 connection.Open();
 
-                using (var reader = connection.ExecuteReader("SELECT 1 AS Id;"))
+                using (var reader = connection.ExecuteReader("SELECT 1 as Id, 'ÆØÅ' AS Value"))
                 {
                     Assert.Equal(0, reader.GetOrdinal("Id"));
+                    Assert.Equal(1, reader.GetOrdinal("Value"));
+                    // Repeated access may use caching
+                    Assert.Equal(1, reader.GetOrdinal("Value"));
                 }
             }
         }
@@ -1296,6 +1301,7 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void GetOrdinal_throws_when_non_query()
             => X_throws_when_non_query(r => r.GetOrdinal("dummy"));
+
 
         [Fact]
         public void GetString_works_utf8()


### PR DESCRIPTION
Add Ordinal and Name Caching to SqliteDataRecord

This speeds up repeated ordinal and Name access, while having probable negligible effect on existing queries to GetName(int) or GetOrdinal(string). 

Fixes #24140

This is my first PR, please guide me if there is anything I must do to improve the submission 👍
 
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines.
      https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines

Review the guidelines for CONTRIBUTING.md for more details.
-->


