### PR TITLE
Add CS8602 suppressor

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,5 +30,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
     <MicrosoftCodeAnalysisVersion>3.7.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20623.3</MicrosoftCodeAnalysisTestingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,6 +30,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Other dependencies">
     <MicrosoftCodeAnalysisVersion>3.7.0</MicrosoftCodeAnalysisVersion>
-    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20623.3</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>1.0.1-beta1.20623.3</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>
   </PropertyGroup>
 </Project>

--- a/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
+++ b/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
@@ -20,10 +20,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public override void ReportSuppressions(SuppressionAnalysisContext context)
         {
-            context.ReportSuppression(Suppression.Create(_descriptor, context.ReportedDiagnostics[0]));
-
-
-            /*var linqExpressionType = context.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+            var linqExpressionType = context.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
             if (linqExpressionType is null)
             {
                 return;
@@ -45,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
                     context.ReportSuppression(Suppression.Create(_descriptor, diagnostic));
                 }
 
-            }*/
+            }
         }
     }
 }

--- a/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
+++ b/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
@@ -45,8 +45,7 @@ namespace Microsoft.EntityFrameworkCore
                 var root = tree.GetRoot(context.CancellationToken);
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
                 var model = context.GetSemanticModel(tree);
-                var operation = model.GetOperation(node, context.CancellationToken);
-                if (operation is null)
+                if (model.GetOperation(node, context.CancellationToken) is not IOperation operation)
                 {
                     continue;
                 }

--- a/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
+++ b/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
         private static readonly SuppressionDescriptor _descriptor = new(
             id: "EFS0001",
             suppressedDiagnosticId: "CS8602",
-            justification: "The dereference is safe inside this expression tree.");
+            justification: "EF Core provides null-safety in translated expression trees.");
 
         public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(_descriptor);
 
@@ -57,7 +57,6 @@ namespace Microsoft.EntityFrameworkCore
                 {
                     context.ReportSuppression(Suppression.Create(_descriptor, diagnostic));
                 }
-
             }
         }
     }

--- a/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
+++ b/src/EFCore.Analyzers/NullableDiagnosticSuppressor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class NullableDiagnosticSuppressor : DiagnosticSuppressor
+    {
+        private static readonly SuppressionDescriptor _descriptor = new(
+            id: "EFS0001",
+            suppressedDiagnosticId: "CS8602",
+            justification: "The dereference is safe inside this expression tree.");
+
+        public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(_descriptor);
+
+        public override void ReportSuppressions(SuppressionAnalysisContext context)
+        {
+            context.ReportSuppression(Suppression.Create(_descriptor, context.ReportedDiagnostics[0]));
+
+
+            /*var linqExpressionType = context.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+            if (linqExpressionType is null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.ReportedDiagnostics)
+            {
+                if (diagnostic.Location.SourceTree is not SyntaxTree tree)
+                {
+                    continue;
+                }
+
+                var root = tree.GetRoot(context.CancellationToken);
+                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+                var model = context.GetSemanticModel(tree);
+                var operation = model.GetOperation(node, context.CancellationToken);
+                if (operation?.IsWithinExpressionTree(linqExpressionType) == true)
+                {
+                    context.ReportSuppression(Suppression.Create(_descriptor, diagnostic));
+                }
+
+            }*/
+        }
+    }
+}

--- a/src/EFCore.Analyzers/Utilities/IOperationExtensions.cs
+++ b/src/EFCore.Analyzers/Utilities/IOperationExtensions.cs
@@ -60,6 +60,5 @@ namespace Microsoft.EntityFrameworkCore.Utilities
             }
         }
 
-
     }
 }

