### PR TITLE
Fix to #22049 - Query: consider updating select expression identifiers when projecting a subset of column and adding distinct

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -769,12 +769,26 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, missingColumn, table);
 
         /// <summary>
-        ///     Unable to translate a collection subquery in a projection since it uses 'Distinct' or 'Group By' operations and doesn't project key columns of all tables required to generate results on the client side. Missing column: {column}. Either add column(s) to the projection or rewrite the query to not use the 'GroupBy'/'Distinct' operation.
+        ///     Subquery with 'Distinct' can only be translated if projection consists only of entities and their properties, or it contains keys of all entities required to generate results on the client side. Either add '{column}' to the projection, remove complex elements of the projection, or rewrite the query to not use the 'Distinct' operation.
         /// </summary>
-        public static string MissingIdentifyingProjectionInDistinctGroupBySubquery([CanBeNull] object? column)
+        public static string UnableToTranslateSubqueryWithDistinct([CanBeNull] object? column)
             => string.Format(
-                GetString("MissingIdentifyingProjectionInDistinctGroupBySubquery", nameof(column)),
+                GetString("UnableToTranslateSubqueryWithDistinct", nameof(column)),
                 column);
+
+        /// <summary>
+        ///     Subquery with 'GroupBy' can only be translated if grouping key consists only of entities and their properties, or it contains keys of all entities required to generate results on the client side. Either add '{column}' to the grouping key, remove complex elements of the grouping key, or rewrite the query to not use the 'GroupBy' operation.
+        /// </summary>
+        public static string UnableToTranslateSubqueryWithGroupBy([CanBeNull] object? column)
+            => string.Format(
+                GetString("UnableToTranslateSubqueryWithGroupBy", nameof(column)),
+                column);
+
+        /// <summary>
+        ///     Using 'Distinct' operation on a projection containing a collection is not supported.
+        /// </summary>
+        public static string DistinctOnCollectionNotSupported
+            => GetString("DistinctOnCollectionNotSupported");
 
         /// <summary>
         ///     'Reverse' could not be translated to the server because there is no ordering on the server side.

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -621,8 +621,14 @@
   <data name="MissingConcurrencyColumn" xml:space="preserve">
     <value>Entity type '{entityType}' doesn't contain a property mapped to the store-generated concurrency token column '{missingColumn}' which is used by another entity type sharing the table '{table}'. Add a store-generated property to '{entityType}' which is mapped to the same column; it may be in shadow state.</value>
   </data>
-  <data name="MissingIdentifyingProjectionInDistinctGroupBySubquery" xml:space="preserve">
-    <value>Unable to translate a collection subquery in a projection since it uses 'Distinct' or 'Group By' operations and doesn't project key columns of all tables required to generate results on the client side. Missing column: {column}. Either add column(s) to the projection or rewrite the query to not use the 'GroupBy'/'Distinct' operation.</value>
+  <data name="UnableToTranslateSubqueryWithDistinct" xml:space="preserve">
+    <value>Subquery with 'Distinct' can only be translated if projection consists only of entities and their properties, or it contains keys of all entities required to generate results on the client side. Either add '{column}' to the projection, remove complex elements of the projection, or rewrite the query to not use the 'Distinct' operation.</value>
+  </data>
+  <data name="UnableToTranslateSubqueryWithGroupBy" xml:space="preserve">
+    <value>Subquery with 'GroupBy' can only be translated if grouping key consists only of entities and their properties, or it contains keys of all entities required to generate results on the client side. Either add '{column}' to the grouping key, remove complex elements of the grouping key, or rewrite the query to not use the 'GroupBy' operation.</value>
+  </data>
+  <data name="DistinctOnCollectionNotSupported" xml:space="preserve">
+    <value>Using 'Distinct' operation on a projection containing a collection is not supported.</value>
   </data>
   <data name="MissingOrderingInSelectExpression" xml:space="preserve">
     <value>'Reverse' could not be translated to the server because there is no ordering on the server side.</value>

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -429,6 +429,34 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             return AddToProjection(sqlExpression, null);
         }
 
+        /// <summary>
+        ///     Adds given <see cref="EntityProjectionExpression" /> to the projection.
+        /// </summary>
+        /// <param name="entityProjection"> An entity projection to add. </param>
+        /// <returns> A dictionary of <see cref="IProperty" /> to int indicating properties and their corresponding indexes in the projection list. </returns>
+        public IDictionary<IProperty, int> AddToProjection([NotNull] EntityProjectionExpression entityProjection)
+        {
+            Check.NotNull(entityProjection, nameof(entityProjection));
+
+            if (!_entityProjectionCache.TryGetValue(entityProjection, out var dictionary))
+            {
+                dictionary = new Dictionary<IProperty, int>();
+                foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
+                {
+                    dictionary[property] = AddToProjection(entityProjection.BindProperty(property));
+                }
+
+                if (entityProjection.DiscriminatorExpression != null)
+                {
+                    AddToProjection(entityProjection.DiscriminatorExpression, DiscriminatorColumnAlias);
+                }
+
+                _entityProjectionCache[entityProjection] = dictionary;
+            }
+
+            return dictionary;
+        }
+
         private int AddToProjection(SqlExpression sqlExpression, string? alias)
         {
             var existingIndex = _projection.FindIndex(pe => pe.Expression.Equals(sqlExpression));
@@ -457,34 +485,6 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             _projection.Add(new ProjectionExpression(sqlExpression, baseAlias ?? ""));
 
             return _projection.Count - 1;
-        }
-
-        /// <summary>
-        ///     Adds given <see cref="EntityProjectionExpression" /> to the projection.
-        /// </summary>
-        /// <param name="entityProjection"> An entity projection to add. </param>
-        /// <returns> A dictionary of <see cref="IProperty" /> to int indicating properties and their corresponding indexes in the projection list. </returns>
-        public IDictionary<IProperty, int> AddToProjection([NotNull] EntityProjectionExpression entityProjection)
-        {
-            Check.NotNull(entityProjection, nameof(entityProjection));
-
-            if (!_entityProjectionCache.TryGetValue(entityProjection, out var dictionary))
-            {
-                dictionary = new Dictionary<IProperty, int>();
-                foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
-                {
-                    dictionary[property] = AddToProjection(entityProjection.BindProperty(property));
-                }
-
-                if (entityProjection.DiscriminatorExpression != null)
-                {
-                    AddToProjection(entityProjection.DiscriminatorExpression, DiscriminatorColumnAlias);
-                }
-
-                _entityProjectionCache[entityProjection] = dictionary;
-            }
-
-            return dictionary;
         }
 
         /// <summary>
