### PR TITLE
Allow providers to override ambient transaction access

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosTransactionManager.cs
@@ -79,6 +79,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual Transaction CurrentAmbientTransaction
+            => null;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IDbContextTransaction CurrentTransaction
             => null;
 

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -183,6 +183,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     The current ambient transaction. Defaults to <see cref="Transaction.Current" />.
+        /// </summary>
+        public virtual Transaction? CurrentAmbientTransaction => Transaction.Current;
+
+        /// <summary>
         ///     Gets the current transaction.
         /// </summary>
         public virtual IDbContextTransaction? CurrentTransaction { get; [param: CanBeNull] protected set; }
@@ -397,7 +402,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 throw new InvalidOperationException(RelationalStrings.TransactionAlreadyStarted);
             }
 
-            if (Transaction.Current != null)
+            if (CurrentAmbientTransaction != null)
             {
                 throw new InvalidOperationException(RelationalStrings.ConflictingAmbientTransaction);
             }
@@ -748,7 +753,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private void HandleAmbientTransactions()
         {
-            var current = Transaction.Current;
+            var current = CurrentAmbientTransaction;
 
             if (current == null)
             {

--- a/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EFCore.Relational/Update/Internal/BatchExecutor.cs
@@ -76,10 +76,11 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             var createdSavepoint = false;
             try
             {
+                var transactionEnlistManager = connection as ITransactionEnlistmentManager;
                 if (transaction == null
-                    && (connection as ITransactionEnlistmentManager)?.EnlistedTransaction == null
-                    && Transaction.Current == null
-                    && CurrentContext.Context.Database.AutoTransactionsEnabled)
+                        && transactionEnlistManager?.EnlistedTransaction is null
+                        && transactionEnlistManager?.CurrentAmbientTransaction is null
+                        && CurrentContext.Context.Database.AutoTransactionsEnabled)
                 {
                     transaction = connection.BeginTransaction();
                     beganTransaction = true;
@@ -170,9 +171,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             var createdSavepoint = false;
             try
             {
+                var transactionEnlistManager = connection as ITransactionEnlistmentManager;
                 if (transaction == null
-                    && (connection as ITransactionEnlistmentManager)?.EnlistedTransaction == null
-                    && Transaction.Current == null
+                    && transactionEnlistManager?.EnlistedTransaction is null
+                    && transactionEnlistManager?.CurrentAmbientTransaction is null
                     && CurrentContext.Context.Database.AutoTransactionsEnabled)
                 {
                     transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -328,9 +328,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual void OnFirstExecution()
         {
-            if (Dependencies.CurrentContext.Context.Database.CurrentTransaction != null
-                || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() != null
-                || Transaction.Current != null)
+            if (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
+                || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
+                || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies.TransactionManager as
+                    ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null)
             {
                 throw new InvalidOperationException(
                     CoreStrings.ExecutionStrategyExistingTransaction(

--- a/src/EFCore/Storage/ITransactionEnlistmentManager.cs
+++ b/src/EFCore/Storage/ITransactionEnlistmentManager.cs
@@ -20,6 +20,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public interface ITransactionEnlistmentManager
     {
         /// <summary>
+        ///     The current ambient transaction. Defaults to <see cref="Transaction.Current" />.
+        /// </summary>
+        Transaction? CurrentAmbientTransaction => Transaction.Current;
+
+        /// <summary>
         ///     The currently enlisted transaction.
         /// </summary>
         Transaction? EnlistedTransaction { get; }


### PR DESCRIPTION
Accessing `Transaction.Current` (in HandleAmbientTransactions) is a heavy operation - profiling shows it to take around 0.3% of the total running time.

Npgsql has connection string parameter to disable this check at the ADO level. Allowing providers to override HandleAmbientTransactions would allow EFCore.PG to skip this if the parameter is set.

HandleAmbientTransactions isn't a great name for a publicly-exposed method, but I don't really have anything better...