--- a/src/EFCore.Analyzers/Utilities/IOperationExtensions.cs
+++ b/src/EFCore.Analyzers/Utilities/IOperationExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.EntityFrameworkCore.Utilities
+{
+    internal static class IOperationExtensions
+    {
+        private static readonly ImmutableArray<OperationKind> s_LambdaAndLocalFunctionKinds =
+            ImmutableArray.Create(OperationKind.AnonymousFunction, OperationKind.LocalFunction);
+
+        public static bool IsWithinExpressionTree(this IOperation operation, INamedTypeSymbol linqExpressionTreeType)
+            => linqExpressionTreeType != null
+                && operation.GetAncestor(s_LambdaAndLocalFunctionKinds)?.Parent?.Type?.OriginalDefinition is { } lambdaType
+                && linqExpressionTreeType.Equals(lambdaType, SymbolEqualityComparer.Default);
+
+        /// <summary>
+        /// Gets the first ancestor of this operation with:
+        ///  1. Any OperationKind from the specified <paramref name="ancestorKinds"/>.
+        ///  2. If <paramref name="predicate"/> is non-null, it succeeds for the ancestor.
+        /// Returns null if there is no such ancestor.
+        /// </summary>
+        public static IOperation? GetAncestor(this IOperation root, ImmutableArray<OperationKind> ancestorKinds, Func<IOperation, bool>? predicate = null)
+        {
+            if (root == null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+
+            var ancestor = root;
+            do
+            {
+                ancestor = ancestor.Parent;
+            } while (ancestor != null && !ancestorKinds.Contains(ancestor.Kind));
+
+            if (ancestor != null)
+            {
+                if (predicate != null && !predicate(ancestor))
+                {
+                    return GetAncestor(ancestor, ancestorKinds, predicate);
+                }
+                return ancestor;
+            }
+            else
+            {
+                return default;
+            }
+        }
+
+
+    }
+}

--- a/src/EFCore.Analyzers/Utilities/NotNullWhenAttribute.cs
+++ b/src/EFCore.Analyzers/Utilities/NotNullWhenAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+}

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion)" />
    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.Analyzers.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
  <ItemGroup>
@@ -13,7 +14,8 @@
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(MicrosoftCodeAnalysisTestingVersion)" />
+   <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
+++ b/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
@@ -51,5 +51,35 @@ class C
 }";
             await AssertWarningIsNotSuppressedAsync(code);
         }
+
+        [Fact]
+        public async Task TestEFCoreIncludeIsSuppressed()
+        {
+            var code = @"
+#nullable enable
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+class SomeModel
+{
+    public NavigationModel? Navigation { get; set; }
+}
+
+class NavigationModel
+{
+    public string DeeperNavigation { get; set; } = null!;
+}
+
+static class C
+{
+    public static void M(IQueryable<SomeModel> q)
+    {
+        _ = q.Include(m => m.Navigation).ThenInclude(n => {|CS8602:n|}.DeeperNavigation);
+    }
+}
+";
+            await AssertWarningIsSuppressedAsync(code);
+        }
     }
 }

--- a/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
+++ b/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+using VerifyWithSuppressor = Microsoft.EntityFrameworkCore.TestUtilities.Verifiers.CSharpCodeFixVerifier<
+    Microsoft.EntityFrameworkCore.NullableDiagnosticSuppressor,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+using VerifyWithoutSuppressor = Microsoft.EntityFrameworkCore.TestUtilities.Verifiers.CSharpCodeFixVerifier<
+    Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class NullableDiagnosticSuppressorTest
+    {
+        /// <summary>
+        /// Assert that given code have warnings specified by markup that are suppressed by <see cref="NullableDiagnosticSuppressor"/>
+        /// </summary>
+        private static async Task AssertWarningIsSuppressedAsync(string code)
+        {
+            await VerifyWithoutSuppressor.VerifyAnalyzerAsync(code);
+
+            await new VerifyWithSuppressor.Test()
+            {
+                TestState = { Sources = { code }, MarkupHandling = MarkupMode.Ignore }
+            }.RunAsync();
+        }
+
+        /// <summary>
+        /// Assert that given code have warnings specified by markup that are not suppressed by <see cref="NullableDiagnosticSuppressor"/>
+        /// </summary>
+        private static async Task AssertWarningIsNotSuppressedAsync(string code)
+        {
+            await VerifyWithSuppressor.VerifyAnalyzerAsync(code);
+            await VerifyWithoutSuppressor.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task TestCompilerWarningAsync()
+        {
+            var code = @"
+#nullable enable
+
+class C
+{
+    public void M(C? c)
+    {
+        _ = {|CS8602:c|}.ToString();
+    }
+}";
+            await AssertWarningIsSuppressedAsync(code);
+        }
+    }
+}