@@ -699,6 +699,11 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         /// </summary>
         public void ApplyDistinct()
         {
+            if (_pendingCollections.Count > 0)
+            {
+                throw new InvalidOperationException(RelationalStrings.DistinctOnCollectionNotSupported);
+            }
+
             if (Limit != null
                 || Offset != null)
             {
@@ -1040,6 +1045,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         private ColumnExpression GenerateOuterColumn(SqlExpression projection, string? alias = null)
         {
             var index = AddToProjection(projection, alias);
+
             return new ColumnExpression(_projection[index], this);
         }
 
@@ -1101,6 +1107,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
             var identifiers = _identifier.ToList();
             _identifier.Clear();
 
+            var projectionMapValues = projectionMap.Select(p => p.Value);
             foreach (var identifier in identifiers)
             {
                 if (projectionMap.TryGetValue(identifier.Column, out var outerColumn))
@@ -1119,6 +1126,20 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                     // if we can't propagate any identifier - clear them all instead
                     // when adding collection join we detect this and throw appropriate exception
                     _identifier.Clear();
+
+                    if (IsDistinct
+                        && projectionMapValues.All(x => x is ColumnExpression))
+                    {
+                        // for distinct try to use entire projection as identifiers
+                        _identifier.AddRange(projectionMapValues.Select(x => ((ColumnExpression)x, x.TypeMapping!.Comparer)));
+                    }
+                    else if (GroupBy.Count > 0
+                        && GroupBy.All(x => x is ColumnExpression))
+                    {
+                        // for group by try to use grouping key as identifiers
+                        _identifier.AddRange(GroupBy.Select(x => ((ColumnExpression)x, x.TypeMapping!.Comparer)));
+                    }
+
                     break;
                 }
             }
@@ -1409,7 +1430,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 var parentIdentifier = GetIdentifierAccessor(identifierFromParent).Item1;
                 innerSelectExpression.ApplyProjection();
 
-                ValidateIdentifyingProjection(innerSelectExpression);
+                RemapIdentifiers(innerSelectExpression);
 
                 for (var i = 0; i < identifierFromParent.Count; i++)
                 {
@@ -1511,7 +1532,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 var innerClientEval = innerSelectExpression.Projection.Count > 0;
                 innerSelectExpression.ApplyProjection();
 
-                ValidateIdentifyingProjection(innerSelectExpression);
+                RemapIdentifiers(innerSelectExpression);
 
                 if (collectionIndex == 0)
                 {
@@ -1635,23 +1656,76 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                 return result;
             }
 
-            static void ValidateIdentifyingProjection(SelectExpression selectExpression)
+            static void RemapIdentifiers(SelectExpression innerSelectExpression)
             {
-                if (selectExpression.IsDistinct
-                    || selectExpression.GroupBy.Count > 0)
+                if (innerSelectExpression.IsDistinct
+                    || innerSelectExpression.GroupBy.Count > 0)
                 {
-                    var innerSelectProjectionExpressions = selectExpression._projection.Select(p => p.Expression).ToList();
-                    foreach (var innerSelectIdentifier in selectExpression._identifier)
+                    if (!IdentifiersInProjection(innerSelectExpression, out var missingIdentifier))
                     {
-                        if (!innerSelectProjectionExpressions.Contains(innerSelectIdentifier.Column)
-                            && (selectExpression.GroupBy.Count == 0
-                                || !selectExpression.GroupBy.Contains(innerSelectIdentifier.Column)))
+                        // we can safely clear identifiers here - child identifiers will always be empty at this point
+                        // - nested collection scenarios where distinct is applied after projection are blocked
+                        //   since we can't translate them in any meaningful way
+                        // - if distinct is applied before the projection, pushdown happens which guarantees child identifiers to be empty
+                        // - for groupby we only support aggregate scenarios so collection can never happen in the projection
+                        if (innerSelectExpression.IsDistinct)
                         {
-                            throw new InvalidOperationException(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery(
-                                innerSelectIdentifier.Column.Table.Alias + "." + innerSelectIdentifier.Column.Name));
+                            if (innerSelectExpression._projection.All(p => p.Expression is ColumnExpression))
+                            {
+                                innerSelectExpression._identifier.Clear();
+                                foreach (var projection in innerSelectExpression._projection)
+                                {
+                                    innerSelectExpression._identifier.Add(((ColumnExpression)projection.Expression, projection.Expression.TypeMapping!.Comparer));
+                                }
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException(
+                                    RelationalStrings.UnableToTranslateSubqueryWithDistinct(
+                                        missingIdentifier.Table.Alias + "." + missingIdentifier.Name));
+                            }
+                        }
+                        else
+                        {
+                            if (innerSelectExpression.GroupBy.All(g => g is ColumnExpression))
+                            {
+                                innerSelectExpression._identifier.Clear();
+                                foreach (var grouping in innerSelectExpression.GroupBy)
+                                {
+                                    innerSelectExpression._identifier.Add(((ColumnExpression)grouping, grouping.TypeMapping!.Comparer));
+                                }
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException(
+                                    RelationalStrings.UnableToTranslateSubqueryWithGroupBy(
+                                        missingIdentifier.Table.Alias + "." + missingIdentifier.Name));
+                            }
                         }
                     }
                 }
+            }
+
+            static bool IdentifiersInProjection(
+                SelectExpression selectExpression,
+                [CA.NotNullWhen(false)] out ColumnExpression? missingIdentifier)
+            {
+                var innerSelectProjectionExpressions = selectExpression._projection.Select(p => p.Expression).ToList();
+                foreach (var innerSelectIdentifier in selectExpression._identifier)
+                {
+                    if (!innerSelectProjectionExpressions.Contains(innerSelectIdentifier.Column)
+                        && (selectExpression.GroupBy.Count == 0
+                            || !selectExpression.GroupBy.Contains(innerSelectIdentifier.Column)))
+                    {
+                        missingIdentifier = innerSelectIdentifier.Column;
+
+                        return false;
+                    }
+                }
+
+                missingIdentifier = null;
+
+                return true;
             }
         }
 
@@ -1709,12 +1783,78 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                     joinPredicate = RemoveRedundantNullChecks(joinPredicate, columnExpressions);
                 }
 
+                // we can't convert apply to join in case of distinct and groupby, if the projection doesn't already contain the join keys
+                // since we can't add the missing keys to the projection - only convert to join if all the keys are already there
+                if (joinPredicate != null
+                    && (selectExpression.IsDistinct
+                    || selectExpression.GroupBy.Count > 0))
+                {
+                    var innerKeyColumns = new List<ColumnExpression>();
+                    InnerKeyColumns(selectExpression.Tables, joinPredicate, innerKeyColumns);
+
+                    // if projection has already been applied we can use it directly
+                    // otherwise we extract future projection columns from projection mapping
+                    // and based on that we determine whether we can convert from APPLY to JOIN
+                    var projectionColumns = selectExpression.Projection.Count > 0
+                        ? selectExpression.Projection.Select(p => p.Expression)
+                        : ExtractColumnsFromProjectionMapping(selectExpression._projectionMapping);
+
+                    foreach (var innerColumn in innerKeyColumns)
+                    {
+                        if (!projectionColumns.Contains(innerColumn))
+                        {
+                            return null;
+                        }
+                    }
+                }
+
                 selectExpression.Predicate = predicate;
 
                 return joinPredicate;
             }
 
             return null;
+
+            static void InnerKeyColumns(IEnumerable<TableExpressionBase> tables, SqlExpression joinPredicate, List<ColumnExpression> resultColumns)
+            {
+                if (joinPredicate is SqlBinaryExpression sqlBinaryExpression)
+                {
+                    InnerKeyColumns(tables, sqlBinaryExpression.Left, resultColumns);
+                    InnerKeyColumns(tables, sqlBinaryExpression.Right, resultColumns);
+                }
+                else if (joinPredicate is ColumnExpression columnExpression
+                    && tables.Contains(columnExpression.Table))
+                {
+                    resultColumns.Add(columnExpression);
+                }
+            }
+
+            static List<ColumnExpression> ExtractColumnsFromProjectionMapping(IDictionary<ProjectionMember, Expression> projectionMapping)
+            {
+                var result = new List<ColumnExpression>();
+                foreach (var mappingElement in projectionMapping)
+                {
+                    if (mappingElement.Value is EntityProjectionExpression entityProjection)
+                    {
+                        foreach (var property in GetAllPropertiesInHierarchy(entityProjection.EntityType))
+                        {
+                            result.Add(entityProjection.BindProperty(property));
+                        }
+
+                        if (entityProjection.DiscriminatorExpression != null
+                            && entityProjection.DiscriminatorExpression is ColumnExpression discriminatorColumn)
+                        {
+                            result.Add(discriminatorColumn);
+                        }
+                    }
+                    else if (mappingElement.Value is ColumnExpression column)
+                    {
+                        result.Add(column);
+                    }
+                }
+
+                return result;
+            }
         }
 
         private SqlExpression? TryExtractJoinKey(

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindMiscellaneousQueryCosmosTest.cs
@@ -4222,6 +4222,24 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] IN (""ALFKI"
                 CoreStrings.QueryUnableToTranslateStringEqualsWithStringComparison);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Select_nested_collection_with_distinct(bool async)
