### PR TITLE
[5.0.x] Don't leave unknown FK values when principal is known but has not-set, non-generated, value

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EFCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -53,13 +53,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             Check.DebugAssert(property.IsForeignKey(), $"property {property} is not part of an FK");
 
-            var principalEntry = TryPropagateValue(entry, property);
+            var generationProperty = property.FindGenerationProperty();
+            var principalEntry = TryPropagateValue(entry, property, generationProperty);
+
             if (principalEntry == null
                 && property.IsKey()
                 && !property.IsForeignKeyToSelf())
             {
-                var valueGenerator = TryGetValueGenerator(property);
-
+                var valueGenerator = TryGetValueGenerator(generationProperty);
                 if (valueGenerator != null)
                 {
                     var value = valueGenerator.Next(new EntityEntry(entry));
@@ -93,12 +94,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             Check.DebugAssert(property.IsForeignKey(), $"property {property} is not part of an FK");
 
-            var principalEntry = TryPropagateValue(entry, property);
+            var generationProperty = property.FindGenerationProperty();
+            var principalEntry = TryPropagateValue(entry, property, generationProperty);
+
             if (principalEntry == null
                 && property.IsKey())
             {
-                var valueGenerator = TryGetValueGenerator(property);
-
+                var valueGenerator = TryGetValueGenerator(generationProperty);
                 if (valueGenerator != null)
                 {
                     var value = await valueGenerator.NextAsync(new EntityEntry(entry), cancellationToken)
@@ -120,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return principalEntry;
         }
 
-        private static InternalEntityEntry TryPropagateValue(InternalEntityEntry entry, IProperty property)
+        private static InternalEntityEntry TryPropagateValue(InternalEntityEntry entry, IProperty property, IProperty generationProperty)
         {
             var entityType = entry.EntityType;
             var stateManager = entry.StateManager;
@@ -158,7 +160,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             if (principalProperty != property)
                             {
                                 var principalValue = principalEntry[principalProperty];
-                                if (!principalProperty.ClrType.IsDefaultValue(principalValue))
+                                if (generationProperty == null
+                                    || !principalProperty.ClrType.IsDefaultValue(principalValue))
                                 {
                                     if (principalEntry.HasTemporaryValue(principalProperty))
                                     {
@@ -182,13 +185,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return null;
         }
 
-        private ValueGenerator TryGetValueGenerator(IProperty property)
-        {
-            var generationProperty = property.GetGenerationProperty();
-
-            return generationProperty != null
+        private ValueGenerator TryGetValueGenerator(IProperty generationProperty)
+            => generationProperty != null
                 ? _valueGeneratorSelector.Select(generationProperty, generationProperty.DeclaringEntityType)
                 : null;
-        }
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -385,17 +385,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     var subDependentEntry = context.Entry(subDependent);
                     Assert.Equal(principal.Id, subDependentEntry.Property("ParentId").CurrentValue);
                     Assert.Equal(useTrackGraph == null ? EntityState.Added : entityState, subDependentEntry.State);
-                    Assert.Equal(
-                        typeof(Parent).ShortDisplayName()
-                        + "."
-                        + nameof(Parent.Child1)
-                        + "#"
-                        + nameof(Child)
-                        + "."
-                        + nameof(Child.SubChild)
-                        + "#"
-                        + nameof(Child.SubChild),
-                        subDependentEntry.Metadata.DisplayName());
+                    Assert.Equal(nameof(ChildPN.SubChild), subDependentEntry.Metadata.DefiningNavigationName);
                 });
         }
 
@@ -2452,6 +2442,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
                 Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, dependent2Entry.State);
                 Assert.Equal(nameof(Parent.Child1), dependent2Entry.Metadata.DefiningNavigationName);
+
                 Assert.Same(subDependent1, dependent1.SubChild);
                 Assert.Same(dependent1, subDependent1.Parent);
                 var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry;
@@ -2855,14 +2846,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             principal2.Child1 = dependent;
             principal1.Child2 = null;
 
-            if (entityState != EntityState.Added)
-            {
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly("ParentId", "Parent.Child2#Child"),
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
-                return;
-            }
-
             context.ChangeTracker.DetectChanges();
 
             Assert.True(context.ChangeTracker.HasChanges());
@@ -3061,14 +3044,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             principal2.ChildCollection1 = principal1.ChildCollection2;
             principal1.ChildCollection2 = null;
 
-            if (entityState != EntityState.Added)
-            {
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly("ParentId", "Parent.ChildCollection2#Child"),
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
-                return;
-            }
-
             context.ChangeTracker.DetectChanges();
 
             Assert.True(context.ChangeTracker.HasChanges());
@@ -3237,14 +3212,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             principal2.Child1 = dependent1;
             principal1.Child2 = dependent2;
-
-            if (entityState != EntityState.Added)
-            {
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly("ParentId", "Parent.Child2#Child"),
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
-                return;
-            }
 
             context.ChangeTracker.DetectChanges();
 
@@ -3533,14 +3500,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
                 .FindEntry(subDependent2);
             newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
-
-            if (entityState != EntityState.Added)
-            {
-                Assert.Equal(
-                    CoreStrings.KeyReadOnly("ParentId", "Parent.ChildCollection2#Child"),
-                    Assert.Throws<InvalidOperationException>(() => context.ChangeTracker.DetectChanges()).Message);
-                return;
-            }
 
             context.ChangeTracker.DetectChanges();
 


### PR DESCRIPTION
Port of 6.0 fix https://github.com/dotnet/efcore/pull/23875 to 5.0 release.

Fixes #23730

**Description**

An exception is thrown when no key value is set for a non-generated key of an owned type. Normally this is a negative case since non-generated key values must be explicitly set. However, this can works when the non-generated value is part of a composite key for which other parts of the key are generated. In this case, the non-generated part can have the same default value for multiple inserts without violating the primary key constraint.

**Customer Impact**

This is a regression for the case described above. There is no reasonable workaround.

(We already fixed this for EF Core 6.0, but decided not to patch since it seemed to be a regression only in a negative case. Since then other customers have reported the issue and one customer outlined the scenario above where it is a regression in working code.)

**How found**

Reported by multiple customers.

**Test coverage**

Test coverage for this case has been added in this PR.

**Regression?**

Yes, from EF Core 3.1.

**Risk**

Low. The fix is already in EF Core 6.0 and is targetted to this case. Also quirked.