--- a/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
+++ b/test/EFCore.Analyzers.Tests/NullableDiagnosticSuppressorTest.cs
@@ -49,7 +49,7 @@ class C
         _ = {|CS8602:c|}.ToString();
     }
 }";
-            await AssertWarningIsSuppressedAsync(code);
+            await AssertWarningIsNotSuppressedAsync(code);
         }
     }
 }

--- a/test/EFCore.Analyzers.Tests/TestUtilities/DiagnosticAnalyzerTestBase.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/DiagnosticAnalyzerTestBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         protected async Task<Diagnostic[]> GetDiagnosticsFullSourceAsync(string source)
         {
             var compilation = await CreateProject(source).GetCompilationAsync();
-            var errors = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+            var errors = compilation!.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
 
             Assert.Empty(errors);
 
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 .AddMetadataReferences(projectId, metadataReferences)
                 .AddDocument(documentId, fileName, SourceText.From(source));
 
-            return solution.GetProject(projectId)
+            return solution.GetProject(projectId)!
                 .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         }
     }

--- a/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/AdditionalMetadataReferences.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/AdditionalMetadataReferences.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
+{
+    public static class AdditionalMetadataReferences
+    {
+        public static ReferenceAssemblies Default { get; } = CreateDefaultReferenceAssemblies();
+
+        public static ReferenceAssemblies DefaultWithoutRoslynSymbols { get; } = ReferenceAssemblies.Default
+            .AddAssemblies(ImmutableArray.Create("System.Xml.Data"))
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis.Workspaces.Common", "3.0.0")));
+
+        public static ReferenceAssemblies DefaultWithSystemWeb { get; } = ReferenceAssemblies.NetFramework.Net472.Default
+            .AddAssemblies(ImmutableArray.Create("System.Web", "System.Web.Extensions"));
+
+        public static ReferenceAssemblies DefaultForTaintedDataAnalysis { get; } = ReferenceAssemblies.NetFramework.Net472.Default
+            .AddAssemblies(ImmutableArray.Create("PresentationFramework", "System.DirectoryServices", "System.Web", "System.Web.Extensions", "System.Xaml"))
+            .AddPackages(ImmutableArray.Create(
+                new PackageIdentity("AntiXSS", "4.3.0"),
+                new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.2.0"),
+                new PackageIdentity("Microsoft.EntityFrameworkCore.Relational", "2.0.3")));
+
+        public static ReferenceAssemblies DefaultWithSerialization { get; } = ReferenceAssemblies.NetFramework.Net472.Default
+            .AddAssemblies(ImmutableArray.Create("System.Runtime.Serialization"));
+
+        public static ReferenceAssemblies DefaultWithAzureStorage { get; } = ReferenceAssemblies.Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("WindowsAzure.Storage", "9.0.0")));
+
+        public static ReferenceAssemblies DefaultWithNewtonsoftJson10 { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "10.0.1")));
+
+        public static ReferenceAssemblies DefaultWithNewtonsoftJson12 { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "12.0.1")));
+
+        public static ReferenceAssemblies DefaultWithWinForms { get; } = ReferenceAssemblies.NetFramework.Net472.WindowsForms;
+
+        public static ReferenceAssemblies DefaultWithWinHttpHandler { get; } = ReferenceAssemblies.NetStandard.NetStandard20
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Net.Http.WinHttpHandler", "4.7.0")));
+
+        public static ReferenceAssemblies DefaultWithAspNetCoreMvc { get; } = Default
+            .AddPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.AspNetCore", "1.1.7"),
+                new PackageIdentity("Microsoft.AspNetCore.Mvc", "1.1.8"),
+                new PackageIdentity("Microsoft.AspNetCore.Http", "1.1.2")));
+
+        public static ReferenceAssemblies DefaultWithNUnit { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("NUnit", "3.12.0")));
+
+        public static ReferenceAssemblies DefaultWithXUnit { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("xunit", "2.4.1")));
+
+        public static ReferenceAssemblies DefaultWithMSTest { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("MSTest.TestFramework", "2.1.0")));
+
+        public static ReferenceAssemblies DefaultWithAsyncInterfaces { get; } = Default
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0")));
+
+        public static MetadataReference SystemCollectionsImmutableReference { get; } = MetadataReference.CreateFromFile(typeof(ImmutableHashSet<>).Assembly.Location);
+        public static MetadataReference SystemComponentModelCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.ComponentModel.Composition.ExportAttribute).Assembly.Location);
+        public static MetadataReference SystemCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.Composition.ExportAttribute).Assembly.Location);
+        public static MetadataReference SystemXmlDataReference { get; } = MetadataReference.CreateFromFile(typeof(System.Data.Rule).Assembly.Location);
+        public static MetadataReference CodeAnalysisReference { get; } = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        public static MetadataReference CSharpSymbolsReference { get; } = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+        public static MetadataReference WorkspacesReference { get; } = MetadataReference.CreateFromFile(typeof(Workspace).Assembly.Location);
+#if !NETCOREAPP
+        public static MetadataReference SystemWebReference { get; } = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
+        public static MetadataReference SystemRuntimeSerialization { get; } = MetadataReference.CreateFromFile(typeof(System.Runtime.Serialization.NetDataContractSerializer).Assembly.Location);
+#endif
+
+#if !NETCOREAPP
+        public static MetadataReference SystemXaml { get; } = MetadataReference.CreateFromFile(typeof(System.Xaml.XamlReader).Assembly.Location);
+        public static MetadataReference PresentationFramework { get; } = MetadataReference.CreateFromFile(typeof(System.Windows.Markup.XamlReader).Assembly.Location);
+        public static MetadataReference SystemWeb { get; } = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
+        public static MetadataReference SystemWebExtensions { get; } = MetadataReference.CreateFromFile(typeof(System.Web.Script.Serialization.JavaScriptSerializer).Assembly.Location);
+        public static MetadataReference SystemServiceModel { get; } = MetadataReference.CreateFromFile(typeof(System.ServiceModel.OperationContractAttribute).Assembly.Location);
+#endif
+
+        private static ReferenceAssemblies CreateDefaultReferenceAssemblies()
+        {
+            var referenceAssemblies = ReferenceAssemblies.Default;
+
+#if !NETCOREAPP
+            referenceAssemblies = referenceAssemblies.AddAssemblies(ImmutableArray.Create("System.Xml.Data"));
+#endif
+
+            referenceAssemblies = referenceAssemblies.AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", "3.0.0")));
+
+#if NETCOREAPP
+            referenceAssemblies = referenceAssemblies.AddPackages(ImmutableArray.Create(
+                new PackageIdentity("System.Runtime.Serialization.Formatters", "4.3.0"),
+                new PackageIdentity("System.Configuration.ConfigurationManager", "4.7.0"),
+                new PackageIdentity("System.Security.Cryptography.Cng", "4.7.0"),
+                new PackageIdentity("System.Security.Permissions", "4.7.0"),
+                new PackageIdentity("Microsoft.VisualBasic", "10.3.0")));
+#endif
+
+            return referenceAssemblies;
+        }
+    }
+
+}