+        {
+            return base.Select_nested_collection_with_distinct(async);
+        }
+        
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(bool async)
+        {
+            return base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(bool async)
+        {
+            return base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1143,12 +1143,34 @@ ORDER BY c[""CustomerID""]");
             return base.Projecting_multiple_collection_with_same_constant_works(async);
         }
 
-        [ConditionalTheory(Skip = "Issue#17246")]
-        public override async Task Projecting_after_navigation_and_distinct_throws(bool isAsync)
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Projecting_after_navigation_and_distinct(bool async)
         {
-            await base.Projecting_after_navigation_and_distinct_throws(isAsync);
+            return base.Projecting_after_navigation_and_distinct(async);
+        }
 
-            AssertSql(" ");
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
+        {
+            return base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
+        {
+            return base.Correlated_collection_after_distinct_not_containing_original_identifier(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            return base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
+        {
+            return base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async);
         }
 
         public override Task Reverse_without_explicit_ordering(bool async)
@@ -1231,6 +1253,18 @@ OFFSET 0 LIMIT @__p_0");
         public override Task Do_not_erase_projection_mapping_when_adding_single_projection(bool async)
         {
             return base.Do_not_erase_projection_mapping_when_adding_single_projection(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
+        {
+            return base.Select_nested_collection_deep_distinct_no_identifiers(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            return base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async);
         }
 
         public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -52,5 +52,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalTheory(Skip = "issue #19584")]
         public override Task Cast_to_derived_followed_by_include_and_FirstOrDefault(bool async)
             => base.Cast_to_derived_followed_by_include_and_FirstOrDefault(async);
+
+        [ConditionalTheory(Skip = "issue #24325")]
+        public override Task Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(bool async)
+            => base.Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(async);
+
+        [ConditionalTheory(Skip = "issue #24325")]
+        public override Task Projecting_entity_as_well_as_complex_correlated_collection_followed_by_Distinct(bool async)
+            => base.Projecting_entity_as_well_as_complex_correlated_collection_followed_by_Distinct(async);
+
+        [ConditionalTheory(Skip = "issue #24325")]
+        public override Task Projecting_entity_as_well_as_correlated_collection_of_scalars_followed_by_Distinct(bool async)
+            => base.Projecting_entity_as_well_as_correlated_collection_of_scalars_followed_by_Distinct(async);
+
+        [ConditionalTheory(Skip = "issue #24325")]
+        public override Task Correlated_collection_with_distinct_3_levels(bool async)
+            => base.Correlated_collection_with_distinct_3_levels(async);
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
@@ -24,5 +24,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Join_GroupBy_Aggregate_with_left_join(async);
         }
+
+        [ConditionalTheory(Skip = "Issue#24324")]
+        public override Task Complex_query_with_groupBy_in_subquery4(bool async)
+        {
+            return base.Complex_query_with_groupBy_in_subquery4(async);
+        }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindMiscellaneousQueryInMemoryTest.cs
@@ -65,6 +65,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Client_code_using_instance_method_throws()
             => base.Client_code_using_instance_method_throws();
 
+        [ConditionalTheory(Skip = "Issue#24291")]
+        public override Task Select_nested_collection_with_distinct(bool async)
+            => base.Select_nested_collection_with_distinct(async);
+
         public override async Task Max_on_empty_sequence_throws(bool async)
         {
             using var context = CreateContext();

--- a/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalTestBase.cs
@@ -21,37 +21,22 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Correlated_collection_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+        public override async Task Correlated_collection_with_groupby_with_complex_grouping_key_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                async,
-                ss => ss.Set<Gear>()
-                    .OrderBy(g => g.Nickname)
-                    .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.BornGears)
-                    .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList())))).Message;
+                  () => base.Correlated_collection_with_groupby_with_complex_grouping_key_not_projecting_identifier_column_with_group_aggregate_in_final_projection(async))).Message;
 
-            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("w.Id"), message);
+            Assert.Equal(RelationalStrings.UnableToTranslateSubqueryWithGroupBy("w.Id"), message);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Correlated_collection_with_GroupBy_missing_indentifying_columns_in_projection(bool async)
+        public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(bool async)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                async,
-                ss => ss.Set<Mission>()
-                    .Select(m => new
-                    {
-                        m.Id,
-                        grouping = m.ParticipatingSquads
-                            .Select(ps => ps.SquadId)
-                            .GroupBy(s => s)
-                            .Select(g => new { g.Key, Count = g.Count() })
-                    })))).Message;
+                  () => base.Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(async))).Message;
 
-            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("s.MissionId"), message);
+            Assert.Equal(RelationalStrings.UnableToTranslateSubqueryWithDistinct("w.Id"), message);
         }
 
         public override async Task Client_eval_followed_by_aggregate_operation(bool async)
@@ -138,6 +123,66 @@ namespace Microsoft.EntityFrameworkCore.Query
                 async,
                 ss => ss.Set<LocustLeader>().OfType<LocustCommander>().Select(ll => new { ll.Name, Discriminator = EF.Property<string>(ll, "Discriminator") }),
                 elementSorter: e => e.Name);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Projecting_correlated_collection_followed_by_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_correlated_collection_followed_by_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Projecting_some_properties_as_well_as_correlated_collection_followed_by_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_some_properties_as_well_as_correlated_collection_followed_by_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Projecting_entity_as_well_as_complex_correlated_collection_followed_by_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_entity_as_well_as_complex_correlated_collection_followed_by_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Projecting_entity_as_well_as_correlated_collection_of_scalars_followed_by_Distinct(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Projecting_entity_as_well_as_correlated_collection_of_scalars_followed_by_Distinct(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Correlated_collection_with_distinct_3_levels(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Correlated_collection_with_distinct_3_levels(async))).Message;
+
+            Assert.Equal(RelationalStrings.DistinctOnCollectionNotSupported, message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -21,77 +19,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+        public override async Task Complex_query_with_groupBy_in_subquery4(bool async)
         {
             var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                async,
-                ss => ss.Set<Order>()
-                    .Where(c => c.CustomerID.StartsWith("A"))
-                    .Select(c => c.Customer.City)
-                    .Distinct()
-                    .Select(c => new
-                    {
-                        c1 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Key).ToArray(),
-                        c2 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Count()).ToArray()
-                    }),
-                assertOrder: true,
-                elementAsserter: (e, a) =>
-                {
-                    AssertCollection(e.c1, a.c1);
-                    AssertCollection(e.c2, a.c2);
-                }))).Message;
+                () => base.Complex_query_with_groupBy_in_subquery4(async))).Message;
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
-        }
-
-
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Complex_query_with_groupBy_in_subquery4(bool async)
-        {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                async,
-                ss => ss.Set<Customer>()
-                    .Select(
-                        c => new
-                        {
-                            Key = c.CustomerID,
-                            Subquery = c.Orders
-                                .Select(o => new { First = o.OrderID, Second = o.Customer.City + o.CustomerID })
-                                .GroupBy(x => x.Second)
-                                .Select(g => new { Sum = g.Sum(x => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
-                        }),
-                elementSorter: e => e.Key,
-                elementAsserter: (e, a) =>
-                {
-                    Assert.Equal(e.Key, a.Key);
-                    AssertCollection(e.Subquery, a.Subquery);
-                }))).Message;
-
-            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("o.OrderID"), message);
-        }
-
-
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual async Task Select_nested_collection_with_distinct(bool async)
-        {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => AssertQuery(
-                async,
-                ss => ss.Set<Customer>()
-                    .OrderBy(c => c.CustomerID)
-                    .Where(c => c.CustomerID.StartsWith("A"))
-                    .Select(
-                        c => c.Orders.Any()
-                            ? c.Orders.Select(o => o.CustomerID).Distinct().ToArray()
-                            : Array.Empty<string>()),
-                assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection(e, a)))).Message;
-
-            Assert.Equal(RelationalStrings.MissingIdentifyingProjectionInDistinctGroupBySubquery("o.OrderID"), message);
+            Assert.Equal(RelationalStrings.UnableToTranslateSubqueryWithGroupBy("o.OrderID"), message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindSelectQueryRelationalTestBase.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -13,6 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected NorthwindSelectQueryRelationalTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override async Task Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
+              () => base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async))).Message;
+
+            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
         }
 
         public override Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2151,6 +2151,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from l1 in ss.Set<Level1>().Include(l => l.OneToMany_Optional1)
