### PR TITLE
Minor stringbuilder cleanup in QuerySqlGenerator

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1052,9 +1052,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             GenerateSetOperationOperand(setOperation, setOperation.Source1);
             _relationalCommandBuilder.AppendLine()
                 .Append(GetSetOperation(setOperation))
-                .Append(setOperation.IsDistinct ? string.Empty : " ALL")
-                .AppendLine();
-
+                .AppendLine(setOperation.IsDistinct ? string.Empty : " ALL");
             GenerateSetOperationOperand(setOperation, setOperation.Source2);
 
             static string GetSetOperation(SetOperationBase operation)

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -1050,7 +1050,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(setOperation, nameof(setOperation));
 
             GenerateSetOperationOperand(setOperation, setOperation.Source1);
-            _relationalCommandBuilder.AppendLine()
+            _relationalCommandBuilder
+                .AppendLine()
                 .Append(GetSetOperation(setOperation))
                 .AppendLine(setOperation.IsDistinct ? string.Empty : " ALL");
             GenerateSetOperationOperand(setOperation, setOperation.Source2);

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -232,7 +232,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 subQueryIndent!.Dispose();
 
                 _relationalCommandBuilder.AppendLine()
-                    .Append(")" + AliasSeparator + _sqlGenerationHelper.DelimitIdentifier(selectExpression.Alias));
+                    .Append(")")
+                    .Append(AliasSeparator)
+                    .Append(_sqlGenerationHelper.DelimitIdentifier(selectExpression.Alias));
             }
 
             return selectExpression;
@@ -255,7 +257,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             if (projectionExpression.Alias != string.Empty
                 && !(projectionExpression.Expression is ColumnExpression column && column.Name == projectionExpression.Alias))
             {
-                _relationalCommandBuilder.Append(AliasSeparator + _sqlGenerationHelper.DelimitIdentifier(projectionExpression.Alias));
+                _relationalCommandBuilder
+                    .Append(AliasSeparator)
+                    .Append(_sqlGenerationHelper.DelimitIdentifier(projectionExpression.Alias));
             }
 
             return projectionExpression;
@@ -1046,8 +1050,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(setOperation, nameof(setOperation));
 
             GenerateSetOperationOperand(setOperation, setOperation.Source1);
-            _relationalCommandBuilder.AppendLine();
-            _relationalCommandBuilder.AppendLine($"{GetSetOperation(setOperation)}{(setOperation.IsDistinct ? "" : " ALL")}");
+            _relationalCommandBuilder.AppendLine()
+                .Append(GetSetOperation(setOperation))
+                .Append(setOperation.IsDistinct ? string.Empty : " ALL")
+                .AppendLine();
+
             GenerateSetOperationOperand(setOperation, setOperation.Source2);
 
             static string GetSetOperation(SetOperationBase operation)

--- a/src/EFCore/Infrastructure/IndentedStringBuilder.cs
+++ b/src/EFCore/Infrastructure/IndentedStringBuilder.cs
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             if (_indentPending && _indent > 0)
             {
-                _stringBuilder.Append(new string(' ', _indent * IndentSize));
+                _stringBuilder.Append(' ', _indent * IndentSize);
             }
 
             _indentPending = false;


### PR DESCRIPTION
Remove redundant string allocation in IndentedStringBuilder.DoIndent. Stringbuilder already has a Append(char, repeat) implementation.

Change a couple of string concats to stringbuilder append for consistency with other parts of the code. Performance difference seems to be neglectable