--- a/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/AdditionalMetadataReferences.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/AdditionalMetadataReferences.cs
@@ -9,93 +9,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
     {
         public static ReferenceAssemblies Default { get; } = CreateDefaultReferenceAssemblies();
 
-        public static ReferenceAssemblies DefaultWithoutRoslynSymbols { get; } = ReferenceAssemblies.Default
-            .AddAssemblies(ImmutableArray.Create("System.Xml.Data"))
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis.Workspaces.Common", "3.0.0")));
-
-        public static ReferenceAssemblies DefaultWithSystemWeb { get; } = ReferenceAssemblies.NetFramework.Net472.Default
-            .AddAssemblies(ImmutableArray.Create("System.Web", "System.Web.Extensions"));
-
-        public static ReferenceAssemblies DefaultForTaintedDataAnalysis { get; } = ReferenceAssemblies.NetFramework.Net472.Default
-            .AddAssemblies(ImmutableArray.Create("PresentationFramework", "System.DirectoryServices", "System.Web", "System.Web.Extensions", "System.Xaml"))
-            .AddPackages(ImmutableArray.Create(
-                new PackageIdentity("AntiXSS", "4.3.0"),
-                new PackageIdentity("Microsoft.AspNetCore.Mvc", "2.2.0"),
-                new PackageIdentity("Microsoft.EntityFrameworkCore.Relational", "2.0.3")));
-
-        public static ReferenceAssemblies DefaultWithSerialization { get; } = ReferenceAssemblies.NetFramework.Net472.Default
-            .AddAssemblies(ImmutableArray.Create("System.Runtime.Serialization"));
-
-        public static ReferenceAssemblies DefaultWithAzureStorage { get; } = ReferenceAssemblies.Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("WindowsAzure.Storage", "9.0.0")));
-
-        public static ReferenceAssemblies DefaultWithNewtonsoftJson10 { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "10.0.1")));
-
-        public static ReferenceAssemblies DefaultWithNewtonsoftJson12 { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Newtonsoft.Json", "12.0.1")));
-
-        public static ReferenceAssemblies DefaultWithWinForms { get; } = ReferenceAssemblies.NetFramework.Net472.WindowsForms;
-
-        public static ReferenceAssemblies DefaultWithWinHttpHandler { get; } = ReferenceAssemblies.NetStandard.NetStandard20
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("System.Net.Http.WinHttpHandler", "4.7.0")));
-
-        public static ReferenceAssemblies DefaultWithAspNetCoreMvc { get; } = Default
-            .AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Microsoft.AspNetCore", "1.1.7"),
-                new PackageIdentity("Microsoft.AspNetCore.Mvc", "1.1.8"),
-                new PackageIdentity("Microsoft.AspNetCore.Http", "1.1.2")));
-
-        public static ReferenceAssemblies DefaultWithNUnit { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("NUnit", "3.12.0")));
-
-        public static ReferenceAssemblies DefaultWithXUnit { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("xunit", "2.4.1")));
-
-        public static ReferenceAssemblies DefaultWithMSTest { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("MSTest.TestFramework", "2.1.0")));
-
-        public static ReferenceAssemblies DefaultWithAsyncInterfaces { get; } = Default
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0")));
-
-        public static MetadataReference SystemCollectionsImmutableReference { get; } = MetadataReference.CreateFromFile(typeof(ImmutableHashSet<>).Assembly.Location);
-        public static MetadataReference SystemComponentModelCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.ComponentModel.Composition.ExportAttribute).Assembly.Location);
-        public static MetadataReference SystemCompositionReference { get; } = MetadataReference.CreateFromFile(typeof(System.Composition.ExportAttribute).Assembly.Location);
-        public static MetadataReference SystemXmlDataReference { get; } = MetadataReference.CreateFromFile(typeof(System.Data.Rule).Assembly.Location);
-        public static MetadataReference CodeAnalysisReference { get; } = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
-        public static MetadataReference CSharpSymbolsReference { get; } = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
-        public static MetadataReference WorkspacesReference { get; } = MetadataReference.CreateFromFile(typeof(Workspace).Assembly.Location);
-#if !NETCOREAPP
-        public static MetadataReference SystemWebReference { get; } = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
-        public static MetadataReference SystemRuntimeSerialization { get; } = MetadataReference.CreateFromFile(typeof(System.Runtime.Serialization.NetDataContractSerializer).Assembly.Location);
-#endif
-
-#if !NETCOREAPP
-        public static MetadataReference SystemXaml { get; } = MetadataReference.CreateFromFile(typeof(System.Xaml.XamlReader).Assembly.Location);
-        public static MetadataReference PresentationFramework { get; } = MetadataReference.CreateFromFile(typeof(System.Windows.Markup.XamlReader).Assembly.Location);
-        public static MetadataReference SystemWeb { get; } = MetadataReference.CreateFromFile(typeof(System.Web.HttpRequest).Assembly.Location);
-        public static MetadataReference SystemWebExtensions { get; } = MetadataReference.CreateFromFile(typeof(System.Web.Script.Serialization.JavaScriptSerializer).Assembly.Location);
-        public static MetadataReference SystemServiceModel { get; } = MetadataReference.CreateFromFile(typeof(System.ServiceModel.OperationContractAttribute).Assembly.Location);
-#endif
-
         private static ReferenceAssemblies CreateDefaultReferenceAssemblies()
         {
             var referenceAssemblies = ReferenceAssemblies.Default;
 
-#if !NETCOREAPP
-            referenceAssemblies = referenceAssemblies.AddAssemblies(ImmutableArray.Create("System.Xml.Data"));
-#endif
-
-            referenceAssemblies = referenceAssemblies.AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", "3.0.0")));
-
-#if NETCOREAPP
             referenceAssemblies = referenceAssemblies.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("System.Runtime.Serialization.Formatters", "4.3.0"),
-                new PackageIdentity("System.Configuration.ConfigurationManager", "4.7.0"),
-                new PackageIdentity("System.Security.Cryptography.Cng", "4.7.0"),
-                new PackageIdentity("System.Security.Permissions", "4.7.0"),
-                new PackageIdentity("Microsoft.VisualBasic", "10.3.0")));
-#endif
+                new PackageIdentity("Microsoft.EntityFrameworkCore", "5.0.3")
+                ));
 
             return referenceAssemblies;
         }

