### PR TITLE
Recycling relational and ADO.NET objects in query pipeline

### DIFF
--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -120,7 +120,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string ToQueryString()
-            => _relationalQueryContext.RelationalQueryStringFactory.Create(CreateDbCommand());
+        {
+            using var dbCommand = CreateDbCommand();
+            return _relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -160,6 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly bool _detailedErrorsEnabled;
             private readonly IConcurrencyDetector? _concurrencyDetector;
 
+            private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
             private int[]? _indexMap;
 
@@ -224,8 +228,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommand = enumerator._relationalCommandCache.GetRelationalCommand(
+                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
                     enumerator._relationalQueryContext.ParameterValues);
+
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
+                relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
                 enumerator._dataReader = relationalCommand.ExecuteReader(
                     new RelationalCommandParameterObject(
@@ -245,8 +252,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public void Dispose()
             {
-                _dataReader?.Dispose();
-                _dataReader = null;
+                if (_dataReader is not null)
+                {
+                    _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
+                    _dataReader?.Dispose();
+                    _dataReader = null;
+                }
             }
 
             public void Reset()
@@ -265,6 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly bool _detailedErrorsEnabled;
             private readonly IConcurrencyDetector? _concurrencyDetector;
 
+            private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
             private int[]? _indexMap;
 
@@ -331,8 +343,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommand = enumerator._relationalCommandCache.GetRelationalCommand(
+                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
                     enumerator._relationalQueryContext.ParameterValues);
+
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
+                relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
                 enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
@@ -356,6 +371,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (_dataReader != null)
                 {
+                    _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
+
                     var dataReader = _dataReader;
                     _dataReader = null;
 

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -122,7 +122,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual string ToQueryString()
-            => $"{_relationalQueryContext.RelationalQueryStringFactory.Create(CreateDbCommand())}{Environment.NewLine}{Environment.NewLine}{RelationalStrings.SplitQueryString}";
+        {
+            using var dbCommand = CreateDbCommand();
+            return $"{_relationalQueryContext.RelationalQueryStringFactory.Create(dbCommand)}{Environment.NewLine}{Environment.NewLine}{RelationalStrings.SplitQueryString}";
+        }
 
         private sealed class Enumerator : IEnumerator<T>
         {
@@ -136,6 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly bool _detailedErrorsEnabled;
             private readonly IConcurrencyDetector? _concurrencyDetector;
 
+            private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
             private IExecutionStrategy? _executionStrategy;
@@ -212,8 +216,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommand = enumerator._relationalCommandCache.GetRelationalCommand(
+                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
                     enumerator._relationalQueryContext.ParameterValues);
+
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
+                relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
                 enumerator._dataReader = relationalCommand.ExecuteReader(
                     new RelationalCommandParameterObject(
@@ -233,20 +240,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public void Dispose()
             {
-                _dataReader?.Dispose();
-                if (_resultCoordinator != null)
+                if (_dataReader is not null)
                 {
-                    foreach (var dataReader in _resultCoordinator.DataReaders)
+                    _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
+                    _dataReader.Dispose();
+                    if (_resultCoordinator != null)
                     {
-                        dataReader?.DataReader.Dispose();
+                        foreach (var dataReader in _resultCoordinator.DataReaders)
+                        {
+                            dataReader?.DataReader.Dispose();
+                        }
+
+                        _resultCoordinator.DataReaders.Clear();
+
+                        _resultCoordinator = null;
                     }
 
-                    _resultCoordinator.DataReaders.Clear();
-
-                    _resultCoordinator = null;
+                    _dataReader = null;
                 }
-
-                _dataReader = null;
             }
 
             public void Reset()
@@ -265,6 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly bool _detailedErrorEnabled;
             private readonly IConcurrencyDetector? _concurrencyDetector;
 
+            private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
             private IExecutionStrategy? _executionStrategy;
@@ -348,8 +360,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommand = enumerator._relationalCommandCache.GetRelationalCommand(
+                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
                     enumerator._relationalQueryContext.ParameterValues);
+
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
+                relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
                 enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
@@ -373,6 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (_dataReader != null)
                 {
+                    _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                     await _dataReader.DisposeAsync().ConfigureAwait(false);
                     if (_resultCoordinator != null)
                     {

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -1478,14 +1478,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                         var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
 
                         dataReader = await relationalCommand.ExecuteReaderAsync(
-                            new RelationalCommandParameterObject(
-                                queryContext.Connection,
-                                queryContext.ParameterValues,
-                                relationalCommandCache.ReaderColumns,
-                                queryContext.Context,
-                                queryContext.CommandLogger,
-                                detailedErrorsEnabled),
-                            cancellationToken)
+                                new RelationalCommandParameterObject(
+                                    queryContext.Connection,
+                                    queryContext.ParameterValues,
+                                    relationalCommandCache.ReaderColumns,
+                                    queryContext.Context,
+                                    queryContext.CommandLogger,
+                                    detailedErrorsEnabled),
+                                cancellationToken)
                             .ConfigureAwait(false);
 
                         return result;

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -245,7 +245,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 _containsCollectionMaterialization = new CollectionShaperFindingExpressionVisitor()
                     .ContainsCollectionMaterialization(shaperExpression);
-                relatedDataLoaders = null;
 
                 if (!_containsCollectionMaterialization)
                 {
@@ -309,11 +308,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }
                         else
                         {
-                            relatedDataLoaders = Expression.Lambda<Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>>(
-                                Expression.Block(_collectionPopulatingExpressions),
-                                QueryCompilationContext.QueryContextParameter,
-                                _executionStrategyParameter!,
-                                _resultCoordinatorParameter);
+                            relatedDataLoaders =
+                                Expression.Lambda<Action<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator>>(
+                                    Expression.Block(_collectionPopulatingExpressions),
+                                    QueryCompilationContext.QueryContextParameter,
+                                    _executionStrategyParameter!,
+                                    _resultCoordinatorParameter);
                         }
                     }
                     else
@@ -1388,14 +1388,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                     || resultCoordinator.DataReaders[collectionId] == null)
                 {
                     // Execute and fetch data reader
-                    RelationalDataReader? dataReader = null;
-                    executionStrategy.Execute(true, InitializeReader, null);
+                    var dataReader = executionStrategy.Execute(
+                        (queryContext, relationalCommandCache, detailedErrorsEnabled),
+                        ((RelationalQueryContext, RelationalCommandCache, bool) tup) => InitializeReader(tup.Item1, tup.Item2, tup.Item3),
+                        verifySucceeded: null);
 
-                    bool InitializeReader(DbContext _, bool result)
+                    static RelationalDataReader InitializeReader(
+                        RelationalQueryContext queryContext,
+                        RelationalCommandCache relationalCommandCache,
+                        bool detailedErrorsEnabled)
                     {
-                        var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommand = queryContext.Connection.RentCommand();
+                        relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
-                        dataReader = relationalCommand.ExecuteReader(
+                        return relationalCommand.ExecuteReader(
                             new RelationalCommandParameterObject(
                                 queryContext.Connection,
                                 queryContext.ParameterValues,
@@ -1403,11 +1410,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 queryContext.Context,
                                 queryContext.CommandLogger,
                                 detailedErrorsEnabled));
-
-                        return result;
                     }
 
-                    resultCoordinator.SetDataReader(collectionId, dataReader!);
+                    resultCoordinator.SetDataReader(collectionId, dataReader);
                 }
 
                 var splitQueryCollectionContext = resultCoordinator.Collections[collectionId]!;
@@ -1469,15 +1474,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                     || resultCoordinator.DataReaders[collectionId] == null)
                 {
                     // Execute and fetch data reader
-                    RelationalDataReader? dataReader = null;
-                    await executionStrategy.ExecuteAsync(
-                        true, InitializeReaderAsync, null, queryContext.CancellationToken).ConfigureAwait(false);
+                    var dataReader = await executionStrategy.ExecuteAsync(
+                            (queryContext, relationalCommandCache, detailedErrorsEnabled),
+                            ((RelationalQueryContext, RelationalCommandCache, bool) tup, CancellationToken cancellationToken)
+                                => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, cancellationToken),
+                            verifySucceeded: null)
+                        .ConfigureAwait(false);
 
-                    async Task<bool> InitializeReaderAsync(DbContext _, bool result, CancellationToken cancellationToken)
+                    async Task<RelationalDataReader> InitializeReaderAsync(
+                        RelationalQueryContext queryContext,
+                        RelationalCommandCache relationalCommandCache,
+                        bool detailedErrorsEnabled,
+                        CancellationToken cancellationToken)
                     {
-                        var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommand = queryContext.Connection.RentCommand();
+                        relationalCommand.PopulateFromTemplate(relationalCommandTemplate);
 
-                        dataReader = await relationalCommand.ExecuteReaderAsync(
+                        return await relationalCommand.ExecuteReaderAsync(
                                 new RelationalCommandParameterObject(
                                     queryContext.Connection,
                                     queryContext.ParameterValues,
@@ -1487,11 +1501,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     detailedErrorsEnabled),
                                 cancellationToken)
                             .ConfigureAwait(false);
-
-                        return result;
                     }
 
-                    resultCoordinator.SetDataReader(collectionId, dataReader!);
+                    resultCoordinator.SetDataReader(collectionId, dataReader);
                 }
 
                 var splitQueryCollectionContext = resultCoordinator.Collections[collectionId]!;
@@ -1707,14 +1719,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                     || resultCoordinator.DataReaders[collectionId] == null)
                 {
                     // Execute and fetch data reader
-                    RelationalDataReader? dataReader = null;
-                    executionStrategy.Execute(true, InitializeReader, null);
+                    var dataReader = executionStrategy.Execute(
+                        (queryContext, relationalCommandCache, detailedErrorsEnabled),
+                        ((RelationalQueryContext, RelationalCommandCache, bool) tup) => InitializeReader(tup.Item1, tup.Item2, tup.Item3),
+                        verifySucceeded: null);
 
-                    bool InitializeReader(DbContext _, bool result)
+                    static RelationalDataReader InitializeReader(
+                        RelationalQueryContext queryContext,
+                        RelationalCommandCache relationalCommandCache,
+                        bool detailedErrorsEnabled)
                     {
                         var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
 
-                        dataReader = relationalCommand.ExecuteReader(
+                        return relationalCommand.ExecuteReader(
                             new RelationalCommandParameterObject(
                                 queryContext.Connection,
                                 queryContext.ParameterValues,
@@ -1722,11 +1739,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 queryContext.Context,
                                 queryContext.CommandLogger,
                                 detailedErrorsEnabled));
-
-                        return result;
                     }
 
-                    resultCoordinator.SetDataReader(collectionId, dataReader!);
+                    resultCoordinator.SetDataReader(collectionId, dataReader);
                 }
 
                 var splitQueryCollectionContext = resultCoordinator.Collections[collectionId]!;
@@ -1780,15 +1795,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                     || resultCoordinator.DataReaders[collectionId] == null)
                 {
                     // Execute and fetch data reader
-                    RelationalDataReader? dataReader = null;
-                    await executionStrategy.ExecuteAsync(
-                        true, InitializeReaderAsync, null, queryContext.CancellationToken).ConfigureAwait(false);
+                    var dataReader = await executionStrategy.ExecuteAsync(
+                            (queryContext, relationalCommandCache, detailedErrorsEnabled),
+                            ((RelationalQueryContext, RelationalCommandCache, bool) tup, CancellationToken cancellationToken)
+                                => InitializeReaderAsync(tup.Item1, tup.Item2, tup.Item3, cancellationToken),
+                            verifySucceeded: null)
+                        .ConfigureAwait(false);
 
-                    async Task<bool> InitializeReaderAsync(DbContext _, bool result, CancellationToken cancellationToken)
+                    async Task<RelationalDataReader> InitializeReaderAsync(
+                        RelationalQueryContext queryContext,
+                        RelationalCommandCache relationalCommandCache,
+                        bool detailedErrorsEnabled,
+                        CancellationToken cancellationToken)
                     {
                         var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
 
-                        dataReader = await relationalCommand.ExecuteReaderAsync(
+                        return await relationalCommand.ExecuteReaderAsync(
                             new RelationalCommandParameterObject(
                                 queryContext.Connection,
                                 queryContext.ParameterValues,
@@ -1798,11 +1820,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 detailedErrorsEnabled),
                             cancellationToken)
                             .ConfigureAwait(false);
-
-                        return result;
                     }
 
-                    resultCoordinator.SetDataReader(collectionId, dataReader!);
+                    resultCoordinator.SetDataReader(collectionId, dataReader);
                 }
 
                 var splitQueryCollectionContext = resultCoordinator.Collections[collectionId]!;

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 #nullable enable
@@ -111,5 +112,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             RelationalCommandParameterObject parameterObject,
             Guid commandId,
             DbCommandMethod commandMethod);
+
+        /// <summary>
+        ///     Populates this command from the provided <paramref name="templateCommand"/>.
+        /// </summary>
+        /// <param name="templateCommand"> A template command from which the command text and parameters will be copied. </param>
+        void PopulateFromTemplate([NotNull] IRelationalCommand templateCommand);
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/IRelationalConnection.cs
@@ -101,6 +101,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
         Task<bool> CloseAsync();
 
         /// <summary>
+        ///     Rents a relational command that can be executed with this connection.
+        /// </summary>
+        /// <returns> A relational command that can be executed with this connection. </returns>
+        IRelationalCommand RentCommand();
+
+        /// <summary>
+        ///     Returns a relational command to this connection, so that it can be reused in the future.
+        /// </summary>
+        void ReturnCommand([NotNull] IRelationalCommand command);
+
+        /// <summary>
         ///     Gets the current transaction.
         /// </summary>
         new IDbContextTransaction? CurrentTransaction { get; }

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -27,6 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
     /// </summary>
     public class RelationalCommand : IRelationalCommand
     {
+        private readonly RelationalDataReader _relationalReader;
+        private readonly Stopwatch _stopwatch = new();
+
         /// <summary>
         ///     <para>
         ///         Constructs a new <see cref="RelationalCommand" />.
@@ -51,6 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Dependencies = dependencies;
             CommandText = commandText;
             Parameters = parameters;
+
+            _relationalReader = CreateRelationalDataReader();
         }
 
         /// <summary>
@@ -61,12 +66,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the command text to be executed.
         /// </summary>
-        public virtual string CommandText { get; }
+        public virtual string CommandText { get; private set; }
 
         /// <summary>
         ///     Gets the parameters for the command.
         /// </summary>
-        public virtual IReadOnlyList<IRelationalParameter> Parameters { get; }
+        public virtual IReadOnlyList<IRelationalParameter> Parameters { get; private set; }
 
         /// <summary>
         ///     Executes the command with no results.
@@ -83,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             connection.Open();
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
             try
             {
                 var interceptionResult = logger?.CommandNonQueryExecuting(
@@ -107,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         connection.ConnectionId,
                         nonQueryResult,
                         startTime,
-                        stopwatch.Elapsed)
+                        _stopwatch.Elapsed)
                     ?? nonQueryResult;
             }
             catch (Exception exception)
@@ -121,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    stopwatch.Elapsed);
+                    _stopwatch.Elapsed);
 
                 throw;
             }
@@ -170,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
             try
             {
                 var interceptionResult = logger == null
@@ -199,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             result,
                             startTime,
-                            stopwatch.Elapsed,
+                            _stopwatch.Elapsed,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -219,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            stopwatch.Elapsed,
+                            _stopwatch.Elapsed,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -247,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             connection.Open();
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
             try
             {
                 var interceptionResult = logger?.CommandScalarExecuting(
@@ -271,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         connection.ConnectionId,
                         result,
                         startTime,
-                        stopwatch.Elapsed)
+                        _stopwatch.Elapsed)
                     ?? result;
             }
             catch (Exception exception)
@@ -285,7 +290,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    stopwatch.Elapsed);
+                    _stopwatch.Elapsed);
 
                 throw;
             }