+                      from l2 in l1.OneToMany_Optional1.Select(x => new { x.Id, x.Name, FK = EF.Property<int>(x, "OneToMany_Optional_Inverse2Id") }).Distinct()
+                      select l1,
+                elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -8262,6 +8262,520 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_projecting_identifier_column(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Id, w.Name })
+                                .Distinct().ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Id,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.Name, aa.Name);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_projecting_identifier_column_and_correlation_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Id, w.Name, w.OwnerFullName })
+                                .Distinct().ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Id,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.OwnerFullName, aa.OwnerFullName);
+                        });
+                });
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_projecting_identifier_column_composite_key(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>()
+                    .Select(
+                        s => new
+                        {
+                            Key = s.Id,
+                            Subquery = s.Members
+                                .Select(m => new { m.Nickname, m.SquadId, m.HasSoulPatch })
+                                .Distinct().ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Nickname,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Nickname, aa.Nickname);
+                            Assert.Equal(ee.SquadId, aa.SquadId);
+                            Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_not_projecting_identifier_column(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic })
+                                .Distinct().ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Name,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.IsAutomatic, aa.IsAutomatic);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_not_projecting_identifier_column_also_projecting_complex_expressions(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic, w.OwnerFullName.Length })
+                                .Distinct().ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Name,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.IsAutomatic, aa.IsAutomatic);
+                            Assert.Equal(ee.Length, aa.Length);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic })
+                                .GroupBy(x => x.IsAutomatic)
+                                .Select(x => new { x.Key }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Key,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Key, aa.Key);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic })
+                                .GroupBy(x => x.IsAutomatic)
+                                .Select(x => new { x.Key, Count = x.Count() }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Key,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Key, aa.Key);
+                            Assert.Equal(ee.Count, aa.Count);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic })
+                                .GroupBy(x => new { x.IsAutomatic, x.Name })
+                                .Select(x => new { x.Key, Count = x.Count() }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Key.Name,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Key.Name, aa.Key.Name);
+                            Assert.Equal(ee.Key.IsAutomatic, aa.Key.IsAutomatic);
+                            Assert.Equal(ee.Count, aa.Count);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_groupby_with_complex_grouping_key_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(
+                        g => new
+                        {
+                            Key = g.Nickname,
+                            Subquery = g.Weapons
+                                .Select(w => new { w.Name, w.IsAutomatic })
+                                .GroupBy(x => x.Name.Length)
+                                .Select(x => new { x.Key, Count = x.Count() }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(
+                        e.Subquery,
+                        a.Subquery,
+                        elementSorter: ee => ee.Key,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Key, aa.Key);
+                            Assert.Equal(ee.Count, aa.Count);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .OrderBy(g => g.Nickname)
+                    .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.BornGears)
+                    .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList()),
+                ss => ss.Set<Gear>()
+                    .OrderBy(g => g.Nickname)
+                    .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.Maybe(x => x.BornGears) ?? new List<Gear>())
+                    .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList()),
+                elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_correlated_collection_followed_by_Distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(g => g.Weapons)
+                    .Distinct(),
+                elementSorter: e => e.OrderBy(w => w.Id).FirstOrDefault().Id,
+                elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_some_properties_as_well_as_correlated_collection_followed_by_Distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(g => new { g.FullName, g.HasSoulPatch, g.Weapons })
+                    .Distinct(),
+                elementSorter: e => e.FullName,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.FullName, a.FullName);
+                    Assert.Equal(e.HasSoulPatch, a.HasSoulPatch);
+                    AssertCollection(e.Weapons, a.Weapons);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_entity_as_well_as_correlated_collection_followed_by_Distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(g => new { g, g.Weapons })
+                    .Distinct(),
+                elementSorter: e => e.g.FullName,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.g, a.g);
+                    AssertCollection(e.Weapons, a.Weapons);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_entity_as_well_as_complex_correlated_collection_followed_by_Distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(g => new { g, Weapons = g.Weapons.Where(w => w.Id == g.SquadId).ToList() })
+                    .Distinct(),
+                elementSorter: e => e.g.FullName,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.g, a.g);
+                    AssertCollection(e.Weapons, a.Weapons);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_entity_as_well_as_correlated_collection_of_scalars_followed_by_Distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Gear>()
+                    .Select(g => new { g, Ids = g.Weapons.Select(w => w.Id).ToList() })
+                    .Distinct(),
+                elementSorter: e => e.g.FullName,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.g, a.g);
+                    AssertCollection(e.Ids, a.Ids);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_with_distinct_3_levels(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>()
+                    .Select(s => new
+                    {
+                        s,
+                        Members = s.Members.Select(m => new
+                        {
+                            m,
+                            Weapons = m.Weapons.Where(w => w.OwnerFullName == m.FullName).ToList()
+                        }).Distinct()
+                    }).Distinct(),
+                elementSorter: e => e.s.Id);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_distinct_3_levels(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>()
+                    .Select(s => new { s.Id, s.Name })
+                    .Distinct()
+                    .Select(x => new
+                    {
+                        x.Id,
+                        x.Name,
+                        Subquery1 = (from g in ss.Set<Gear>()
+                                     where g.SquadId == x.Id
+                                     select new { g.Nickname, g.FullName, g.HasSoulPatch })
+                                     .Distinct()
+                                     .Select(xx => new
+                                     {
+                                         xx.Nickname,
+                                         xx.FullName,
+                                         xx.HasSoulPatch,
+                                         Subquery2 = (from w in ss.Set<Weapon>()
+                                                      where w.OwnerFullName == xx.FullName
+                                                      select new { x.Id, x.Name, xx.Nickname, xx.FullName, xx.HasSoulPatch }).ToList()
+                                     })
+                                     .ToList()
+                    }),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+                    Assert.Equal(e.Name, a.Name);
+                    AssertCollection(
+                        e.Subquery1,
+                        a.Subquery1,
+                        elementSorter: ee => ee.Nickname,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Nickname, aa.Nickname);
+                            Assert.Equal(ee.FullName, aa.FullName);
+                            Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
+                            AssertCollection(
+                                ee.Subquery2,
+                                aa.Subquery2,
+                                elementSorter: eee => eee.Id,
+                                elementAsserter: (eee, aaa) =>
+                                {
+                                    Assert.Equal(eee.Id, aaa.Id);
+                                    Assert.Equal(eee.Name, aaa.Name);
+                                    Assert.Equal(eee.Nickname, aaa.Nickname);
+                                    Assert.Equal(eee.FullName, aaa.FullName);
+                                    Assert.Equal(eee.HasSoulPatch, aaa.HasSoulPatch);
+                                });
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_distinct_3_levels_without_original_identifiers(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Squad>()
+                    .Select(s => new { s.Name.Length })
+                    .Distinct()
+                    .Select(x => new
+                    {
+                        x.Length,
+                        Subquery1 = (from g in ss.Set<Gear>()
+                                     where g.Nickname.Length == x.Length
+                                     select new { g.HasSoulPatch, g.CityOfBirthName })
+                                     .Distinct()
+                                     .Select(xx => new
+                                     {
+                                         xx.HasSoulPatch,
+                                         Subquery2 = (from w in ss.Set<Weapon>()
+                                                      where w.OwnerFullName == xx.CityOfBirthName
+                                                      select new { w.Id, x.Length, xx.HasSoulPatch }).ToList()
+                                     })
+                                     .ToList()
+                    }),
+                elementSorter: e => e.Length,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Length, a.Length);
+                    AssertCollection(
+                        e.Subquery1,
+                        a.Subquery1,
+                        elementSorter: ee => ee.HasSoulPatch,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.HasSoulPatch, aa.HasSoulPatch);
+                            AssertCollection(
+                                ee.Subquery2,
+                                aa.Subquery2,
+                                elementSorter: eee => eee.Id,
+                                elementAsserter: (eee, aaa) =>
+                                {
+                                    Assert.Equal(eee.Id, aaa.Id);
+                                    Assert.Equal(eee.Length, aaa.Length);
+                                    Assert.Equal(eee.HasSoulPatch, aaa.HasSoulPatch);
+                                });
+                        });
+                });
+        }
+
         protected GearsOfWarContext CreateContext()
             => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2978,6 +2978,30 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Complex_query_with_groupBy_in_subquery4(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>()
+                    .Select(
+                        c => new
+                        {
+                            Key = c.CustomerID,
+                            Subquery = c.Orders
+                                .Select(o => new { First = o.OrderID, Second = o.Customer.City + o.CustomerID })
+                                .GroupBy(x => x.Second)
+                                .Select(g => new { Sum = g.Sum(x => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
+                        }),
+                elementSorter: e => e.Key,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Key, a.Key);
+                    AssertCollection(e.Subquery, a.Subquery);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_scalar_subquery(bool async)
         {
             return AssertQuery(
@@ -3034,6 +3058,33 @@ namespace Microsoft.EntityFrameworkCore.Query
                         AssertEqual(e.Customer, a.Customer);
                         AssertCollection(e.Orders, a.Orders);
                     }));
+        }
+
+        #endregion
+
+        #region GroupByAndDistinctWithCorrelatedCollection
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Where(c => c.CustomerID.StartsWith("A"))
+                    .Select(c => c.Customer.City)
+                    .Distinct()
+                    .Select(c => new
+                    {
+                        c1 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Key).ToArray(),
+                        c2 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Count()).ToArray()
+                    }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e.c1, a.c1);
+                    AssertCollection(e.c2, a.c2);
+                });
         }
 
         #endregion

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -650,6 +650,36 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss =>
+                    (from c in ss.Set<Customer>()
+                    where c.City == "London"
+                    orderby c.CustomerID
+                    select new { c.City }).Distinct().Select(x => 
+
+                           ((from o1 in ss.Set<Order>()
+                            where o1.CustomerID == x.City
+                                && o1.OrderDate.Value.Year == 1997
+                            orderby o1.OrderID
+                            select o1).Distinct().Select(xx => 
+
+                             (from o2 in ss.Set<Order>()
+                                    where xx.CustomerID == x.City
+                                    orderby o2.OrderID
+                                    select xx.OrderID).ToList()).ToList())),
+                elementSorter: e => e.Count,
+                elementAsserter: (e, a) => AssertCollection(
+                    e,
+                    a,
+                    ordered: true,
+                    elementAsserter: (ee, aa) => AssertCollection(ee, aa)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task New_date_time_in_anonymous_type_works(bool async)
         {
             return AssertQuery(
@@ -1795,7 +1825,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Projecting_after_navigation_and_distinct_throws(bool async)
+        public virtual Task Projecting_after_navigation_and_distinct(bool async)
         {
             var filteredOrderIds = new[] { 10248, 10249, 10250 };
 
@@ -1822,6 +1852,120 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     Assert.Equal(e.CustomerID, a.CustomerID);
                     AssertCollection(e.Orders, a.Orders, elementSorter: ee => ee.CustomerID);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
+        {
+            var filteredOrderIds = new[] { 10248, 10249, 10250 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Select(o => new { o.OrderID, Complex = o.OrderDate.Value.Month })
+                    .Distinct()
+                    .Select(c => new
+                    {
+                        c.OrderID,
+                        c.Complex,
+                        Subquery = (from x in ss.Set<Order>()
+                                    where x.OrderID == c.OrderID && filteredOrderIds.Contains(x.OrderID)
+                                    select new { Outer = c.OrderID, Inner = x.OrderID, x.OrderDate }).ToList()
+                    }),
+                elementSorter: e => e.OrderID,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.OrderID, a.OrderID);
+                    Assert.Equal(e.Complex, a.Complex);
+                    AssertCollection(e.Subquery, a.Subquery, elementSorter: ee => ee.Outer);
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
+        {
+            var filteredOrderIds = new[] { 10248, 10249, 10250 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Select(o => new { o.OrderDate, o.CustomerID })
+                    .Distinct()
+                    .Select(c => new
+                    {
+                        c.OrderDate,
+                        c.CustomerID,
+                        Subquery = (from x in ss.Set<Order>()
+                                    where x.CustomerID == c.CustomerID && filteredOrderIds.Contains(x.OrderID)
+                                    select new { Outer1 = c.OrderDate, Outer2 = c.CustomerID, Inner = x.OrderID, x.OrderDate }).ToList()
+                    }),
+                elementSorter: e => (e.OrderDate, e.CustomerID),
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.OrderDate, a.OrderDate);
+                    Assert.Equal(e.CustomerID, a.CustomerID);
+                    AssertCollection(e.Subquery, a.Subquery, elementSorter: ee => (ee.Outer1, ee.Outer2, ee.Inner, ee.OrderDate));
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            var filteredOrderIds = new[] { 10248, 10249, 10250 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .Select(o => new { o.OrderDate, o.CustomerID, Complex = o.OrderDate.Value.Month })
+                    .Distinct()
+                    .Select(c => new
+                    {
+                        c.OrderDate,
+                        c.CustomerID,
+                        c.Complex,
+                        Subquery = (from x in ss.Set<Order>()
+                                    where x.CustomerID == c.CustomerID && filteredOrderIds.Contains(x.OrderID)
+                                    select new { Outer1 = c.OrderDate, Outer2 = c.CustomerID, Outer3 = c.Complex, Inner = x.OrderID, x.OrderDate }).ToList()
+                    }),
+                elementSorter: e => (e.OrderDate, e.CustomerID, e.Complex),
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.OrderDate, a.OrderDate);
+                    Assert.Equal(e.CustomerID, a.CustomerID);
+                    Assert.Equal(e.Complex, a.Complex);
+                    AssertCollection(e.Subquery, a.Subquery, elementSorter: ee => (ee.Outer1, ee.Outer2, ee.Outer3, ee.Inner, ee.OrderDate));
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
+        {
+            var filteredOrderIds = new[] { 10248, 10249, 10250 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .GroupBy(o => new { o.OrderID, Complex = o.OrderDate.Value.Month })
+                    .Select(g => new { g.Key, Aggregate = g.Count() })
+                    .Select(c => new
+                    {
+                        c.Key.OrderID,
+                        c.Key.Complex,
+                        Subquery = (from x in ss.Set<Order>()
+                                    where x.OrderID == c.Key.OrderID && filteredOrderIds.Contains(x.OrderID)
+                                    select new { Outer = c.Key.OrderID, Inner = x.OrderID, x.OrderDate }).ToList()
+                    }),
+                elementSorter: e => e.OrderID,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.OrderID, a.OrderID);
+                    Assert.Equal(e.Complex, a.Complex);
+                    AssertCollection(e.Subquery, a.Subquery, elementSorter: ee => ee.Outer);
                 });
         }
 
@@ -2047,6 +2191,34 @@ namespace Microsoft.EntityFrameworkCore.Query
                   AssertEqual(e.Customer, a.Customer);
                   AssertEqual(e.HasOrder, a.HasOrder);
               }));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            var filteredOrderIds = new[] { 10248, 10249, 10250 };
+
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, Complex = o.OrderDate.Value.Month })
+                    .Select(g => new { g.Key, Aggregate = g.Count() })
+                    .Select(c => new
+                    {
+                        c.Key.CustomerID,
+                        c.Key.Complex,
+                        Subquery = (from x in ss.Set<Order>()
+                                    where x.CustomerID == c.Key.CustomerID && filteredOrderIds.Contains(x.OrderID)
+                                    select new { Outer = c.Key.CustomerID, Inner = x.OrderID, x.OrderDate }).ToList()
+                    }),
+                elementSorter: e => (e.CustomerID, e.Complex),
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.CustomerID, a.CustomerID);
+                    Assert.Equal(e.Complex, a.Complex);
+                    AssertCollection(e.Subquery, a.Subquery, elementSorter: ee => ee.Outer);
+                });
         }
 
         private static string ClientMethod(string s) => s;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1958,6 +1958,21 @@ LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
 ORDER BY [l].[Id], [t].[Id], [l1].[Id]");
         }
 
