### PR TITLE
Add support for CosmosSerializer and CosmosSerializationOptions in the Cosmos Provider

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -106,6 +106,22 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithGatewayModeMaxConnectionLimit(Check.NotNull(connectionLimit, nameof(connectionLimit))));
 
         /// <summary>
+        ///     Configures an optional JSON serializer. The client will use it to serialize or
+        ///     de-serialize user's cosmos request/responses. SDK owned types such as DatabaseProperties
+        ///     and ContainerProperties will always use the SDK default serializer.
+        /// </summary>
+        /// <param name="serializer"> The JSON serializer. </param>
+        public virtual CosmosDbContextOptionsBuilder Serializer(CosmosSerializer serializer)
+            => WithOption(e => e.WithSerializer(serializer));
+
+        /// <summary>
+        ///     Configures the optional serializer options.
+        /// </summary>
+        /// <param name="serializationOptions"> Provides a way to configure basic serializer settings. </param>
+        public virtual CosmosDbContextOptionsBuilder SerializationOptions(CosmosSerializationOptions serializationOptions)
+            => WithOption(e => e.WithSerializationOptions(serializationOptions));
+
+        /// <summary>
         ///     Configures the maximum number of TCP connections that may be opened to each Cosmos DB back-end.
         ///     Together with MaxRequestsPerTcpConnection, this setting limits the number of requests that are
         ///     simultaneously sent to a single Cosmos DB back-end (MaxRequestsPerTcpConnection x MaxTcpConnectionPerEndpoint).

--- a/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/CosmosSingletonOptions.cs
@@ -145,6 +145,22 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual CosmosSerializer? Serializer { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual CosmosSerializationOptions? SerializationOptions { get; private set; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual void Initialize(IDbContextOptions options)
         {
             var cosmosOptions = options.FindExtension<CosmosOptionsExtension>();
@@ -164,6 +180,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                 MaxTcpConnectionsPerEndpoint = cosmosOptions.MaxTcpConnectionsPerEndpoint;
                 MaxRequestsPerTcpConnection = cosmosOptions.MaxRequestsPerTcpConnection;
                 EnableContentResponseOnWrite = cosmosOptions.EnableContentResponseOnWrite;
+                Serializer = cosmosOptions.Serializer;
+                SerializationOptions = cosmosOptions.SerializationOptions;
             }
         }
 
@@ -192,6 +210,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
                     || MaxTcpConnectionsPerEndpoint != cosmosOptions.MaxTcpConnectionsPerEndpoint
                     || MaxRequestsPerTcpConnection != cosmosOptions.MaxRequestsPerTcpConnection
                     || EnableContentResponseOnWrite != cosmosOptions.EnableContentResponseOnWrite
+                    || Serializer != cosmosOptions.Serializer
+                    || SerializationOptions != cosmosOptions.SerializationOptions
                     ))
             {
                 throw new InvalidOperationException(

--- a/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
+++ b/src/EFCore.Cosmos/Infrastructure/Internal/ICosmosSingletonOptions.cs
@@ -138,5 +138,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         bool? EnableContentResponseOnWrite { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        CosmosSerializer? Serializer { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        CosmosSerializationOptions? SerializationOptions { get; }
     }
 }

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -290,6 +290,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
         public static string VisitChildrenMustBeOverridden
             => GetString("VisitChildrenMustBeOverridden");
 
+        /// <summary>
+        ///     SerializerOptions is not compatible with Serializer. Only one can be set.
+        /// </summary>
+        public static string SerializerOptionsConflictingSerializer
+            => GetString("SerializerOptionsConflictingSerializer");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -218,6 +218,9 @@
   <data name="ReverseAfterSkipTakeNotSupported" xml:space="preserve">
     <value>Reversing the ordering is not supported when limit or offset are already applied.</value>
   </data>
+  <data name="SerializerOptionsConflictingSerializer" xml:space="preserve">
+    <value>SerializerOptions is not compatible with Serializer. Only one can be set.</value>
+  </data>
   <data name="TransactionsNotSupported" xml:space="preserve">
     <value>The Cosmos database provider does not support transactions.</value>
   </data>

--- a/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/SingletonCosmosClientWrapper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             _endpoint = options.AccountEndpoint;
             _key = options.AccountKey;
             _connectionString = options.ConnectionString;
-            var configuration = new CosmosClientOptions { ApplicationName = _userAgent, Serializer = new JsonCosmosSerializer() };
+            var configuration = new CosmosClientOptions { ApplicationName = _userAgent };
 
             if (options.Region != null)
             {
@@ -95,6 +95,16 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             if (options.MaxRequestsPerTcpConnection != null)
             {
                 configuration.MaxRequestsPerTcpConnection = options.MaxRequestsPerTcpConnection.Value;
+            }
+
+            if (options.Serializer != null)
+            {
+                configuration.Serializer = options.Serializer;
+            }
+
+            if (options.SerializationOptions != null)
+            {
+                configuration.SerializerOptions = options.SerializationOptions;
             }
 
             _options = configuration;


### PR DESCRIPTION
Added support for [CosmosSerializationOptions](https://docs.microsoft.com/uk-ua/dotnet/api/microsoft.azure.cosmos.cosmosserializationoptions?view=azure-dotnet) and [CosmosSerializer ](https://docs.microsoft.com/uk-ua/dotnet/api/microsoft.azure.cosmos.cosmosserializer?view=azure-dotnet)

It is a very useful feature when we want to ignore null values when saving data in CosmosDb with Entity Framework
https://stackoverflow.com/questions/66424039/ignore-null-values-when-saving-data-in-cosmosdb-with-entity-framework

Fixes #20670

Please review
Thank you in advance