@@ -316,7 +321,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
 
             try
             {
@@ -346,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         connection.ConnectionId,
                         result,
                         startTime,
-                        stopwatch.Elapsed,
+                        _stopwatch.Elapsed,
                         cancellationToken).ConfigureAwait(false);
                 }
 
@@ -365,7 +370,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            stopwatch.Elapsed,
+                            _stopwatch.Elapsed,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -397,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             connection.Open();
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
 
             var readerOpen = false;
             DbDataReader reader;
@@ -426,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         connection.ConnectionId,
                         reader,
                         startTime,
-                        stopwatch.Elapsed);
+                        _stopwatch.Elapsed);
                 }
             }
             catch (Exception exception)
@@ -440,7 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    stopwatch.Elapsed);
+                    _stopwatch.Elapsed);
 
                 CleanupCommand(command, connection);
 
@@ -454,16 +459,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     reader = new BufferedDataReader(reader, detailedErrorsEnabled).Initialize(readerColumns);
                 }
 
-                var result = CreateRelationalDataReader(
-                    connection,
-                    command,
-                    reader,
-                    commandId,
-                    logger);
+                _relationalReader.Initialize(parameterObject.Connection, command, reader, commandId, logger);
 
                 readerOpen = true;
 
-                return result;
+                return _relationalReader;
             }
             finally
             {
@@ -499,7 +499,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
 
             var readerOpen = false;
             DbDataReader reader;
@@ -531,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             reader,
                             startTime,
-                            stopwatch.Elapsed,
+                            _stopwatch.Elapsed,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -549,7 +549,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            stopwatch.Elapsed,
+                            _stopwatch.Elapsed,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -567,17 +567,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         .ConfigureAwait(false);
                 }
 