--- a/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Net;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        {
+            static Test()
+            {
+                // If we have outdated defaults from the host unit test application targeting an older .NET Framework, use more
+                // reasonable TLS protocol version for outgoing connections.
+#pragma warning disable CA5364 // Do Not Use Deprecated Security Protocols
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (ServicePointManager.SecurityProtocol == (SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls))
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CA5364 // Do Not Use Deprecated Security Protocols
+                {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                }
+            }
+
+            internal static readonly ImmutableDictionary<string, ReportDiagnostic> NullableWarnings = GetNullableWarningsFromCompiler();
+
+            public Test()
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.Default;
+
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (CSharpParseOptions)project.ParseOptions!;
+                    solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
+
+                    var compilationOptions = project.CompilationOptions!;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(NullableWarnings));
+                    
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    if (AnalyzerConfigDocument is not null)
+                    {
+                        solution = solution.AddAnalyzerConfigDocument(
+                            DocumentId.CreateNewId(projectId, debugName: ".editorconfig"),
+                            ".editorconfig",
+                            SourceText.From($"is_global = true" + Environment.NewLine + AnalyzerConfigDocument),
+                            filePath: @"z:\.editorconfig");
+                    }
+
+                    return solution;
+                });
+            }
+
+            private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+            {
+                string[] args = { "/warnaserror:nullable" };
+                var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+                var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+                return nullableWarnings;
+            }
+
+            public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp9;
+
+            public string? AnalyzerConfigDocument { get; set; }
+        }
+    }
+
+}

