### PR TITLE
Stop capturing in logging

### DIFF
--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -323,9 +324,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             var definition = ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogExecutingReadItem;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogExecutingReadItem,
-                    () => new EventDefinition<string, string, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string?>(
                         logger.Options,
                         CosmosEventId.ExecutingReadItem,
                         LogLevel.Debug,
@@ -347,9 +349,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
             var definition = ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogExecutingSqlQuery;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.CosmosLoggingDefinitions)logger.Definitions).LogExecutingSqlQuery,
-                    () => new EventDefinition<string, string?, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string?, string, string, string>(
                         logger.Options,
                         CosmosEventId.ExecutingSqlQuery,
                         LogLevel.Debug,

--- a/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
+++ b/src/EFCore.InMemory/Properties/InMemoryStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -123,9 +124,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
             var definition = ((Diagnostics.Internal.InMemoryLoggingDefinitions)logger.Definitions).LogSavedChanges;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.InMemoryLoggingDefinitions)logger.Definitions).LogSavedChanges,
-                    () => new EventDefinition<int>(
+                    logger,
+                    static logger => new EventDefinition<int>(
                         logger.Options,
                         InMemoryEventId.ChangesSaved,
                         LogLevel.Information,
@@ -147,9 +149,10 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Internal
             var definition = ((Diagnostics.Internal.InMemoryLoggingDefinitions)logger.Definitions).LogTransactionsNotSupported;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.InMemoryLoggingDefinitions)logger.Definitions).LogTransactionsNotSupported,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         InMemoryEventId.TransactionIgnoredWarning,
                         LogLevel.Warning,

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -1229,9 +1230,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogAmbientTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogAmbientTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.AmbientTransactionWarning,
                         LogLevel.Warning,
@@ -1253,9 +1255,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogAmbientTransactionEnlisted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogAmbientTransactionEnlisted,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.AmbientTransactionEnlisted,
                         LogLevel.Debug,
@@ -1277,9 +1280,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogApplyingMigration;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogApplyingMigration,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationApplying,
                         LogLevel.Information,
@@ -1301,9 +1305,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBatchExecutorFailedToReleaseSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBatchExecutorFailedToReleaseSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.BatchExecutorFailedToReleaseSavepoint,
                         LogLevel.Debug,
@@ -1325,9 +1330,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBatchExecutorFailedToRollbackToSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBatchExecutorFailedToRollbackToSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.BatchExecutorFailedToRollbackToSavepoint,
                         LogLevel.Debug,