-                var result = CreateRelationalDataReader(
-                    connection,
-                    command,
-                    reader,
-                    commandId,
-                    logger);
+                _relationalReader.Initialize(parameterObject.Connection, command, reader, commandId, logger);
 
                 readerOpen = true;
 
-                return result;
-
+                return _relationalReader;
             }
             finally
             {
@@ -612,7 +606,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var connectionId = connection.ConnectionId;
 
             var startTime = DateTimeOffset.UtcNow;
-            var stopwatch = Stopwatch.StartNew();
+            _stopwatch.Restart();
 
             var interceptionResult = logger?.CommandCreating(connection, commandMethod, context, commandId, connectionId, startTime)
                 ?? default;
@@ -624,7 +618,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             if (logger != null)
             {
                 command = logger.CommandCreated(
-                    connection, command, commandMethod, context, commandId, connectionId, startTime, stopwatch.Elapsed);
+                    connection, command, commandMethod, context, commandId, connectionId, startTime, _stopwatch.Elapsed);
             }
 
             command.CommandText = CommandText;
@@ -660,28 +654,27 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         /// <summary>
         ///     <para>
-        ///         Creates a new <see cref="RelationalDataReader" /> to be used by <see cref="ExecuteReader" /> and <see cref="ExecuteReaderAsync" />.
+        ///         Creates a new <see cref="RelationalDataReader" /> to be used by <see cref="ExecuteReader" /> and
+        ///         <see cref="ExecuteReaderAsync" />. The returned <see cref="RelationalDataReader" /> may get used more for multiple
+        ///         queries, and will be re-initialized each time via <see cref="RelationalDataReader.Initialize" />.
         ///     </para>
         ///     <para>
         ///         This method is typically used by database providers (and other extensions). It is generally
         ///         not used in application code.
         ///     </para>
         /// </summary>
