### PR TITLE
Remove IAsyncEnumerable from DbSet

### DIFF
--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -13,6 +13,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Microsoft.EntityFrameworkCore
@@ -39,8 +40,7 @@ namespace Microsoft.EntityFrameworkCore
     ///     </para>
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being operated on by this set. </typeparam>
-    public abstract class DbSet<TEntity>
-        : IQueryable<TEntity>, IAsyncEnumerable<TEntity>, IInfrastructure<IServiceProvider>, IListSource
+    public abstract class DbSet<TEntity> : IQueryable<TEntity>, IInfrastructure<IServiceProvider>, IListSource
         where TEntity : class
     {
         /// <summary>
@@ -60,20 +60,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> This object. </returns>
         public virtual IAsyncEnumerable<TEntity> AsAsyncEnumerable()
-            => this;
-
-        /// <summary>
-        ///     <para>
-        ///         Returns this object typed as <see cref="IQueryable{T}" />.
-        ///     </para>
-        ///     <para>
-        ///         This is a convenience method to help with disambiguation of extension methods in the same
-        ///         namespace that extend both interfaces.
-        ///     </para>
-        /// </summary>
-        /// <returns> This object. </returns>
-        public virtual IQueryable<TEntity> AsQueryable()
-            => this;
+            => throw new NotSupportedException();
 
         /// <summary>
         ///     <para>
@@ -527,14 +514,6 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> The query results. </returns>
         IEnumerator IEnumerable.GetEnumerator()
-            => throw new NotSupportedException();
-
-        /// <summary>
-        ///     Returns an <see cref="IAsyncEnumerator{T}" /> which when enumerated will asynchronously execute a query against
-        ///     the database.
-        /// </summary>
-        /// <returns> The query results. </returns>
-        IAsyncEnumerator<TEntity> IAsyncEnumerable<TEntity>.GetAsyncEnumerator(CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         /// <summary>

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -64,6 +64,20 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
+        ///         Returns this object typed as <see cref="IQueryable{T}" />.
+        ///     </para>
+        ///     <para>
+        ///         This is a convenience method to help with disambiguation of extension methods in the same
+        ///         namespace that extend both interfaces.
+        ///     </para>
+        /// </summary>
+        /// <returns> This object. </returns>
+        [Obsolete("Calling this method on DbSet is no longer necessary.")]
+        public virtual IQueryable<TEntity> AsQueryable()
+            => this;
+
+        /// <summary>
+        ///     <para>
         ///         Gets an <see cref="LocalView{TEntity}" /> that represents a local view of all Added, Unchanged,
         ///         and Modified entities in this set.
         ///     </para>

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -50,17 +50,11 @@ namespace Microsoft.EntityFrameworkCore
             => null;
 
         /// <summary>
-        ///     <para>
-        ///         Returns this object typed as <see cref="IAsyncEnumerable{T}" />.
-        ///     </para>
-        ///     <para>
-        ///         This is a convenience method to help with disambiguation of extension methods in the same
-        ///         namespace that extend both interfaces.
-        ///     </para>
+        ///     Returns this object typed as <see cref="IAsyncEnumerable{T}" />.
         /// </summary>
         /// <returns> This object. </returns>
         public virtual IAsyncEnumerable<TEntity> AsAsyncEnumerable()
-            => throw new NotSupportedException();
+            => (IAsyncEnumerable<TEntity>)this;
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -66,7 +66,6 @@ namespace Microsoft.EntityFrameworkCore
         ///     </para>
         /// </summary>
         /// <returns> This object. </returns>
-        [Obsolete("Calling this method on DbSet is no longer necessary.")]
         public virtual IQueryable<TEntity> AsQueryable()
             => this;
 

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -116,6 +116,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override IAsyncEnumerable<TEntity> AsAsyncEnumerable()
+            => this;
+
         private void CheckState()
         {
             // ReSharper disable once AssignmentIsFullyDiscarded

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -116,15 +116,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
         }
 
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public override IAsyncEnumerable<TEntity> AsAsyncEnumerable()
-            => this;
-
         private void CheckState()
         {
             // ReSharper disable once AssignmentIsFullyDiscarded

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -141,9 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             public IQueryable<T> Find()
-            {
-                return _context.Set<T>().AsQueryable();
-            }
+                => _context.Set<T>();
         }
 
         [ConditionalFact]

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -6010,7 +6010,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Null_parameter_name_works(bool async)
         {
             using var context = CreateContext();
-            var customerDbSet = context.Set<Customer>().AsQueryable();
+            var customerDbSet = (IQueryable<Customer>)context.Set<Customer>();
 
             var parameter = Expression.Parameter(typeof(Customer));
             var body = Expression.Equal(parameter, Expression.Default(typeof(Customer)));

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -6010,7 +6010,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task Null_parameter_name_works(bool async)
         {
             using var context = CreateContext();
-            var customerDbSet = (IQueryable<Customer>)context.Set<Customer>();
+            var customerDbSet = context.Set<Customer>().AsQueryable();
 
             var parameter = Expression.Parameter(typeof(Customer));
             var body = Expression.Equal(parameter, Expression.Default(typeof(Customer)));


### PR DESCRIPTION
Fixes #24041

Some compat notes:
* `await foreach` works fine, even if LangVersion is set to 7.0. Am not sure if this is because the SDK is new - if so, then new SDKs are required to build anything depending on EF Core 6.0 anyway (since we target net5.0).
* ToListAsync and friends work fine because they're over IQueryable