--- a/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 
@@ -31,8 +32,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
                 }
             }
 
-            internal static readonly ImmutableDictionary<string, ReportDiagnostic> NullableWarnings = GetNullableWarningsFromCompiler();
-
             public Test()
             {
                 ReferenceAssemblies = AdditionalMetadataReferences.Default;
@@ -44,7 +43,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
 
                     var compilationOptions = project.CompilationOptions!;
-                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(NullableWarnings));
                     
                     solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 
@@ -61,12 +59,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
                 });
             }
 
-            private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+            protected override bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic, CompilerDiagnostics compilerDiagnostics)
             {
-                string[] args = { "/warnaserror:nullable" };
-                var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
-                var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
-                return nullableWarnings;
+                return !diagnostic.IsSuppressed;
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp9;

--- a/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.Verifiers
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public static DiagnosticResult Diagnostic()
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(descriptor);
+
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+    }
+
+}


### PR DESCRIPTION
~~The actual implementation (which is still incomplete) is currently commented out (**for testing purposes**).~~

~~On its current form, it should suppress every CS8602 warning. However, the test reports CS8602.~~

~~@sharwell Is this a test framework issue? or roslyn issue? or something I'm doing wrong in the test?~~ (Fixed)

@roji Can you review? This currently checks for expression trees where the invoked method is in `Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions`. Are there any other methods I need to handle?

Fixes #21663