-        /// <param name="connection">The connection, to pass to the <see cref="RelationalDataReader" /> constructor.</param>
-        /// <param name="command">The command that was executed, to pass to the <see cref="RelationalDataReader" /> constructor.</param>
-        /// <param name="reader">The underlying reader for the result set, to pass to the <see cref="RelationalDataReader" /> constructor.</param>
-        /// <param name="commandId">
-        ///     A correlation ID that identifies the <see cref="DbCommand" /> instance being used, to pass to the
-        ///     <see cref="RelationalDataReader" /> constructor.
-        /// </param>
-        /// <param name="logger">The diagnostic source, to pass to the <see cref="RelationalDataReader" /> constructor.</param>
         /// <returns>The created <see cref="RelationalDataReader" />.</returns>
-        protected virtual RelationalDataReader CreateRelationalDataReader(
-            [NotNull] IRelationalConnection connection,
-            [NotNull] DbCommand command,
-            [NotNull] DbDataReader reader,
-            Guid commandId,
-            [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command>? logger)
-            => new(connection, command, reader, commandId, logger);
+        protected virtual RelationalDataReader CreateRelationalDataReader()
+             => new(this);
+
+        /// <summary>
+        ///     Populates this command from the provided <paramref name="templateCommand"/>.
+        /// </summary>
+        /// <param name="templateCommand"> A template command from which the command text and parameters will be copied. </param>
+        public virtual void PopulateFromTemplate(IRelationalCommand templateCommand)
+        {
+            CommandText = templateCommand.CommandText;
+            Parameters = templateCommand.Parameters;
+        }
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -63,7 +63,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger,
             [NotNull] INamedConnectionStringResolver connectionStringResolver,
             [NotNull] IRelationalTransactionFactory relationalTransactionFactory,
-            [NotNull] ICurrentDbContext currentContext)
+            [NotNull] ICurrentDbContext currentContext,
+            [NotNull] IRelationalCommandBuilderFactory relationalCommandBuilderFactory)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
             Check.NotNull(transactionLogger, nameof(transactionLogger));