+        public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
+        {
+            await base.SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [t].[Id], [l1].[Id], [l1].[Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_Inverse2Id], [l1].[OneToMany_Optional_Self_Inverse2Id], [l1].[OneToMany_Required_Inverse2Id], [l1].[OneToMany_Required_Self_Inverse2Id], [l1].[OneToOne_Optional_PK_Inverse2Id], [l1].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l0].[Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id] AS [FK]
+    FROM [LevelTwo] AS [l0]
+) AS [t] ON [l].[Id] = [t].[FK]
+LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
+ORDER BY [l].[Id], [t].[Id], [l1].[Id]");
+        }
+
         public override async Task SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty(bool async)
         {
             await base.SelectMany_with_navigation_filter_and_explicit_DefaultIfEmpty(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -281,10 +281,47 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t1].[Id], [t1].[Id0], [t1].[Id00]");
 
         public override async Task SelectMany_with_navigation_and_Distinct(bool async)
         {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.SelectMany_with_navigation_and_Distinct(async))).Message;
+            await base.SelectMany_with_navigation_and_Distinct(async);
 
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id0]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l0].[Id], [l0].[OneToOne_Required_PK_Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l3].[Id] AS [Id0]
+    FROM [Level1] AS [l2]
+    INNER JOIN [Level1] AS [l3] ON [l2].[Id] = [l3].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
+WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
+ORDER BY [l].[Id], [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id], [t0].[Id0]");
+        }
+
+        public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
+        {
+            await base.SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(async);
+
+            AssertSql(
+                @"SELECT [l].[Id], [l].[Date], [l].[Name], [t].[Id], [t].[Name], [t].[FK], [t0].[Id], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToMany_Optional_Inverse2Id], [t0].[OneToMany_Required_Inverse2Id], [t0].[OneToOne_Optional_PK_Inverse2Id], [t0].[Id0]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l0].[Id], [l0].[Level2_Name] AS [Name], [l0].[OneToMany_Optional_Inverse2Id] AS [FK]
+    FROM [Level1] AS [l0]
+    INNER JOIN [Level1] AS [l1] ON [l0].[Id] = [l1].[Id]
+    WHERE [l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t] ON [l].[Id] = [t].[FK]
+LEFT JOIN (
+    SELECT [l2].[Id], [l2].[OneToOne_Required_PK_Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Level2_Name], [l2].[OneToMany_Optional_Inverse2Id], [l2].[OneToMany_Required_Inverse2Id], [l2].[OneToOne_Optional_PK_Inverse2Id], [l3].[Id] AS [Id0]
+    FROM [Level1] AS [l2]
+    INNER JOIN [Level1] AS [l3] ON [l2].[Id] = [l3].[Id]
+    WHERE [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l2].[Level1_Required_Id] IS NOT NULL AND [l2].[OneToOne_Required_PK_Date] IS NOT NULL)
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
+ORDER BY [l].[Id], [t].[Id], [t].[Name], [t].[FK], [t0].[Id], [t0].[Id0]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7761,6 +7761,182 @@ ORDER BY CASE
 END, [t].[Note]");
         }
 
+        public override async Task Correlated_collection_with_distinct_projecting_identifier_column(bool async)
+        {
+            await base.Correlated_collection_with_distinct_projecting_identifier_column(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[Id], [t].[Name]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT DISTINCT [w].[Id], [w].[Name]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+        }
+
+        public override async Task Correlated_collection_with_distinct_projecting_identifier_column_and_correlation_key(bool async)
+        {
+            await base.Correlated_collection_with_distinct_projecting_identifier_column_and_correlation_key(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[Id], [t].[Name], [t].[OwnerFullName]
+FROM [Gears] AS [g]
+LEFT JOIN (
+    SELECT DISTINCT [w].[Id], [w].[Name], [w].[OwnerFullName]
+    FROM [Weapons] AS [w]
+) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+        }
+
+        public override async Task Correlated_collection_with_distinct_projecting_identifier_column_composite_key(bool async)
+        {
+            await base.Correlated_collection_with_distinct_projecting_identifier_column_composite_key(async);
+
+            AssertSql(
+                @"SELECT [s].[Id], [t].[Nickname], [t].[SquadId], [t].[HasSoulPatch]
+FROM [Squads] AS [s]
+LEFT JOIN (
+    SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
+    FROM [Gears] AS [g]
+) AS [t] ON [s].[Id] = [t].[SquadId]
+ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column(bool async)
+        {
+            await base.Correlated_collection_with_distinct_not_projecting_identifier_column(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[Name], [t].[IsAutomatic]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT DISTINCT [w].[Name], [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name], [t].[IsAutomatic]");
+        }
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(bool async)
+        {
+            await base.Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[Key]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT [w].[IsAutomatic] AS [Key]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    GROUP BY [w].[IsAutomatic]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Key]");
+        }
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
+        {
+            await base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[Key], [t].[Count]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT [w].[IsAutomatic] AS [Key], COUNT(*) AS [Count]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    GROUP BY [w].[IsAutomatic]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Key]");
+        }
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(bool async)
+        {
+            await base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[IsAutomatic], [t].[Name], [t].[Count]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT [w].[IsAutomatic], [w].[Name], COUNT(*) AS [Count]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    GROUP BY [w].[IsAutomatic], [w].[Name]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[IsAutomatic], [t].[Name]");
+        }
+     
+        public override async Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+        {
+            await base.Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(async);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [t].[HasSoulPatch]
+FROM [Gears] AS [g]
+OUTER APPLY (
+    SELECT DISTINCT [g1].[HasSoulPatch]
+    FROM [Weapons] AS [w]
+    LEFT JOIN [Gears] AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
+    LEFT JOIN [Cities] AS [c] ON [g0].[AssignedCityName] = [c].[Name]
+    INNER JOIN [Gears] AS [g1] ON [c].[Name] = [g1].[CityOfBirthName]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+) AS [t]
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[HasSoulPatch]");
+        }
+
+        public override async Task Correlated_collection_after_distinct_3_levels(bool async)
+        {
+            await base.Correlated_collection_after_distinct_3_levels(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[Name], [t2].[Nickname], [t2].[FullName], [t2].[HasSoulPatch], [t2].[Id], [t2].[Name], [t2].[Nickname0], [t2].[FullName0], [t2].[HasSoulPatch0], [t2].[Id0]
+FROM (
+    SELECT DISTINCT [s].[Id], [s].[Name]
+    FROM [Squads] AS [s]
+) AS [t]
+OUTER APPLY (
+    SELECT [t0].[Nickname], [t0].[FullName], [t0].[HasSoulPatch], [t1].[Id], [t1].[Name], [t1].[Nickname] AS [Nickname0], [t1].[FullName] AS [FullName0], [t1].[HasSoulPatch] AS [HasSoulPatch0], [t1].[Id0]
+    FROM (
+        SELECT DISTINCT [g].[Nickname], [g].[FullName], [g].[HasSoulPatch]
+        FROM [Gears] AS [g]
+        WHERE [g].[SquadId] = [t].[Id]
+    ) AS [t0]
+    OUTER APPLY (
+        SELECT [t].[Id], [t].[Name], [t0].[Nickname], [t0].[FullName], [t0].[HasSoulPatch], [w].[Id] AS [Id0]
+        FROM [Weapons] AS [w]
+        WHERE [t0].[FullName] = [w].[OwnerFullName]
+    ) AS [t1]
+) AS [t2]
+ORDER BY [t].[Id], [t2].[Nickname], [t2].[FullName], [t2].[HasSoulPatch], [t2].[Id0]");
+        }
+
+        public override async Task Correlated_collection_after_distinct_3_levels_without_original_identifiers(bool async)
+        {
+            await base.Correlated_collection_after_distinct_3_levels_without_original_identifiers(async);
+
+            AssertSql(
+                @"SELECT [t].[Length], [t2].[HasSoulPatch], [t2].[CityOfBirthName], [t2].[Id], [t2].[Length], [t2].[HasSoulPatch0]
+FROM (
+    SELECT DISTINCT CAST(LEN([s].[Name]) AS int) AS [Length]
+    FROM [Squads] AS [s]
+) AS [t]
+OUTER APPLY (
+    SELECT [t0].[HasSoulPatch], [t0].[CityOfBirthName], [t1].[Id], [t1].[Length], [t1].[HasSoulPatch] AS [HasSoulPatch0]
+    FROM (
+        SELECT DISTINCT [g].[HasSoulPatch], [g].[CityOfBirthName]
+        FROM [Gears] AS [g]
+        WHERE CAST(LEN([g].[Nickname]) AS int) = [t].[Length]
+    ) AS [t0]
+    OUTER APPLY (
+        SELECT [w].[Id], [t].[Length], [t0].[HasSoulPatch]
+        FROM [Weapons] AS [w]
+        WHERE [t0].[CityOfBirthName] = [w].[OwnerFullName]
+    ) AS [t1]
+) AS [t2]
+ORDER BY [t].[Length], [t2].[HasSoulPatch], [t2].[CityOfBirthName], [t2].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2508,6 +2508,31 @@ FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
 
+        public override async Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+        {
+            await base.Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(async);
+
+            AssertSql(
+                @"SELECT [t].[City], [t0].[ProductID], [t1].[c], [t1].[ProductID]
+FROM (
+    SELECT DISTINCT [c].[City]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
+) AS [t]
+OUTER APPLY (
+    SELECT [p].[ProductID]
+    FROM [Products] AS [p]
+    GROUP BY [p].[ProductID]
+) AS [t0]
+OUTER APPLY (
+    SELECT COUNT(*) AS [c], [p0].[ProductID]
+    FROM [Products] AS [p0]
+    GROUP BY [p0].[ProductID]
+) AS [t1]
+ORDER BY [t].[City], [t0].[ProductID], [t1].[ProductID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -5392,6 +5392,58 @@ ORDER BY [c].[CustomerID]");
             }
         }
 
+        public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(bool async)
+        {
+            await base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t].[First], [t].[Second]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT DISTINCT [o].[OrderID] AS [First], [o].[OrderDate] AS [Second]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+ORDER BY [c].[CustomerID], [t].[First]");
+        }
+
+        public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(bool async)
+        {
+            await base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t].[First], [t].[Second], [t].[Third]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT DISTINCT [o].[OrderID] AS [First], [o].[OrderDate] AS [Second], [c0].[City] AS [Third]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+) AS [t]
+ORDER BY [c].[CustomerID], [t].[First], [t].[Second], [t].[Third]");
+        }
+
+        public override async Task Select_nested_collection_with_distinct(bool async)
+        {
+            await base.Select_nested_collection_with_distinct(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o]
+        WHERE [c].[CustomerID] = [o].[CustomerID]) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END, [c].[CustomerID], [t].[CustomerID]
+FROM [Customers] AS [c]
+LEFT JOIN (
+    SELECT DISTINCT [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'A%'
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1426,14 +1426,6 @@ WHERE [c].[CustomerID] = N'ALFKI'
 ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
-        public override async Task Projecting_after_navigation_and_distinct_throws(bool async)
-        {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Projecting_after_navigation_and_distinct_throws(async))).Message;
-
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
-        }
-
         public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
         {
             await base.Custom_projection_reference_navigation_PK_to_FK_optimization(async);
@@ -1585,6 +1577,146 @@ END
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] < 10300
 ORDER BY [o].[OrderID]");
+        }
+
+        public override async Task Projecting_after_navigation_and_distinct(bool async)
+        {
+            await base.Projecting_after_navigation_and_distinct(async);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[CustomerID], [t0].[OrderID], [t0].[OrderDate]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[CustomerID], [o0].[OrderID], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+) AS [t0]
+ORDER BY [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region], [t0].[OrderID]");
+        }
+
+        public override async Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
+        {
+            await base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderID], [t].[Complex], [t0].[Outer], [t0].[Inner], [t0].[OrderDate]
+FROM (
+    SELECT DISTINCT [o].[OrderID], DATEPART(month, [o].[OrderDate]) AS [Complex]
+    FROM [Orders] AS [o]
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[OrderID] AS [Outer], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND ([t].[OrderID] = [o0].[OrderID])
+) AS [t0]
+ORDER BY [t].[OrderID], [t0].[Inner]");
+        }
+
+        public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
+        {
+            await base.Correlated_collection_after_distinct_not_containing_original_identifier(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderDate], [t].[CustomerID], [t0].[Outer1], [t0].[Outer2], [t0].[Inner], [t0].[OrderDate]
+FROM (
+    SELECT DISTINCT [o].[OrderDate], [o].[CustomerID]
+    FROM [Orders] AS [o]
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[OrderDate] AS [Outer1], [t].[CustomerID] AS [Outer2], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+) AS [t0]
+ORDER BY [t].[OrderDate], [t].[CustomerID], [t0].[Inner]");
+        }
+
+        public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
+        {
+            await base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderDate], [t].[CustomerID], [t].[Complex], [t0].[Outer1], [t0].[Outer2], [t0].[Outer3], [t0].[Inner], [t0].[OrderDate]
+FROM (
+    SELECT DISTINCT [o].[OrderDate], [o].[CustomerID], DATEPART(month, [o].[OrderDate]) AS [Complex]
+    FROM [Orders] AS [o]
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[OrderDate] AS [Outer1], [t].[CustomerID] AS [Outer2], [t].[Complex] AS [Outer3], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
+) AS [t0]
+ORDER BY [t].[OrderDate], [t].[CustomerID], [t].[Complex], [t0].[Inner]");
+        }
+
+        public override async Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
+        {
+            await base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderID], [t].[c], [t0].[Outer], [t0].[Inner], [t0].[OrderDate]
+FROM (
+    SELECT [o].[OrderID], DATEPART(month, [o].[OrderDate]) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[OrderID], DATEPART(month, [o].[OrderDate])
+) AS [t]
+OUTER APPLY (
+    SELECT [t].[OrderID] AS [Outer], [o0].[OrderID] AS [Inner], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND ([t].[OrderID] = [o0].[OrderID])
+) AS [t0]
+ORDER BY [t].[OrderID], [t0].[Inner]");
+        }
+
+        public override async Task Select_nested_collection_deep(bool async)
+        {
+            await base.Select_nested_collection_deep(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[OrderID00]
+FROM [Customers] AS [c]
+OUTER APPLY (
+    SELECT [o].[OrderID], [t].[OrderID] AS [OrderID0], [t].[OrderID0] AS [OrderID00]
+    FROM [Orders] AS [o]
+    OUTER APPLY (
+        SELECT [o].[OrderID], [o0].[OrderID] AS [OrderID0]
+        FROM [Orders] AS [o0]
+        WHERE [o].[CustomerID] = [c].[CustomerID]
+    ) AS [t]
+    WHERE (DATEPART(year, [o].[OrderDate]) = 1997) AND ([c].[CustomerID] = [o].[CustomerID])
+) AS [t0]
+WHERE [c].[City] = N'London'
+ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[OrderID00]");
+        }
+
+        public override async Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
+        {
+            await base.Select_nested_collection_deep_distinct_no_identifiers(async);
+
+            AssertSql(
+                @"SELECT [t].[City], [t2].[OrderID], [t2].[OrderID0], [t2].[OrderID00]
+FROM (
+    SELECT DISTINCT [c].[City]
+    FROM [Customers] AS [c]
+    WHERE [c].[City] = N'London'
+) AS [t]
+OUTER APPLY (
+    SELECT [t0].[OrderID], [t1].[OrderID] AS [OrderID0], [t1].[OrderID0] AS [OrderID00]
+    FROM (
+        SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+        FROM [Orders] AS [o]
+        WHERE (([o].[CustomerID] = [t].[City]) OR ([o].[CustomerID] IS NULL AND [t].[City] IS NULL)) AND (DATEPART(year, [o].[OrderDate]) = 1997)
+    ) AS [t0]
+    OUTER APPLY (
+        SELECT [t0].[OrderID], [o0].[OrderID] AS [OrderID0]
+        FROM [Orders] AS [o0]
+        WHERE ([t0].[CustomerID] = [t].[City]) OR ([t0].[CustomerID] IS NULL AND [t].[City] IS NULL)
+    ) AS [t1]
+) AS [t2]
+ORDER BY [t].[City], [t2].[OrderID], [t2].[OrderID00]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
@@ -18,14 +18,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        public override async Task SelectMany_with_navigation_and_Distinct(bool async)
-        {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.SelectMany_with_navigation_and_Distinct(async))).Message;
-
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
-        }
-
         public override async Task Filtered_include_after_different_filtered_include_different_level(bool async)
             => Assert.Equal(
                 SqliteStrings.ApplyNotSupported,

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -136,6 +136,54 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Correlated_collection_with_inner_collection_references_element_two_levels_up(async))).Message);
 
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(async))).Message);
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(async))).Message);
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(async))).Message);
+
+        public override async Task Correlated_collection_with_distinct_projecting_identifier_column(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_projecting_identifier_column(async))).Message);
+
+        public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_not_projecting_identifier_column(async))).Message);
+
+        public override async Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_3_levels_without_original_identifiers(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_3_levels_without_original_identifiers(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_3_levels(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_3_levels(async))).Message);
+
         public override async Task Negate_on_binary_expression(bool async)
         {
             await base.Negate_on_binary_expression(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -31,5 +31,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Select_uncorrelated_collection_with_groupby_works(async))).Message);
