### PR TITLE
[release/3.1] Clear disabled package sources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,7 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
+    <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-corefx -->
     <!--  End: Package sources from dotnet-corefx -->


### PR DESCRIPTION
- remove remaining way user NuGet.config can infect builds