@@ -71,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(connectionStringResolver, nameof(connectionStringResolver));
             Check.NotNull(relationalTransactionFactory, nameof(relationalTransactionFactory));
             Check.NotNull(currentContext, nameof(currentContext));
+            Check.NotNull(relationalCommandBuilderFactory, nameof(relationalCommandBuilderFactory));
 
             ContextOptions = contextOptions;
             TransactionLogger = transactionLogger;
@@ -78,6 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             ConnectionStringResolver = connectionStringResolver;
             RelationalTransactionFactory = relationalTransactionFactory;
             CurrentContext = currentContext;
+            RelationalCommandBuilderFactory = relationalCommandBuilderFactory;
         }
 
         /// <summary>
@@ -110,5 +113,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Contains the <see cref="DbContext" /> instance currently in use.
         /// </summary>
         public ICurrentDbContext CurrentContext { get; [param: NotNull] init; }
+
+        /// <summary>
+        ///     Contains the <see cref="DbContext" /> instance currently in use.
+        /// </summary>
+        public IRelationalCommandBuilderFactory RelationalCommandBuilderFactory { get; [param: NotNull] init; }
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -25,13 +25,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
     /// </summary>
     public class RelationalDataReader : IDisposable, IAsyncDisposable
     {
-        private readonly IRelationalConnection _connection;
-        private readonly DbCommand _command;
-        private readonly DbDataReader _reader;
-        private readonly Guid _commandId;
-        private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command>? _logger;
-        private readonly DateTimeOffset _startTime;
-        private readonly Stopwatch _stopwatch;
+        private readonly IRelationalCommand _relationalCommand;
+
+        private IRelationalConnection _relationalConnection = default!;
+        private DbCommand _command = default!;
+        private DbDataReader _reader = default!;
+        private Guid _commandId;
+        private IDiagnosticsLogger<DbLoggerCategory.Database.Command>? _logger;
+        private DateTimeOffset _startTime;
+        private readonly Stopwatch _stopwatch = new();
 
         private int _readCount;
 
@@ -40,29 +42,40 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Initializes a new instance of the <see cref="RelationalDataReader" /> class.
         /// </summary>
-        /// <param name="connection"> The connection. </param>
+        /// <param name="relationalCommand"> The relational command which owns this relational reader. </param>
+        public RelationalDataReader([NotNull] IRelationalCommand relationalCommand)
+        {
+            Check.NotNull(relationalCommand, nameof(relationalCommand));
+
+            _relationalCommand = relationalCommand;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalDataReader" /> class.
+        /// </summary>
+        /// <param name="relationalConnection"> The relational connection. </param>
         /// <param name="command"> The command that was executed. </param>
         /// <param name="reader"> The underlying reader for the result set. </param>
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="logger"> The diagnostic source. </param>
-        public RelationalDataReader(
-            [NotNull] IRelationalConnection connection,
+        public virtual void Initialize(
+            [NotNull] IRelationalConnection relationalConnection,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
             Guid commandId,
             [CanBeNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command>? logger)
         {
-            Check.NotNull(connection, nameof(connection));
             Check.NotNull(command, nameof(command));
             Check.NotNull(reader, nameof(reader));
 
-            _connection = connection;
+            _relationalConnection = relationalConnection;
             _command = command;
             _reader = reader;
             _commandId = commandId;
             _logger = logger;
             _startTime = DateTimeOffset.UtcNow;
-            _stopwatch = Stopwatch.StartNew();
+            _disposed = false;
+            _stopwatch.Restart();
         }
 
         /// <summary>
@@ -115,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     if (_logger != null)
                     {
                         interceptionResult = _logger.DataReaderDisposing(
-                            _connection,
+                            _relationalConnection,
                             _command,
                             _reader,
                             _commandId,
@@ -134,7 +147,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         _reader.Dispose();
                         _command.Parameters.Clear();
                         _command.Dispose();
-                        _connection.Close();
+                        _relationalConnection.Close();
                     }
                 }
             }
@@ -150,12 +163,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 var interceptionResult = default(InterceptionResult);
                 try
                 {
-                    _reader.Close(); // can throw
+                    await _reader.CloseAsync().ConfigureAwait(false); // can throw
 
                     if (_logger != null)
                     {
                         interceptionResult = _logger.DataReaderDisposing(
-                            _connection,
+                            _relationalConnection,
                             _command,
                             _reader,
                             _commandId,
@@ -174,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         await _reader.DisposeAsync().ConfigureAwait(false);
                         _command.Parameters.Clear();
                         await _command.DisposeAsync().ConfigureAwait(false);
-                        await _connection.CloseAsync().ConfigureAwait(false);
+                        await _relationalConnection.CloseAsync().ConfigureAwait(false);
                     }
                 }
             }

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -256,6 +256,12 @@ namespace Microsoft.EntityFrameworkCore
 
             public ValueTask DisposeAsync()
                 => throw new NotImplementedException();
+
+            public IRelationalCommand RentCommand()
+                => throw new NotImplementedException();
+
+            public void ReturnCommand(IRelationalCommand command)
+                => throw new NotImplementedException();
         }
 
         private class FakeDbConnection : DbConnection

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -40,7 +40,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new RelationalTransactionFactoryDependencies(
                             new RelationalSqlGenerationHelper(
                                 new RelationalSqlGenerationHelperDependencies()))),
-                    new CurrentDbContext(new FakeDbContext())))
+                    new CurrentDbContext(new FakeDbContext()),
+                    new RelationalCommandBuilderFactory(
+                        new RelationalCommandBuilderDependencies(
+                            new TestRelationalTypeMappingSource(
+                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))))
         {
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -207,7 +207,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
+
+            public void PopulateFromTemplate(IRelationalCommand templateCommand)
+                => _realRelationalCommand.PopulateFromTemplate(templateCommand);
 
             private int? PreExecution(IRelationalConnection connection)
             {

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -85,7 +86,12 @@ namespace Microsoft.EntityFrameworkCore
                     new RelationalTransactionFactoryDependencies(
                         new RelationalSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()))),
