### PR TITLE
[release/5.0] Don't compare values from different keys for deleted entities

### DIFF
--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -625,14 +625,14 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             }
         }
 
-        private static void AddMatchingPredecessorEdge(
-            Dictionary<IKeyValueIndex, List<ModificationCommand>> predecessorsMap,
-            IKeyValueIndex dependentKeyValue,
+        private static void AddMatchingPredecessorEdge<T>(
+            Dictionary<T, List<ModificationCommand>> predecessorsMap,
+            T keyValue,
             Multigraph<ModificationCommand, IAnnotatable> commandGraph,
             ModificationCommand command,
             IAnnotatable edge)
         {
-            if (predecessorsMap.TryGetValue(dependentKeyValue, out var predecessorCommands))
+            if (predecessorsMap.TryGetValue(keyValue, out var predecessorCommands))
             {
                 foreach (var predecessor in predecessorCommands)
                 {
@@ -647,7 +647,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         private void AddUniqueValueEdges(Multigraph<ModificationCommand, IAnnotatable> commandGraph)
         {
             Dictionary<IIndex, Dictionary<object[], ModificationCommand>> indexPredecessorsMap = null;
-            var keyPredecessorsMap = new Dictionary<IKeyValueIndex, List<ModificationCommand>>();
+            var keyPredecessorsMap = new Dictionary<(IKey, IKeyValueIndex), List<ModificationCommand>>();
             foreach (var command in commandGraph.Vertices)
             {
                 if (command.EntityState != EntityState.Modified
@@ -697,10 +697,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                         if (principalKeyValue != null)
                         {
-                            if (!keyPredecessorsMap.TryGetValue(principalKeyValue, out var predecessorCommands))
+                            if (!keyPredecessorsMap.TryGetValue((key, principalKeyValue), out var predecessorCommands))
                             {
                                 predecessorCommands = new List<ModificationCommand>();
-                                keyPredecessorsMap.Add(principalKeyValue, predecessorCommands);
+                                keyPredecessorsMap.Add((key, principalKeyValue), predecessorCommands);
                             }
 
                             predecessorCommands.Add(command);
@@ -761,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             if (principalKeyValue != null)
                             {
                                 AddMatchingPredecessorEdge(
-                                    keyPredecessorsMap, principalKeyValue, commandGraph, command, key);
+                                    keyPredecessorsMap, (key, principalKeyValue), commandGraph, command, key);
                             }
                         }
                     }

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -697,10 +697,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
                         if (principalKeyValue != null)
                         {
-                            if (!keyPredecessorsMap.TryGetValue((key, principalKeyValue), out var predecessorCommands))
+                            if (!keyPredecessorsMap.TryGetValue((GetKey(key), principalKeyValue), out var predecessorCommands))
                             {
                                 predecessorCommands = new List<ModificationCommand>();
-                                keyPredecessorsMap.Add((key, principalKeyValue), predecessorCommands);
+                                keyPredecessorsMap.Add((GetKey(key), principalKeyValue), predecessorCommands);
                             }
 
                             predecessorCommands.Add(command);
@@ -761,12 +761,18 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                             if (principalKeyValue != null)
                             {
                                 AddMatchingPredecessorEdge(
-                                    keyPredecessorsMap, (key, principalKeyValue), commandGraph, command, key);
+                                    keyPredecessorsMap, (GetKey(key), principalKeyValue), commandGraph, command, key);
                             }
                         }
                     }
                 }
             }
         }
+
+        private static readonly bool _useOldKeyComparison =
+            AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue24221", out var enabled) && enabled;
+
+        private IKey GetKey(IKey key)
+            => _useOldKeyComparison ? null : key;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -330,6 +330,70 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public async Task Can_add_and_remove_entities_with_keys_of_different_type()
+        {
+            using var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName);
+
+            var options = Fixture.CreateOptions(testDatabase);
+            using (var context = new CompositeKeysDbContext(options))
+            {
+                context.Database.EnsureCreatedResiliently();
+                var first = new Int32CompositeKeys
+                {
+                    Id1 = 1, Id2 = 2
+                };
+
+                context.Add(first);
+
+                var second = new Int64CompositeKeys
+                {
+                    Id1 = 1,
+                    Id2 = 2
+                };
+
+                context.Add(second);
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new CompositeKeysDbContext(options))
+            {
+                var first = context.Set<Int32CompositeKeys>().Single();
+                context.Remove(first);
+
+                var second = context.Set<Int64CompositeKeys>().Single();
+                context.Remove(second);
+
+                await context.SaveChangesAsync();
+            }
+        }
+
+        private class CompositeKeysDbContext : DbContext
+        {
+            public CompositeKeysDbContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Int32CompositeKeys>().HasKey(i => new { i.Id1, i.Id2 });
+                modelBuilder.Entity<Int64CompositeKeys>().HasKey(l => new { l.Id1, l.Id2 });
+            }
+        }
+
+        private class Int32CompositeKeys
+        {
+            public int Id1 { get; set; }
+            public int Id2 { get; set; }
+        }
+
+        private class Int64CompositeKeys
+        {
+            public long Id1 { get; set; }
+            public long Id2 { get; set; }
+        }
+
+        [ConditionalFact]
         public void Can_insert_non_owner_principal_for_owned()
         {
             using var testDatabase = SqlServerTestStore.CreateInitialized(DatabaseName);


### PR DESCRIPTION
Fixes #24221

**Description**

An exception is thrown when comparing key values of different types for deleted entities. This code was added in 5.0.0 to delete the entities in the correct order relative to inserted entities.

**Customer Impact**

Deleting entities with different key types always throws an exception, and this is a fairly common scenario.
A workaround would be to delete entities one by one, but this isn't possible in all scenarios.

**How found**

Reported by a customer.

**Test coverage**

Test coverage for this case has been added in this PR.

**Regression?**

Yes, from EF Core 3.1.

**Risk**

Low. This code has good test coverage aside from the above scenario. Also quirked.