@@ -1349,9 +1355,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBatchReadyForExecution;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBatchReadyForExecution,
-                    () => new EventDefinition<int>(
+                    logger,
+                    static logger => new EventDefinition<int>(
                         logger.Options,
                         RelationalEventId.BatchReadyForExecution,
                         LogLevel.Debug,
@@ -1373,9 +1380,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBatchSmallerThanMinBatchSize;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBatchSmallerThanMinBatchSize,
-                    () => new EventDefinition<int, int>(
+                    logger,
+                    static logger => new EventDefinition<int, int>(
                         logger.Options,
                         RelationalEventId.BatchSmallerThanMinBatchSize,
                         LogLevel.Debug,
@@ -1397,9 +1405,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBeganTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBeganTransaction,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.TransactionStarted,
                         LogLevel.Debug,
@@ -1421,9 +1430,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBeginningTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBeginningTransaction,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.TransactionStarting,
                         LogLevel.Debug,
@@ -1445,9 +1455,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogBoolWithDefaultWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogBoolWithDefaultWarning,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.BoolWithDefaultWarning,
                         LogLevel.Warning,
@@ -1469,9 +1480,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogClosedConnection;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogClosedConnection,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionClosed,
                         LogLevel.Debug,
@@ -1493,9 +1505,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogClosingConnection;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogClosingConnection,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionClosing,
                         LogLevel.Debug,
@@ -1517,9 +1530,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCreated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCreated,
-                    () => new EventDefinition<string, int>(
+                    logger,
+                    static logger => new EventDefinition<string, int>(
                         logger.Options,
                         RelationalEventId.CommandCreated,
                         LogLevel.Debug,
@@ -1541,9 +1555,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCreating;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommandCreating,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.CommandCreating,
                         LogLevel.Debug,
@@ -1565,9 +1580,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommandFailed;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommandFailed,
-                    () => new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
                         logger.Options,
                         RelationalEventId.CommandError,
                         LogLevel.Error,
@@ -1589,9 +1605,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommittedTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommittedTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionCommitted,
                         LogLevel.Debug,
@@ -1613,9 +1630,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCommittingTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCommittingTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionCommitting,
                         LogLevel.Debug,
@@ -1637,9 +1655,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionError;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionError,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionError,
                         LogLevel.Error,
@@ -1661,9 +1680,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionErrorAsDebug;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogConnectionErrorAsDebug,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionError,
                         LogLevel.Debug,
@@ -1685,9 +1705,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCreatedTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCreatedTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.CreatedTransactionSavepoint,
                         LogLevel.Debug,
@@ -1709,9 +1730,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogCreatingTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogCreatingTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.CreatingTransactionSavepoint,
                         LogLevel.Debug,
@@ -1733,9 +1755,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingDataReader;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingDataReader,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.DataReaderDisposing,
                         LogLevel.Debug,
@@ -1757,9 +1780,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogDisposingTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionDisposed,
                         LogLevel.Debug,
@@ -1781,9 +1805,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogExecutedCommand;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogExecutedCommand,
-                    () => new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, System.Data.CommandType, int, string, string>(
                         logger.Options,
                         RelationalEventId.CommandExecuted,
                         LogLevel.Information,
@@ -1805,9 +1830,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogExecutingCommand;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogExecutingCommand,
-                    () => new EventDefinition<string, System.Data.CommandType, int, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, System.Data.CommandType, int, string, string>(
                         logger.Options,
                         RelationalEventId.CommandExecuting,
                         LogLevel.Debug,
@@ -1829,9 +1855,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogExplicitTransactionEnlisted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogExplicitTransactionEnlisted,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.ExplicitTransactionEnlisted,
                         LogLevel.Debug,
@@ -1853,9 +1880,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogForeignKeyPropertiesMappedToUnrelatedTables;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogForeignKeyPropertiesMappedToUnrelatedTables,
-                    () => new FallbackEventDefinition(
+                    logger,
+                    static logger => new FallbackEventDefinition(
                         logger.Options,
                         RelationalEventId.ForeignKeyPropertiesMappedToUnrelatedTables,
                         LogLevel.Error,
@@ -1874,9 +1902,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogGeneratingDown;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogGeneratingDown,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationGeneratingDownScript,
                         LogLevel.Debug,
@@ -1898,9 +1927,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogGeneratingUp;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogGeneratingUp,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationGeneratingUpScript,
                         LogLevel.Debug,
@@ -1922,9 +1952,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogKeyHasDefaultValue;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogKeyHasDefaultValue,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ModelValidationKeyDefaultValueWarning,
                         LogLevel.Warning,
@@ -1946,9 +1977,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrating;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrating,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.MigrateUsingConnection,
                         LogLevel.Debug,
@@ -1970,9 +2002,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationAttributeMissingWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogMigrationAttributeMissingWarning,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationAttributeMissingWarning,
                         LogLevel.Warning,
@@ -1994,9 +2027,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogMultipleCollectionIncludeWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogMultipleCollectionIncludeWarning,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.MultipleCollectionIncludeWarning,
                         LogLevel.Warning,
@@ -2018,9 +2052,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexAllPropertiesNotToMappedToAnyTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexAllPropertiesNotToMappedToAnyTable,
-                    () => new EventDefinition<string?, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string?, string, string>(
                         logger.Options,
                         RelationalEventId.AllIndexPropertiesNotToMappedToAnyTable,
                         LogLevel.Information,
@@ -2042,9 +2077,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexPropertiesBothMappedAndNotMappedToTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexPropertiesBothMappedAndNotMappedToTable,
-                    () => new EventDefinition<string?, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string?, string, string, string>(
                         logger.Options,
                         RelationalEventId.IndexPropertiesBothMappedAndNotMappedToTable,
                         LogLevel.Error,
@@ -2066,9 +2102,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexPropertiesMappedToNonOverlappingTables;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogNamedIndexPropertiesMappedToNonOverlappingTables,
-                    () => new FallbackEventDefinition(
+                    logger,
+                    static logger => new FallbackEventDefinition(
                         logger.Options,
                         RelationalEventId.IndexPropertiesMappedToNonOverlappingTables,
                         LogLevel.Error,
@@ -2087,9 +2124,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNoMigrationsApplied;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogNoMigrationsApplied,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.MigrationsNotApplied,
                         LogLevel.Information,
@@ -2111,9 +2149,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogNoMigrationsFound;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogNoMigrationsFound,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationsNotFound,
                         LogLevel.Debug,
@@ -2135,9 +2174,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogOpenedConnection;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogOpenedConnection,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionOpened,
                         LogLevel.Debug,
@@ -2159,9 +2199,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogOpeningConnection;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogOpeningConnection,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.ConnectionOpening,
                         LogLevel.Debug,
@@ -2183,9 +2224,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogPossibleUnintendedUseOfEquals;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogPossibleUnintendedUseOfEquals,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning,
                         LogLevel.Warning,
@@ -2208,9 +2250,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogQueryPossibleExceptionWithAggregateOperatorWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogQueryPossibleExceptionWithAggregateOperatorWarning,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.QueryPossibleExceptionWithAggregateOperatorWarning,
                         LogLevel.Warning,
@@ -2232,9 +2275,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogReleasedTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogReleasedTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.ReleasedTransactionSavepoint,
                         LogLevel.Debug,
@@ -2256,9 +2300,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogReleasingTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogReleasingTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.ReleasingTransactionSavepoint,
                         LogLevel.Debug,
@@ -2280,9 +2325,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogRevertingMigration;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogRevertingMigration,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.MigrationReverting,
                         LogLevel.Information,
@@ -2304,9 +2350,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogRolledBackToTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogRolledBackToTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.RolledBackToTransactionSavepoint,
                         LogLevel.Debug,
@@ -2328,9 +2375,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogRolledBackTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogRolledBackTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionRolledBack,
                         LogLevel.Debug,
@@ -2352,9 +2400,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogRollingBackToTransactionSavepoint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogRollingBackToTransactionSavepoint,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.RollingBackToTransactionSavepoint,
                         LogLevel.Debug,
@@ -2376,9 +2425,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogRollingBackTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogRollingBackTransaction,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionRollingBack,
                         LogLevel.Debug,
@@ -2400,9 +2450,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogTransactionError;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogTransactionError,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         RelationalEventId.TransactionError,
                         LogLevel.Error,
@@ -2424,9 +2475,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexAllPropertiesNotToMappedToAnyTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexAllPropertiesNotToMappedToAnyTable,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         RelationalEventId.AllIndexPropertiesNotToMappedToAnyTable,
                         LogLevel.Information,
@@ -2448,9 +2500,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexPropertiesBothMappedAndNotMappedToTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexPropertiesBothMappedAndNotMappedToTable,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         RelationalEventId.IndexPropertiesBothMappedAndNotMappedToTable,
                         LogLevel.Error,
@@ -2472,9 +2525,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexPropertiesMappedToNonOverlappingTables;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogUnnamedIndexPropertiesMappedToNonOverlappingTables,
-                    () => new EventDefinition<string, string, string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string, string, string>(
                         logger.Options,
                         RelationalEventId.IndexPropertiesMappedToNonOverlappingTables,
                         LogLevel.Error,
@@ -2496,9 +2550,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((RelationalLoggingDefinitions)logger.Definitions).LogUsingTransaction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((RelationalLoggingDefinitions)logger.Definitions).LogUsingTransaction,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         RelationalEventId.TransactionUsed,
                         LogLevel.Debug,

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -259,9 +260,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogByteIdentityColumn;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogByteIdentityColumn,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.ByteIdentityColumnWarning,
                         LogLevel.Warning,
@@ -283,9 +285,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogConflictingValueGenerationStrategies;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogConflictingValueGenerationStrategies,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         SqlServerEventId.ConflictingValueGenerationStrategiesWarning,
                         LogLevel.Warning,
@@ -307,9 +310,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDecimalTypeKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDecimalTypeKey,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.DecimalTypeKeyWarning,
                         LogLevel.Warning,
@@ -331,9 +335,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDefaultDecimalTypeColumn;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogDefaultDecimalTypeColumn,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.DecimalTypeDefaultWarning,
                         LogLevel.Warning,
@@ -355,9 +360,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundColumn;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundColumn,
-                    () => new FallbackEventDefinition(
+                    logger,
+                    static logger => new FallbackEventDefinition(
                         logger.Options,
                         SqlServerEventId.ColumnFound,
                         LogLevel.Debug,
@@ -376,9 +382,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundDefaultSchema;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundDefaultSchema,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqlServerEventId.DefaultSchemaFound,
                         LogLevel.Debug,
@@ -400,9 +407,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundForeignKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundForeignKey,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         SqlServerEventId.ForeignKeyFound,
                         LogLevel.Debug,
@@ -424,9 +432,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundIndex;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundIndex,
-                    () => new EventDefinition<string, string, bool>(
+                    logger,
+                    static logger => new EventDefinition<string, string, bool>(
                         logger.Options,
                         SqlServerEventId.IndexFound,
                         LogLevel.Debug,
@@ -448,9 +457,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundPrimaryKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundPrimaryKey,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.PrimaryKeyFound,
                         LogLevel.Debug,
@@ -472,9 +482,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundSequence;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundSequence,
-                    () => new FallbackEventDefinition(
+                    logger,
+                    static logger => new FallbackEventDefinition(
                         logger.Options,
                         SqlServerEventId.SequenceFound,
                         LogLevel.Debug,
@@ -493,9 +504,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundTable,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqlServerEventId.TableFound,
                         LogLevel.Debug,
@@ -517,9 +529,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundTypeAlias;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundTypeAlias,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.TypeAliasFound,
                         LogLevel.Debug,
@@ -541,9 +554,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundUniqueConstraint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogFoundUniqueConstraint,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.UniqueConstraintFound,
                         LogLevel.Debug,
@@ -565,9 +579,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogMissingSchema;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogMissingSchema,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqlServerEventId.MissingSchemaWarning,
                         LogLevel.Warning,
@@ -589,9 +604,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogMissingTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogMissingTable,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqlServerEventId.MissingTableWarning,
                         LogLevel.Warning,
@@ -613,9 +629,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogPrincipalColumnNotFound;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogPrincipalColumnNotFound,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         SqlServerEventId.ForeignKeyPrincipalColumnMissingWarning,
                         LogLevel.Warning,
@@ -637,9 +654,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogPrincipalTableNotInSelectionSet;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogPrincipalTableNotInSelectionSet,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         SqlServerEventId.ForeignKeyReferencesMissingPrincipalTableWarning,
                         LogLevel.Warning,
@@ -661,9 +679,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogReflexiveConstraintIgnored;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogReflexiveConstraintIgnored,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqlServerEventId.ReflexiveConstraintIgnored,
                         LogLevel.Debug,
@@ -685,9 +704,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
             var definition = ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogSavepointsDisabledBecauseOfMARS;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqlServerLoggingDefinitions)logger.Definitions).LogSavepointsDisabledBecauseOfMARS,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         SqlServerEventId.SavepointsDisabledBecauseOfMARS,
                         LogLevel.Warning,

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -107,9 +108,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogForeignKeyScaffoldErrorPrincipalTableNotFound;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogForeignKeyScaffoldErrorPrincipalTableNotFound,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         SqliteEventId.ForeignKeyReferencesMissingTableWarning,
                         LogLevel.Warning,
@@ -131,9 +133,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundColumn;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundColumn,
-                    () => new EventDefinition<string, string, string, bool, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, bool, string>(
                         logger.Options,
                         SqliteEventId.ColumnFound,
                         LogLevel.Debug,
@@ -155,9 +158,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundForeignKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundForeignKey,
-                    () => new EventDefinition<string, long, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, long, string, string>(
                         logger.Options,
                         SqliteEventId.ForeignKeyFound,
                         LogLevel.Debug,
@@ -179,9 +183,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundIndex;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundIndex,
-                    () => new EventDefinition<string, string, bool?>(
+                    logger,
+                    static logger => new EventDefinition<string, string, bool?>(
                         logger.Options,
                         SqliteEventId.IndexFound,
                         LogLevel.Debug,
@@ -203,9 +208,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundPrimaryKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundPrimaryKey,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqliteEventId.PrimaryKeyFound,
                         LogLevel.Debug,
@@ -227,9 +233,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundTable,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqliteEventId.TableFound,
                         LogLevel.Debug,
@@ -251,9 +258,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundUniqueConstraint;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogFoundUniqueConstraint,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqliteEventId.UniqueConstraintFound,
                         LogLevel.Debug,
@@ -275,9 +283,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogMissingTable;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogMissingTable,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqliteEventId.MissingTableWarning,
                         LogLevel.Warning,
@@ -299,9 +308,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogPrincipalColumnNotFound;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogPrincipalColumnNotFound,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         SqliteEventId.ForeignKeyPrincipalColumnMissingWarning,
                         LogLevel.Warning,
@@ -323,9 +333,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogSchemaConfigured;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogSchemaConfigured,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqliteEventId.SchemaConfiguredWarning,
                         LogLevel.Warning,
@@ -347,9 +358,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogSequenceConfigured;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogSequenceConfigured,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqliteEventId.SequenceConfiguredWarning,
                         LogLevel.Warning,
@@ -371,9 +383,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogTableRebuildPendingWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogTableRebuildPendingWarning,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         SqliteEventId.TableRebuildPendingWarning,
                         LogLevel.Warning,
@@ -395,9 +408,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogUnexpectedConnectionType;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogUnexpectedConnectionType,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         SqliteEventId.UnexpectedConnectionTypeWarning,
                         LogLevel.Warning,
@@ -419,9 +433,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
             var definition = ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogUsingSchemaSelectionsWarning;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((Diagnostics.Internal.SqliteLoggingDefinitions)logger.Definitions).LogUsingSchemaSelectionsWarning,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         SqliteEventId.SchemasNotSupportedWarning,
                         LogLevel.Warning,

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -6,6 +6,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
@@ -1284,6 +1285,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
+        ///     Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context. However the model contains an entity type with the same name in a different namespace: '{entityTypeName}'.
+        /// </summary>
+        public static string InvalidSetSameTypeWithDifferentNamespace([CanBeNull] object? typeName, [CanBeNull] object? entityTypeName)
+            => string.Format(
+                GetString("InvalidSetSameTypeWithDifferentNamespace", nameof(typeName), nameof(entityTypeName)),
+                typeName, entityTypeName);
+
+        /// <summary>
         ///     Cannot create a DbSet for '{typeName}' because it is configured as an shared-type entity type. Access the entity type via the 'Set' method overload that accepts an entity type name.
         /// </summary>
         public static string InvalidSetSharedType([CanBeNull] object? typeName)
@@ -1296,17 +1305,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string InvalidSetType([CanBeNull] object? typeName)
             => string.Format(
-                GetString("InvalidSetType", nameof(typeName)), typeName);
-
-        /// <summary>
-        ///     Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context.
-        ///     entityType : is an '{entityType}' that exist in your DbSets
-        ///     this exception will happen when you are using two types with the same name but the different namespace
-        /// </summary>
-        public static string InvalidSetSameTypeWithDifferentNamespace([CanBeNull] object? typeName, [CanBeNull] string entityTypeName)
-            => string.Format(
-                GetString("InvalidSetSameTypeWithDifferentNamespace", nameof(typeName), nameof(entityTypeName)),
-                typeName, entityTypeName);
+                GetString("InvalidSetType", nameof(typeName)),
+                typeName);
 
         /// <summary>
         ///     Cannot create a DbSet for '{typeName}' because it is configured as an owned entity type and must be accessed through its owning entity type '{ownerType}'.
@@ -2827,9 +2827,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogAmbiguousEndRequired;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogAmbiguousEndRequired,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.AmbiguousEndRequiredWarning,
                         LogLevel.Warning,
@@ -2851,9 +2852,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCascadeDelete;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCascadeDelete,
-                    () => new EventDefinition<string, EntityState, string>(
+                    logger,
+                    static logger => new EventDefinition<string, EntityState, string>(
                         logger.Options,
                         CoreEventId.CascadeDelete,
                         LogLevel.Debug,
@@ -2875,9 +2877,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteOrphan;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteOrphan,
-                    () => new EventDefinition<string, EntityState, string>(
+                    logger,
+                    static logger => new EventDefinition<string, EntityState, string>(
                         logger.Options,
                         CoreEventId.CascadeDeleteOrphan,
                         LogLevel.Debug,
@@ -2899,9 +2902,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteOrphanSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteOrphanSensitive,
-                    () => new EventDefinition<string, string, EntityState, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, EntityState, string>(
                         logger.Options,
                         CoreEventId.CascadeDeleteOrphan,
                         LogLevel.Debug,
@@ -2923,9 +2927,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCascadeDeleteSensitive,
-                    () => new EventDefinition<string, string, EntityState, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, EntityState, string, string>(
                         logger.Options,
                         CoreEventId.CascadeDelete,
                         LogLevel.Debug,
@@ -2947,9 +2952,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCollectionChangeDetected;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCollectionChangeDetected,
-                    () => new EventDefinition<int, int, string, string>(
+                    logger,
+                    static logger => new EventDefinition<int, int, string, string>(
                         logger.Options,
                         CoreEventId.CollectionChangeDetected,
                         LogLevel.Debug,
@@ -2971,9 +2977,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCollectionChangeDetectedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCollectionChangeDetectedSensitive,
-                    () => new EventDefinition<int, int, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<int, int, string, string, string>(
                         logger.Options,
                         CoreEventId.CollectionChangeDetected,
                         LogLevel.Debug,
@@ -2995,9 +3002,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogCollectionWithoutComparer;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogCollectionWithoutComparer,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.CollectionWithoutComparer,
                         LogLevel.Warning,
@@ -3019,9 +3027,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogConflictingForeignKeyAttributesOnNavigationAndProperty;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogConflictingForeignKeyAttributesOnNavigationAndProperty,
-                    () => new EventDefinition<string, string?, string, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string?, string, string?>(
                         logger.Options,
                         CoreEventId.ConflictingForeignKeyAttributesOnNavigationAndPropertyWarning,
                         LogLevel.Warning,
@@ -3043,9 +3052,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogConflictingKeylessAndKeyAttributes;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogConflictingKeylessAndKeyAttributes,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.ConflictingKeylessAndKeyAttributesWarning,
                         LogLevel.Warning,
@@ -3067,9 +3077,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogConflictingShadowForeignKeys;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogConflictingShadowForeignKeys,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.ConflictingShadowForeignKeysWarning,
                         LogLevel.Warning,
@@ -3091,9 +3102,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogContextDisposed;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogContextDisposed,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         CoreEventId.ContextDisposed,
                         LogLevel.Debug,
@@ -3115,9 +3127,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogContextInitialized;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogContextInitialized,
-                    () => new EventDefinition<string, string, string?, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string?, string>(
                         logger.Options,
                         CoreEventId.ContextInitialized,
                         LogLevel.Information,
@@ -3139,9 +3152,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogDetachedLazyLoading;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogDetachedLazyLoading,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.DetachedLazyLoadingWarning,
                         LogLevel.Warning,
@@ -3163,9 +3177,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogDetectChangesCompleted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogDetectChangesCompleted,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         CoreEventId.DetectChangesCompleted,
                         LogLevel.Debug,
@@ -3187,9 +3202,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogDetectChangesStarting;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogDetectChangesStarting,
-                    () => new EventDefinition<string?>(
+                    logger,
+                    static logger => new EventDefinition<string?>(
                         logger.Options,
                         CoreEventId.DetectChangesStarting,
                         LogLevel.Debug,
@@ -3211,9 +3227,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogDuplicateDependentEntityTypeInstance;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogDuplicateDependentEntityTypeInstance,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.DuplicateDependentEntityTypeInstanceWarning,
                         LogLevel.Warning,
@@ -3235,9 +3252,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogExceptionDuringQueryIteration;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogExceptionDuringQueryIteration,
-                    () => new EventDefinition<Type, string, Exception>(
+                    logger,
+                    static logger => new EventDefinition<Type, string, Exception>(
                         logger.Options,
                         CoreEventId.QueryIterationFailed,
                         LogLevel.Error,
@@ -3259,9 +3277,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogExceptionDuringSaveChanges;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogExceptionDuringSaveChanges,
-                    () => new EventDefinition<Type?, string, Exception>(
+                    logger,
+                    static logger => new EventDefinition<Type?, string, Exception>(
                         logger.Options,
                         CoreEventId.SaveChangesFailed,
                         LogLevel.Error,
@@ -3283,9 +3302,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogExecutionStrategyRetrying;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogExecutionStrategyRetrying,
-                    () => new EventDefinition<int, string, Exception>(
+                    logger,
+                    static logger => new EventDefinition<int, string, Exception>(
                         logger.Options,
                         CoreEventId.ExecutionStrategyRetrying,
                         LogLevel.Information,
@@ -3307,9 +3327,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogFirstWithoutOrderByAndFilter;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogFirstWithoutOrderByAndFilter,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.FirstWithoutOrderByAndFilterWarning,
                         LogLevel.Warning,
@@ -3331,9 +3352,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogForeignKeyAttributesOnBothNavigations;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogForeignKeyAttributesOnBothNavigations,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         CoreEventId.ForeignKeyAttributesOnBothNavigationsWarning,
                         LogLevel.Warning,
@@ -3355,9 +3377,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogForeignKeyAttributesOnBothProperties;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogForeignKeyAttributesOnBothProperties,
-                    () => new EventDefinition<string, string?, string, string?, string?, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string?, string, string?, string?, string?>(
                         logger.Options,
                         CoreEventId.ForeignKeyAttributesOnBothPropertiesWarning,
                         LogLevel.Warning,
@@ -3379,9 +3402,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogForeignKeyChangeDetected;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogForeignKeyChangeDetected,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.ForeignKeyChangeDetected,
                         LogLevel.Debug,
@@ -3403,9 +3427,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogForeignKeyChangeDetectedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogForeignKeyChangeDetectedSensitive,
-                    () => new EventDefinition<string, string, object?, object?, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, object?, object?, string>(
                         logger.Options,
                         CoreEventId.ForeignKeyChangeDetected,
                         LogLevel.Debug,
@@ -3427,9 +3452,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogIncompatibleMatchingForeignKeyProperties;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogIncompatibleMatchingForeignKeyProperties,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         CoreEventId.IncompatibleMatchingForeignKeyProperties,
                         LogLevel.Debug,
@@ -3451,9 +3477,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogInvalidIncludePath;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogInvalidIncludePath,
-                    () => new EventDefinition<object, object>(
+                    logger,
+                    static logger => new EventDefinition<object, object>(
                         logger.Options,
                         CoreEventId.InvalidIncludePathError,
                         LogLevel.Error,
@@ -3475,9 +3502,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogLazyLoadOnDisposedContext;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogLazyLoadOnDisposedContext,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.LazyLoadOnDisposedContextWarning,
                         LogLevel.Warning,
@@ -3499,9 +3527,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogManyServiceProvidersCreated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogManyServiceProvidersCreated,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.ManyServiceProvidersCreatedWarning,
                         LogLevel.Warning,
@@ -3523,9 +3552,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogMultipleInversePropertiesSameTarget;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogMultipleInversePropertiesSameTarget,
-                    () => new EventDefinition<string, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string?>(
                         logger.Options,
                         CoreEventId.MultipleInversePropertiesSameTargetWarning,
                         LogLevel.Warning,
@@ -3547,9 +3577,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogMultipleNavigationProperties;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogMultipleNavigationProperties,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         CoreEventId.MultipleNavigationProperties,
                         LogLevel.Debug,
@@ -3571,9 +3602,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogMultiplePrimaryKeyCandidates;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogMultiplePrimaryKeyCandidates,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.MultiplePrimaryKeyCandidates,
                         LogLevel.Debug,
@@ -3595,9 +3627,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNavigationBaseIncluded;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNavigationBaseIncluded,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         CoreEventId.NavigationBaseIncluded,
                         LogLevel.Debug,
@@ -3619,9 +3652,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNavigationLazyLoading;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNavigationLazyLoading,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.NavigationLazyLoading,
                         LogLevel.Debug,
@@ -3644,9 +3678,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNonDefiningInverseNavigation;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNonDefiningInverseNavigation,
-                    () => new EventDefinition<string, string?, string, string?, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string?, string, string?, string?>(
                         logger.Options,
                         CoreEventId.NonDefiningInverseNavigationWarning,
                         LogLevel.Warning,
@@ -3669,9 +3704,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNonNullableInverted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNonNullableInverted,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.NonNullableInverted,
                         LogLevel.Debug,
@@ -3694,9 +3730,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnBothNavigations;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnBothNavigations,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         CoreEventId.NonNullableReferenceOnBothNavigations,
                         LogLevel.Debug,
@@ -3719,9 +3756,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnDependent;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNonNullableReferenceOnDependent,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.NonNullableReferenceOnDependent,
                         LogLevel.Debug,
@@ -3743,9 +3781,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogNonOwnershipInverseNavigation;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogNonOwnershipInverseNavigation,
-                    () => new EventDefinition<string, string?, string, string?, string?>(
+                    logger,
+                    static logger => new EventDefinition<string, string?, string, string?, string?>(
                         logger.Options,
                         CoreEventId.NonOwnershipInverseNavigationWarning,
                         LogLevel.Warning,
@@ -3767,9 +3806,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogOptimisticConcurrencyException;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogOptimisticConcurrencyException,
-                    () => new EventDefinition<Exception>(
+                    logger,
+                    static logger => new EventDefinition<Exception>(
                         logger.Options,
                         CoreEventId.OptimisticConcurrencyException,
                         LogLevel.Debug,
@@ -3791,9 +3831,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning,
                         LogLevel.Warning,
@@ -3815,9 +3856,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogPossibleUnintendedCollectionNavigationNullComparison;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogPossibleUnintendedCollectionNavigationNullComparison,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         CoreEventId.PossibleUnintendedCollectionNavigationNullComparisonWarning,
                         LogLevel.Warning,
@@ -3839,9 +3881,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogPossibleUnintendedReferenceComparison;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogPossibleUnintendedReferenceComparison,
-                    () => new EventDefinition<object, object>(
+                    logger,
+                    static logger => new EventDefinition<object, object>(
                         logger.Options,
                         CoreEventId.PossibleUnintendedReferenceComparisonWarning,
                         LogLevel.Warning,
@@ -3863,9 +3906,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogPropertyChangeDetected;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogPropertyChangeDetected,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.PropertyChangeDetected,
                         LogLevel.Debug,
@@ -3887,9 +3931,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogPropertyChangeDetectedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogPropertyChangeDetectedSensitive,
-                    () => new EventDefinition<string, string, object?, object?, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, object?, object?, string>(
                         logger.Options,
                         CoreEventId.PropertyChangeDetected,
                         LogLevel.Debug,
@@ -3911,9 +3956,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogQueryCompilationStarting;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogQueryCompilationStarting,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.QueryCompilationStarting,
                         LogLevel.Debug,
@@ -3935,9 +3981,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogQueryExecutionPlanned;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogQueryExecutionPlanned,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.QueryExecutionPlanned,
                         LogLevel.Debug,
@@ -3959,9 +4006,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRedundantAddServicesCall;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRedundantAddServicesCall,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.RedundantAddServicesCallWarning,
                         LogLevel.Warning,
@@ -3983,9 +4031,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRedundantForeignKey;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRedundantForeignKey,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.RedundantForeignKeyWarning,
                         LogLevel.Warning,
@@ -4007,9 +4056,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRedundantIndexRemoved;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRedundantIndexRemoved,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.RedundantIndexRemoved,
                         LogLevel.Debug,
@@ -4031,9 +4081,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogReferenceChangeDetected;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogReferenceChangeDetected,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.ReferenceChangeDetected,
                         LogLevel.Debug,
@@ -4055,9 +4106,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogReferenceChangeDetectedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogReferenceChangeDetectedSensitive,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.ReferenceChangeDetected,
                         LogLevel.Debug,
@@ -4080,9 +4132,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeInverted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeInverted,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.RequiredAttributeInverted,
                         LogLevel.Debug,
@@ -4105,9 +4158,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnBothNavigations;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnBothNavigations,
-                    () => new EventDefinition<string, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, string>(
                         logger.Options,
                         CoreEventId.RequiredAttributeOnBothNavigations,
                         LogLevel.Debug,
@@ -4129,9 +4183,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnCollection;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnCollection,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.RequiredAttributeOnCollection,
                         LogLevel.Debug,
@@ -4154,9 +4209,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnDependent;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnDependent,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.RequiredAttributeOnDependent,
                         LogLevel.Error,
@@ -4178,9 +4234,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnSkipNavigation;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRequiredAttributeOnSkipNavigation,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.RequiredAttributeOnSkipNavigation,
                         LogLevel.Debug,
@@ -4202,9 +4259,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogRowLimitingOperationWithoutOrderBy;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogRowLimitingOperationWithoutOrderBy,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.RowLimitingOperationWithoutOrderByWarning,
                         LogLevel.Warning,
@@ -4226,9 +4284,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogSaveChangesCompleted;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogSaveChangesCompleted,
-                    () => new EventDefinition<string?, int>(
+                    logger,
+                    static logger => new EventDefinition<string?, int>(
                         logger.Options,
                         CoreEventId.SaveChangesCompleted,
                         LogLevel.Debug,
@@ -4250,9 +4309,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogSaveChangesStarting;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogSaveChangesStarting,
-                    () => new EventDefinition<string?>(
+                    logger,
+                    static logger => new EventDefinition<string?>(
                         logger.Options,
                         CoreEventId.SaveChangesStarting,
                         LogLevel.Debug,
@@ -4274,9 +4334,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogSensitiveDataLoggingEnabled;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogSensitiveDataLoggingEnabled,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.SensitiveDataLoggingEnabledWarning,
                         LogLevel.Warning,
@@ -4298,9 +4359,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogServiceProviderCreated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogServiceProviderCreated,
-                    () => new EventDefinition(
+                    logger,
+                    static logger => new EventDefinition(
                         logger.Options,
                         CoreEventId.ServiceProviderCreated,
                         LogLevel.Debug,
@@ -4322,9 +4384,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogServiceProviderDebugInfo;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogServiceProviderDebugInfo,
-                    () => new EventDefinition<string>(
+                    logger,
+                    static logger => new EventDefinition<string>(
                         logger.Options,
                         CoreEventId.ServiceProviderDebugInfo,
                         LogLevel.Debug,
@@ -4346,9 +4409,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogShadowPropertyCreated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogShadowPropertyCreated,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.ShadowPropertyCreated,
                         LogLevel.Debug,
@@ -4370,9 +4434,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogSkipCollectionChangeDetected;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogSkipCollectionChangeDetected,
-                    () => new EventDefinition<int, int, string, string>(
+                    logger,
+                    static logger => new EventDefinition<int, int, string, string>(
                         logger.Options,
                         CoreEventId.SkipCollectionChangeDetected,
                         LogLevel.Debug,
@@ -4394,9 +4459,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogSkipCollectionChangeDetectedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogSkipCollectionChangeDetectedSensitive,
-                    () => new EventDefinition<int, int, string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<int, int, string, string, string>(
                         logger.Options,
                         CoreEventId.SkipCollectionChangeDetected,
                         LogLevel.Debug,
@@ -4418,9 +4484,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogStartedTracking;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogStartedTracking,
-                    () => new EventDefinition<string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string>(
                         logger.Options,
                         CoreEventId.StartedTracking,
                         LogLevel.Debug,
@@ -4442,9 +4509,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogStartedTrackingSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogStartedTrackingSensitive,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.StartedTracking,
                         LogLevel.Debug,
@@ -4466,9 +4534,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogStateChanged;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogStateChanged,
-                    () => new EventDefinition<string, string, EntityState, EntityState>(
+                    logger,
+                    static logger => new EventDefinition<string, string, EntityState, EntityState>(
                         logger.Options,
                         CoreEventId.StateChanged,
                         LogLevel.Debug,
@@ -4490,9 +4559,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogStateChangedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogStateChangedSensitive,
-                    () => new EventDefinition<string, string, string, EntityState, EntityState>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string, EntityState, EntityState>(
                         logger.Options,
                         CoreEventId.StateChanged,
                         LogLevel.Debug,
@@ -4514,9 +4584,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogTempValueGenerated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogTempValueGenerated,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.ValueGenerated,
                         LogLevel.Debug,
@@ -4538,9 +4609,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogTempValueGeneratedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogTempValueGeneratedSensitive,
-                    () => new EventDefinition<string, object?, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, object?, string, string>(
                         logger.Options,
                         CoreEventId.ValueGenerated,
                         LogLevel.Debug,
@@ -4562,9 +4634,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogValueGenerated;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogValueGenerated,
-                    () => new EventDefinition<string, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, string, string>(
                         logger.Options,
                         CoreEventId.ValueGenerated,
                         LogLevel.Debug,
@@ -4586,9 +4659,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             var definition = ((LoggingDefinitions)logger.Definitions).LogValueGeneratedSensitive;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((LoggingDefinitions)logger.Definitions).LogValueGeneratedSensitive,
-                    () => new EventDefinition<string, object?, string, string>(
+                    logger,
+                    static logger => new EventDefinition<string, object?, string, string>(
                         logger.Options,
                         CoreEventId.ValueGenerated,
                         LogLevel.Debug,

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -605,14 +605,14 @@
   <data name="InvalidSetKeylessOperation" xml:space="preserve">
     <value>The invoked method cannot be used for the entity type '{entityType}' because it does not have a primary key.</value>
   </data>
+  <data name="InvalidSetSameTypeWithDifferentNamespace" xml:space="preserve">
+    <value>Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context. However the model contains an entity type with the same name in a different namespace: '{entityTypeName}'.</value>
+  </data>
   <data name="InvalidSetSharedType" xml:space="preserve">
     <value>Cannot create a DbSet for '{typeName}' because it is configured as an shared-type entity type. Access the entity type via the 'Set' method overload that accepts an entity type name.</value>
   </data>
   <data name="InvalidSetType" xml:space="preserve">
     <value>Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context.</value>
-  </data>
-  <data name="InvalidSetSameTypeWithDifferentNamespace" xml:space="preserve">
-    <value>Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context. However the model contains an entity type with the same name in a different namespace: '{entityTypeName}'.</value>
   </data>
   <data name="InvalidSetTypeOwned" xml:space="preserve">
     <value>Cannot create a DbSet for '{typeName}' because it is configured as an owned entity type and must be accessed through its owning entity type '{ownerType}'.</value>

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -25,6 +25,7 @@ using System.Resources;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 <#
     }
@@ -172,9 +173,10 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
             var definition = ((<#= model.LoggingDefinitionsClass #>)logger.Definitions).<#= resource.Name #>;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((<#= model.LoggingDefinitionsClass #>)logger.Definitions).<#= resource.Name #>,
-                    () => new FallbackEventDefinition(
+                    logger,
+                    static logger => new FallbackEventDefinition(
                         logger.Options,
                         <#= resource.EventId #>,
                         LogLevel.<#= resource.Level #>,
@@ -201,9 +203,10 @@ namespace <#= model.Namespace.EndsWith(".Internal") ? model.Namespace : (model.N
             var definition = ((<#= model.LoggingDefinitionsClass #>)logger.Definitions).<#= resource.Name #>;
             if (definition == null)
             {
-                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                definition = NonCapturingLazyInitializer.EnsureInitialized(
                     ref ((<#= model.LoggingDefinitionsClass #>)logger.Definitions).<#= resource.Name #>,
-                    () => new EventDefinition<#= genericTypes #>(
+                    logger,
+                    static logger => new EventDefinition<#= genericTypes #>(
                         logger.Options,
                         <#= resource.EventId #>,
                         LogLevel.<#= resource.Level #>,


### PR DESCRIPTION
![LoggingAllocations](https://user-images.githubusercontent.com/1862641/108524695-98a9e580-72cf-11eb-8b73-3ffe32dca285.png)

On a local 30k iteration Fortunes run, allocations were reduced from 2.5M instances (153.21MB) to 2.23M instances (146.99MB) (10% reduction in instances, 4% in bytes).

Interestingly, no discernible effect on RPS throughput at the perf lab. The GC must be doing its job quite well.