-                new CurrentDbContext(new FakeDbContext()));
+                new CurrentDbContext(new FakeDbContext()),
+                new RelationalCommandBuilderFactory(
+                    new RelationalCommandBuilderDependencies(
+                        new TestRelationalTypeMappingSource(
+                            TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                            TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()))));
         }
 
         private class FakeDbContext : DbContext

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -292,6 +292,9 @@ namespace Microsoft.EntityFrameworkCore
                 RelationalCommandParameterObject parameterObject,
                 CancellationToken cancellationToken = default)
                 => throw new NotImplementedException();
+
+            public void PopulateFromTemplate(IRelationalCommand templateCommand)
+                => throw new NotImplementedException();
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -280,6 +280,9 @@ namespace Microsoft.EntityFrameworkCore
 
                 public DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
                     => throw new NotImplementedException();
+
+                public void PopulateFromTemplate(IRelationalCommand templateCommand)
+                    => throw new NotImplementedException();
             }
         }
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -157,7 +157,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 private class BadDataRelationalCommand : RelationalCommand
                 {
-                    private readonly object[] _values;
+                    private object[] _values;
 
                     public BadDataRelationalCommand(
                         RelationalCommandBuilderDependencies dependencies,
@@ -173,162 +173,92 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         var command = parameterObject.Connection.DbConnection.CreateCommand();
                         command.CommandText = CommandText;
-                        return new BadDataRelationalDataReader(
+                        var reader = new BadDataRelationalDataReader(this);
+                        reader.Initialize(
+                            new FakeConnection(),
                             command,
-                            _values,
+                            new BadDataDataReader(_values),
+                            Guid.NewGuid(),
                             parameterObject.Logger);
+                        return reader;
+                    }
+
+                    public override void PopulateFromTemplate(IRelationalCommand templateCommand)
+                    {
+                        base.PopulateFromTemplate(templateCommand);
+                        _values = ((BadDataRelationalCommand)templateCommand)._values;
                     }
 
                     private class BadDataRelationalDataReader : RelationalDataReader
                     {
-                        public BadDataRelationalDataReader(
-                            DbCommand command,
-                            object[] values,
-                            IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
-                            : base(new FakeConnection(), command, new BadDataDataReader(values), Guid.NewGuid(), logger)
+                        public BadDataRelationalDataReader(BadDataRelationalCommand relationalCommand)
+                            : base(relationalCommand)
                         {
                         }
+                    }
 
-                        private class BadDataDataReader : DbDataReader
+                    private class BadDataDataReader : DbDataReader
+                    {
+                        private readonly object[] _values;
+
+                        public BadDataDataReader(object[] values)
                         {
-                            private readonly object[] _values;
-
-                            public BadDataDataReader(object[] values)
-                            {
-                                _values = values;
-                            }
-
-                            public override bool Read()
-                                => true;
-
-                            public override bool IsDBNull(int ordinal)
-                                => false;
-
-                            public override int GetInt32(int ordinal)
-                                => (int)GetValue(ordinal);
-
-                            public override short GetInt16(int ordinal)
-                                => (short)GetValue(ordinal);
-
-                            public override bool GetBoolean(int ordinal)
-                                => (bool)GetValue(ordinal);
-
-                            public override string GetString(int ordinal)
-                                => (string)GetValue(ordinal);
-
-                            public override object GetValue(int ordinal)
-                                => _values[ordinal];
-
-                            #region NotImplemented members
-
-                            public override string GetName(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override int GetValues(object[] values)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override int FieldCount
-                                => throw new NotImplementedException();
-
-                            public override object this[int ordinal]
-                                => throw new NotImplementedException();
-
-                            public override object this[string name]
-                                => throw new NotImplementedException();
-
-                            public override bool HasRows
-                                => throw new NotImplementedException();
-
-                            public override bool IsClosed
-                                => throw new NotImplementedException();
-
-                            public override int RecordsAffected
-                                => 0;
-
-                            public override bool NextResult()
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override int Depth
-                                => throw new NotImplementedException();
-
-                            public override int GetOrdinal(string name)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override byte GetByte(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override char GetChar(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override Guid GetGuid(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override long GetInt64(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override DateTime GetDateTime(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override decimal GetDecimal(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override double GetDouble(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override float GetFloat(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override string GetDataTypeName(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override Type GetFieldType(int ordinal)
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            public override IEnumerator GetEnumerator()
-                            {
-                                throw new NotImplementedException();
-                            }
-
-                            #endregion
+                            _values = values;
                         }
+
+                        public override bool Read()
+                            => true;
+
+                        public override bool IsDBNull(int ordinal)
+                            => false;
+
+                        public override int GetInt32(int ordinal)
+                            => (int)GetValue(ordinal);
+
+                        public override short GetInt16(int ordinal)
+                            => (short)GetValue(ordinal);
+
+                        public override bool GetBoolean(int ordinal)
+                            => (bool)GetValue(ordinal);
+
+                        public override string GetString(int ordinal)
+                            => (string)GetValue(ordinal);
+
+                        public override object GetValue(int ordinal)
+                            => _values[ordinal];
+
+                        #region NotImplemented members
+
+                        public override string GetName(int ordinal) => throw new NotImplementedException();
+                        public override int GetValues(object[] values) => throw new NotImplementedException();
+                        public override int FieldCount => throw new NotImplementedException();
+                        public override object this[int ordinal] => throw new NotImplementedException();
+                        public override object this[string name] => throw new NotImplementedException();
+                        public override bool HasRows => throw new NotImplementedException();
+                        public override bool IsClosed => throw new NotImplementedException();
+                        public override int RecordsAffected => 0;
+                        public override bool NextResult() => throw new NotImplementedException();
+                        public override int Depth => throw new NotImplementedException();
+                        public override int GetOrdinal(string name) => throw new NotImplementedException();
+                        public override byte GetByte(int ordinal) => throw new NotImplementedException();
+                        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+                            => throw new NotImplementedException();
+
+                        public override char GetChar(int ordinal) => throw new NotImplementedException();
+                        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+                            => throw new NotImplementedException();
+
+                        public override Guid GetGuid(int ordinal) => throw new NotImplementedException();
+                        public override long GetInt64(int ordinal) => throw new NotImplementedException();
+                        public override DateTime GetDateTime(int ordinal) => throw new NotImplementedException();
+                        public override decimal GetDecimal(int ordinal) => throw new NotImplementedException();
+                        public override double GetDouble(int ordinal) => throw new NotImplementedException();
+                        public override float GetFloat(int ordinal) => throw new NotImplementedException();
+                        public override string GetDataTypeName(int ordinal) => throw new NotImplementedException();
+                        public override Type GetFieldType(int ordinal) => throw new NotImplementedException();
+                        public override IEnumerator GetEnumerator() => throw new NotImplementedException();
+
+                        #endregion
                     }
                 }
             }
@@ -420,6 +350,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 DbTransaction transaction,
                 Guid transactionId,
                 CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+
+            public IRelationalCommand RentCommand()
+                => throw new NotImplementedException();
+
+            public void ReturnCommand(IRelationalCommand command)
                 => throw new NotImplementedException();
 
             public void Dispose()


### PR DESCRIPTION
Reduces query allocations by around 10% (both instance numbers and total bytes).

This causes the following to be recycled:

* All the stopwatches
* RelationalCommand
* RelationalDataReader
* DbConnection

... plus various other tidbits.

* DbCommand (and dependencies) is notably excluded since I plan to implement that at the ADO layer (cache inside NpgsqlConnection).
* I can also do RelationalTransaction in a later PR.

@AndriySvyryd @smitpatel would be good to get your eyes on this, some touchy changes.

See #24206