### PR TITLE
Cosmos: Add translator for Substring method which map to SUBSTRING built-in functions

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -54,6 +54,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         private static readonly MethodInfo _trimMethodInfoWithCharArrayArg
             = typeof(string).GetRequiredRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) });
 
+        private static readonly MethodInfo _substringMethodInfo
+            = typeof(string).GetRequiredRuntimeMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) });
+
         private static readonly MethodInfo _firstOrDefaultMethodInfoWithoutArgs
             = typeof(Enumerable).GetRuntimeMethods().Single(
                 m => m.Name == nameof(Enumerable.FirstOrDefault)
@@ -154,6 +157,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         && ((arguments[0] as SqlConstantExpression)?.Value as Array)?.Length == 0))
                 {
                     return TranslateSystemFunction("TRIM", method.ReturnType, instance);
+                }
+
+                if (_substringMethodInfo.Equals(method))
+                {
+                    return TranslateSystemFunction("SUBSTRING", method.ReturnType, instance, arguments[0], arguments[1]);
                 }
             }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -750,7 +750,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Substring_with_zero_startindex(async);
 
             AssertSql(
-                @"SELECT c[""ContactName""]
+                @"SELECT SUBSTRING(c[""ContactName""], 0, 3) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
@@ -760,7 +760,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Substring_with_zero_length(async);
 
             AssertSql(
-                @"SELECT c[""ContactName""]
+                @"SELECT SUBSTRING(c[""ContactName""], 2, 0) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
@@ -770,7 +770,7 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Substring_with_constant(async);
 
             AssertSql(
-                @"SELECT c[""ContactName""]
+                @"SELECT SUBSTRING(c[""ContactName""], 1, 3) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }
@@ -780,7 +780,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")
             await base.Substring_with_closure(async);
 
             AssertSql(
-                @"SELECT c[""ContactName""]
+                @"@__start_0='2'
+
+SELECT SUBSTRING(c[""ContactName""], @__start_0, 3) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
         }

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindWhereQueryCosmosTest.cs
@@ -1016,7 +1016,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_string_substring(bool async)
         {
             await base.Where_string_substring(async);
@@ -1024,7 +1023,7 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""Customer"")");
+WHERE ((c[""Discriminator""] = ""Customer"") AND (SUBSTRING(c[""City""], 1, 2) = ""ea""))");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]


### PR DESCRIPTION
Add translator for `string.Substring()`

Issue #16143

Please review.
Thank you in advance