### PR TITLE
[release/5.0] Warn for walking back up the Include tree

### DIFF
--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -70,6 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             InvalidIncludePathError,
             QueryCompilationStarting,
             NavigationBaseIncluded,
+            NavigationBaseIncludeIgnored,
 
             // Infrastructure events
             SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
@@ -249,6 +250,20 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static readonly EventId NavigationBaseIncluded
             = MakeQueryId(Id.NavigationBaseIncluded);
+
+        /// <summary>
+        ///     <para>
+        ///         A navigation base specific in Include in the query was ignored because it will be populated already due to fix-up.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Query" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="NavigationBaseEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NavigationBaseIncludeIgnored
+            = MakeQueryId(Id.NavigationBaseIncludeIgnored);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -417,6 +417,40 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         /// <summary>
+        ///     Logs for the <see cref="CoreEventId.NavigationBaseIncludeIgnored" /> event.
+        /// </summary>
+        /// <param name="diagnostics"> The diagnostics logger to use. </param>
+        /// <param name="navigation"> The navigation being included. </param>
+        public static void NavigationBaseIncludeIgnored(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Query> diagnostics,
+            [NotNull] INavigationBase navigation)
+        {
+            var definition = CoreResources.LogNavigationBaseIncludeIgnored(diagnostics);
+
+            if (diagnostics.ShouldLog(definition))
+            {
+                definition.Log(diagnostics, navigation.DeclaringEntityType.ShortName() + "." + navigation.Name);
+            }
+
+            if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+            {
+                var eventData = new NavigationBaseEventData(
+                    definition,
+                    NavigationBaseIncludeIgnored,
+                    navigation);
+
+                diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+            }
+        }
+
+        private static string NavigationBaseIncludeIgnored(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string>)definition;
+            var p = (NavigationBaseEventData)payload;
+            return d.GenerateMessage(p.NavigationBase.DeclaringEntityType.ShortName() + "." + p.NavigationBase.Name);
+        }
+
+        /// <summary>
         ///     Logs for the <see cref="CoreEventId.QueryExecutionPlanned" /> event.
         /// </summary>
         /// <param name="diagnostics"> The diagnostics logger to use. </param>

--- a/src/EFCore/Diagnostics/LoggingDefinitions.cs
+++ b/src/EFCore/Diagnostics/LoggingDefinitions.cs
@@ -696,6 +696,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         [EntityFrameworkInternal]
+        public EventDefinitionBase LogNavigationBaseIncludeIgnored;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
         public EventDefinitionBase LogQueryCompilationStarting;
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -3550,6 +3550,30 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
+        ///     The navigation '{navigation}' was ignored from 'Include' in the query since the fix-up will automatically populate it. If any further navigations are specified in 'Include' afterwards then they will be ignored. Walking back include tree is not allowed.
+        /// </summary>
+        public static EventDefinition<string> LogNavigationBaseIncludeIgnored([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((LoggingDefinitions)logger.Definitions).LogNavigationBaseIncludeIgnored;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((LoggingDefinitions)logger.Definitions).LogNavigationBaseIncludeIgnored,
+                    () => new EventDefinition<string>(
+                        logger.Options,
+                        CoreEventId.NavigationBaseIncludeIgnored,
+                        LogLevel.Warning,
+                        "CoreEventId.NavigationBaseIncludeIgnored",
+                        level => LoggerMessage.Define<string>(
+                            level,
+                            CoreEventId.NavigationBaseIncludeIgnored,
+                            _resourceManager.GetString("LogNavigationBaseIncludeIgnored"))));
+            }
+
+            return (EventDefinition<string>)definition;
+        }
+
+        /// <summary>
         ///     The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.
         /// </summary>
         public static EventDefinition<string, string> LogNavigationLazyLoading([NotNull] IDiagnosticsLogger logger)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -792,6 +792,10 @@
     <value>Including navigation: '{navigation}'.</value>
     <comment>Debug CoreEventId.NavigationBaseIncluded string</comment>
   </data>
+  <data name="LogNavigationBaseIncludeIgnored" xml:space="preserve">
+    <value>The navigation '{navigation}' was ignored from 'Include' in the query since the fix-up will automatically populate it. If any further navigations are specified in 'Include' afterwards then they will be ignored. Walking back include tree is not allowed.</value>
+    <comment>Warning CoreEventId.NavigationBaseIncludeIgnored string</comment>
+  </data>
   <data name="LogNavigationLazyLoading" xml:space="preserve">
     <value>The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.</value>
     <comment>Debug CoreEventId.NavigationLazyLoading string string</comment>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -687,9 +687,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         && previousNavigation?.Inverse == navigationBase)
                     {
                         // This skips one-to-one navigations which are pointing to each other.
-                        if (!navigationBase.IsEagerLoaded)
+                        if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23674", out var enabled)
+                            && enabled))
                         {
-                            _logger.NavigationBaseIncludeIgnored(navigationBase);
+                            if (!navigationBase.IsEagerLoaded)
+                            {
+                                _logger.NavigationBaseIncludeIgnored(navigationBase);
+                            }
                         }
 
                         continue;
@@ -744,10 +748,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             {
                                 // This skips inverse navigation of a collection navigation if they are pointing to each other.
                                 // Not a skip navigation
-                                if (innerEntityReference.IncludePaths.ContainsKey(inverseNavigation)
-                                    && !inverseNavigation.IsEagerLoaded)
+                                if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue23674", out var enabled)
+                                    && enabled))
                                 {
-                                    _logger.NavigationBaseIncludeIgnored(inverseNavigation);
+                                    if (innerEntityReference.IncludePaths.ContainsKey(inverseNavigation)
+                                    && !inverseNavigation.IsEagerLoaded)
+                                    {
+                                        _logger.NavigationBaseIncludeIgnored(inverseNavigation);
+                                    }
                                 }
 
                                 innerEntityReference.IncludePaths.Remove(inverseNavigation);


### PR DESCRIPTION
Resolves #23674

**Description**

When walking up the include tree to add more navigations, includes are walk back paths are dropped. 

**Customer Impact**

Customers who wrote query by walking back include tree will not get results included. Earlier this was incorrect results from relationship fixup. Now it won't give results to user what they would expect. The scenario is negative case and should be blocked but currently silently ignored without informing user of possible error.

**How found**

Reported by a customer.

**Test coverage**

Test coverage for this case has been added in this PR.

**Regression?**

No.

**Risk**

Low. This code has good test coverage for all possible variations. It also adds only a warning message.