+
+        public override async Task Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_uncorrelated_collection_with_groupby_when_outer_is_distinct(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -319,6 +319,18 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Select_correlated_subquery_ordered(async))).Message);
 
+        public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(async))).Message);
+
+        public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_without_default_identifiers_projecting_columns(async))).Message);
+
         [ConditionalFact]
         public async Task Single_Predicate_Cancellation()
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -182,17 +182,47 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.SelectMany_whose_selector_references_outer_source(async))).Message);
 
-        public override async Task Projecting_after_navigation_and_distinct_throws(bool async)
+        public override async Task Projecting_after_navigation_and_distinct(bool async)
             => Assert.Equal(
-                RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
+                SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Projecting_after_navigation_and_distinct_throws(async))).Message);
+                    () => base.Projecting_after_navigation_and_distinct(async))).Message);
 
         public override async Task Select_nested_collection_deep(bool async)
             => Assert.Equal(
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Select_nested_collection_deep(async))).Message);
+
+        public override async Task Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_not_containing_original_identifier(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async))).Message);
+
+        public override async Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Select_nested_collection_deep_distinct_no_identifiers(async))).Message);
 
         [ConditionalTheory(Skip = "Issue#17324")]
         public override Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool async)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
@@ -137,6 +137,54 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Correlated_collection_with_inner_collection_references_element_two_levels_up(async))).Message);
 
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(async))).Message);
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(async))).Message);
+
+        public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(async))).Message);
+
+        public override async Task Correlated_collection_with_distinct_projecting_identifier_column(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_projecting_identifier_column(async))).Message);
+
+        public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_with_distinct_not_projecting_identifier_column(async))).Message);
+
+        public override async Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_3_levels_without_original_identifiers(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_3_levels_without_original_identifiers(async))).Message);
+
+        public override async Task Correlated_collection_after_distinct_3_levels(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Correlated_collection_after_distinct_3_levels(async))).Message);
+
         public override async Task Negate_on_binary_expression(bool async)
         {
             await base.Negate_on_binary_expression(async);


### PR DESCRIPTION
As fix to #15873 we started blocking some scenarios that used to work (by accident) - when we have a subquery using Distinct or GroupBy that doesn't happen to have any duplicates.

Fix is to enable those scenarios (and others) by modifying identifier columns in case of distinct and group by, if the original identifiers are not already present. In case of distinct, the entire projection becomes unique identifier, as distinct guarantees it to be unique.
In case of groupby, the grouping key becomes the identifier - since we only support grouping key or group aggregate in the projection, we are also guaranteed to have 1 row per unique grouping key.

Also fix to #24288 - Query: add collection join tries to convert correlated collection from APPLY to JOIN for subqueries with Distinct and GroupBy, which is incorrect

we would always try to convert subquery with groupby and distinct from apply to join, however we can only do this if the projection already contains the join key. Otherwise, adding the join key to the projection would change the meaning of operation in case of distinct and create invalid query in case of group by (projecting column that is not part of grouping key or aggregate).

Fixes #22049
Fixes #24288