### PR TITLE
Remove last ORDER BY for collection joins

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -737,17 +737,16 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
                                     // We omit the last ordering as an optimization
                                     var orderingExpression = new OrderingExpression(updatedColumn, ascending: true);
 
-                                    if (!_orderings.Any(o => o.Expression.Equals(orderingExpression.Expression)))
+                                    if (!_orderings.Any(o => o.Expression.Equals(updatedColumn)))
                                     {
                                         if (pendingOrdering is not null)
                                         {
-                                            AppendOrderingInternal(pendingOrdering);
-
                                             if (orderingExpression.Equals(pendingOrdering))
                                             {
-                                                pendingOrdering = null;
                                                 continue;
                                             }
+
+                                            AppendOrderingInternal(pendingOrdering);
                                         }
 
                                         pendingOrdering = orderingExpression;

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1213,15 +1213,17 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         {
             Check.NotNull(orderingExpression, nameof(orderingExpression));
 
+            if (orderingExpression.Equals(_pendingOrdering))
+            {
+                AppendOrderingCore(_pendingOrdering);
+                _pendingOrdering = null;
+                return;
+            }
+
             if (_orderings.FirstOrDefault(o => o.Expression.Equals(orderingExpression.Expression)) == null)
             {
                 if (_pendingOrdering is not null)
                 {
-                    if (orderingExpression.Equals(_pendingOrdering) && isPending)
-                    {
-                        return;
-                    }
-
                     AppendOrderingCore(_pendingOrdering);
                     _pendingOrdering = null;
                 }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -1213,17 +1213,15 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         {
             Check.NotNull(orderingExpression, nameof(orderingExpression));
 
-            if (orderingExpression.Equals(_pendingOrdering))
-            {
-                AppendOrderingCore(_pendingOrdering);
-                _pendingOrdering = null;
-                return;
-            }
-
             if (_orderings.FirstOrDefault(o => o.Expression.Equals(orderingExpression.Expression)) == null)
             {
                 if (_pendingOrdering is not null)
                 {
+                    if (orderingExpression.Equals(_pendingOrdering) && isPending)
+                    {
+                        return;
+                    }
+
                     AppendOrderingCore(_pendingOrdering);
                     _pendingOrdering = null;
                 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6568,7 +6568,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Acessing_reference_navigation_collection_composition_generates_single_query(bool async)
+        public virtual Task Accessing_reference_navigation_collection_composition_generates_single_query(bool async)
         {
             return AssertQuery(
                 async,

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -1095,11 +1095,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 Assert.Equal(ee.Id, aa.Id);
                                 Assert.Equal(ee.Name, aa.Name);
                                 Assert.Equal(ee.Composition.Count, aa.Composition.Count);
-                                for (var i = 0; i < ee.Composition.Count; i++)
+                                foreach (var (eec, aac) in Enumerable.Zip(
+                                    ee.Composition.OrderBy(eec => eec.Id),
+                                    aa.Composition.OrderBy(aac => aac.Id)))
                                 {
-                                    Assert.Equal(ee.Composition[i].Id, aa.Composition[i].Id);
-                                    Assert.Equal(ee.Composition[i].Name, aa.Composition[i].Name);
-                                    Assert.Equal(ee.Composition[i].StarId, aa.Composition[i].StarId);
+                                    Assert.Equal(eec.Id, aac.Id);
+                                    Assert.Equal(eec.Name, aac.Name);
+                                    Assert.Equal(eec.StarId, aac.StarId);
                                 }
                             }
                         }

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
@@ -40,7 +40,7 @@ LEFT JOIN (
     WHERE [e1].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_Include_for_inverse(bool async)
@@ -64,7 +64,7 @@ LEFT JOIN (
     WHERE [e3].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_Include_for_same_collection(bool async)
@@ -93,7 +93,7 @@ LEFT JOIN (
     WHERE [e3].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[EntityOneId0], [t0].[EntityTwoId0], [t0].[Id0]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[EntityOneId0], [t0].[EntityTwoId0]");
         }
 
         public override async Task Load_collection_using_Query_with_Include(bool async)
@@ -122,7 +122,7 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
 ) AS [t1] ON [t].[Id] = [t1].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_filtered_Include(bool async)
@@ -152,7 +152,7 @@ LEFT JOIN (
     WHERE [e4].[Id] IN (13, 11)
 ) AS [t1] ON [t].[Id] = [t1].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_filtered_Include_and_projection(bool async)
@@ -211,7 +211,7 @@ LEFT JOIN (
     WHERE [e6].[Id] = @__p_0
 ) AS [t2] ON [t].[Id] = [t2].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id0], [t2].[EntityOneId], [t2].[EntityTwoId], [t2].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id0], [t2].[EntityOneId], [t2].[EntityTwoId]");
         }
 
         protected override void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -39,7 +39,7 @@ LEFT JOIN (
     WHERE [e1].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId], [t0].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t0].[OneId], [t0].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_Include_for_inverse(bool async)
@@ -63,7 +63,7 @@ LEFT JOIN (
     WHERE [e3].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_Include_for_same_collection(bool async)
@@ -92,7 +92,7 @@ LEFT JOIN (
     WHERE [e3].[Id] = @__p_0
 ) AS [t0] ON [t].[Id] = [t0].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[EntityOneId0], [t0].[EntityTwoId0], [t0].[Id0]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t0].[EntityOneId0], [t0].[EntityTwoId0]");
         }
 
         public override async Task Load_collection_using_Query_with_Include(bool async)
@@ -121,7 +121,7 @@ LEFT JOIN (
     INNER JOIN [EntityThrees] AS [e4] ON [j].[ThreeId] = [e4].[Id]
 ) AS [t1] ON [t].[Id] = [t1].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_filtered_Include(bool async)
@@ -151,7 +151,7 @@ LEFT JOIN (
     WHERE [e4].[Id] IN (13, 11)
 ) AS [t1] ON [t].[Id] = [t1].[TwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId], [t1].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id], [t1].[ThreeId], [t1].[TwoId]");
         }
 
         public override async Task Load_collection_using_Query_with_filtered_Include_and_projection(bool async)
@@ -210,7 +210,7 @@ LEFT JOIN (
     WHERE [e6].[Id] = @__p_0
 ) AS [t2] ON [t].[Id] = [t2].[EntityTwoId]
 WHERE [e].[Id] = @__p_0
-ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id0], [t2].[EntityOneId], [t2].[EntityTwoId], [t2].[Id]");
+ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t0].[EntityOneId], [t0].[EntityTwoId], [t0].[Id0], [t2].[EntityOneId], [t2].[EntityTwoId]");
         }
 
         protected override void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -30,7 +30,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(bool async)
@@ -50,7 +50,7 @@ LEFT JOIN (
         LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[OneToMany_Optional_Inverse3Id]
     ) AS [t] ON [l0].[Id] = [t].[OneToMany_Optional_Inverse3Id]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[Id], [t0].[Id0], [t0].[Id00], [t0].[Id1]");
+ORDER BY [l].[Id], [t0].[Id], [t0].[Id0], [t0].[Id00]");
         }
 
         public override async Task Multiple_complex_includes(bool async)
@@ -67,7 +67,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l2]
     LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[Level2_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id]");
         }
 
         public override async Task Multiple_complex_includes_self_ref(bool async)
@@ -84,7 +84,7 @@ LEFT JOIN (
     FROM [LevelOne] AS [l2]
     LEFT JOIN [LevelOne] AS [l3] ON [l2].[OneToOne_Optional_Self1Id] = [l3].[Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Self_Inverse1Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id]");
         }
 
         public override async Task Include_reference_and_collection_order_by(bool async)
@@ -96,7 +96,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id], [t].[Id0]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Name], [l].[Id], [l0].[Id]");
         }
 
         public override async Task Include_reference_ThenInclude_collection_order_by(bool async)
@@ -108,7 +108,7 @@ ORDER BY [l].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Name], [l].[Id], [l0].[Id]");
         }
 
         public override async Task Include_collection_then_reference(bool async)
@@ -123,7 +123,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Include_collection_with_conditional_order_by(bool async)
@@ -137,7 +137,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 ORDER BY CASE
     WHEN [l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'%03') THEN 1
     ELSE 2
-END, [l].[Id], [l0].[Id]");
+END, [l].[Id]");
         }
 
         public override async Task Multiple_complex_include_select(bool async)
@@ -154,7 +154,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l2]
     LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[Level2_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id]");
         }
 
         public override async Task Include_nested_with_optional_navigation(bool async)
@@ -171,7 +171,7 @@ LEFT JOIN (
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 ) AS [t] ON [l0].[Id] = [t].[OneToMany_Required_Inverse3Id]
 WHERE ([l0].[Name] <> N'L2 09') OR [l0].[Name] IS NULL
-ORDER BY [l].[Id], [l0].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [l0].[Id], [t].[Id]");
         }
 
         public override async Task Complex_multi_include_with_order_by_and_paging(bool async)
@@ -192,7 +192,7 @@ FROM (
 LEFT JOIN [LevelTwo] AS [l0] ON [t].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Required_Inverse3Id]
-ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override async Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(bool async)
@@ -214,7 +214,7 @@ LEFT JOIN [LevelTwo] AS [l0] ON [t].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [t].[Id] = [l1].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
 LEFT JOIN [LevelThree] AS [l3] ON [l1].[Id] = [l3].[OneToMany_Required_Inverse3Id]
-ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id]");
+ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
         }
 
         public override async Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key2(bool async)
@@ -235,7 +235,7 @@ FROM (
 LEFT JOIN [LevelTwo] AS [l0] ON [t].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[OneToMany_Optional_Inverse4Id]
-ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [t].[Name], [t].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override async Task Multiple_include_with_multiple_optional_navigations(bool async)
@@ -252,7 +252,7 @@ LEFT JOIN [LevelTwo] AS [l3] ON [l].[Id] = [l3].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l4] ON [l3].[Id] = [l4].[Level2_Optional_Id]
 LEFT JOIN [LevelThree] AS [l5] ON [l0].[Id] = [l5].[OneToMany_Optional_Inverse3Id]
 WHERE ([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id], [l5].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id]");
         }
 
         public override async Task SelectMany_with_Include1(bool async)
@@ -264,7 +264,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id], [l4].[Id], [l5].[
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Orderby_SelectMany_with_Include1(bool async)
@@ -276,7 +276,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task SelectMany_with_Include2(bool async)
@@ -300,7 +300,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[OneToMany_Optional_Inverse4Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override async Task Multiple_SelectMany_with_Include(bool async)
@@ -314,7 +314,7 @@ INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Required_Id]
 LEFT JOIN [LevelFour] AS [l3] ON [l1].[Id] = [l3].[OneToMany_Optional_Inverse4Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [l3].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
         }
 
         public override async Task Required_navigation_with_Include(bool async)
@@ -446,7 +446,7 @@ ORDER BY [l].[Name], [l0].[Id]");
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l0].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l0].[Name], [l].[Id], [l0].[Id]");
         }
 
         public override async Task SelectMany_with_Include_and_order_by(bool async)
@@ -458,7 +458,7 @@ ORDER BY [l0].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l0].[Name], [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l0].[Name], [l].[Id], [l0].[Id]");
         }
 
         public override async Task SelectMany_with_navigation_and_Distinct(bool async)
@@ -473,7 +473,7 @@ INNER JOIN (
     FROM [LevelTwo] AS [l0]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
@@ -488,7 +488,7 @@ INNER JOIN (
     FROM [LevelTwo] AS [l0]
 ) AS [t] ON [l].[Id] = [t].[FK]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Complex_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_with_other_query_operators_composed_on_top(bool async)
@@ -525,7 +525,7 @@ LEFT JOIN (
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
 WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
-ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id], [t1].[Id]");
+ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
         public override async Task Project_collection_navigation(bool async)
@@ -536,7 +536,7 @@ ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[I
                 @"SELECT [l].[Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override async Task Project_collection_navigation_nested(bool async)
@@ -548,7 +548,7 @@ ORDER BY [l].[Id], [l0].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Project_collection_navigation_using_ef_property(bool async)
@@ -560,7 +560,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Project_collection_navigation_nested_anonymous(bool async)
@@ -572,7 +572,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Project_collection_navigation_composed(bool async)
@@ -588,7 +588,7 @@ LEFT JOIN (
     WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
 WHERE [l].[Id] < 3
-ORDER BY [l].[Id], [t].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override async Task Project_collection_and_root_entity(bool async)
@@ -599,7 +599,7 @@ ORDER BY [l].[Id], [t].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override async Task Project_collection_and_include(bool async)
@@ -611,7 +611,7 @@ ORDER BY [l].[Id], [l0].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Project_navigation_and_collection(bool async)
@@ -623,7 +623,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Include_inside_subquery(bool async)
@@ -640,7 +640,7 @@ OUTER APPLY (
     WHERE [l0].[Id] > 0
 ) AS [t]
 WHERE [l].[Id] < 3
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Include_collection_with_multiple_orderbys_member(bool async)
@@ -651,7 +651,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Name], [l].[Level1_Required_Id], [l].[Id], [l0].[Id]");
+ORDER BY [l].[Name], [l].[Level1_Required_Id], [l].[Id]");
         }
 
         public override async Task Include_collection_with_multiple_orderbys_property(bool async)
@@ -662,7 +662,7 @@ ORDER BY [l].[Name], [l].[Level1_Required_Id], [l].[Id], [l0].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Level1_Required_Id], [l].[Name], [l].[Id], [l0].[Id]");
+ORDER BY [l].[Level1_Required_Id], [l].[Name], [l].[Id]");
         }
 
         public override async Task Include_collection_with_multiple_orderbys_methodcall(bool async)
@@ -673,7 +673,7 @@ ORDER BY [l].[Level1_Required_Id], [l].[Name], [l].[Id], [l0].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
-ORDER BY ABS([l].[Level1_Required_Id]), [l].[Name], [l].[Id], [l0].[Id]");
+ORDER BY ABS([l].[Level1_Required_Id]), [l].[Name], [l].[Id]");
         }
 
         public override async Task Include_collection_with_multiple_orderbys_complex(bool async)
@@ -684,7 +684,7 @@ ORDER BY ABS([l].[Level1_Required_Id]), [l].[Name], [l].[Id], [l0].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
-ORDER BY ABS([l].[Level1_Required_Id]) + 7, [l].[Name], [l].[Id], [l0].[Id]");
+ORDER BY ABS([l].[Level1_Required_Id]) + 7, [l].[Name], [l].[Id]");
         }
 
         public override async Task Include_collection_with_multiple_orderbys_complex_repeated(bool async)
@@ -695,7 +695,7 @@ ORDER BY ABS([l].[Level1_Required_Id]) + 7, [l].[Name], [l].[Id], [l0].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_Inverse2Id], [l].[OneToMany_Optional_Self_Inverse2Id], [l].[OneToMany_Required_Inverse2Id], [l].[OneToMany_Required_Self_Inverse2Id], [l].[OneToOne_Optional_PK_Inverse2Id], [l].[OneToOne_Optional_Self2Id], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
 FROM [LevelTwo] AS [l]
 LEFT JOIN [LevelThree] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse3Id]
-ORDER BY -[l].[Level1_Required_Id], [l].[Name], [l].[Id], [l0].[Id]");
+ORDER BY -[l].[Level1_Required_Id], [l].[Name], [l].[Id]");
         }
 
         public override async Task Include_reference_collection_order_by_reference_navigation(bool async)
@@ -707,7 +707,7 @@ ORDER BY -[l].[Level1_Required_Id], [l].[Name], [l].[Id], [l0].[Id]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l0].[Id], [l].[Id], [l1].[Id]");
+ORDER BY [l0].[Id], [l].[Id]");
         }
 
         public override async Task Include_after_SelectMany_and_reference_navigation(bool async)
@@ -820,7 +820,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Null_check_in_Dto_projection_should_not_be_removed(bool async)
@@ -838,7 +838,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Required_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task SelectMany_navigation_property_followed_by_select_collection_navigation(bool async)
@@ -850,7 +850,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
 FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation(bool async)
@@ -863,7 +863,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 INNER JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[OneToMany_Optional_Inverse4Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override async Task SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation(bool async)
@@ -876,7 +876,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override void Include15()
@@ -903,7 +903,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override void IncludeCollection2()
@@ -918,7 +918,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override void IncludeCollection3()
@@ -930,7 +930,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override void IncludeCollection4()
@@ -941,7 +941,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
                 @"SELECT [l].[Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override void IncludeCollection5()
@@ -956,7 +956,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override void IncludeCollection6()
@@ -972,7 +972,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override void IncludeCollection6_1()
@@ -988,7 +988,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override void IncludeCollection6_2()
@@ -1006,7 +1006,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l3] ON [l0].[Id] = [l3].[Level2_Optional_Id]
     LEFT JOIN [LevelFour] AS [l4] ON [l3].[Id] = [l4].[OneToMany_Optional_Inverse4Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t].[Id3]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2]");
         }
 
         public override void IncludeCollection6_3()
@@ -1024,7 +1024,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l3] ON [l0].[Id] = [l3].[Level2_Optional_Id]
     LEFT JOIN [LevelFour] AS [l4] ON [l3].[Id] = [l4].[OneToMany_Optional_Inverse4Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t].[Id3]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2]");
         }
 
         public override void IncludeCollection6_4()
@@ -1040,7 +1040,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id1], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id1], [t].[Id]");
         }
 
         public override void IncludeCollection7()
@@ -1060,7 +1060,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l2]
     LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id]");
         }
 
         public override async Task IncludeCollection8(bool async)
@@ -1081,7 +1081,7 @@ WHERE (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l1].[Name] <> N'Foo') OR [l1].[Name] IS NULL)) > 0
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Lift_projection_mapping_when_pushing_down_subquery(bool async)
@@ -1105,7 +1105,7 @@ LEFT JOIN (
     WHERE [t1].[row] <= 1
 ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Required_Inverse2Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [t].[Id] = [l1].[OneToMany_Required_Inverse2Id]
-ORDER BY [t].[Id], [t0].[Id], [l1].[Id]");
+ORDER BY [t].[Id], [t0].[Id]");
         }
 
         public override async Task Including_reference_navigation_and_projecting_collection_navigation(bool async)
@@ -1118,7 +1118,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[Level2_Optional_Id]
 LEFT JOIN [LevelTwo] AS [l2] ON [l].[Id] = [l2].[OneToMany_Required_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override async Task LeftJoin_with_Any_on_outer_source_and_projecting_collection_from_inner(bool async)
@@ -1134,7 +1134,7 @@ FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Required_Inverse3Id]
 WHERE [l].[Name] IN (N'L1 01', N'L1 02')
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task Select_subquery_single_nested_subquery(bool async)
@@ -1197,7 +1197,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     WHERE [l0].[Id] > 5
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override async Task Filtered_include_OrderBy(bool async)
@@ -1211,7 +1211,7 @@ LEFT JOIN (
     SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
     FROM [LevelTwo] AS [l0]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Name], [t].[Id]");
+ORDER BY [l].[Id], [t].[Name]");
         }
 
         public override async Task Filtered_ThenInclude_OrderBy(bool async)
@@ -1229,7 +1229,7 @@ LEFT JOIN (
         FROM [LevelThree] AS [l1]
     ) AS [t] ON [l0].[Id] = [t].[OneToMany_Optional_Inverse3Id]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[Id], [t0].[Name0], [t0].[Id0]");
+ORDER BY [l].[Id], [t0].[Id], [t0].[Name0]");
         }
 
         public override async Task Filtered_include_ThenInclude_OrderBy(bool async)
@@ -1247,7 +1247,7 @@ LEFT JOIN (
         FROM [LevelThree] AS [l1]
     ) AS [t] ON [l0].[Id] = [t].[OneToMany_Optional_Inverse3Id]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[Name], [t0].[Id], [t0].[Name0] DESC, [t0].[Id0]");
+ORDER BY [l].[Id], [t0].[Name], [t0].[Id], [t0].[Name0] DESC");
         }
 
         public override async Task Filtered_include_basic_OrderBy_Take(bool async)
@@ -1265,7 +1265,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 3
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name], [t0].[Id]");
+ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name]");
         }
 
         public override async Task Filtered_include_basic_OrderBy_Skip(bool async)
@@ -1283,7 +1283,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 1 < [t].[row]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name], [t0].[Id]");
+ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name]");
         }
 
         public override async Task Filtered_include_basic_OrderBy_Skip_Take(bool async)
@@ -1301,7 +1301,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name], [t0].[Id]");
+ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name]");
         }
 
         public override void Filtered_include_Skip_without_OrderBy()
@@ -1357,7 +1357,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [t0].[OneToMany_Optional_Inverse3Id], [t0].[Name], [t0].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [t0].[OneToMany_Optional_Inverse3Id], [t0].[Name]");
         }
 
         public override async Task Filtered_include_after_reference_navigation(bool async)
@@ -1377,7 +1377,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 4)
 ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [t0].[OneToMany_Optional_Inverse3Id], [t0].[Name], [t0].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [t0].[OneToMany_Optional_Inverse3Id], [t0].[Name]");
         }
 
         public override async Task Filtered_include_after_different_filtered_include_same_level(bool async)
@@ -1405,7 +1405,7 @@ LEFT JOIN (
     ) AS [t2]
     WHERE 1 < [t2].[row]
 ) AS [t1] ON [l].[Id] = [t1].[OneToMany_Required_Inverse2Id]
-ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name], [t0].[Id], [t1].[OneToMany_Required_Inverse2Id], [t1].[Name] DESC, [t1].[Id]");
+ORDER BY [l].[Id], [t0].[OneToMany_Optional_Inverse2Id], [t0].[Name], [t0].[Id], [t1].[OneToMany_Required_Inverse2Id], [t1].[Name] DESC");
         }
 
         public override async Task Filtered_include_after_different_filtered_include_different_level(bool async)
@@ -1433,7 +1433,7 @@ OUTER APPLY (
         WHERE 1 < [t1].[row]
     ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Required_Inverse3Id]
 ) AS [t2]
-ORDER BY [l].[Id], [t2].[Name], [t2].[Id], [t2].[OneToMany_Required_Inverse3Id], [t2].[Name0] DESC, [t2].[Id0]");
+ORDER BY [l].[Id], [t2].[Name], [t2].[Id], [t2].[OneToMany_Required_Inverse3Id], [t2].[Name0] DESC");
         }
 
         public override async Task Filtered_include_same_filter_set_on_same_navigation_twice(bool async)
@@ -1473,7 +1473,7 @@ OUTER APPLY (
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
     LEFT JOIN [LevelThree] AS [l1] ON [t].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 ) AS [t0]
-ORDER BY [l].[Id], [t0].[Id], [t0].[Id0], [t0].[Id1]");
+ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]");
         }
 
         public override async Task
@@ -1496,7 +1496,7 @@ OUTER APPLY (
     LEFT JOIN [LevelThree] AS [l0] ON [t].[Id] = [l0].[Level2_Required_Id]
     LEFT JOIN [LevelThree] AS [l1] ON [t].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 ) AS [t0]
-ORDER BY [l].[Id], [t0].[Id], [t0].[Id0], [t0].[Id1]");
+ORDER BY [l].[Id], [t0].[Id], [t0].[Id0]");
         }
 
         public override async Task Filtered_include_and_non_filtered_include_on_same_navigation1(bool async)
@@ -1559,7 +1559,7 @@ OUTER APPLY (
         WHERE [l2].[Id] > 1
     ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse4Id]
 ) AS [t1]
-ORDER BY [l].[Id], [t1].[Id], [t1].[Id0], [t1].[Id1]");
+ORDER BY [l].[Id], [t1].[Id], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_complex_three_level_with_middle_having_filter1(bool async)
@@ -1584,7 +1584,7 @@ LEFT JOIN (
         LEFT JOIN [LevelFour] AS [l2] ON [t].[Id] = [l2].[OneToMany_Required_Inverse4Id]
     ) AS [t0]
 ) AS [t1] ON [l].[Id] = [t1].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t1].[Id], [t1].[Id0], [t1].[Id00], [t1].[Id1]");
+ORDER BY [l].[Id], [t1].[Id], [t1].[Id0], [t1].[Id00]");
         }
 
         public override async Task Filtered_include_complex_three_level_with_middle_having_filter2(bool async)
@@ -1609,7 +1609,7 @@ LEFT JOIN (
         LEFT JOIN [LevelFour] AS [l2] ON [t].[Id] = [l2].[OneToMany_Required_Inverse4Id]
     ) AS [t0]
 ) AS [t1] ON [l].[Id] = [t1].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t1].[Id], [t1].[Id0], [t1].[Id00], [t1].[Id1]");
+ORDER BY [l].[Id], [t1].[Id], [t1].[Id0], [t1].[Id00]");
         }
 
         public override void Filtered_include_variable_used_inside_filter()
@@ -1700,7 +1700,7 @@ OUTER APPLY (
         WHERE [l3].[Id] <> [l].[Id]
     ) AS [t1] ON [l2].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
 ) AS [t0]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id]");
         }
 
         public override async Task Complex_query_with_let_collection_projection_FirstOrDefault(bool async)
@@ -1727,7 +1727,7 @@ OUTER APPLY (
         FROM [LevelTwo] AS [l2]
         WHERE ([l1].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Id] = [t0].[Id]))
 ) AS [t1]
-ORDER BY [l].[Id], [t0].[Id], [t1].[Id]");
+ORDER BY [l].[Id], [t0].[Id]");
         }
 
         public override async Task SelectMany_DefaultIfEmpty_multiple_times_with_joins_projecting_a_collection(bool async)
@@ -1764,7 +1764,7 @@ LEFT JOIN (
     WHERE [l15].[Id] <> 42
 ) AS [t1] ON [t].[Id2] = [t1].[OneToMany_Optional_Self_Inverse2Id]
 WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
-ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id], [t1].[Id]");
+ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id]");
         }
 
         public override async Task Take_Select_collection_Take(bool async)
@@ -1790,7 +1790,7 @@ OUTER APPLY (
     ) AS [t1]
     INNER JOIN [LevelOne] AS [l0] ON [t1].[Level1_Required_Id] = [l0].[Id]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[Id]");
         }
 
         public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
@@ -1818,7 +1818,7 @@ OUTER APPLY (
     ) AS [t1]
     INNER JOIN [LevelOne] AS [l0] ON [t1].[Level1_Required_Id] = [l0].[Id]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[Id]");
         }
 
         public override async Task Projecting_collection_with_FirstOrDefault(bool async)
@@ -1833,7 +1833,7 @@ FROM (
     WHERE [l].[Id] = 1
 ) AS [t]
 LEFT JOIN [LevelTwo] AS [l0] ON [t].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [t].[Id], [l0].[Id]");
+ORDER BY [t].[Id]");
         }
 
         public override async Task Filtered_include_Take_with_another_Take_on_top_level(bool async)
@@ -1859,7 +1859,7 @@ OUTER APPLY (
     ) AS [t1]
     LEFT JOIN [LevelThree] AS [l0] ON [t1].[Id] = [l0].[Level2_Optional_Id]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Name] DESC, [t0].[Id], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[Name] DESC, [t0].[Id]");
         }
 
         public override async Task Filtered_include_Skip_Take_with_another_Skip_Take_on_top_level(bool async)
@@ -1888,7 +1888,7 @@ OUTER APPLY (
     ) AS [t1]
     LEFT JOIN [LevelThree] AS [l0] ON [t1].[Id] = [l0].[Level2_Optional_Id]
 ) AS [t0]
-ORDER BY [t].[Id] DESC, [t0].[Name] DESC, [t0].[Id], [t0].[Id0]");
+ORDER BY [t].[Id] DESC, [t0].[Name] DESC, [t0].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -42,7 +42,7 @@ LEFT JOIN (
     ) AS [t1] ON [l2].[Id] = [t1].[Id]
     WHERE [l2].[Level2_Required_Id] IS NOT NULL AND [l2].[OneToMany_Required_Inverse3Id] IS NOT NULL
 ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0], [t0].[Id00]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
         }
 
         public override async Task SelectMany_with_navigation_and_Distinct(bool async)
@@ -65,7 +65,7 @@ LEFT JOIN (
     WHERE ([l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL) AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
 WHERE ([t].[OneToOne_Required_PK_Date] IS NOT NULL AND [t].[Level1_Required_Id] IS NOT NULL) AND [t].[OneToMany_Required_Inverse2Id] IS NOT NULL
-ORDER BY [l].[Id], [t].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [l].[Id], [t].[Id], [t0].[Id]");
         }
 
         public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
@@ -87,7 +87,7 @@ LEFT JOIN (
     INNER JOIN [Level1] AS [l3] ON [l2].[Id] = [l3].[Id]
     WHERE ([l2].[OneToOne_Required_PK_Date] IS NOT NULL AND [l2].[Level1_Required_Id] IS NOT NULL) AND [l2].[OneToMany_Required_Inverse2Id] IS NOT NULL
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Name], [t].[FK], [t0].[Id], [t0].[Id0]");
+ORDER BY [l].[Id], [t].[Id], [t].[Name], [t].[FK], [t0].[Id]");
         }
 
         public override async Task Take_Select_collection_Take(bool async)
@@ -114,7 +114,7 @@ OUTER APPLY (
     ) AS [t1]
     INNER JOIN [Level1] AS [l1] ON [t1].[Level1_Required_Id] = [l1].[Id]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Id], [t0].[Id00], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id00]");
         }
 
         public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
@@ -143,7 +143,7 @@ OUTER APPLY (
     ) AS [t1]
     INNER JOIN [Level1] AS [l1] ON [t1].[Level1_Required_Id] = [l1].[Id]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Id], [t0].[Id00], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id00]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -2235,7 +2235,7 @@ ORDER BY [l0].[Id], [l].[Id]");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override void IncludeCollection2()
@@ -2250,7 +2250,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override void IncludeCollection3()
@@ -2262,7 +2262,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override void IncludeCollection4()
@@ -2273,7 +2273,7 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
                 @"SELECT [l].[Id], [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id]");
+ORDER BY [l].[Id]");
         }
 
         public override void IncludeCollection5()
@@ -2288,7 +2288,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l0]
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override void IncludeCollection6()
@@ -2304,7 +2304,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override void IncludeCollection6_1()
@@ -2320,7 +2320,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override void IncludeCollection6_2()
@@ -2338,7 +2338,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l3] ON [l0].[Id] = [l3].[Level2_Optional_Id]
     LEFT JOIN [LevelFour] AS [l4] ON [l3].[Id] = [l4].[OneToMany_Optional_Inverse4Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t].[Id3]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2]");
         }
 
         public override void IncludeCollection6_3()
@@ -2356,7 +2356,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l3] ON [l0].[Id] = [l3].[Level2_Optional_Id]
     LEFT JOIN [LevelFour] AS [l4] ON [l3].[Id] = [l4].[OneToMany_Optional_Inverse4Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t].[Id3]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2]");
         }
 
         public override void IncludeCollection6_4()
@@ -2372,7 +2372,7 @@ LEFT JOIN (
     LEFT JOIN [LevelThree] AS [l1] ON [l0].[Id] = [l1].[OneToOne_Optional_PK_Inverse3Id]
     LEFT JOIN [LevelFour] AS [l2] ON [l1].[Id] = [l2].[Level3_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id1], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id1], [t].[Id]");
         }
 
         public override void IncludeCollection7()
@@ -2392,7 +2392,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l2]
     LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[OneToOne_Optional_PK_Inverse3Id]
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
+ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id]");
         }
 
         public override async Task IncludeCollection8(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -174,7 +174,7 @@ LEFT JOIN (
     FROM [Globalizations] AS [g0]
     LEFT JOIN [Languages] AS [l0] ON [g0].[LanguageName] = [l0].[Name]
 ) AS [t0] ON [m0].[DefaultText] = [t0].[ComplexNavigationStringDefaultText]
-ORDER BY [f].[Name], [m].[DefaultText], [m0].[DefaultText], [t].[Text], [t].[Name], [t0].[Text], [t0].[Name]");
+ORDER BY [f].[Name], [m].[DefaultText], [m0].[DefaultText], [t].[Text], [t].[Name], [t0].[Text]");
         }
 
         public override async Task Join_navigation_key_access_optional(bool async)
@@ -1119,7 +1119,7 @@ LEFT JOIN (
     FROM [LevelTwo] AS [l2]
     LEFT JOIN [LevelThree] AS [l3] ON [l2].[Id] = [l3].[Level2_Optional_Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [t].[Id]");
         }
 
         public override async Task Where_navigation_property_to_collection(bool async)
@@ -2595,7 +2595,7 @@ FROM [InheritanceOne] AS [i]
 LEFT JOIN [InheritanceLeafOne] AS [i0] ON [i].[Id] = [i0].[DifferentTypeReference_InheritanceDerived1Id]
 LEFT JOIN [InheritanceLeafTwo] AS [i1] ON [i].[Id] = [i1].[DifferentTypeReference_InheritanceDerived2Id]
 LEFT JOIN [InheritanceTwo] AS [i2] ON [i1].[Id] = [i2].[InheritanceLeaf2Id]
-ORDER BY [i].[Id], [i0].[Id], [i1].[Id], [i2].[Id]");
+ORDER BY [i].[Id], [i0].[Id], [i1].[Id]");
         }
 
         public override async Task String_include_multiple_derived_collection_navigation_with_same_name_and_same_type(bool async)
@@ -2607,7 +2607,7 @@ ORDER BY [i].[Id], [i0].[Id], [i1].[Id], [i2].[Id]");
 FROM [InheritanceOne] AS [i]
 LEFT JOIN [InheritanceLeafOne] AS [i0] ON [i].[Id] = [i0].[InheritanceDerived1Id1]
 LEFT JOIN [InheritanceLeafOne] AS [i1] ON [i].[Id] = [i1].[InheritanceDerived2Id]
-ORDER BY [i].[Id], [i0].[Id], [i1].[Id]");
+ORDER BY [i].[Id], [i0].[Id]");
         }
 
         public override async Task String_include_multiple_derived_collection_navigation_with_same_name_and_different_type(bool async)
@@ -2619,7 +2619,7 @@ ORDER BY [i].[Id], [i0].[Id], [i1].[Id]");
 FROM [InheritanceOne] AS [i]
 LEFT JOIN [InheritanceLeafOne] AS [i0] ON [i].[Id] = [i0].[InheritanceDerived1Id]
 LEFT JOIN [InheritanceLeafTwo] AS [i1] ON [i].[Id] = [i1].[InheritanceDerived2Id]
-ORDER BY [i].[Id], [i0].[Id], [i1].[Id]");
+ORDER BY [i].[Id], [i0].[Id]");
         }
 
         public override async Task
@@ -2639,7 +2639,7 @@ LEFT JOIN (
     FROM [InheritanceLeafTwo] AS [i1]
     LEFT JOIN [InheritanceTwo] AS [i2] ON [i1].[Id] = [i2].[InheritanceLeaf2Id]
 ) AS [t] ON [i].[Id] = [t].[InheritanceDerived2Id]
-ORDER BY [i].[Id], [i0].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [i].[Id], [i0].[Id], [t].[Id]");
         }
 
         public override async Task String_include_multiple_derived_navigations_complex(bool async)
@@ -2658,7 +2658,7 @@ LEFT JOIN (
     LEFT JOIN [InheritanceLeafOne] AS [i4] ON [i3].[Id] = [i4].[SameTypeReference_InheritanceDerived1Id]
     LEFT JOIN [InheritanceLeafOne] AS [i5] ON [i3].[Id] = [i5].[SameTypeReference_InheritanceDerived2Id]
 ) AS [t] ON [i].[Id] = [t].[InheritanceBase2Id1]
-ORDER BY [i].[Id], [i0].[Id], [i1].[Id], [i2].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [i].[Id], [i0].[Id], [i1].[Id], [i2].[Id], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(bool async)
@@ -3057,7 +3057,7 @@ FROM [LevelOne] AS [l]
 INNER JOIN [LevelTwo] AS [l0] ON [l].[Id] = [l0].[Level1_Required_Id]
 LEFT JOIN [LevelTwo] AS [l1] ON [l].[Id] = [l1].[Level1_Optional_Id]
 LEFT JOIN [LevelThree] AS [l2] ON [l0].[Id] = [l2].[OneToMany_Optional_Inverse3Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
         }
 
         public override void GroupJoin_with_navigations_in_the_result_selector()
@@ -3248,7 +3248,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 1
 ) AS [t0] ON [l].[Id] = [t0].[OneToMany_Required_Inverse2Id]
-ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
+ORDER BY [l].[Id], [l0].[Id]");
         }
 
         public override async Task OrderBy_collection_count_ThenBy_reference_navigation(bool async)
@@ -3539,7 +3539,7 @@ OUTER APPLY (
         WHERE ([l].[Id] = [l1].[OneToMany_Required_Inverse2Id]) AND ([l1].[Id] = [l0].[Level2_Required_Id]))
 ) AS [t]
 LEFT JOIN [LevelTwo] AS [l2] ON [l].[Id] = [l2].[OneToMany_Required_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [l2].[Id]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         public override async Task Multiple_conditionals_in_projection(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/CompositeKeysQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/CompositeKeysQuerySqlServerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 FROM [CompositeOnes] AS [c]
 LEFT JOIN [CompositeTwos] AS [c0] ON ([c].[Id1] = [c0].[OneToMany_Optional_Inverse2Id1]) AND ([c].[Id2] = [c0].[OneToMany_Optional_Inverse2Id2])
 LEFT JOIN [CompositeTwos] AS [c1] ON ([c].[Id1] = [c1].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [c1].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Id2], [c].[Id1], [c0].[Id1], [c0].[Id2], [c1].[Id1], [c1].[Id2]");
+ORDER BY [c].[Id2], [c].[Id1], [c0].[Id1], [c0].[Id2], [c1].[Id1]");
         }
 
         public override async Task Projecting_multiple_collections_same_level_top_level_ordering_using_entire_composite_key(bool async)
@@ -41,7 +41,7 @@ ORDER BY [c].[Id2], [c].[Id1], [c0].[Id1], [c0].[Id2], [c1].[Id1], [c1].[Id2]");
 FROM [CompositeOnes] AS [c]
 LEFT JOIN [CompositeTwos] AS [c0] ON ([c].[Id1] = [c0].[OneToMany_Optional_Inverse2Id1]) AND ([c].[Id2] = [c0].[OneToMany_Optional_Inverse2Id2])
 LEFT JOIN [CompositeTwos] AS [c1] ON ([c].[Id1] = [c1].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [c1].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Id2], [c].[Id1] DESC, [c0].[Id1], [c0].[Id2], [c1].[Id1], [c1].[Id2]");
+ORDER BY [c].[Id2], [c].[Id1] DESC, [c0].[Id1], [c0].[Id2], [c1].[Id1]");
         }
 
         public override async Task Projecting_multiple_collections_with_ordering_same_level(bool async)
@@ -59,7 +59,7 @@ LEFT JOIN (
     SELECT [c1].[Id1], [c1].[Id2], [c1].[Date], [c1].[Level1_Optional_Id1], [c1].[Level1_Optional_Id2], [c1].[Level1_Required_Id1], [c1].[Level1_Required_Id2], [c1].[Name], [c1].[OneToMany_Optional_Inverse2Id1], [c1].[OneToMany_Optional_Inverse2Id2], [c1].[OneToMany_Optional_Self_Inverse2Id1], [c1].[OneToMany_Optional_Self_Inverse2Id2], [c1].[OneToMany_Required_Inverse2Id1], [c1].[OneToMany_Required_Inverse2Id2], [c1].[OneToMany_Required_Self_Inverse2Id1], [c1].[OneToMany_Required_Self_Inverse2Id2], [c1].[OneToOne_Optional_PK_Inverse2Id1], [c1].[OneToOne_Optional_PK_Inverse2Id2], [c1].[OneToOne_Optional_Self2Id1], [c1].[OneToOne_Optional_Self2Id2]
     FROM [CompositeTwos] AS [c1]
 ) AS [t0] ON ([c].[Id1] = [t0].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [t0].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Id1], [c].[Id2], [t].[Id2], [t].[Id1], [t0].[Name] DESC, [t0].[Id1], [t0].[Id2]");
+ORDER BY [c].[Id1], [c].[Id2], [t].[Id2], [t].[Id1], [t0].[Name] DESC, [t0].[Id1]");
         }
 
         public override async Task Projecting_multiple_collections_with_ordering_same_level_top_level_ordering(bool async)
@@ -77,7 +77,7 @@ LEFT JOIN (
     SELECT [c1].[Id1], [c1].[Id2], [c1].[Date], [c1].[Level1_Optional_Id1], [c1].[Level1_Optional_Id2], [c1].[Level1_Required_Id1], [c1].[Level1_Required_Id2], [c1].[Name], [c1].[OneToMany_Optional_Inverse2Id1], [c1].[OneToMany_Optional_Inverse2Id2], [c1].[OneToMany_Optional_Self_Inverse2Id1], [c1].[OneToMany_Optional_Self_Inverse2Id2], [c1].[OneToMany_Required_Inverse2Id1], [c1].[OneToMany_Required_Inverse2Id2], [c1].[OneToMany_Required_Self_Inverse2Id1], [c1].[OneToMany_Required_Self_Inverse2Id2], [c1].[OneToOne_Optional_PK_Inverse2Id1], [c1].[OneToOne_Optional_PK_Inverse2Id2], [c1].[OneToOne_Optional_Self2Id1], [c1].[OneToOne_Optional_Self2Id2]
     FROM [CompositeTwos] AS [c1]
 ) AS [t0] ON ([c].[Id1] = [t0].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [t0].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Id2], [c].[Id1], [t].[Id2], [t].[Id1], [t0].[Name] DESC, [t0].[Id1], [t0].[Id2]");
+ORDER BY [c].[Id2], [c].[Id1], [t].[Id2], [t].[Id1], [t0].[Name] DESC, [t0].[Id1]");
         }
 
         public override async Task Projecting_collections_multi_level(bool async)
@@ -95,7 +95,7 @@ LEFT JOIN (
         FROM [CompositeThrees] AS [c1]
     ) AS [t] ON ([c0].[Id1] = [t].[OneToMany_Required_Inverse3Id1]) AND ([c0].[Id2] = [t].[OneToMany_Required_Inverse3Id2])
 ) AS [t0] ON ([c].[Id1] = [t0].[OneToMany_Optional_Inverse2Id1]) AND ([c].[Id2] = [t0].[OneToMany_Optional_Inverse2Id2])
-ORDER BY [c].[Id2], [c].[Id1], [t0].[Id2], [t0].[Id1], [t0].[Id20] DESC, [t0].[Id10]");
+ORDER BY [c].[Id2], [c].[Id1], [t0].[Id2], [t0].[Id1], [t0].[Id20] DESC");
         }
 
         public override async Task Projecting_multiple_collections_on_multiple_levels_no_explicit_ordering(bool async)
@@ -137,7 +137,7 @@ LEFT JOIN (
         LEFT JOIN [CompositeFours] AS [c13] ON ([c11].[Id1] = [c13].[OneToMany_Required_Inverse4Id1]) AND ([c11].[Id2] = [c13].[OneToMany_Required_Inverse4Id2])
     ) AS [t4] ON ([c7].[Id1] = [t4].[OneToMany_Optional_Inverse3Id1]) AND ([c7].[Id2] = [t4].[OneToMany_Optional_Inverse3Id2])
 ) AS [t2] ON ([c].[Id1] = [t2].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [t2].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Id1], [c].[Id2], [t1].[Id1], [t1].[Id2], [t1].[Id10], [t1].[Id20], [t1].[Id100], [t1].[Id200], [t1].[Id11], [t1].[Id21], [t1].[Id12], [t1].[Id22], [t1].[Id101], [t1].[Id201], [t1].[Id110], [t1].[Id210], [t2].[Id1], [t2].[Id2], [t2].[Id10], [t2].[Id20], [t2].[Id100], [t2].[Id200], [t2].[Id11], [t2].[Id21], [t2].[Id12], [t2].[Id22], [t2].[Id101], [t2].[Id201], [t2].[Id110], [t2].[Id210]");
+ORDER BY [c].[Id1], [c].[Id2], [t1].[Id1], [t1].[Id2], [t1].[Id10], [t1].[Id20], [t1].[Id100], [t1].[Id200], [t1].[Id11], [t1].[Id21], [t1].[Id12], [t1].[Id22], [t1].[Id101], [t1].[Id201], [t1].[Id110], [t1].[Id210], [t2].[Id1], [t2].[Id2], [t2].[Id10], [t2].[Id20], [t2].[Id100], [t2].[Id200], [t2].[Id11], [t2].[Id21], [t2].[Id12], [t2].[Id22], [t2].[Id101], [t2].[Id201], [t2].[Id110]");
         }
 
         public override async Task Projecting_multiple_collections_on_multiple_levels_some_explicit_ordering(bool async)
@@ -182,7 +182,7 @@ LEFT JOIN (
         ) AS [t5] ON ([c11].[Id1] = [t5].[OneToMany_Required_Inverse4Id1]) AND ([c11].[Id2] = [t5].[OneToMany_Required_Inverse4Id2])
     ) AS [t4] ON ([c7].[Id1] = [t4].[OneToMany_Optional_Inverse3Id1]) AND ([c7].[Id2] = [t4].[OneToMany_Optional_Inverse3Id2])
 ) AS [t2] ON ([c].[Id1] = [t2].[OneToMany_Required_Inverse2Id1]) AND ([c].[Id2] = [t2].[OneToMany_Required_Inverse2Id2])
-ORDER BY [c].[Name], [c].[Id1], [c].[Id2], [t1].[Id1], [t1].[Id2], [t1].[Id20] DESC, [t1].[Id10] DESC, [t1].[Id100], [t1].[Id200], [t1].[Id11], [t1].[Id21], [t1].[Id12], [t1].[Id22], [t1].[Id101], [t1].[Id201], [t1].[Id110], [t1].[Id210], [t2].[c], [t2].[Id1], [t2].[Id2], [t2].[Id10], [t2].[Id20], [t2].[Id100], [t2].[Id200], [t2].[Id11], [t2].[Id21], [t2].[Id12], [t2].[Id22], [t2].[Id101], [t2].[Id201], [t2].[c0] DESC, [t2].[Id110], [t2].[Id210]");
+ORDER BY [c].[Name], [c].[Id1], [c].[Id2], [t1].[Id1], [t1].[Id2], [t1].[Id20] DESC, [t1].[Id10] DESC, [t1].[Id100], [t1].[Id200], [t1].[Id11], [t1].[Id21], [t1].[Id12], [t1].[Id22], [t1].[Id101], [t1].[Id201], [t1].[Id110], [t1].[Id210], [t2].[c], [t2].[Id1], [t2].[Id2], [t2].[Id10], [t2].[Id20], [t2].[Id100], [t2].[Id200], [t2].[Id11], [t2].[Id21], [t2].[Id12], [t2].[Id22], [t2].[Id101], [t2].[Id201], [t2].[c0] DESC, [t2].[Id110]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -418,7 +418,7 @@ FROM (
     SELECT * FROM ""Customers""
 ) AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task FromSqlRaw_queryable_simple_composed_include(bool async)
@@ -432,7 +432,7 @@ FROM (
 ) AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[City] = N'London'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task FromSqlRaw_annotations_do_not_affect_successive_calls(bool async)
@@ -521,7 +521,7 @@ CROSS JOIN (
     SELECT * FROM ""Customers"" WHERE ""CustomerID"" = 'AROUT'
 ) AS [c0]
 LEFT JOIN [Orders] AS [o] ON [c0].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [c0].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID], [c0].[CustomerID]");
         }
 
         public override async Task FromSqlRaw_with_join_and_include(bool async)
@@ -537,7 +537,7 @@ INNER JOIN (
     SELECT * FROM ""Orders"" WHERE ""OrderID"" <> 1
 ) AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task FromSqlInterpolated_with_inlined_db_parameter(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -73,7 +73,7 @@ WHERE 0 = 1");
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_multiple_one_to_one_optional_and_one_to_one_required(bool async)
@@ -96,7 +96,7 @@ LEFT JOIN [Squads] AS [s] ON [g].[SquadId] = [s].[Id]");
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Gears] AS [g0] ON [c].[Name] = [g0].[AssignedCityName]
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [g0].[Nickname]");
         }
 
         public override async Task Include_multiple_circular_with_filter(bool async)
@@ -109,7 +109,7 @@ FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Gears] AS [g0] ON [c].[Name] = [g0].[AssignedCityName]
 WHERE [g].[Nickname] = N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [g0].[Nickname]");
         }
 
         public override async Task Include_using_alternate_key(bool async)
@@ -121,7 +121,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [g0].[Nickname], [g0].[Squad
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] = N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_navigation_on_derived_type(bool async)
@@ -133,7 +133,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task String_based_Include_navigation_on_derived_type(bool async)
@@ -145,7 +145,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Select_Where_Navigation_Included(bool async)
@@ -190,7 +190,7 @@ INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]");
 FROM [Gears] AS [g]
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Include_with_join_collection2(bool async)
@@ -202,7 +202,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
 FROM [Tags] AS [t]
 INNER JOIN [Gears] AS [g] ON ([t].[GearSquadId] = [g].[SquadId]) AND ([t].[GearNickName] = [g].[Nickname])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_where_list_contains_navigation(bool async)
@@ -258,7 +258,7 @@ FROM [Gears] AS [g]
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
 INNER JOIN [Cities] AS [c] ON [g].[CityOfBirthName] = [c].[Name]
 LEFT JOIN [Gears] AS [g0] ON [c].[Name] = [g0].[AssignedCityName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [c].[Name], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [c].[Name], [g0].[Nickname]");
         }
 
         public override async Task Include_with_join_and_inheritance1(bool async)
@@ -289,7 +289,7 @@ INNER JOIN (
     WHERE [g].[Discriminator] = N'Officer'
 ) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
 LEFT JOIN [Gears] AS [g0] ON ([t0].[Nickname] = [g0].[LeaderNickname]) AND ([t0].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_with_join_and_inheritance2(bool async)
@@ -302,7 +302,7 @@ FROM [Gears] AS [g]
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Include_with_join_and_inheritance3(bool async)
@@ -318,7 +318,7 @@ INNER JOIN (
     WHERE [g].[Discriminator] = N'Officer'
 ) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
 LEFT JOIN [Gears] AS [g0] ON ([t0].[Nickname] = [g0].[LeaderNickname]) AND ([t0].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_with_nested_navigation_in_order_by(bool async)
@@ -1901,7 +1901,7 @@ WHERE COALESCE([c].[Location], '') + 'Added' LIKE '%Add%'");
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON [g].[LeaderNickname] = [g0].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
@@ -1914,7 +1914,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [w].[Id
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON [g].[LeaderNickname] = [g0].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g0].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3(bool async)
@@ -1928,7 +1928,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON [g].[LeaderNickname] = [g0].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g0].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [w].[Id], [w0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId], [w].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4(bool async)
@@ -1991,7 +1991,7 @@ LEFT JOIN (
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id], [w0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result(bool async)
@@ -2415,7 +2415,7 @@ LEFT JOIN (
     WHERE ([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [c].[Name] IN (N'Ephyra', N'Hanover')
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name]");
         }
 
         public override async Task Select_correlated_filtered_collection_with_composite_key(bool async)
@@ -2431,7 +2431,7 @@ LEFT JOIN (
     WHERE [g0].[Nickname] <> N'Dom'
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Select_correlated_filtered_collection_works_with_caching(bool async)
@@ -2442,7 +2442,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
                 @"SELECT [t].[Id], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname]
-ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId]");
+ORDER BY [t].[Note], [t].[Id], [g].[Nickname]");
         }
 
         public override async Task Join_predicate_value_equals_condition(bool async)
@@ -3210,7 +3210,7 @@ LEFT JOIN (
     WHERE [l].[Discriminator] = N'LocustCommander'
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [LocustLeaders] AS [l0] ON [f].[Id] = [l0].[LocustHordeId]
-ORDER BY [f].[Name], [f].[Id], [t].[Name], [l0].[Name]");
+ORDER BY [f].[Name], [f].[Id], [t].[Name]");
         }
 
         public override async Task Distinct_on_subquery_doesnt_get_lifted(bool async)
@@ -3346,7 +3346,7 @@ LEFT JOIN (
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Factions] AS [f0] ON [t].[Name] = [f0].[CommanderName]
 LEFT JOIN [LocustLeaders] AS [l0] ON [f0].[Id] = [l0].[LocustHordeId]
-ORDER BY [f].[Id], [t].[Name], [f0].[Id], [l0].[Name]");
+ORDER BY [f].[Id], [t].[Name], [f0].[Id]");
         }
 
         public override async Task Project_collection_navigation_with_inheritance2(bool async)
@@ -3363,7 +3363,7 @@ LEFT JOIN (
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Project_collection_navigation_with_inheritance3(bool async)
@@ -3380,7 +3380,7 @@ LEFT JOIN (
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_reference_on_derived_type_using_string(bool async)
@@ -3417,7 +3417,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     INNER JOIN [Cities] AS [c] ON [g0].[CityOfBirthName] = [c].[Name]
 ) AS [t] ON (([g].[Nickname] = [t].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [t].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [l].[Name], [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Name]");
+ORDER BY [l].[Name], [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Include_reference_on_derived_type_using_lambda(bool async)
@@ -3458,7 +3458,7 @@ LEFT JOIN [Gears] AS [g] ON ([l].[DefeatedByNickname] = [g].[Nickname]) AND ([l]
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_collection_on_derived_type_using_lambda(bool async)
@@ -3469,7 +3469,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_collection_on_derived_type_using_lambda_with_soft_cast(bool async)
@@ -3480,7 +3480,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOfBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
 FROM [Gears] AS [g]
 LEFT JOIN [Gears] AS [g0] ON ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_base_navigation_on_derived_entity(bool async)
@@ -3492,7 +3492,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
 FROM [Gears] AS [g]
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_base_reference(bool async)
@@ -3504,7 +3504,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_derived_reference(bool async)
@@ -3521,7 +3521,7 @@ LEFT JOIN (
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_derived_collection(bool async)
@@ -3536,7 +3536,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Gears] AS [g1] ON ([g0].[Nickname] = [g1].[LeaderNickname]) AND ([g0].[SquadId] = [g1].[LeaderSquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Nickname0], [t].[SquadId0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Nickname0]");
         }
 
         public override async Task ThenInclude_reference_on_derived_after_derived_collection(bool async)
@@ -3551,7 +3551,7 @@ LEFT JOIN (
     FROM [LocustLeaders] AS [l]
     LEFT JOIN [Gears] AS [g] ON ([l].[DefeatedByNickname] = [g].[Nickname]) AND ([l].[DefeatedBySquadId] = [g].[SquadId])
 ) AS [t] ON [f].[Id] = [t].[LocustHordeId]
-ORDER BY [f].[Id], [t].[Name], [t].[Nickname], [t].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [t].[Nickname]");
         }
 
         public override async Task Multiple_derived_included_on_one_method(bool async)
@@ -3568,7 +3568,7 @@ LEFT JOIN (
 ) AS [t] ON [f].[CommanderName] = [t].[Name]
 LEFT JOIN [Gears] AS [g] ON ([t].[DefeatedByNickname] = [g].[Nickname]) AND ([t].[DefeatedBySquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_on_derived_multi_level(bool async)
@@ -3584,7 +3584,7 @@ LEFT JOIN (
     INNER JOIN [Squads] AS [s] ON [g0].[SquadId] = [s].[Id]
     LEFT JOIN [SquadMissions] AS [s0] ON [s].[Id] = [s0].[SquadId]
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id], [t].[SquadId0], [t].[MissionId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id], [t].[SquadId0]");
         }
 
         public override async Task Projecting_nullable_bool_in_conditional_works(bool async)
@@ -3644,7 +3644,7 @@ FROM [Factions] AS [f]");
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_naked_navigation_with_ToList_followed_by_projecting_count(bool async)
@@ -3670,7 +3670,7 @@ ORDER BY [g].[Nickname]");
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection(bool async)
@@ -3686,7 +3686,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_explicit_to_list(bool async)
@@ -3702,7 +3702,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_explicit_to_array(bool async)
@@ -3718,7 +3718,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_ordered(bool async)
@@ -3734,7 +3734,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC, [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC");
         }
 
         public override async Task Correlated_collections_basic_projection_composite_key(bool async)
@@ -3750,7 +3750,7 @@ LEFT JOIN (
     WHERE [g0].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE ([g].[Discriminator] = N'Officer') AND ([g].[Nickname] <> N'Foo')
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_basic_projecting_single_property(bool async)
@@ -3766,7 +3766,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projecting_constant(bool async)
@@ -3782,7 +3782,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projecting_constant_bool(bool async)
@@ -3798,7 +3798,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_projection_of_collection_thru_navigation(bool async)
@@ -3815,7 +3815,7 @@ LEFT JOIN (
     WHERE [s0].[MissionId] <> 17
 ) AS [t] ON [s].[Id] = [t].[SquadId]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [s].[Id], [t].[SquadId], [t].[MissionId]");
+ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [s].[Id], [t].[SquadId]");
         }
 
         public override async Task Correlated_collections_project_anonymous_collection_result(bool async)
@@ -3827,7 +3827,7 @@ ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [s].[Id], [t].[SquadId],
 FROM [Squads] AS [s]
 LEFT JOIN [Gears] AS [g] ON [s].[Id] = [g].[SquadId]
 WHERE [s].[Id] < 20
-ORDER BY [s].[Id], [g].[Nickname], [g].[SquadId]");
+ORDER BY [s].[Id], [g].[Nickname]");
         }
 
         public override async Task Correlated_collections_nested(bool async)
@@ -3848,7 +3848,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 42
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool async)
@@ -3869,7 +3869,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 3
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool async)
@@ -3890,7 +3890,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 42
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_with_custom_ordering(bool async)
@@ -3911,7 +3911,7 @@ LEFT JOIN (
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[HasSoulPatch] DESC, [g].[Nickname], [g].[SquadId], [t0].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[IsAutomatic], [t0].[Id]");
+ORDER BY [g].[HasSoulPatch] DESC, [g].[Nickname], [g].[SquadId], [t0].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[IsAutomatic]");
         }
 
         public override async Task Correlated_collections_same_collection_projected_multiple_times(bool async)
@@ -3931,7 +3931,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(1 AS bit)
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Correlated_collections_similar_collection_projected_multiple_times(bool async)
@@ -3951,7 +3951,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(0 AS bit)
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[Rank], [g].[Nickname], [g].[SquadId], [t].[OwnerFullName], [t].[Id], [t0].[IsAutomatic], [t0].[Id]");
+ORDER BY [g].[Rank], [g].[Nickname], [g].[SquadId], [t].[OwnerFullName], [t].[Id], [t0].[IsAutomatic]");
         }
 
         public override async Task Correlated_collections_different_collections_projected(bool async)
@@ -3971,7 +3971,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[FullName], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[FullName], [t0].[Nickname]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys(bool async)
@@ -4007,7 +4007,7 @@ WHERE ([g].[Discriminator] = N'Officer') AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id], [t0].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_duplicated_orderings(
@@ -4029,7 +4029,7 @@ WHERE ([g].[Discriminator] = N'Officer') AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id], [t0].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[IsAutomatic], [t0].[Nickname] DESC, [t0].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_complex_orderings(
@@ -4054,7 +4054,7 @@ WHERE ([g].[Discriminator] = N'Officer') AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[Id] DESC, [t0].[c], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t0].[Id] DESC, [t0].[c], [t0].[Nickname]");
         }
 
         public override async Task Correlated_collections_multiple_nested_complex_collections(bool async)
@@ -4092,7 +4092,7 @@ WHERE ([g].[Discriminator] = N'Officer') AND EXISTS (
     SELECT 1
     FROM [Gears] AS [g0]
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t1].[Rank], [t1].[Nickname], [t1].[SquadId], [t1].[IsAutomatic0], [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Id1], [t1].[Nickname00], [t1].[SquadId00], [t3].[IsAutomatic], [t3].[Nickname] DESC, [t3].[Id], [t3].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [g1].[Nickname], [g1].[SquadId], [t1].[Rank], [t1].[Nickname], [t1].[SquadId], [t1].[IsAutomatic0], [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Id1], [t1].[Nickname00], [t1].[SquadId00], [t3].[IsAutomatic], [t3].[Nickname] DESC, [t3].[Id]");
         }
 
         public override async Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool async)
@@ -4108,7 +4108,7 @@ OUTER APPLY (
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ) AS [t]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool async)
@@ -4124,7 +4124,7 @@ OUTER APPLY (
     WHERE ([g].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_nested_inner_subquery_references_outer_qsre_one_level_up(bool async)
@@ -4145,7 +4145,7 @@ LEFT JOIN (
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool async)
@@ -4166,7 +4166,7 @@ OUTER APPLY (
     WHERE ([g0].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t0]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_on_select_many(bool async)
@@ -4188,7 +4188,7 @@ LEFT JOIN (
     WHERE [g0].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [g].[Nickname], [s].[Id] DESC, [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [s].[Id] DESC, [g].[SquadId], [t].[Id], [t0].[Nickname]");
         }
 
         public override async Task Correlated_collections_with_Skip(bool async)
@@ -4258,7 +4258,7 @@ OUTER APPLY (
         OFFSET 0 ROWS
     ) AS [t]
 ) AS [t0]
-ORDER BY [s].[Name], [s].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [s].[Name], [s].[Id], [t0].[Nickname]");
         }
 
         public override async Task Correlated_collections_with_FirstOrDefault(bool async)
@@ -4285,7 +4285,7 @@ FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_on_left_join_with_null_value(bool async)
@@ -4297,7 +4297,7 @@ ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON [t].[GearNickName] = [g].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_left_join_with_self_reference(bool async)
@@ -4313,7 +4313,7 @@ LEFT JOIN (
     WHERE [g].[Discriminator] = N'Officer'
 ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
 LEFT JOIN [Gears] AS [g0] ON (([t0].[Nickname] = [g0].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [g0].[LeaderSquadId])
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Correlated_collections_deeply_nested_left_join(bool async)
@@ -4335,7 +4335,7 @@ LEFT JOIN (
     ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
     WHERE [g0].[HasSoulPatch] = CAST(1 AS bit)
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [t].[Note], [g].[Nickname] DESC, [t].[Id], [g].[SquadId], [s].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+ORDER BY [t].[Note], [g].[Nickname] DESC, [t].[Id], [g].[SquadId], [s].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_from_left_join_with_additional_elements_projected_of_that_join(bool async)
@@ -4376,7 +4376,7 @@ LEFT JOIN (
         FROM [Gears] AS [g1]
     ) AS [t] ON [s].[Id] = [t].[SquadId]
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[Id0], [t0].[Nickname0], [t0].[SquadId0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[Id0], [t0].[Nickname0]");
         }
 
         public override async Task Correlated_collections_complex_scenario2(bool async)
@@ -4401,7 +4401,7 @@ LEFT JOIN (
     ) AS [t0] ON [g0].[FullName] = [t0].[OwnerFullName]
 ) AS [t1] ON ([g].[Nickname] = [t1].[LeaderNickname]) AND ([g].[SquadId] = [t1].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Nickname], [t1].[SquadId], [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Nickname00], [t1].[SquadId00]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Nickname], [t1].[SquadId], [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Nickname00]");
         }
 
         public override async Task Correlated_collections_with_funky_orderby_complex_scenario1(bool async)
@@ -4421,7 +4421,7 @@ LEFT JOIN (
         FROM [Gears] AS [g1]
     ) AS [t] ON [s].[Id] = [t].[SquadId]
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[Id0], [t0].[Nickname0], [t0].[SquadId0]");
+ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId], [t0].[Id0], [t0].[Nickname0]");
         }
 
         public override async Task Correlated_collections_with_funky_orderby_complex_scenario2(bool async)
@@ -4446,7 +4446,7 @@ LEFT JOIN (
     ) AS [t0] ON [g0].[FullName] = [t0].[OwnerFullName]
 ) AS [t1] ON ([g].[Nickname] = [t1].[LeaderNickname]) AND ([g].[SquadId] = [t1].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[HasSoulPatch], [g].[LeaderNickname], [g].[FullName], [g].[Nickname], [g].[SquadId], [t1].[FullName], [t1].[HasSoulPatch0] DESC, [t1].[Nickname], [t1].[SquadId], [t1].[IsAutomatic], [t1].[Name] DESC, [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Nickname00], [t1].[SquadId00]");
+ORDER BY [g].[HasSoulPatch], [g].[LeaderNickname], [g].[FullName], [g].[Nickname], [g].[SquadId], [t1].[FullName], [t1].[HasSoulPatch0] DESC, [t1].[Nickname], [t1].[SquadId], [t1].[IsAutomatic], [t1].[Name] DESC, [t1].[Id], [t1].[Nickname0], [t1].[SquadId0], [t1].[Id0], [t1].[Nickname00]");
         }
 
         public override async Task Correlated_collection_with_top_level_FirstOrDefault(bool async)
@@ -4461,7 +4461,7 @@ FROM (
     ORDER BY [g].[Nickname]
 ) AS [t]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_top_level_Count(bool async)
@@ -4485,7 +4485,7 @@ FROM (
     ORDER BY [g].[FullName]
 ) AS [t]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_top_level_Last_with_order_by_on_inner(bool async)
@@ -4503,7 +4503,7 @@ LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
 ) AS [t0] ON [t].[FullName] = [t0].[OwnerFullName]
-ORDER BY [t].[FullName] DESC, [t].[Nickname], [t].[SquadId], [t0].[Name], [t0].[Id]");
+ORDER BY [t].[FullName] DESC, [t].[Nickname], [t].[SquadId], [t0].[Name]");
         }
 
         public override async Task Null_semantics_on_nullable_bool_from_inner_join_subquery_is_fully_applied(bool async)
@@ -4552,7 +4552,7 @@ FROM (
     ORDER BY [t].[Note]
 ) AS [t0]
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t0].[Note], [t0].[Name], [t0].[Nickname], [t0].[SquadId], [t0].[Id], [w].[Id]");
+ORDER BY [t0].[Note], [t0].[Name], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
         }
 
         public override async Task Select_required_navigation_on_derived_type(bool async)
@@ -4599,7 +4599,7 @@ OUTER APPLY (
     INNER JOIN [Gears] AS [g0] ON [g].[FullName] = [g0].[FullName]
 ) AS [t0]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname]");
         }
 
         public override async Task Outer_parameter_in_join_key_inner_and_outer(bool async)
@@ -4615,7 +4615,7 @@ OUTER APPLY (
     INNER JOIN [Gears] AS [g0] ON [g].[FullName] = [g].[Nickname]
 ) AS [t0]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname]");
         }
 
         public override async Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool async)
@@ -4631,7 +4631,7 @@ OUTER APPLY (
     LEFT JOIN [Gears] AS [g0] ON [g].[FullName] = [g0].[FullName]
 ) AS [t0]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname]");
         }
 
         public override async Task Negated_bool_ternary_inside_anonymous_type_in_projection(bool async)
@@ -4959,7 +4959,7 @@ LEFT JOIN (
                 @"SELECT [s].[Id], [s].[Banner], [s].[Banner5], [s].[InternalNumber], [s].[Name], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Squads] AS [s]
 LEFT JOIN [Gears] AS [g] ON [s].[Id] = [g].[SquadId]
-ORDER BY [s].[Id], [g].[Nickname], [g].[SquadId]");
+ORDER BY [s].[Id], [g].[Nickname]");
         }
 
         public override async Task Correlated_collection_order_by_constant(bool async)
@@ -4970,7 +4970,7 @@ ORDER BY [s].[Id], [g].[Nickname], [g].[SquadId]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Select_subquery_projecting_single_constant_null_of_non_mapped_type(bool async)
@@ -5021,7 +5021,7 @@ WHERE [g].[Discriminator] = N'Officer'
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_collection_with_complex_OrderBy2(bool async)
@@ -5037,7 +5037,7 @@ ORDER BY (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+    ORDER BY [w].[Id]), [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Include_collection_with_complex_OrderBy3(bool async)
@@ -5053,7 +5053,7 @@ ORDER BY COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), CAST(0 AS bit)), [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+    ORDER BY [w].[Id]), CAST(0 AS bit)), [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Correlated_collection_with_complex_OrderBy(bool async)
@@ -5072,7 +5072,7 @@ WHERE [g].[Discriminator] = N'Officer'
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collection_with_very_complex_order_by(bool async)
@@ -5094,7 +5094,7 @@ ORDER BY (
     WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[IsAutomatic] = COALESCE((
         SELECT TOP(1) [g0].[HasSoulPatch]
         FROM [Gears] AS [g0]
-        WHERE [g0].[Nickname] = N'Marcus'), CAST(0 AS bit)))), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+        WHERE [g0].[Nickname] = N'Marcus'), CAST(0 AS bit)))), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Cast_to_derived_type_after_OfType_works(bool async)
@@ -5314,7 +5314,7 @@ WHERE [g].[HasSoulPatch] = CAST(1 AS bit)");
 FROM [Cities] AS [c]
 LEFT JOIN [Gears] AS [g] ON [c].[Name] = [g].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [g].[Nickname], [g].[SquadId]");
+ORDER BY [c].[Name], [g].[Nickname]");
         }
 
         public override async Task Cast_ordered_subquery_to_base_type_using_typed_ToArray(bool async)
@@ -5329,7 +5329,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t] ON [c].[Name] = [t].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [t].[Nickname] DESC, [t].[SquadId]");
+ORDER BY [c].[Name], [t].[Nickname] DESC");
         }
 
         public override async Task Correlated_collection_with_complex_order_by_funcletized_to_constant_bool(bool async)
@@ -5601,7 +5601,7 @@ ORDER BY [g].[Rank]");
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_with_client_method_and_member_access_still_applies_includes(bool async)
@@ -5622,7 +5622,7 @@ LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[Squad
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Multiple_includes_with_client_method_around_entity_and_also_projecting_included_collection()
@@ -5638,7 +5638,7 @@ LEFT JOIN (
     LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ) AS [t] ON [s].[Id] = [t].[SquadId]
 WHERE [s].[Name] = N'Delta'
-ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId], [t].[Id]");
+ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool async)
@@ -5933,7 +5933,7 @@ LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 ORDER BY (
     SELECT TOP(1) [w].[Name]
     FROM [Weapons] AS [w]
-    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Gnasher%')), [g].[Nickname], [g].[SquadId], [w0].[Id]");
+    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Gnasher%')), [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Anonymous_projection_take_followed_by_projecting_single_element_from_collection_navigation(bool async)
@@ -6036,7 +6036,7 @@ FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 LEFT JOIN [Gears] AS [g0] ON (([g].[Nickname] = [g0].[LeaderNickname]) OR ([g].[Nickname] IS NULL AND [g0].[LeaderNickname] IS NULL)) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId]");
+ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [g0].[Nickname]");
         }
 
         public override async Task Null_checks_in_correlated_predicate_are_correctly_translated(bool async)
@@ -6047,7 +6047,7 @@ ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId], [g0].[Nickname], [g0].[SquadId
                 @"SELECT [t].[Id], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Tags] AS [t]
 LEFT JOIN [Gears] AS [g] ON (([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])) AND [t].[Note] IS NOT NULL
-ORDER BY [t].[Id], [g].[Nickname], [g].[SquadId]");
+ORDER BY [t].[Id], [g].[Nickname]");
         }
 
         public override async Task SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector(bool async)
@@ -6237,9 +6237,9 @@ END AS [IsEradicated]
 FROM [Factions] AS [f]");
         }
 
-        public override async Task Acessing_reference_navigation_collection_composition_generates_single_query(bool async)
+        public override async Task Accessing_reference_navigation_collection_composition_generates_single_query(bool async)
         {
-            await base.Acessing_reference_navigation_collection_composition_generates_single_query(async);
+            await base.Accessing_reference_navigation_collection_composition_generates_single_query(async);
 
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [t].[Id], [t].[IsAutomatic], [t].[Name], [t].[Id0]
@@ -6249,7 +6249,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [t].[Id0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Reference_include_chain_loads_correctly_when_middle_is_null(bool async)
@@ -6280,7 +6280,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w]
     LEFT JOIN [Gears] AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname]");
         }
 
         public override async Task Collection_navigation_ofType_filter_works(bool async)
@@ -7286,7 +7286,7 @@ LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[Ow
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] < [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join2(bool async)
@@ -7297,7 +7297,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] <= [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join3(bool async)
@@ -7308,7 +7308,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] >= [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async)
@@ -7353,7 +7353,7 @@ OUTER APPLY (
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ) AS [t]
 WHERE [g].[Discriminator] = N'Officer'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Accessing_derived_property_using_hard_and_soft_cast(bool async)
@@ -7804,7 +7804,7 @@ OUTER APPLY (
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_distinct_projecting_identifier_column_and_correlation_key(bool async)
@@ -7818,7 +7818,7 @@ LEFT JOIN (
     SELECT DISTINCT [w].[Id], [w].[Name], [w].[OwnerFullName]
     FROM [Weapons] AS [w]
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_distinct_projecting_identifier_column_composite_key(bool async)
@@ -7832,7 +7832,7 @@ LEFT JOIN (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId], [g].[HasSoulPatch]
     FROM [Gears] AS [g]
 ) AS [t] ON [s].[Id] = [t].[SquadId]
-ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
+ORDER BY [s].[Id], [t].[Nickname]");
         }
 
         public override async Task Correlated_collection_with_distinct_not_projecting_identifier_column(bool async)
@@ -7847,7 +7847,7 @@ OUTER APPLY (
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name], [t].[IsAutomatic]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name]");
         }
 
         public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_but_only_grouping_key_in_final_projection(bool async)
@@ -7863,7 +7863,7 @@ OUTER APPLY (
     WHERE [g].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Key]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection(bool async)
@@ -7879,7 +7879,7 @@ OUTER APPLY (
     WHERE [g].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Key]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_groupby_not_projecting_identifier_column_with_group_aggregate_in_final_projection_multiple_grouping_keys(bool async)
@@ -7895,7 +7895,7 @@ OUTER APPLY (
     WHERE [g].[FullName] = [w].[OwnerFullName]
     GROUP BY [w].[IsAutomatic], [w].[Name]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[IsAutomatic], [t].[Name]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[IsAutomatic]");
         }
 
         public override async Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
@@ -7913,7 +7913,7 @@ OUTER APPLY (
     INNER JOIN [Gears] AS [g1] ON [c].[Name] = [g1].[CityOfBirthName]
     WHERE [g].[FullName] = [w].[OwnerFullName]
 ) AS [t]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[HasSoulPatch]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collection_after_distinct_3_levels(bool async)
@@ -7939,7 +7939,7 @@ OUTER APPLY (
         WHERE [t0].[FullName] = [w].[OwnerFullName]
     ) AS [t2]
 ) AS [t1]
-ORDER BY [t].[Id], [t1].[Nickname], [t1].[FullName], [t1].[HasSoulPatch], [t1].[Id0]");
+ORDER BY [t].[Id], [t1].[Nickname], [t1].[FullName], [t1].[HasSoulPatch]");
         }
 
         public override async Task Correlated_collection_after_distinct_3_levels_without_original_identifiers(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncompleteMappingInheritanceQuerySqlServerTest.cs
@@ -307,7 +307,7 @@ LEFT JOIN (
     FROM [Animals] AS [a0]
     WHERE [a0].[Discriminator] IN (N'Eagle', N'Kiwi')
 ) AS [t0] ON [t].[Species] = [t0].[EagleId]
-ORDER BY [t].[Species], [t0].[Species]");
+ORDER BY [t].[Species]");
         }
 
         public override async Task Can_include_animals(bool async)
@@ -322,7 +322,7 @@ LEFT JOIN (
     FROM [Animals] AS [a]
     WHERE [a].[Discriminator] IN (N'Eagle', N'Kiwi')
 ) AS [t] ON [c].[Id] = [t].[CountryId]
-ORDER BY [c].[Name], [c].[Id], [t].[Species]");
+ORDER BY [c].[Name], [c].[Id]");
         }
 
         public override async Task Can_use_of_type_kiwi_where_north_on_derived_property(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceQuerySqlServerTest.cs
@@ -286,7 +286,7 @@ FROM (
     WHERE [a].[Discriminator] = N'Eagle'
 ) AS [t]
 LEFT JOIN [Animals] AS [a0] ON [t].[Species] = [a0].[EagleId]
-ORDER BY [t].[Species], [a0].[Species]");
+ORDER BY [t].[Species]");
         }
 
         public override async Task Can_include_animals(bool async)
@@ -297,7 +297,7 @@ ORDER BY [t].[Species], [a0].[Species]");
                 @"SELECT [c].[Id], [c].[Name], [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Countries] AS [c]
 LEFT JOIN [Animals] AS [a] ON [c].[Id] = [a].[CountryId]
-ORDER BY [c].[Name], [c].[Id], [a].[Species]");
+ORDER BY [c].[Name], [c].[Id]");
         }
 
         public override async Task Can_use_of_type_kiwi_where_north_on_derived_property(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -29,7 +29,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_reverse(bool async)
@@ -42,7 +42,7 @@ FROM [BaseReferencesOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_self_reference_with_inheritance(bool async)
@@ -61,7 +61,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b3] ON [t].[Id] = [b3].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b4] ON [t].[Id] = [b4].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [b3].[BaseInheritanceRelationshipEntityId], [b3].[Id], [b4].[DerivedInheritanceRelationshipEntityId], [b4].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [b3].[BaseInheritanceRelationshipEntityId], [b3].[Id], [b4].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_self_reference_with_inheritance_reverse(bool async)
@@ -77,7 +77,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[De
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b3] ON [b0].[Id] = [b3].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b4] ON [b0].[Id] = [b4].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [b3].[BaseInheritanceRelationshipEntityId], [b3].[Id], [b4].[DerivedInheritanceRelationshipEntityId], [b4].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [b3].[BaseInheritanceRelationshipEntityId], [b3].[Id], [b4].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_with_filter(bool async)
@@ -91,7 +91,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_with_filter_reverse(bool async)
@@ -105,7 +105,7 @@ LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance(bool async)
@@ -118,7 +118,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_reverse(bool async)
@@ -131,7 +131,7 @@ FROM [ReferencesOnBase] AS [r]
 LEFT JOIN [BaseEntities] AS [b] ON [r].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [r].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [r].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_with_filter(bool async)
@@ -145,7 +145,7 @@ LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_with_filter_reverse(bool async)
@@ -159,7 +159,7 @@ LEFT JOIN [BaseEntities] AS [b] ON [r].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([r].[Name] <> N'Bar') OR [r].[Name] IS NULL
-ORDER BY [r].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [r].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance(bool async)
@@ -172,7 +172,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseCollectionsOnBase] AS [b2] ON [b].[Id] = [b2].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_reverse(bool async)
@@ -185,7 +185,7 @@ FROM [BaseCollectionsOnBase] AS [b]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance_with_filter(bool async)
@@ -199,7 +199,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseCollectionsOnBase] AS [b2] ON [b].[Id] = [b2].[BaseParentId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_with_filter_reverse(bool async)
@@ -213,7 +213,7 @@ LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_without_inheritance(bool async)
@@ -226,7 +226,7 @@ FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [c].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_without_inheritance_reverse(bool async)
@@ -239,7 +239,7 @@ FROM [CollectionsOnBase] AS [c]
 LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [c].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [c].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_without_inheritance_with_filter(bool async)
@@ -253,7 +253,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [c].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_without_inheritance_with_filter_reverse(bool async)
@@ -267,7 +267,7 @@ LEFT JOIN [BaseEntities] AS [b] ON [c].[ParentId] = [b].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [c].[Id], [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived1(bool async)
@@ -281,7 +281,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived2(bool async)
@@ -295,7 +295,7 @@ LEFT JOIN [BaseReferencesOnDerived] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived4(bool async)
@@ -313,7 +313,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_reverse(bool async)
@@ -330,7 +330,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [t].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter1(bool async)
@@ -344,7 +344,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter2(bool async)
@@ -358,7 +358,7 @@ LEFT JOIN [BaseReferencesOnDerived] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter4(bool async)
@@ -376,7 +376,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([b].[Name] <> N'Bar') OR [b].[Name] IS NULL)
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter_reverse(bool async)
@@ -394,7 +394,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [t].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived1(bool async)
@@ -408,7 +408,7 @@ LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived2(bool async)
@@ -422,7 +422,7 @@ LEFT JOIN [ReferencesOnDerived] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived_reverse(bool async)
@@ -439,7 +439,7 @@ LEFT JOIN (
 ) AS [t] ON [r].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [t].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
+ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived1(bool async)
@@ -453,7 +453,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseCollectionsOnBase] AS [b2] ON [b].[Id] = [b2].[BaseParentId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived2(bool async)
@@ -467,7 +467,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b1] ON [b].[Id] = [b1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseCollectionsOnDerived] AS [b2] ON [b].[Id] = [b2].[ParentId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived3(bool async)
@@ -485,7 +485,7 @@ LEFT JOIN (
     WHERE [b2].[Discriminator] = N'DerivedCollectionOnDerived'
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived_reverse(bool async)
@@ -502,7 +502,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [t].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference(bool async)
@@ -516,7 +516,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [NestedReferences] AS [n] ON [b0].[Id] = [n].[ParentReferenceId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [b0].[Id], [n].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [n].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference_on_base(bool async)
@@ -531,7 +531,7 @@ LEFT JOIN [NestedReferences] AS [n] ON [b0].[Id] = [n].[ParentReferenceId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[Id], [n].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [n].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference_reverse(bool async)
@@ -545,7 +545,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b] ON [n].[ParentReferenceId] = [b].[Id]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection(bool async)
@@ -559,7 +559,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [NestedCollections] AS [n] ON [b0].[Id] = [n].[ParentReferenceId]
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [n].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection_on_base(bool async)
@@ -574,7 +574,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseI
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [NestedCollections] AS [n] ON [b0].[Id] = [n].[ParentReferenceId]
 WHERE [b].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
-ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id], [n].[Id]");
+ORDER BY [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection_reverse(bool async)
@@ -588,7 +588,7 @@ LEFT JOIN [BaseReferencesOnBase] AS [b] ON [n].[ParentReferenceId] = [b].[Id]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_reference(bool async)
@@ -605,7 +605,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b2]
     LEFT JOIN [NestedReferences] AS [n] ON [b2].[Id] = [n].[ParentCollectionId]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_reference_reverse(bool async)
@@ -619,7 +619,7 @@ LEFT JOIN [BaseCollectionsOnBase] AS [b] ON [n].[ParentCollectionId] = [b].[Id]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_collection(bool async)
@@ -636,7 +636,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b2]
     LEFT JOIN [NestedCollections] AS [n] ON [b2].[Id] = [n].[ParentCollectionId]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_collection_reverse(bool async)
@@ -650,7 +650,7 @@ LEFT JOIN [BaseCollectionsOnBase] AS [b] ON [n].[ParentCollectionId] = [b].[Id]
 LEFT JOIN [BaseEntities] AS [b0] ON [b].[BaseParentId] = [b0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnDerived] AS [b2] ON [b0].[Id] = [b2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId], [b2].[Id]");
+ORDER BY [n].[Id], [b].[Id], [b0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [b2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_collection_reference_on_non_entity_base(bool async)
@@ -665,7 +665,7 @@ LEFT JOIN (
     FROM [PrincipalEntities] AS [p]
     LEFT JOIN [ReferencedEntities] AS [r0] ON [p].[ReferenceId] = [r0].[Id]
 ) AS [t] ON [r].[Id] = [t].[ReferencedEntityId]
-ORDER BY [r].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [r].[Id], [t].[Id]");
         }
 
         public override async Task Collection_projection_on_base_type(bool async)
@@ -676,7 +676,7 @@ ORDER BY [r].[Id], [t].[Id], [t].[Id0]");
                 @"SELECT [b].[Id], [b0].[Id], [b0].[BaseParentId], [b0].[Discriminator], [b0].[Name], [b0].[DerivedProperty]
 FROM [BaseEntities] AS [b]
 LEFT JOIN [BaseCollectionsOnBase] AS [b0] ON [b].[Id] = [b0].[BaseParentId]
-ORDER BY [b].[Id], [b0].[Id]");
+ORDER BY [b].[Id]");
         }
 
         public override async Task Include_on_derived_type_with_queryable_Cast(bool async)
@@ -694,7 +694,7 @@ LEFT JOIN (
     WHERE [b2].[Discriminator] = N'DerivedCollectionOnDerived'
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Id] >= 4
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [b1].[DerivedInheritanceRelationshipEntityId], [b1].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_split(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyNoTrackingQuerySqlServerTest.cs
@@ -335,7 +335,7 @@ LEFT JOIN (
         WHERE [e0].[Discriminator] = N'EntityLeaf'
     ) AS [t] ON [j].[LeafId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]");
         }
 
         public override async Task Skip_navigation_of_type(bool async)
@@ -351,7 +351,7 @@ LEFT JOIN (
     INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
     WHERE [e0].[Discriminator] = N'EntityLeaf'
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -517,7 +517,7 @@ LEFT JOIN (
     FROM [JoinOneSelfPayload] AS [j]
     INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[RightId]
-ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
         }
 
         public override async Task Select_skip_navigation_multiple(bool async)
@@ -542,7 +542,7 @@ LEFT JOIN (
     FROM [JoinTwoToCompositeKeyShared] AS [j1]
     INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
 ) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -576,7 +576,7 @@ LEFT JOIN (
     FROM [JoinCompositeKeyToRootShared] AS [j]
     INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -592,7 +592,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
         }
 
         public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
@@ -616,7 +616,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e1] ON [j0].[EntityOneId] = [e1].[Id]
     ) AS [t0] ON [t].[Id] = [t0].[EntityBranchId]
 ) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId], [t1].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId]");
         }
 
         public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
@@ -637,7 +637,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
     ) AS [t] ON [e0].[Id] = [t].[LeftId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId]");
         }
 
         public override async Task Include_skip_navigation_and_reference(bool async)
@@ -653,7 +653,7 @@ LEFT JOIN (
     FROM [EntityOneEntityTwo] AS [e1]
     INNER JOIN [EntityOnes] AS [e2] ON [e1].[EntityOneId] = [e2].[Id]
 ) AS [t] ON [e].[Id] = [t].[EntityTwoId]
-ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id]");
+ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId]");
         }
 
         public override async Task Filtered_include_skip_navigation_where(bool async)
@@ -669,7 +669,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by(bool async)
@@ -684,7 +684,7 @@ LEFT JOIN (
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[Id], [t].[ThreeId], [t].[TwoId]");
+ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
@@ -703,7 +703,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 2 < [t].[row]
 ) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id], [t0].[RightId]");
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -722,7 +722,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[TwoId]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -741,7 +741,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_where(bool async)
@@ -762,7 +762,7 @@ LEFT JOIN (
         WHERE [e2].[Id] < 10
     ) AS [t] ON [e1].[Id] = [t].[ThreeId]
 ) AS [t0] ON [e].[Id] = [t0].[EntityRootId]
-ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -786,7 +786,7 @@ LEFT JOIN (
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
     ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
 ) AS [t1] ON [e].[Id] = [t1].[RootId]
-ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -808,7 +808,7 @@ LEFT JOIN (
     WHERE [e0].[Key1] < 5
 ) AS [t0] ON [e].[Id] = [t0].[LeafId]
 WHERE [e].[Discriminator] = N'EntityLeaf'
-ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -835,7 +835,7 @@ OUTER APPLY (
         WHERE [e1].[Id] < 10
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
-ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -860,7 +860,7 @@ LEFT JOIN (
     ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
     WHERE [e0].[Id] < 10
 ) AS [t1] ON [e].[Id] = [t1].[OneId]
-ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0], [t1].[ThreeId]");
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined(bool async)
@@ -878,7 +878,7 @@ LEFT JOIN (
     LEFT JOIN [EntityTwos] AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
@@ -913,7 +913,7 @@ LEFT JOIN (
     ) AS [t1] ON [e0].[Id] = [t1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [t3] ON [e].[Id] = [t3].[ThreeId]
-ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId], [t3].[Id1]");
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId]");
         }
 
         public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
@@ -934,7 +934,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
@@ -955,7 +955,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[TwoId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
-ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
         }
 
         public override async Task Includes_accessed_via_different_path_are_merged(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyQuerySqlServerTest.cs
@@ -334,7 +334,7 @@ LEFT JOIN (
         WHERE [e0].[Discriminator] = N'EntityLeaf'
     ) AS [t] ON [j].[LeafId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]");
         }
 
         public override async Task Skip_navigation_of_type(bool async)
@@ -350,7 +350,7 @@ LEFT JOIN (
     INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
     WHERE [e0].[Discriminator] = N'EntityLeaf'
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -516,7 +516,7 @@ LEFT JOIN (
     FROM [JoinOneSelfPayload] AS [j]
     INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[RightId]
-ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
         }
 
         public override async Task Select_skip_navigation_multiple(bool async)
@@ -541,7 +541,7 @@ LEFT JOIN (
     FROM [JoinTwoToCompositeKeyShared] AS [j1]
     INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
 ) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -575,7 +575,7 @@ LEFT JOIN (
     FROM [JoinCompositeKeyToRootShared] AS [j]
     INNER JOIN [EntityRoots] AS [e0] ON [j].[RootId] = [e0].[Id]
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -591,7 +591,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
         }
 
         public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
@@ -615,7 +615,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e1] ON [j0].[EntityOneId] = [e1].[Id]
     ) AS [t0] ON [t].[Id] = [t0].[EntityBranchId]
 ) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId], [t1].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId]");
         }
 
         public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
@@ -636,7 +636,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
     ) AS [t] ON [e0].[Id] = [t].[LeftId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId]");
         }
 
         public override async Task Include_skip_navigation_and_reference(bool async)
@@ -652,7 +652,7 @@ LEFT JOIN (
     FROM [EntityOneEntityTwo] AS [e1]
     INNER JOIN [EntityOnes] AS [e2] ON [e1].[EntityOneId] = [e2].[Id]
 ) AS [t] ON [e].[Id] = [t].[EntityTwoId]
-ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id]");
+ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId]");
         }
 
         public override async Task Filtered_include_skip_navigation_where(bool async)
@@ -668,7 +668,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by(bool async)
@@ -683,7 +683,7 @@ LEFT JOIN (
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[Id], [t].[ThreeId], [t].[TwoId]");
+ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
@@ -702,7 +702,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 2 < [t].[row]
 ) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id], [t0].[RightId]");
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -721,7 +721,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[TwoId]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -740,7 +740,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_where(bool async)
@@ -761,7 +761,7 @@ LEFT JOIN (
         WHERE [e2].[Id] < 10
     ) AS [t] ON [e1].[Id] = [t].[ThreeId]
 ) AS [t0] ON [e].[Id] = [t0].[EntityRootId]
-ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -785,7 +785,7 @@ LEFT JOIN (
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
     ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
 ) AS [t1] ON [e].[Id] = [t1].[RootId]
-ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0], [t1].[Id]");
+ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -807,7 +807,7 @@ LEFT JOIN (
     WHERE [e0].[Key1] < 5
 ) AS [t0] ON [e].[Id] = [t0].[LeafId]
 WHERE [e].[Discriminator] = N'EntityLeaf'
-ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -834,7 +834,7 @@ OUTER APPLY (
         WHERE [e1].[Id] < 10
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
-ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -859,7 +859,7 @@ LEFT JOIN (
     ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
     WHERE [e0].[Id] < 10
 ) AS [t1] ON [e].[Id] = [t1].[OneId]
-ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0], [t1].[ThreeId]");
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined(bool async)
@@ -877,7 +877,7 @@ LEFT JOIN (
     LEFT JOIN [EntityTwos] AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
@@ -912,7 +912,7 @@ LEFT JOIN (
     ) AS [t1] ON [e0].[Id] = [t1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [t3] ON [e].[Id] = [t3].[ThreeId]
-ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId], [t3].[Id1]");
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId]");
         }
 
         public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
@@ -933,7 +933,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
@@ -954,7 +954,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[TwoId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
-ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
         }
 
         public override async Task Includes_accessed_via_different_path_are_merged(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindCompiledQuerySqlServerTest.cs
@@ -53,12 +53,12 @@ ORDER BY [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]",
+ORDER BY [c].[CustomerID]",
                 //
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override void Untyped_context()
@@ -230,7 +230,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE (((((((((((((([c].[CustomerID] = @__s1) OR ([c].[CustomerID] = @__s2)) OR ([c].[CustomerID] = @__s3)) OR ([c].[CustomerID] = @__s4)) OR ([c].[CustomerID] = @__s5)) OR ([c].[CustomerID] = @__s6)) OR ([c].[CustomerID] = @__s7)) OR ([c].[CustomerID] = @__s8)) OR ([c].[CustomerID] = @__s9)) OR ([c].[CustomerID] = @__s10)) OR ([c].[CustomerID] = @__s11)) OR ([c].[CustomerID] = @__s12)) OR ([c].[CustomerID] = @__s13)) OR ([c].[CustomerID] = @__s14)) OR ([c].[CustomerID] = @__s15)
-ORDER BY [c].[CustomerID], [o].[OrderID]",
+ORDER BY [c].[CustomerID]",
                 //
                 @"@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
 @__s2='ANATR' (Size = 5) (DbType = StringFixedLength)
@@ -292,7 +292,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE (((((((((((((([c].[CustomerID] = @__s1) OR ([c].[CustomerID] = @__s2)) OR ([c].[CustomerID] = @__s3)) OR ([c].[CustomerID] = @__s4)) OR ([c].[CustomerID] = @__s5)) OR ([c].[CustomerID] = @__s6)) OR ([c].[CustomerID] = @__s7)) OR ([c].[CustomerID] = @__s8)) OR ([c].[CustomerID] = @__s9)) OR ([c].[CustomerID] = @__s10)) OR ([c].[CustomerID] = @__s11)) OR ([c].[CustomerID] = @__s12)) OR ([c].[CustomerID] = @__s13)) OR ([c].[CustomerID] = @__s14)) OR ([c].[CustomerID] = @__s15)
-ORDER BY [c].[CustomerID], [o].[OrderID]",
+ORDER BY [c].[CustomerID]",
                 //
                 @"@__s1='ALFKI' (Size = 5) (DbType = StringFixedLength)
 @__s2='ANATR' (Size = 5) (DbType = StringFixedLength)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1700,7 +1700,7 @@ ORDER BY CAST(LEN([c].[CustomerID]) AS int), [c].[CustomerID]");
                 @"SELECT [c].[CustomerID], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY CAST(LEN([c].[CustomerID]) AS int), [c].[CustomerID], [o].[OrderID]");
+ORDER BY CAST(LEN([c].[CustomerID]) AS int), [c].[CustomerID]");
         }
 
         public override async Task Static_string_equals_in_predicate(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1599,7 +1599,7 @@ OUTER APPLY (
     GROUP BY [o].[OrderID]
 ) AS [t]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [t].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)
@@ -1620,7 +1620,7 @@ OUTER APPLY (
     GROUP BY [p0].[ProductID]
 ) AS [t0]
 WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'A%')
-ORDER BY [o].[OrderID], [t].[ProductID], [t0].[ProductID]");
+ORDER BY [o].[OrderID], [t].[ProductID]");
         }
 
         public override async Task Select_GroupBy_All(bool async)
@@ -2630,7 +2630,7 @@ OUTER APPLY (
     FROM [Products] AS [p0]
     GROUP BY [p0].[ProductID]
 ) AS [t1]
-ORDER BY [t].[City], [t0].[ProductID], [t1].[ProductID]");
+ORDER BY [t].[City], [t0].[ProductID]");
         }
 
         public override async Task Select_correlated_collection_after_GroupBy_aggregate_when_identifier_does_not_change(bool async)
@@ -2646,7 +2646,7 @@ FROM (
     HAVING [c].[CustomerID] LIKE N'F%'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Select_correlated_collection_after_GroupBy_aggregate_when_identifier_changes(bool async)
@@ -2662,7 +2662,7 @@ FROM (
     HAVING [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[CustomerID], [o0].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Select_correlated_collection_after_GroupBy_aggregate_when_identifier_changes_to_complex(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindIncludeQuerySqlServerTest.cs
@@ -38,7 +38,7 @@ LEFT JOIN (
     INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 ) AS [t] ON [p].[ProductID] = [t].[ProductID]
 WHERE (([p].[ProductID] % 17) = 5) AND ([p].[UnitPrice] < 20.0)
-ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID], [t].[OrderID0]");
+ORDER BY [p].[ProductID], [t].[OrderID], [t].[ProductID]");
         }
 
         public override async Task Include_reference(bool async)
@@ -74,7 +74,7 @@ END");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Include_collection_with_last(bool async)
@@ -89,7 +89,7 @@ FROM (
     ORDER BY [c].[CompanyName] DESC
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CompanyName] DESC, [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
         }
 
         public override async Task Include_collection_skip_no_order_by(bool async)
@@ -107,7 +107,7 @@ FROM (
     OFFSET @__p_0 ROWS
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_collection_take_no_order_by(bool async)
@@ -123,7 +123,7 @@ FROM (
     FROM [Customers] AS [c]
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_collection_skip_take_no_order_by(bool async)
@@ -142,7 +142,7 @@ FROM (
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_reference_and_collection(bool async)
@@ -155,7 +155,7 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
-ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
         }
 
         [ConditionalFact]
@@ -168,7 +168,7 @@ ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID]");
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
-ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID], [o0].[ProductID]",
+ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]",
                 context.Set<Order>().Include(o => o.Customer).Include(o => o.OrderDetails).ToQueryString(),
                 ignoreLineEndingDifferences: true,
                 ignoreWhiteSpaceDifferences: true);
@@ -223,7 +223,7 @@ INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
 WHERE (([o].[OrderID] % 23) = 13) AND ([o].[UnitPrice] < 10.0)
-ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [o1].[OrderID]");
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
         }
 
         public override async Task Include_multi_level_reference_and_collection_predicate(bool async)
@@ -239,7 +239,7 @@ FROM (
     WHERE [o].[OrderID] = 10248
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID0] = [o0].[CustomerID]
-ORDER BY [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
+ORDER BY [t].[OrderID], [t].[CustomerID0]");
         }
 
         public override async Task Include_multi_level_collection_and_then_include_reference_predicate(bool async)
@@ -258,7 +258,7 @@ LEFT JOIN (
     FROM [Order Details] AS [o0]
     INNER JOIN [Products] AS [p] ON [o0].[ProductID] = [p].[ProductID]
 ) AS [t0] ON [t].[OrderID] = [t0].[OrderID]
-ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0]");
+ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID]");
         }
 
         public override async Task Include_collection_alias_generation(bool async)
@@ -270,7 +270,7 @@ ORDER BY [t].[OrderID], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0]");
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 WHERE [o].[CustomerID] IS NOT NULL AND ([o].[CustomerID] LIKE N'F%')
-ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [o].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Include_collection_order_by_collection_column(bool async)
@@ -294,7 +294,7 @@ FROM (
         ORDER BY [o].[OrderDate] DESC) DESC
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[c] DESC, [t].[CustomerID], [o0].[OrderID]");
+ORDER BY [t].[c] DESC, [t].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_key(bool async)
@@ -306,7 +306,7 @@ ORDER BY [t].[c] DESC, [t].[CustomerID], [o0].[OrderID]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_non_key(bool async)
@@ -318,7 +318,7 @@ ORDER BY [c].[CustomerID], [o].[OrderID]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[PostalCode], [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[PostalCode], [c].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_non_key_with_take(bool async)
@@ -335,7 +335,7 @@ FROM (
     ORDER BY [c].[ContactTitle]
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[ContactTitle], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_non_key_with_skip(bool async)
@@ -354,7 +354,7 @@ FROM (
     OFFSET @__p_0 ROWS
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[ContactTitle], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[ContactTitle], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_non_key_with_first_or_default(bool async)
@@ -369,7 +369,7 @@ FROM (
     ORDER BY [c].[CompanyName] DESC
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CompanyName] DESC, [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CompanyName] DESC, [t].[CustomerID]");
         }
 
         public override async Task Include_collection_order_by_subquery(bool async)
@@ -393,7 +393,7 @@ FROM (
         ORDER BY [o].[EmployeeID])
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[c], [t].[CustomerID], [o0].[OrderID]");
+ORDER BY [t].[c], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_principal_already_tracked(bool async)
@@ -412,7 +412,7 @@ FROM (
     WHERE [c].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_collection_with_filter(bool async)
@@ -424,7 +424,7 @@ ORDER BY [t].[CustomerID], [o].[OrderID]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Include_collection_with_filter_reordered(bool async)
@@ -436,7 +436,7 @@ ORDER BY [c].[CustomerID], [o].[OrderID]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Include_collection_then_include_collection(bool async)
@@ -452,7 +452,7 @@ LEFT JOIN (
     LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0], [t].[ProductID]");
+ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0]");
         }
 
         public override async Task Include_collection_then_include_collection_then_include_reference(bool async)
@@ -472,7 +472,7 @@ LEFT JOIN (
     ) AS [t] ON [o].[OrderID] = [t].[OrderID]
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID], [t0].[ProductID0]");
+ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
         }
 
         public override async Task Include_collection_when_projection(bool async)
@@ -494,7 +494,7 @@ FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Include_collection_with_left_join_clause_with_filter(bool async)
@@ -507,7 +507,7 @@ FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Include_collection_with_cross_join_clause_with_filter(bool async)
@@ -524,7 +524,7 @@ CROSS JOIN (
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override async Task Include_collection_with_cross_apply_with_filter(bool async)
@@ -542,7 +542,7 @@ CROSS APPLY (
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override async Task Include_collection_with_outer_apply_with_filter(bool async)
@@ -560,7 +560,7 @@ OUTER APPLY (
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override async Task Include_collection_on_additional_from_clause_with_filter(bool async)
@@ -576,7 +576,7 @@ CROSS JOIN (
     WHERE [c0].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_on_additional_from_clause(bool async)
@@ -598,7 +598,7 @@ CROSS JOIN (
     WHERE [c0].[CustomerID] LIKE N'F%'
 ) AS [t0]
 LEFT JOIN [Orders] AS [o] ON [t0].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [t0].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID], [t0].[CustomerID]");
         }
 
         public override async Task Include_duplicate_collection(bool async)
@@ -622,7 +622,7 @@ CROSS JOIN (
 ) AS [t0]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [t0].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[CustomerID], [t0].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [t].[CustomerID], [t0].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Include_duplicate_collection_result_operator(bool async)
@@ -651,7 +651,7 @@ FROM (
 ) AS [t1]
 LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [t1].[CustomerID0] = [o0].[CustomerID]
-ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]");
         }
 
         public override async Task Include_collection_on_join_clause_with_order_by_and_filter(bool async)
@@ -664,7 +664,7 @@ FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[City], [c].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Include_collection_with_outer_apply_with_filter_non_equality(bool async)
@@ -682,7 +682,7 @@ OUTER APPLY (
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override async Task Include_collection_on_additional_from_clause2(bool async)
@@ -747,7 +747,7 @@ FROM (
     ORDER BY [t].[CustomerID]
 ) AS [t1]
 LEFT JOIN [Orders] AS [o] ON [t1].[CustomerID] = [o].[CustomerID]
-ORDER BY [t1].[CustomerID], [t1].[CustomerID0], [o].[OrderID]");
+ORDER BY [t1].[CustomerID], [t1].[CustomerID0]");
         }
 
         public override async Task Include_multiple_references(bool async)
@@ -890,7 +890,7 @@ FROM (
     WHERE [c].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_reference_dependent_already_tracked(bool async)
@@ -949,7 +949,7 @@ FROM (
     ORDER BY [c].[ContactName] DESC
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[ContactName] DESC, [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[ContactName] DESC, [t].[CustomerID]");
         }
 
         public override async Task Include_with_skip(bool async)
@@ -967,7 +967,7 @@ FROM (
     OFFSET @__p_0 ROWS
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[ContactName], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[ContactName], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_with_multiple_conditional_order_by(bool async)
@@ -997,7 +997,7 @@ FROM (
     END
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
         }
 
         public override async Task Then_include_collection_order_by_collection_column(bool async)
@@ -1025,7 +1025,7 @@ LEFT JOIN (
     FROM [Orders] AS [o0]
     LEFT JOIN [Order Details] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
 ) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t].[c] DESC, [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+ORDER BY [t].[c] DESC, [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
         }
 
         public override async Task Include_collection_with_conditional_order_by(bool async)
@@ -1040,7 +1040,7 @@ WHERE [c].[CustomerID] LIKE N'F%'
 ORDER BY CASE
     WHEN [c].[CustomerID] LIKE N'S%' THEN 1
     ELSE 2
-END, [c].[CustomerID], [o].[OrderID]");
+END, [c].[CustomerID]");
         }
 
         public override async Task Include_reference_distinct_is_server_evaluated(bool async)
@@ -1069,7 +1069,7 @@ FROM (
     WHERE [c].[CustomerID] LIKE N'A%'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_collection_OrderBy_object(bool async)
@@ -1081,7 +1081,7 @@ ORDER BY [t].[CustomerID], [o].[OrderID]");
 FROM [Orders] AS [o]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 WHERE [o].[OrderID] < 10250
-ORDER BY [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [o].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Include_collection_OrderBy_empty_list_contains(bool async)
@@ -1160,7 +1160,7 @@ FROM (
     OFFSET @__p_1 ROWS
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[c], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[c], [t].[CustomerID]");
         }
 
         public override async Task Include_collection_OrderBy_list_does_not_contains(bool async)
@@ -1185,7 +1185,7 @@ FROM (
     OFFSET @__p_1 ROWS
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[c], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[c], [t].[CustomerID]");
         }
 
         public override async Task Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(bool async)
@@ -1223,7 +1223,7 @@ LEFT JOIN (
     FROM [Orders] AS [o]
     LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 ) AS [t0] ON [t].[CustomerID] = [t0].[CustomerID]
-ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0], [t0].[ProductID]");
+ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
         }
 
         public override async Task Multi_level_includes_are_applied_with_take(bool async)
@@ -1249,7 +1249,7 @@ LEFT JOIN (
     FROM [Orders] AS [o]
     LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 ) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
-ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]");
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
         }
 
         public override async Task Multi_level_includes_are_applied_with_skip_take(bool async)
@@ -1276,7 +1276,7 @@ LEFT JOIN (
     FROM [Orders] AS [o]
     LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 ) AS [t1] ON [t0].[CustomerID] = [t1].[CustomerID]
-ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0], [t1].[ProductID]");
+ORDER BY [t0].[CustomerID], [t1].[OrderID], [t1].[OrderID0]");
         }
 
         public override async Task Filtered_include_with_multiple_ordering(bool async)
@@ -1297,7 +1297,7 @@ OUTER APPLY (
     ) AS [t]
 ) AS [t0]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t0].[OrderDate] DESC, [t0].[OrderID]");
+ORDER BY [c].[CustomerID], [t0].[OrderDate] DESC");
         }
 
         public override async Task Outer_idenfier_correctly_determined_when_doing_include_on_right_side_of_left_join(bool async)
@@ -1310,7 +1310,7 @@ FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 WHERE [c].[City] = N'Seattle'
-ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
@@ -1330,7 +1330,7 @@ LEFT JOIN (
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 LEFT JOIN [Order Details] AS [o0] ON [t0].[OrderID] = [o0].[OrderID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t0].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [c].[CustomerID], [t0].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Repro9735(bool async)
@@ -1360,7 +1360,7 @@ FROM (
     END
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[c], [t].[c0], [t].[OrderID], [t].[CustomerID0], [o0].[OrderID]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -558,7 +558,7 @@ CROSS APPLY (
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [c].[CustomerID], [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task SelectMany_with_client_eval_with_collection_shaper_ignored(bool async)
@@ -593,7 +593,7 @@ LEFT JOIN (
     ) AS [t] ON [o].[OrderID] = [t].[OrderID]
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [t0].[OrderID0], [t0].[OrderID], [t0].[ProductID]");
+ORDER BY [c].[CustomerID], [t0].[OrderID0], [t0].[OrderID]");
         }
 
         public override async Task SelectMany_with_selecting_outer_entity(bool async)
@@ -745,7 +745,7 @@ OUTER APPLY (
     ) AS [t1]
     LEFT JOIN [Customers] AS [c0] ON [t1].[CustomerID] = [c0].[CustomerID]
 ) AS [t0]
-ORDER BY [t].[CustomerID], [t0].[OrderDate], [t0].[OrderID], [t0].[CustomerID]");
+ORDER BY [t].[CustomerID], [t0].[OrderDate], [t0].[OrderID]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindMiscellaneousQuerySqlServerTest.cs
@@ -2384,7 +2384,7 @@ WHERE [c].[CustomerID] LIKE N'A%'");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Select_correlated_subquery_ordered(bool async)
@@ -3869,7 +3869,7 @@ FROM (
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[City], [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[City], [t].[CustomerID]");
         }
 
         public override async Task Int16_parameter_can_be_used_for_int_column(bool async)
@@ -4430,7 +4430,7 @@ OUTER APPLY (
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
 WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[CustomerID], [t].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(bool async)
@@ -4475,7 +4475,7 @@ LEFT JOIN (
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID0]
-ORDER BY [c].[CustomerID], [t].[OrderID], [t].[CustomerID0]");
+ORDER BY [c].[CustomerID], [t].[OrderID]");
         }
 
         public override async Task Join_take_count_works(bool async)
@@ -4740,7 +4740,7 @@ FROM (
     OFFSET @__p_0 ROWS
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Projection_take_collection_projection(bool async)
@@ -4758,7 +4758,7 @@ FROM (
     ORDER BY [o].[OrderID]
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Projection_skip_take_collection_projection(bool async)
@@ -4778,7 +4778,7 @@ FROM (
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Projection_skip_projection(bool async)
@@ -4854,7 +4854,7 @@ FROM (
     OFFSET @__p_0 ROWS
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Collection_projection_take(bool async)
@@ -4872,7 +4872,7 @@ FROM (
     ORDER BY [o].[OrderID]
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Collection_projection_skip_take(bool async)
@@ -4892,7 +4892,7 @@ FROM (
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]
 LEFT JOIN [Order Details] AS [o0] ON [t].[OrderID] = [o0].[OrderID]
-ORDER BY [t].[OrderID], [o0].[OrderID], [o0].[ProductID]");
+ORDER BY [t].[OrderID], [o0].[OrderID]");
         }
 
         public override async Task Anonymous_projection_skip_empty_collection_FirstOrDefault(bool async)
@@ -5419,7 +5419,7 @@ OUTER APPLY (
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
-ORDER BY [c].[CustomerID], [t].[First]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Correlated_collection_with_distinct_without_default_identifiers_projecting_columns_with_navigation(bool async)
@@ -5435,7 +5435,7 @@ OUTER APPLY (
     LEFT JOIN [Customers] AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
     WHERE [c].[CustomerID] = [o].[CustomerID]
 ) AS [t]
-ORDER BY [c].[CustomerID], [t].[First], [t].[Second], [t].[Third]");
+ORDER BY [c].[CustomerID], [t].[First], [t].[Second]");
         }
 
         public override async Task Select_nested_collection_with_distinct(bool async)
@@ -5456,7 +5456,7 @@ LEFT JOIN (
     FROM [Orders] AS [o0]
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [t].[CustomerID]");
+ORDER BY [c].[CustomerID]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindNavigationsQuerySqlServerTest.cs
@@ -388,7 +388,7 @@ WHERE [e0].[EmployeeID] IS NULL");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Select_collection_navigation_simple2(bool async)
@@ -414,7 +414,7 @@ ORDER BY [c].[CustomerID]");
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Select_collection_navigation_multi_part(bool async)
@@ -427,7 +427,7 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [o].[CustomerID] = N'ALFKI'
-ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [o].[OrderID], [c].[CustomerID]");
         }
 
         public override async Task Select_collection_navigation_multi_part2(bool async)
@@ -441,7 +441,7 @@ INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o1] ON [c].[CustomerID] = [o1].[CustomerID]
 WHERE [o0].[CustomerID] IN (N'ALFKI', N'ANTON')
-ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID], [o1].[OrderID]");
+ORDER BY [o].[OrderID], [o].[ProductID], [o0].[OrderID], [c].[CustomerID]");
         }
 
         public override async Task Collection_select_nav_prop_any(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -132,7 +132,7 @@ LEFT JOIN (
     WHERE [t].[CustomerID] IS NOT NULL AND [t].[CompanyName] IS NOT NULL
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 WHERE (@__ef_filter__TenantPrefix_0 = N'') OR ([c].[CompanyName] IS NOT NULL AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0))
-ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID0]");
+ORDER BY [c].[CustomerID], [t0].[OrderID]");
         }
 
         public override async Task Include_query_opt_out(bool async)
@@ -143,7 +143,7 @@ ORDER BY [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID0]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Included_many_to_one_query(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryTaggingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryTaggingQuerySqlServerTest.cs
@@ -92,7 +92,7 @@ FROM (
     ORDER BY [c].[CustomerID]
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -81,7 +81,7 @@ FROM [Customers] AS [c]");
                 @"SELECT [c].[CustomerID], [o].[CustomerID], [o].[OrderID]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Project_to_object_array(bool async)
@@ -1136,7 +1136,7 @@ LEFT JOIN (
     WHERE [o].[OrderID] > 11000
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [t].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Filtered_collection_projection_with_to_list_is_tracked(bool async)
@@ -1152,7 +1152,7 @@ LEFT JOIN (
     WHERE [o].[OrderID] > 11000
 ) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
 WHERE [c].[CustomerID] LIKE N'A%'
-ORDER BY [c].[CustomerID], [t].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(
@@ -1201,7 +1201,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
-ORDER BY [o].[OrderID], [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [o].[OrderID], [c].[CustomerID]");
         }
 
         public override async Task Select_entity_compared_to_null(bool async)
@@ -1317,7 +1317,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
                 @"SELECT [c].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
-ORDER BY [c].[CustomerID], [o].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Coalesce_over_nullable_uint(bool async)
@@ -1397,7 +1397,7 @@ WHERE ([c].[CustomerID] LIKE N'A%') AND ((
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[OrderID] < 11000)) > 0)
-ORDER BY [c].[CustomerID], [t].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Projection_custom_type_in_both_sides_of_ternary(bool async)
@@ -1423,7 +1423,7 @@ FROM [Customers] AS [c]
 LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 LEFT JOIN [Orders] AS [o0] ON [c].[CustomerID] = [o0].[CustomerID]
 WHERE [c].[CustomerID] = N'ALFKI'
-ORDER BY [c].[CustomerID], [o].[OrderID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
         public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
@@ -1559,7 +1559,7 @@ LEFT JOIN (
     WHERE [o2].[UnitPrice] < 10.0
 ) AS [t2] ON [o].[OrderID] = [t2].[OrderID]
 WHERE [o].[OrderID] < 10350
-ORDER BY [o].[OrderID], [t].[OrderID], [t].[ProductID], [t].[ProductID0], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0], [t2].[OrderID], [t2].[ProductID], [t2].[ProductID0]");
+ORDER BY [o].[OrderID], [t].[OrderID], [t].[ProductID], [t].[ProductID0], [t0].[OrderID], [t0].[ProductID], [t0].[ProductID0], [t2].[OrderID], [t2].[ProductID]");
         }
 
         public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
@@ -1613,7 +1613,7 @@ OUTER APPLY (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND ([t].[OrderID] = [o0].[OrderID])
 ) AS [t0]
-ORDER BY [t].[OrderID], [t0].[Inner]");
+ORDER BY [t].[OrderID]");
         }
 
         public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
@@ -1631,7 +1631,7 @@ OUTER APPLY (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND (([t].[CustomerID] = [o0].[CustomerID]) OR ([t].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL))
 ) AS [t0]
-ORDER BY [t].[OrderDate], [t].[CustomerID], [t0].[Inner]");
+ORDER BY [t].[OrderDate], [t].[CustomerID]");
         }
 
         public override async Task Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
@@ -1668,7 +1668,7 @@ OUTER APPLY (
     FROM [Orders] AS [o0]
     WHERE [o0].[OrderID] IN (10248, 10249, 10250) AND ([t].[OrderID] = [o0].[OrderID])
 ) AS [t0]
-ORDER BY [t].[OrderID], [t0].[Inner]");
+ORDER BY [t].[OrderID]");
         }
 
         public override async Task Select_nested_collection_deep(bool async)
@@ -1741,7 +1741,7 @@ LEFT JOIN (
 ) AS [t0] ON [c].[CustomerID] = [t0].[CustomerID]
 LEFT JOIN [Order Details] AS [o2] ON [t0].[OrderID] = [o2].[OrderID]
 WHERE [c].[CustomerID] LIKE N'F%'
-ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0], [t].[ProductID], [t0].[OrderID], [o2].[OrderID], [o2].[ProductID]");
+ORDER BY [c].[CustomerID], [t].[OrderID], [t].[OrderID0], [t].[ProductID], [t0].[OrderID], [o2].[OrderID]");
         }
 
         public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
@@ -1768,7 +1768,7 @@ OUTER APPLY (
     ) AS [t1]
     WHERE [t].[CustomerID] = [o].[CustomerID]
 ) AS [t0]
-ORDER BY [t].[CustomerID], [t0].[OrderID], [t0].[OrderID0]");
+ORDER BY [t].[CustomerID], [t0].[OrderID]");
         }
 
         public override async Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
@@ -1793,7 +1793,7 @@ OUTER APPLY (
     ) AS [t1]
     INNER JOIN [Products] AS [p] ON [t1].[ProductID] = [p].[ProductID]
 ) AS [t0]
-ORDER BY [t].[OrderID], [t0].[OrderID] DESC, [t0].[ProductID0], [t0].[ProductID]");
+ORDER BY [t].[OrderID], [t0].[OrderID] DESC, [t0].[ProductID0]");
         }
 
         public override async Task Take_on_correlated_collection_in_first(bool async)
@@ -1821,7 +1821,7 @@ OUTER APPLY (
     ) AS [t1]
     LEFT JOIN [Customers] AS [c0] ON [t1].[CustomerID] = [c0].[CustomerID]
 ) AS [t0]
-ORDER BY [t].[CustomerID], [t0].[OrderDate], [t0].[OrderID], [t0].[CustomerID]");
+ORDER BY [t].[CustomerID], [t0].[OrderDate], [t0].[OrderID]");
         }
 
         public override async Task Client_projection_via_ctor_arguments(bool async)
@@ -1839,7 +1839,7 @@ FROM (
     WHERE [c].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
-ORDER BY [t].[CustomerID], [o0].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -342,7 +342,7 @@ FROM (
     WHERE [c0].[City] = N'London'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Include_Union(bool async)
@@ -361,7 +361,7 @@ FROM (
     WHERE [c0].[City] = N'London'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Select_Except_reference_projection(bool async)
@@ -558,7 +558,7 @@ FROM (
     WHERE [c0].[CustomerID] LIKE N'F%'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Concat_with_one_side_being_GroupBy_aggregate(bool async)
@@ -594,7 +594,7 @@ FROM (
     WHERE [o0].[OrderID] < 10250
 ) AS [t]
 LEFT JOIN [Orders] AS [o1] ON [t].[CustomerID] = [o1].[CustomerID]
-ORDER BY [t].[CustomerID], [o1].[OrderID]");
+ORDER BY [t].[CustomerID]");
         }
 
         public override async Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
@@ -615,7 +615,7 @@ FROM (
     WHERE [o0].[OrderID] < 10250
 ) AS [t]
 LEFT JOIN [Orders] AS [o1] ON [t].[CustomerID] = [o1].[CustomerID]
-ORDER BY [t].[CustomerID], [t].[OrderDate], [o1].[OrderID]");
+ORDER BY [t].[CustomerID], [t].[OrderDate]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindWhereQuerySqlServerTest.cs
@@ -1589,7 +1589,7 @@ FROM (
     WHERE [c].[CustomerID] = N'ALFKI'
 ) AS [t]
 LEFT JOIN [Orders] AS [o] ON [t].[CustomerID] = [o].[CustomerID]
-ORDER BY [t].[CustomerID], [o].[OrderID]",
+ORDER BY [t].[CustomerID]",
                 //
                 @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
@@ -1839,7 +1839,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = [c].[CustomerID]) = 0
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_ToList_Contains(bool async)
@@ -1854,7 +1854,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[CustomerID] = N'ALFKI'))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_ToArray_Count(bool async)
@@ -1869,7 +1869,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = [c].[CustomerID]) = 0
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_ToArray_Contains(bool async)
@@ -1884,7 +1884,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[CustomerID] = N'ALFKI'))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_AsEnumerable_Count(bool async)
@@ -1899,7 +1899,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = [c].[CustomerID]) = 0
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_AsEnumerable_Contains(bool async)
@@ -1914,7 +1914,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[CustomerID] = N'ALFKI'))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_AsEnumerable_Contains_negated(bool async)
@@ -1929,7 +1929,7 @@ WHERE NOT (EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = [c].[CustomerID]) AND ([o].[CustomerID] = N'ALFKI')))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_ToList_Count_member(bool async)
@@ -1944,7 +1944,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = [c].[CustomerID]) = 0
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_Queryable_ToArray_Length_member(bool async)
@@ -1959,7 +1959,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Orders] AS [o]
     WHERE [o].[CustomerID] = [c].[CustomerID]) = 0
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_collection_navigation_ToList_Count(bool async)
@@ -1974,7 +1974,7 @@ WHERE ([o].[OrderID] < 10300) AND ((
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]) = 0)
-ORDER BY [o].[OrderID], [o1].[OrderID], [o1].[ProductID]");
+ORDER BY [o].[OrderID], [o1].[OrderID]");
         }
 
         public override async Task Where_collection_navigation_ToList_Contains(bool async)
@@ -1991,7 +1991,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderID] = @__entity_equality_order_0_OrderID))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_collection_navigation_ToArray_Count(bool async)
@@ -2006,7 +2006,7 @@ WHERE ([o].[OrderID] < 10300) AND ((
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]) = 0)
-ORDER BY [o].[OrderID], [o1].[OrderID], [o1].[ProductID]");
+ORDER BY [o].[OrderID], [o1].[OrderID]");
         }
 
         public override async Task Where_collection_navigation_ToArray_Contains(bool async)
@@ -2023,7 +2023,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderID] = @__entity_equality_order_0_OrderID))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
@@ -2038,7 +2038,7 @@ WHERE ([o].[OrderID] < 10300) AND ((
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]) = 0)
-ORDER BY [o].[OrderID], [o1].[OrderID], [o1].[ProductID]");
+ORDER BY [o].[OrderID], [o1].[OrderID]");
         }
 
         public override async Task Where_collection_navigation_AsEnumerable_Contains(bool async)
@@ -2055,7 +2055,7 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderID] = @__entity_equality_order_0_OrderID))
-ORDER BY [c].[CustomerID], [o0].[OrderID]");
+ORDER BY [c].[CustomerID]");
         }
 
         public override async Task Where_collection_navigation_ToList_Count_member(bool async)
@@ -2070,7 +2070,7 @@ WHERE ([o].[OrderID] < 10300) AND ((
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]) = 0)
-ORDER BY [o].[OrderID], [o1].[OrderID], [o1].[ProductID]");
+ORDER BY [o].[OrderID], [o1].[OrderID]");
         }
 
         public override async Task Where_collection_navigation_ToArray_Length_member(bool async)
@@ -2085,7 +2085,7 @@ WHERE ([o].[OrderID] < 10300) AND ((
     SELECT COUNT(*)
     FROM [Order Details] AS [o0]
     WHERE [o].[OrderID] = [o0].[OrderID]) = 0)
-ORDER BY [o].[OrderID], [o1].[OrderID], [o1].[ProductID]");
+ORDER BY [o].[OrderID], [o1].[OrderID]");
         }
 
         public override async Task Where_list_object_contains_over_value_type(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -36,7 +36,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o2] ON ([o1].[ClientId] = [o2].[OrderClientId]) AND ([o1].[Id] = [o2].[OrderId])
 ) AS [t0] ON [o].[Id] = [t0].[ClientId]
 WHERE 0 = 1
-ORDER BY [o].[Id], [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [o].[Id], [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Query_for_base_type_loads_all_owned_navs(bool async)
@@ -52,7 +52,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task No_ignored_include_warning_when_implicit_load(bool async)
@@ -77,7 +77,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Query_for_branch_type_loads_all_owned_navs_tracking(bool async)
@@ -93,7 +93,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Discriminator] IN (N'Branch', N'LeafA')
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Query_for_leaf_type_loads_all_owned_navs(bool async)
@@ -109,7 +109,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Query_when_subquery(bool async)
@@ -133,7 +133,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t1] ON [t0].[Id] = [t1].[ClientId]
-ORDER BY [t0].[Id], [t1].[ClientId], [t1].[Id], [t1].[OrderClientId], [t1].[OrderId], [t1].[Id0]");
+ORDER BY [t0].[Id], [t1].[ClientId], [t1].[Id], [t1].[OrderClientId], [t1].[OrderId]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool async)
@@ -159,7 +159,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[PersonAddress_Country_Name] = N'USA'
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Navigation_rewrite_on_owned_collection(bool async)
@@ -178,7 +178,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [Order] AS [o0]
     WHERE [o].[Id] = [o0].[ClientId]) > 0
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Navigation_rewrite_on_owned_collection_with_composition(bool async)
@@ -221,7 +221,7 @@ FROM [OwnedPerson] AS [o]");
 FROM [OwnedPerson] AS [o]
 INNER JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
 LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o1].[OrderClientId], [o1].[OrderId], [o1].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o1].[OrderClientId], [o1].[OrderId]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity(bool async)
@@ -248,7 +248,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE ([p].[Id] <> 42) OR [p].[Id] IS NULL
-ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Project_multiple_owned_navigations(bool async)
@@ -264,7 +264,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Project_multiple_owned_navigations_with_expansion_on_owned_collections(bool async)
@@ -298,7 +298,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE ([p].[Id] <> 7) OR [p].[Id] IS NULL
-ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [p].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool async)
@@ -320,7 +320,7 @@ LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]");
 FROM [OwnedPerson] AS [o]
 LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Moon] AS [m] ON [p].[Id] = [m].[PlanetId]
-ORDER BY [o].[Id], [p].[Id], [m].[Id]");
+ORDER BY [o].[Id], [p].[Id]");
         }
 
         public override async Task SelectMany_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
@@ -356,7 +356,7 @@ FROM [OwnedPerson] AS [o]
 LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
-ORDER BY [o].[Id], [p].[Id], [s].[Id], [e].[Id]");
+ORDER BY [o].[Id], [p].[Id], [s].[Id]");
         }
 
         public override async Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_and_scalar(
@@ -384,7 +384,7 @@ LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
 LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
 LEFT JOIN [Element] AS [e] ON [s].[Id] = [e].[StarId]
 WHERE [s].[Name] = N'Sol'
-ORDER BY [o].[Id], [p].[Id], [s].[Id], [e].[Id]");
+ORDER BY [o].[Id], [p].[Id], [s].[Id]");
         }
 
         public override async Task Query_with_OfType_eagerly_loads_correct_owned_navigations(bool async)
@@ -400,7 +400,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Discriminator] = N'LeafA'
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Preserve_includes_when_applying_skip_take_after_anonymous_type_select(bool async)
@@ -426,7 +426,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Unmapped_property_projection_loads_owned_navigations(bool async)
@@ -442,7 +442,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Id] = 1
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Client_method_skip_loads_owned_navigations(bool async)
@@ -464,7 +464,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Client_method_take_loads_owned_navigations(bool async)
@@ -485,7 +485,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Client_method_skip_take_loads_owned_navigations(bool async)
@@ -508,7 +508,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Client_method_skip_loads_owned_navigations_variation_2(bool async)
@@ -530,7 +530,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Client_method_take_loads_owned_navigations_variation_2(bool async)
@@ -551,7 +551,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Client_method_skip_take_loads_owned_navigations_variation_2(bool async)
@@ -574,7 +574,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t0] ON [t].[Id] = [t0].[ClientId]
-ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId], [t0].[Id0]");
+ORDER BY [t].[Id], [t0].[ClientId], [t0].[Id], [t0].[OrderClientId], [t0].[OrderId]");
         }
 
         public override async Task Where_owned_collection_navigation_ToList_Count(bool async)
@@ -590,7 +590,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
     WHERE ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])) = 0
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId]");
         }
 
         public override async Task Where_collection_navigation_ToArray_Count(bool async)
@@ -606,7 +606,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
     WHERE ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])) = 0
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId]");
         }
 
         public override async Task Where_collection_navigation_AsEnumerable_Count(bool async)
@@ -622,7 +622,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
     WHERE ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])) = 0
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId]");
         }
 
         public override async Task Where_collection_navigation_ToList_Count_member(bool async)
@@ -638,7 +638,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
     WHERE ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])) = 0
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId]");
         }
 
         public override async Task Where_collection_navigation_ToArray_Length_member(bool async)
@@ -654,7 +654,7 @@ WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
     WHERE ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])) = 0
-ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id]");
+ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId]");
         }
 
         public override async Task Can_query_on_indexer_properties(bool async)
@@ -670,7 +670,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[Name] = N'Mona Cy'
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Can_query_on_owned_indexer_properties(bool async)
@@ -741,7 +741,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-ORDER BY [o].[Name], [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Name], [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Can_OrderBy_indexer_properties_converted(bool async)
@@ -1097,7 +1097,7 @@ LEFT JOIN (
     FROM [Order] AS [o0]
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
-ORDER BY [o].[PersonAddress_PlaceType], [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[PersonAddress_PlaceType], [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Using_from_sql_on_owner_generates_join_with_table_for_owned_shared_dependents(bool async)
@@ -1150,7 +1150,7 @@ LEFT JOIN (
     FROM [Order] AS [o8]
     LEFT JOIN [OrderDetail] AS [o9] ON ([o8].[ClientId] = [o9].[OrderClientId]) AND ([o8].[Id] = [o9].[OrderId])
 ) AS [t6] ON [o].[Id] = [t6].[ClientId]
-ORDER BY [o].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0], [t2].[Id], [t2].[Id0], [t4].[Id], [t4].[Id0], [t6].[ClientId], [t6].[Id], [t6].[OrderClientId], [t6].[OrderId], [t6].[Id0]");
+ORDER BY [o].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0], [t2].[Id], [t2].[Id0], [t4].[Id], [t4].[Id0], [t6].[ClientId], [t6].[Id], [t6].[OrderClientId], [t6].[OrderId]");
         }
 
         public override async Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool async)
@@ -1162,7 +1162,7 @@ ORDER BY [o].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0], [t2].[Id], [t2].[
 FROM [Fink] AS [f]
 LEFT JOIN [Barton] AS [b] ON [f].[BartonId] = [b].[Id]
 LEFT JOIN [Planet] AS [p] ON ([b].[Throned_Value] <> [p].[Id]) OR [b].[Throned_Value] IS NULL
-ORDER BY [f].[Id], [b].[Id], [p].[Id]");
+ORDER BY [f].[Id], [b].[Id]");
         }
 
         public override async Task Filter_on_indexer_using_closure(bool async)
@@ -1178,7 +1178,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[PersonAddress_ZipCode] = 38654
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         public override async Task Filter_on_indexer_using_function_argument(bool async)
@@ -1194,7 +1194,7 @@ LEFT JOIN (
     LEFT JOIN [OrderDetail] AS [o1] ON ([o0].[ClientId] = [o1].[OrderClientId]) AND ([o0].[Id] = [o1].[OrderId])
 ) AS [t] ON [o].[Id] = [t].[ClientId]
 WHERE [o].[PersonAddress_ZipCode] = 38654
-ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId], [t].[Id0]");
+ORDER BY [o].[Id], [t].[ClientId], [t].[Id], [t].[OrderClientId], [t].[OrderId]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -550,7 +550,7 @@ INSERT ZeroKey VALUES (NULL)");
                 @"SELECT [c].[FirstName], [c].[LastName], [o].[Id], [o].[CustomerFirstName], [o].[CustomerLastName], [o].[Name]
 FROM [Customer] AS [c]
 LEFT JOIN [Order] AS [o] ON ([c].[FirstName] = [o].[CustomerFirstName]) AND ([c].[LastName] = [o].[CustomerLastName])
-ORDER BY [c].[FirstName], [c].[LastName], [o].[Id]");
+ORDER BY [c].[FirstName], [c].[LastName]");
         }
 
         [ConditionalFact]
@@ -2108,7 +2108,7 @@ WHERE [e].[Name] IS NULL");
                     @"SELECT [m].[Id], [m].[Title], [m].[Details_Info], [m].[Details_Rating], [a].[Id], [a].[Movie9202Id], [a].[Name], [a].[Details_Info], [a].[Details_Rating]
 FROM [Movies] AS [m]
 LEFT JOIN [Actors] AS [a] ON [m].[Id] = [a].[Movie9202Id]
-ORDER BY [m].[Id], [a].[Id]");
+ORDER BY [m].[Id]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -2125,12 +2125,12 @@ ORDER BY [m].[Id], [a].[Id]");
                     @"SELECT [m].[Id], [m].[Title], [m].[Details_Info], [m].[Details_Rating], [a].[Id], [a].[Movie9202Id], [a].[Name], [a].[Details_Info], [a].[Details_Rating]
 FROM [Movies] AS [m]
 LEFT JOIN [Actors] AS [a] ON [m].[Id] = [a].[Movie9202Id]
-ORDER BY [m].[Id], [a].[Id]",
+ORDER BY [m].[Id]",
                     //
                     @"SELECT [m].[Id], [m].[Title], [m].[Details_Info], [m].[Details_Rating], [a].[Id], [a].[Movie9202Id], [a].[Name], [a].[Details_Info], [a].[Details_Rating]
 FROM [Movies] AS [m]
 LEFT JOIN [Actors] AS [a] ON [m].[Id] = [a].[Movie9202Id]
-ORDER BY [m].[Id], [a].[Id]");
+ORDER BY [m].[Id]");
             }
         }
 
@@ -2592,7 +2592,7 @@ LEFT JOIN [Configuration9468] AS [c0] ON [c].[ConfigurationId] = [c0].[Id]");
                     @"SELECT [p].[Id], [p].[Name], [c].[Id], [c].[Name], [c].[Parent10635Id], [c].[ParentId]
 FROM [Parents] AS [p]
 LEFT JOIN [Children] AS [c] ON [p].[Id] = [c].[Parent10635Id]
-ORDER BY [p].[Id], [c].[Id]");
+ORDER BY [p].[Id]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -2604,7 +2604,7 @@ ORDER BY [p].[Id], [c].[Id]");
                     @"SELECT [p].[Id], [c].[Id], [c].[Name], [c].[Parent10635Id], [c].[ParentId]
 FROM [Parents] AS [p]
 LEFT JOIN [Children] AS [c] ON [p].[Id] = [c].[Parent10635Id]
-ORDER BY [p].[Id], [c].[Id]");
+ORDER BY [p].[Id]");
             }
         }
 
@@ -3873,7 +3873,7 @@ END IN ('0a47bcb7-a1cb-4345-8944-c58f82d6aac7', '5f221fb9-66f4-442a-92c9-d97ed59
 END, [a].[Turnovers_AmountIn], [a].[Id]
 FROM [Partners] AS [p]
 LEFT JOIN [Address13157] AS [a] ON [p].[Id] = [a].[Partner13157Id]
-ORDER BY [p].[Id], [a].[Id]");
+ORDER BY [p].[Id]");
             }
         }
 
@@ -5407,7 +5407,7 @@ OUTER APPLY (
         FROM [Values] AS [v0]
         WHERE [e].[Id] = [v0].[Entity11023Id]) IS NULL AND [t].[Value11023Id] IS NULL))
 ) AS [t0]
-ORDER BY [e].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id]");
             }
         }
 
@@ -5660,7 +5660,7 @@ OUTER APPLY (
         FROM [CompetitionSeasons] AS [c1]
         WHERE ([c1].[StartDate] <= [a].[DateTime]) AND ([a].[DateTime] < [c1].[EndDate]))) AND ([a0].[Id] = [a1].[ActivityTypeId])
 ) AS [t]
-ORDER BY [a].[Id], [a0].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [a].[Id], [a0].[Id], [t].[Id]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -5808,7 +5808,7 @@ LEFT JOIN (
     INNER JOIN [DbContract] AS [d0] ON [d].[ContractId] = [d0].[Id]
     LEFT JOIN [DbSeason] AS [d1] ON [d0].[SeasonId] = [d1].[Id]
 ) AS [t1] ON [t0].[Id] = [t1].[DbTradeId]
-ORDER BY [t0].[Id], [t1].[Id], [t1].[Id0], [t1].[Id1]");
+ORDER BY [t0].[Id], [t1].[Id], [t1].[Id0]");
             }
         }
 
@@ -6627,7 +6627,7 @@ WHERE [e].[Id] = CAST(1 AS bigint)");
                     @"SELECT [p].[Id], [c].[Id], [c].[ParentId]
 FROM [Parents] AS [p]
 LEFT JOIN [Child21355] AS [c] ON [p].[Id] = [c].[ParentId]
-ORDER BY [p].[Id], [c].[Id]"
+ORDER BY [p].[Id]"
                     });
             }
 
@@ -6662,7 +6662,7 @@ ORDER BY [p].[Id]"
 FROM [Parents] AS [p]
 LEFT JOIN [Child21355] AS [c] ON [p].[Id] = [c].[ParentId]
 LEFT JOIN [AnotherChild21355] AS [a] ON [p].[Id] = [a].[ParentId]
-ORDER BY [p].[Id], [c].[Id], [a].[Id]"
+ORDER BY [p].[Id], [c].[Id]"
                     });
             }
         }
@@ -6702,7 +6702,7 @@ ORDER BY [p].[Id]"
                     @"SELECT [p].[Id], [c].[Id], [c].[ParentId]
 FROM [Parents] AS [p]
 LEFT JOIN [Child21355] AS [c] ON [p].[Id] = [c].[ParentId]
-ORDER BY [p].[Id], [c].[Id]"
+ORDER BY [p].[Id]"
                     });
             }
 
@@ -6786,7 +6786,7 @@ ORDER BY [p].[Id]"
 FROM [Parents] AS [p]
 LEFT JOIN [Child21355] AS [c] ON [p].[Id] = [c].[ParentId]
 LEFT JOIN [AnotherChild21355] AS [a] ON [p].[Id] = [a].[ParentId]
-ORDER BY [p].[Id], [c].[Id], [a].[Id]"
+ORDER BY [p].[Id], [c].[Id]"
                 });
         }
 
@@ -6905,7 +6905,7 @@ LEFT JOIN (
     FROM [JoinEntity21540] AS [j]
     INNER JOIN [OtherSide21540] AS [o] ON [j].[OtherSideId] = [o].[Id]
 ) AS [t] ON [p].[Id] = [t].[ParentId]
-ORDER BY [p].[Id], [r].[Id], [c].[Id], [t].[ParentId], [t].[OtherSideId], [t].[Id]");
+ORDER BY [p].[Id], [r].[Id], [c].[Id], [t].[ParentId], [t].[OtherSideId]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -7472,7 +7472,7 @@ ORDER BY [e].[Id]");
                         @"SELECT [e].[Id], [o].[Id], [o].[AppEntityId]
 FROM [Entities] AS [e]
 LEFT JOIN [OtherEntity21803] AS [o] ON [e].[Id] = [o].[AppEntityId]
-ORDER BY [e].[Id], [o].[Id]");
+ORDER BY [e].[Id]");
                 }
             }
         }
@@ -7758,7 +7758,7 @@ LEFT JOIN (
         LEFT JOIN [ThirdFifthValueObjects] AS [t3] ON [t0].[Id] = [t3].[ThirdValueObjectId]
     ) AS [t1] ON [s].[Id] = [t1].[SecondValueObjectId]
 ) AS [t2] ON [t].[Id] = [t2].[AggregateId]
-ORDER BY [t].[Id] DESC, [t2].[Id], [t2].[Id0], [t2].[Id1], [t2].[Id00]");
+ORDER BY [t].[Id] DESC, [t2].[Id], [t2].[Id0], [t2].[Id1]");
             }
         }
 
@@ -8014,7 +8014,7 @@ FROM (
 ) AS [t]
 LEFT JOIN [FungibleBag_Currencies] AS [f0] ON [t].[MasterTrunk22340Id] = [f0].[CurrencyBag22340MasterTrunk22340Id]
 LEFT JOIN [StaticBag_Currencies] AS [s0] ON [t].[MasterTrunk22340Id0] = [s0].[CurrencyBag22340MasterTrunk22340Id]
-ORDER BY [t].[Id], [t].[MasterTrunk22340Id], [t].[MasterTrunk22340Id0], [f0].[CurrencyBag22340MasterTrunk22340Id], [f0].[Id], [s0].[CurrencyBag22340MasterTrunk22340Id], [s0].[Id]");
+ORDER BY [t].[Id], [t].[MasterTrunk22340Id], [t].[MasterTrunk22340Id0], [f0].[CurrencyBag22340MasterTrunk22340Id], [f0].[Id], [s0].[CurrencyBag22340MasterTrunk22340Id]");
             }
         }
 
@@ -8157,13 +8157,13 @@ INNER JOIN [PrincipalOneToOne] AS [p] ON [d].[PrincipalId] = [p].[Id]");
                     @"SELECT [p].[Id], [d].[Id], [d].[PrincipalId]
 FROM [PrincipalOneToMany] AS [p]
 LEFT JOIN [DependentOneToMany] AS [d] ON [p].[Id] = [d].[PrincipalId]
-ORDER BY [p].[Id], [d].[Id]",
+ORDER BY [p].[Id]",
                     //
                     @"SELECT [d].[Id], [d].[PrincipalId], [p].[Id], [d0].[Id], [d0].[PrincipalId]
 FROM [DependentOneToMany] AS [d]
 INNER JOIN [PrincipalOneToMany] AS [p] ON [d].[PrincipalId] = [p].[Id]
 LEFT JOIN [DependentOneToMany] AS [d0] ON [p].[Id] = [d0].[PrincipalId]
-ORDER BY [d].[Id], [p].[Id], [d0].[Id]");
+ORDER BY [d].[Id], [p].[Id]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -8405,7 +8405,7 @@ LEFT JOIN (
     FROM [Posts] AS [p]
     WHERE [p].[Name] LIKE N'%2%'
 ) AS [t] ON [b].[Id] = [t].[BlogId]
-ORDER BY [b].[Id], [t].[Id]");
+ORDER BY [b].[Id]");
             }
 
             using (var context = contextFactory.CreateContext())
@@ -9495,7 +9495,7 @@ OUTER APPLY (
     INNER JOIN [MovieEntity] AS [m2] ON [m1].[MovieId] = [m2].[Id]
     WHERE [t].[Id1] IS NOT NULL AND ([t].[Id1] = [m1].[DirectorId])
 ) AS [t0]
-ORDER BY [t].[Id], [t].[Id0], [t].[Id1], [p0].[Id], [t0].[Id]");
+ORDER BY [t].[Id], [t].[Id0], [t].[Id1], [p0].[Id]");
         }
 
         private class PersonEntity
@@ -9641,7 +9641,7 @@ OUTER APPLY (
     ) AS [t2]
     LEFT JOIN [Users] AS [u0] ON [t2].[UserEUserId] = [u0].[Id]
 ) AS [t1]
-ORDER BY [t].[Id], [t1].[DateArrived] DESC, [t1].[Id], [t1].[Id0], [t1].[UserId]");
+ORDER BY [t].[Id], [t1].[DateArrived] DESC, [t1].[Id], [t1].[Id0]");
         }
 
         [ConditionalFact]
@@ -9681,7 +9681,7 @@ OUTER APPLY (
     ) AS [t0]
     LEFT JOIN [Users] AS [u0] ON [t0].[UserEUserId] = [u0].[Id]
 ) AS [t1]
-ORDER BY [t].[Id], [t1].[DateArrived] DESC, [t1].[Id], [t1].[Id0], [t1].[UserId]");
+ORDER BY [t].[Id], [t1].[DateArrived] DESC, [t1].[Id], [t1].[Id0]");
         }
 
         private class EUser
@@ -9772,7 +9772,7 @@ OUTER APPLY (
     ) AS [t1]
     WHERE [t].[Id] = [i].[OrderId]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Id], [t0].[Id0], [t0].[Id00]");
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id0]");
         }
 
         private class Order
@@ -9878,7 +9878,7 @@ OUTER APPLY (
     FROM [OutDoorSports] AS [o]
     WHERE [o].[Id] = [t].[OutCategoryId]
 ) AS [t0]
-ORDER BY [t].[Id], [t0].[Name]");
+ORDER BY [t].[Id]");
         }
 
         private class StudentGameMapper

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -713,7 +713,7 @@ FROM (
     ORDER BY [p].[Id]
 ) AS [t]
 LEFT JOIN [PointEntity] AS [p0] ON [t].[Id] = [p0].[Id]
-ORDER BY [t].[Id], [p0].[Id]");
+ORDER BY [t].[Id]");
         }
 
         public override async Task IsEmpty_equal_to_null(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -771,7 +771,7 @@ FROM (
     ORDER BY [p].[Id]
 ) AS [t]
 LEFT JOIN [PointEntity] AS [p0] ON [t].[Id] = [p0].[Id]
-ORDER BY [t].[Id], [p0].[Id]");
+ORDER BY [t].[Id]");
         }
 
         public override async Task IsEmpty_equal_to_null(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -81,7 +81,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Include_multiple_one_to_one_optional_and_one_to_one_required(bool async)
@@ -119,7 +119,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON [c].[Name] = [t].[AssignedCityName]
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Nickname]");
         }
 
         public override async Task Include_multiple_circular_with_filter(bool async)
@@ -141,7 +141,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON [c].[Name] = [t].[AssignedCityName]
 WHERE [g].[Nickname] = N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Nickname]");
         }
 
         public override async Task Include_using_alternate_key(bool async)
@@ -156,7 +156,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] = N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_navigation_on_derived_type(bool async)
@@ -177,7 +177,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task String_based_Include_navigation_on_derived_type(bool async)
@@ -198,7 +198,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Select_Where_Navigation_Included(bool async)
@@ -261,7 +261,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Include_with_join_collection2(bool async)
@@ -279,7 +279,7 @@ INNER JOIN (
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Include_where_list_contains_navigation(bool async)
@@ -353,7 +353,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t0] ON [c].[Name] = [t0].[AssignedCityName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [c].[Name], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [c].[Name], [t0].[Nickname]");
         }
 
         public override async Task Include_with_join_and_inheritance1(bool async)
@@ -396,7 +396,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON ([t0].[Nickname] = [t1].[LeaderNickname]) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [t0].[HasSoulPatch], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Include_with_join_and_inheritance2(bool async)
@@ -412,7 +412,7 @@ LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[Squad
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Include_with_join_and_inheritance3(bool async)
@@ -437,7 +437,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON ([t0].[Nickname] = [t1].[LeaderNickname]) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Include_with_nested_navigation_in_order_by(bool async)
@@ -2298,7 +2298,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result2()
@@ -2320,7 +2320,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3(bool async)
@@ -2343,7 +2343,7 @@ LEFT JOIN (
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id], [w0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4(bool async)
@@ -2412,7 +2412,7 @@ LEFT JOIN (
 ) AS [t] ON [g].[LeaderNickname] = [t].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
 LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id], [w0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [w].[Id]");
         }
 
         public override async Task Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result(bool async)
@@ -2891,7 +2891,7 @@ LEFT JOIN (
     WHERE ([w].[Name] <> N'Lancer') OR [w].[Name] IS NULL
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [c].[Name] IN (N'Ephyra', N'Hanover')
-ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [c].[Name]");
         }
 
         public override async Task Select_correlated_filtered_collection_with_composite_key(bool async)
@@ -2911,7 +2911,7 @@ LEFT JOIN (
     WHERE [g0].[Nickname] <> N'Dom'
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Select_correlated_filtered_collection_works_with_caching(bool async)
@@ -2928,7 +2928,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [t].[Note], [t].[Id], [t0].[Nickname]");
         }
 
         public override async Task Join_predicate_value_equals_condition(bool async)
@@ -3772,7 +3772,7 @@ LEFT JOIN (
     LEFT JOIN [LocustCommanders] AS [l3] ON [l2].[Name] = [l3].[Name]
 ) AS [t0] ON [f].[Id] = [t0].[LocustHordeId]
 WHERE [l].[Id] IS NOT NULL
-ORDER BY [f].[Name], [f].[Id], [t].[Name], [t0].[Name]");
+ORDER BY [f].[Name], [f].[Id], [t].[Name]");
         }
 
         public override async Task Distinct_on_subquery_doesnt_get_lifted(bool async)
@@ -3947,7 +3947,7 @@ LEFT JOIN (
     LEFT JOIN [LocustCommanders] AS [l4] ON [l3].[Name] = [l4].[Name]
 ) AS [t1] ON [t0].[Id] = [t1].[LocustHordeId]
 WHERE [l].[Id] IS NOT NULL
-ORDER BY [f].[Id], [t].[Name], [t0].[Id], [t1].[Name]");
+ORDER BY [f].[Id], [t].[Name], [t0].[Id]");
         }
 
         public override async Task Project_collection_navigation_with_inheritance2(bool async)
@@ -3975,7 +3975,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [l].[Id] IS NOT NULL
-ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Project_collection_navigation_with_inheritance3(bool async)
@@ -4003,7 +4003,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [l].[Id] IS NOT NULL
-ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Include_reference_on_derived_type_using_string(bool async)
@@ -4070,7 +4070,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     INNER JOIN [Cities] AS [c] ON [g0].[CityOfBirthName] = [c].[Name]
 ) AS [t0] ON (([t].[Nickname] = [t0].[LeaderNickname]) OR ([t].[Nickname] IS NULL AND [t0].[LeaderNickname] IS NULL)) AND ([t].[SquadId] = [t0].[LeaderSquadId])
-ORDER BY [l].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Name]");
+ORDER BY [l].[Name], [t].[Nickname], [t].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Include_reference_on_derived_type_using_lambda(bool async)
@@ -4147,7 +4147,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Include_collection_on_derived_type_using_lambda(bool async)
@@ -4167,7 +4167,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Include_collection_on_derived_type_using_lambda_with_soft_cast(bool async)
@@ -4187,7 +4187,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Include_base_navigation_on_derived_entity(bool async)
@@ -4202,7 +4202,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Tags] AS [t] ON ([g].[Nickname] = [t].[GearNickName]) AND ([g].[SquadId] = [t].[GearSquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_base_reference(bool async)
@@ -4220,7 +4220,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_derived_reference(bool async)
@@ -4252,7 +4252,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task ThenInclude_collection_on_derived_after_derived_collection(bool async)
@@ -4279,7 +4279,7 @@ LEFT JOIN (
         LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
     ) AS [t] ON ([g0].[Nickname] = [t].[LeaderNickname]) AND ([g0].[SquadId] = [t].[LeaderSquadId])
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Nickname0], [t0].[SquadId0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Nickname0]");
         }
 
         public override async Task ThenInclude_reference_on_derived_after_derived_collection(bool async)
@@ -4306,7 +4306,7 @@ LEFT JOIN (
         LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
     ) AS [t] ON ([l1].[DefeatedByNickname] = [t].[Nickname]) AND ([l1].[DefeatedBySquadId] = [t].[SquadId])
 ) AS [t0] ON [f].[Id] = [t0].[LocustHordeId]
-ORDER BY [f].[Id], [t0].[Name], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [f].[Id], [t0].[Name], [t0].[Nickname]");
         }
 
         public override async Task Multiple_derived_included_on_one_method(bool async)
@@ -4338,7 +4338,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [f].[Id], [t].[Name], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Include_on_derived_multi_level(bool async)
@@ -4360,7 +4360,7 @@ LEFT JOIN (
     INNER JOIN [Squads] AS [s] ON [g0].[SquadId] = [s].[Id]
     LEFT JOIN [SquadMissions] AS [s0] ON [s].[Id] = [s0].[SquadId]
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id], [t].[SquadId0], [t].[MissionId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId], [t].[Id], [t].[SquadId0]");
         }
 
         public override async Task Projecting_nullable_bool_in_conditional_works(bool async)
@@ -4398,7 +4398,7 @@ ORDER BY [g].[SquadId], [g].[Nickname]");
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_naked_navigation_with_ToList_followed_by_projecting_count(bool async)
@@ -4424,7 +4424,7 @@ ORDER BY [g].[Nickname]");
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection(bool async)
@@ -4440,7 +4440,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_explicit_to_list(bool async)
@@ -4456,7 +4456,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_explicit_to_array(bool async)
@@ -4472,7 +4472,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projection_ordered(bool async)
@@ -4488,7 +4488,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC, [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Name] DESC");
         }
 
         public override async Task Correlated_collections_basic_projection_composite_key(bool async)
@@ -4505,7 +4505,7 @@ LEFT JOIN (
     WHERE [g0].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [t] ON ([g].[Nickname] = [t].[LeaderNickname]) AND ([g].[SquadId] = [t].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL AND ([g].[Nickname] <> N'Foo')
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_basic_projecting_single_property(bool async)
@@ -4521,7 +4521,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projecting_constant(bool async)
@@ -4537,7 +4537,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_basic_projecting_constant_bool(bool async)
@@ -4553,7 +4553,7 @@ LEFT JOIN (
     WHERE ([w].[IsAutomatic] = CAST(1 AS bit)) OR (([w].[Name] <> N'foo') OR [w].[Name] IS NULL)
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Correlated_collections_projection_of_collection_thru_navigation(bool async)
@@ -4570,7 +4570,7 @@ LEFT JOIN (
     WHERE [s0].[MissionId] <> 17
 ) AS [t] ON [s].[Id] = [t].[SquadId]
 WHERE [g].[Nickname] <> N'Marcus'
-ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [s].[Id], [t].[SquadId], [t].[MissionId]");
+ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [s].[Id], [t].[SquadId]");
         }
 
         public override async Task Correlated_collections_project_anonymous_collection_result(bool async)
@@ -4585,7 +4585,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t] ON [s].[Id] = [t].[SquadId]
 WHERE [s].[Id] < 20
-ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
+ORDER BY [s].[Id], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_nested(bool async)
@@ -4606,7 +4606,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 42
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_mixed_streaming_with_buffer1(bool async)
@@ -4627,7 +4627,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 3
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_mixed_streaming_with_buffer2(bool async)
@@ -4648,7 +4648,7 @@ LEFT JOIN (
     ) AS [t] ON [m].[Id] = [t].[MissionId]
     WHERE [s0].[MissionId] < 42
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
-ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0], [t0].[MissionId0]");
+ORDER BY [s].[Id], [t0].[SquadId], [t0].[MissionId], [t0].[Id], [t0].[SquadId0]");
         }
 
         public override async Task Correlated_collections_nested_with_custom_ordering(bool async)
@@ -4670,7 +4670,7 @@ LEFT JOIN (
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[HasSoulPatch] DESC, [g].[Nickname], [g].[SquadId], [t0].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[IsAutomatic], [t0].[Id]");
+ORDER BY [g].[HasSoulPatch] DESC, [g].[Nickname], [g].[SquadId], [t0].[Rank], [t0].[Nickname], [t0].[SquadId], [t0].[IsAutomatic]");
         }
 
         public override async Task Correlated_collections_same_collection_projected_multiple_times(bool async)
@@ -4690,7 +4690,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(1 AS bit)
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Correlated_collections_similar_collection_projected_multiple_times(bool async)
@@ -4710,7 +4710,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w0]
     WHERE [w0].[IsAutomatic] = CAST(0 AS bit)
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [g].[Rank], [g].[Nickname], [g].[SquadId], [t].[OwnerFullName], [t].[Id], [t0].[IsAutomatic], [t0].[Id]");
+ORDER BY [g].[Rank], [g].[Nickname], [g].[SquadId], [t].[OwnerFullName], [t].[Id], [t0].[IsAutomatic]");
         }
 
         public override async Task Correlated_collections_different_collections_projected(bool async)
@@ -4731,7 +4731,7 @@ LEFT JOIN (
     FROM [Gears] AS [g0]
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[FullName], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[FullName], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[FullName], [t0].[Nickname]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys(bool async)
@@ -4777,7 +4777,7 @@ WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[IsAutomatic], [t1].[Nickname] DESC, [t1].[Id], [t1].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[IsAutomatic], [t1].[Nickname] DESC, [t1].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_duplicated_orderings(
@@ -4807,7 +4807,7 @@ WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[IsAutomatic], [t1].[Nickname] DESC, [t1].[Id], [t1].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[IsAutomatic], [t1].[Nickname] DESC, [t1].[Id]");
         }
 
         public override async Task Multiple_orderby_with_navigation_expansion_on_one_of_the_order_bys_inside_subquery_complex_orderings(
@@ -4840,7 +4840,7 @@ WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Id] DESC, [t1].[c], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Id] DESC, [t1].[c], [t1].[Nickname]");
         }
 
         public override async Task Correlated_collections_multiple_nested_complex_collections(bool async)
@@ -4889,7 +4889,7 @@ WHERE [o].[Nickname] IS NOT NULL AND EXISTS (
     FROM [Gears] AS [g0]
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
-ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t2].[Rank], [t2].[Nickname], [t2].[SquadId], [t2].[IsAutomatic0], [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Id1], [t2].[Nickname00], [t2].[SquadId00], [t5].[IsAutomatic], [t5].[Nickname] DESC, [t5].[Id], [t5].[SquadId]");
+ORDER BY [g].[HasSoulPatch] DESC, [t].[Note], [g].[Nickname], [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t2].[Rank], [t2].[Nickname], [t2].[SquadId], [t2].[IsAutomatic0], [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Id1], [t2].[Nickname00], [t2].[SquadId00], [t5].[IsAutomatic], [t5].[Nickname] DESC, [t5].[Id]");
         }
 
         public override async Task Correlated_collections_inner_subquery_selector_references_outer_qsre(bool async)
@@ -4906,7 +4906,7 @@ OUTER APPLY (
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ) AS [t]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_inner_subquery_predicate_references_outer_qsre(bool async)
@@ -4923,7 +4923,7 @@ OUTER APPLY (
     WHERE ([g].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collections_nested_inner_subquery_references_outer_qsre_one_level_up(bool async)
@@ -4945,7 +4945,7 @@ LEFT JOIN (
     WHERE [g0].[FullName] <> N'Foo'
 ) AS [t0] ON ([g].[Nickname] = [t0].[LeaderNickname]) AND ([g].[SquadId] = [t0].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_nested_inner_subquery_references_outer_qsre_two_levels_up(bool async)
@@ -4967,7 +4967,7 @@ OUTER APPLY (
     WHERE ([g0].[FullName] <> N'Foo') AND (([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId]))
 ) AS [t0]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId], [t0].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_on_select_many(bool async)
@@ -4992,7 +4992,7 @@ LEFT JOIN (
     WHERE [g0].[HasSoulPatch] = CAST(0 AS bit)
 ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 WHERE [g].[HasSoulPatch] = CAST(1 AS bit)
-ORDER BY [g].[Nickname], [s].[Id] DESC, [g].[SquadId], [t].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [g].[Nickname], [s].[Id] DESC, [g].[SquadId], [t].[Id], [t0].[Nickname]");
         }
 
         public override async Task Correlated_collections_with_Skip(bool async)
@@ -5065,7 +5065,7 @@ OUTER APPLY (
         OFFSET 0 ROWS
     ) AS [t]
 ) AS [t0]
-ORDER BY [s].[Name], [s].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [s].[Name], [s].[Id], [t0].[Nickname]");
         }
 
         public override async Task Correlated_collections_with_FirstOrDefault(bool async)
@@ -5096,7 +5096,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
 WHERE [t0].[HasSoulPatch] = CAST(0 AS bit)
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_on_left_join_with_null_value(bool async)
@@ -5111,7 +5111,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t0] ON [t].[GearNickName] = [t0].[Nickname]
 LEFT JOIN [Weapons] AS [w] ON [t0].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId], [w].[Id]");
+ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId]");
         }
 
         public override async Task Correlated_collections_left_join_with_self_reference(bool async)
@@ -5131,7 +5131,7 @@ LEFT JOIN (
     SELECT [g0].[FullName], [g0].[Nickname], [g0].[SquadId], [g0].[LeaderNickname], [g0].[LeaderSquadId]
     FROM [Gears] AS [g0]
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Correlated_collections_deeply_nested_left_join(bool async)
@@ -5156,7 +5156,7 @@ LEFT JOIN (
     ) AS [t2] ON [g0].[FullName] = [t2].[OwnerFullName]
     WHERE [g0].[HasSoulPatch] = CAST(1 AS bit)
 ) AS [t1] ON [s].[Id] = [t1].[SquadId]
-ORDER BY [t].[Note], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [s].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
+ORDER BY [t].[Note], [t0].[Nickname] DESC, [t].[Id], [t0].[SquadId], [s].[Id], [t1].[Nickname], [t1].[SquadId]");
         }
 
         public override async Task Correlated_collections_from_left_join_with_additional_elements_projected_of_that_join(bool async)
@@ -5203,7 +5203,7 @@ LEFT JOIN (
         FROM [Gears] AS [g1]
     ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 ) AS [t1] ON [g].[FullName] = [t1].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id0], [t1].[Nickname0], [t1].[SquadId0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id0], [t1].[Nickname0]");
         }
 
         public override async Task Correlated_collections_complex_scenario2(bool async)
@@ -5232,7 +5232,7 @@ LEFT JOIN (
     ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
 ) AS [t2] ON ([g].[Nickname] = [t2].[LeaderNickname]) AND ([g].[SquadId] = [t2].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t2].[Nickname], [t2].[SquadId], [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Nickname00], [t2].[SquadId00]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t2].[Nickname], [t2].[SquadId], [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Nickname00]");
         }
 
         public override async Task Correlated_collections_with_funky_orderby_complex_scenario1(bool async)
@@ -5255,7 +5255,7 @@ LEFT JOIN (
         FROM [Gears] AS [g1]
     ) AS [t0] ON [s].[Id] = [t0].[SquadId]
 ) AS [t1] ON [g].[FullName] = [t1].[OwnerFullName]
-ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id0], [t1].[Nickname0], [t1].[SquadId0]");
+ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId], [t1].[Id0], [t1].[Nickname0]");
         }
 
         public override async Task Correlated_collections_with_funky_orderby_complex_scenario2(bool async)
@@ -5284,7 +5284,7 @@ LEFT JOIN (
     ) AS [t1] ON [g0].[FullName] = [t1].[OwnerFullName]
 ) AS [t2] ON ([g].[Nickname] = [t2].[LeaderNickname]) AND ([g].[SquadId] = [t2].[LeaderSquadId])
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[HasSoulPatch], [g].[LeaderNickname], [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[FullName], [t2].[HasSoulPatch0] DESC, [t2].[Nickname], [t2].[SquadId], [t2].[IsAutomatic], [t2].[Name] DESC, [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Nickname00], [t2].[SquadId00]");
+ORDER BY [g].[HasSoulPatch], [g].[LeaderNickname], [g].[FullName], [g].[Nickname], [g].[SquadId], [t2].[FullName], [t2].[HasSoulPatch0] DESC, [t2].[Nickname], [t2].[SquadId], [t2].[IsAutomatic], [t2].[Name] DESC, [t2].[Id], [t2].[Nickname0], [t2].[SquadId0], [t2].[Id0], [t2].[Nickname00]");
         }
 
         public override async Task Correlated_collection_with_top_level_FirstOrDefault(bool async)
@@ -5299,7 +5299,7 @@ FROM (
     ORDER BY [g].[Nickname]
 ) AS [t]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_top_level_Count(bool async)
@@ -5323,7 +5323,7 @@ FROM (
     ORDER BY [g].[FullName]
 ) AS [t]
 LEFT JOIN [Weapons] AS [w] ON [t].[FullName] = [w].[OwnerFullName]
-ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId], [w].[Id]");
+ORDER BY [t].[FullName], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_top_level_Last_with_order_by_on_inner(bool async)
@@ -5341,7 +5341,7 @@ LEFT JOIN (
     SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
     FROM [Weapons] AS [w]
 ) AS [t0] ON [t].[FullName] = [t0].[OwnerFullName]
-ORDER BY [t].[FullName] DESC, [t].[Nickname], [t].[SquadId], [t0].[Name], [t0].[Id]");
+ORDER BY [t].[FullName] DESC, [t].[Nickname], [t].[SquadId], [t0].[Name]");
         }
 
         public override async Task Null_semantics_on_nullable_bool_from_inner_join_subquery_is_fully_applied(bool async)
@@ -5405,7 +5405,7 @@ FROM (
     ORDER BY [t0].[Note]
 ) AS [t1]
 LEFT JOIN [Weapons] AS [w] ON [t1].[FullName] = [w].[OwnerFullName]
-ORDER BY [t1].[Note], [t1].[Name], [t1].[Nickname], [t1].[SquadId], [t1].[Id], [w].[Id]");
+ORDER BY [t1].[Note], [t1].[Name], [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
         }
 
         public override async Task Select_required_navigation_on_derived_type(bool async)
@@ -5460,7 +5460,7 @@ OUTER APPLY (
     ) AS [t0] ON [g].[FullName] = [t0].[FullName]
 ) AS [t1]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname]");
         }
 
         public override async Task Outer_parameter_in_join_key_inner_and_outer(bool async)
@@ -5480,7 +5480,7 @@ OUTER APPLY (
     ) AS [t0] ON [g].[FullName] = [g].[Nickname]
 ) AS [t1]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname]");
         }
 
         public override async Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool async)
@@ -5500,7 +5500,7 @@ OUTER APPLY (
     ) AS [t0] ON [g].[FullName] = [t0].[FullName]
 ) AS [t1]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t1].[Id], [t1].[Nickname]");
         }
 
         public override async Task Negated_bool_ternary_inside_anonymous_type_in_projection(bool async)
@@ -5862,7 +5862,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t] ON [s].[Id] = [t].[SquadId]
-ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
+ORDER BY [s].[Id], [t].[Nickname]");
         }
 
         public override async Task Correlated_collection_order_by_constant(bool async)
@@ -5873,7 +5873,7 @@ ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Name], [w].[Id]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Select_subquery_projecting_single_constant_null_of_non_mapped_type(bool async)
@@ -5933,7 +5933,7 @@ WHERE [o].[Nickname] IS NOT NULL
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Include_collection_with_complex_OrderBy2(bool async)
@@ -5958,7 +5958,7 @@ ORDER BY (
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+    ORDER BY [w].[Id]), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Include_collection_with_complex_OrderBy3(bool async)
@@ -5983,7 +5983,7 @@ ORDER BY COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]
     WHERE [g].[FullName] = [w].[OwnerFullName]
-    ORDER BY [w].[Id]), CAST(0 AS bit)), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+    ORDER BY [w].[Id]), CAST(0 AS bit)), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collection_with_complex_OrderBy(bool async)
@@ -6006,7 +6006,7 @@ WHERE [o].[Nickname] IS NOT NULL
 ORDER BY (
     SELECT COUNT(*)
     FROM [Weapons] AS [w]
-    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+    WHERE [g].[FullName] = [w].[OwnerFullName]), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Correlated_collection_with_very_complex_order_by(bool async)
@@ -6033,7 +6033,7 @@ ORDER BY (
         SELECT TOP(1) [g0].[HasSoulPatch]
         FROM [Gears] AS [g0]
         LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
-        WHERE [g0].[Nickname] = N'Marcus'), CAST(0 AS bit)))), [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+        WHERE [g0].[Nickname] = N'Marcus'), CAST(0 AS bit)))), [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Cast_to_derived_type_after_OfType_works(bool async)
@@ -6259,7 +6259,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t] ON [c].[Name] = [t].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [t].[Nickname], [t].[SquadId]");
+ORDER BY [c].[Name], [t].[Nickname]");
         }
 
         public override async Task Cast_ordered_subquery_to_base_type_using_typed_ToArray(bool async)
@@ -6274,7 +6274,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
 ) AS [t] ON [c].[Name] = [t].[AssignedCityName]
 WHERE [c].[Name] = N'Ephyra'
-ORDER BY [c].[Name], [t].[Nickname] DESC, [t].[SquadId]");
+ORDER BY [c].[Name], [t].[Nickname] DESC");
         }
 
         public override async Task Correlated_collection_with_complex_order_by_funcletized_to_constant_bool(bool async)
@@ -6549,7 +6549,7 @@ FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Include_with_client_method_and_member_access_still_applies_includes(bool async)
@@ -6576,7 +6576,7 @@ END AS [Discriminator], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Multiple_includes_with_client_method_around_entity_and_also_projecting_included_collection()
@@ -6595,7 +6595,7 @@ LEFT JOIN (
     LEFT JOIN [Weapons] AS [w] ON [g].[FullName] = [w].[OwnerFullName]
 ) AS [t] ON [s].[Id] = [t].[SquadId]
 WHERE [s].[Name] = N'Delta'
-ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId], [t].[Id]");
+ORDER BY [s].[Id], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool async)
@@ -6915,7 +6915,7 @@ LEFT JOIN [Weapons] AS [w0] ON [g].[FullName] = [w0].[OwnerFullName]
 ORDER BY (
     SELECT TOP(1) [w].[Name]
     FROM [Weapons] AS [w]
-    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Gnasher%')), [g].[Nickname], [g].[SquadId], [w0].[Id]");
+    WHERE ([g].[FullName] = [w].[OwnerFullName]) AND ([w].[Name] LIKE N'%Gnasher%')), [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Anonymous_projection_take_followed_by_projecting_single_element_from_collection_navigation(bool async)
@@ -7058,7 +7058,7 @@ LEFT JOIN (
     LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
 ) AS [t1] ON (([t0].[Nickname] = [t1].[LeaderNickname]) OR ([t0].[Nickname] IS NULL AND [t1].[LeaderNickname] IS NULL)) AND ([t0].[SquadId] = [t1].[LeaderSquadId])
 WHERE [t0].[Discriminator] = N'Officer'
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Nickname]");
         }
 
         public override async Task Null_checks_in_correlated_predicate_are_correctly_translated(bool async)
@@ -7075,7 +7075,7 @@ LEFT JOIN (
     FROM [Gears] AS [g]
     LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 ) AS [t0] ON (([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])) AND [t].[Note] IS NOT NULL
-ORDER BY [t].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [t].[Id], [t0].[Nickname]");
         }
 
         public override async Task SelectMany_Where_DefaultIfEmpty_with_navigation_in_the_collection_selector(bool async)
@@ -7249,9 +7249,9 @@ FROM [Factions] AS [f]
 INNER JOIN [LocustHordes] AS [l] ON [f].[Id] = [l].[Id]");
         }
 
-        public override async Task Acessing_reference_navigation_collection_composition_generates_single_query(bool async)
+        public override async Task Accessing_reference_navigation_collection_composition_generates_single_query(bool async)
         {
-            await base.Acessing_reference_navigation_collection_composition_generates_single_query(async);
+            await base.Accessing_reference_navigation_collection_composition_generates_single_query(async);
 
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [t].[Id], [t].[IsAutomatic], [t].[Name], [t].[Id0]
@@ -7261,7 +7261,7 @@ LEFT JOIN (
     FROM [Weapons] AS [w]
     LEFT JOIN [Weapons] AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [t].[Id0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task Reference_include_chain_loads_correctly_when_middle_is_null(bool async)
@@ -7304,7 +7304,7 @@ LEFT JOIN (
         FROM [Gears] AS [g0]
     ) AS [t2] ON [w].[OwnerFullName] = [t2].[FullName]
 ) AS [t1] ON [t0].[FullName] = [t1].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Id], [t1].[Nickname], [t1].[SquadId]");
+ORDER BY [t].[Note], [t].[Id], [t0].[Nickname], [t0].[SquadId], [t1].[Id], [t1].[Nickname]");
         }
 
         public override async Task Collection_navigation_ofType_filter_works(bool async)
@@ -8440,7 +8440,7 @@ LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] <> [w].[OwnerFullName]) OR [w].[Ow
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] < [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join2(bool async)
@@ -8451,7 +8451,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] <= [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task Filtered_collection_projection_with_order_comparison_predicate_converted_to_join3(bool async)
@@ -8462,7 +8462,7 @@ ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Gears] AS [g]
 LEFT JOIN [Weapons] AS [w] ON ([g].[FullName] = [w].[OwnerFullName]) AND ([g].[SquadId] >= [w].[Id])
-ORDER BY [g].[Nickname], [g].[SquadId], [w].[Id]");
+ORDER BY [g].[Nickname], [g].[SquadId]");
         }
 
         public override async Task SelectMany_predicate_with_non_equality_comparison_with_Take_doesnt_convert_to_join(bool async)
@@ -8512,7 +8512,7 @@ OUTER APPLY (
     WHERE ([g].[Nickname] = [g0].[LeaderNickname]) AND ([g].[SquadId] = [g0].[LeaderSquadId])
 ) AS [t]
 WHERE [o].[Nickname] IS NOT NULL
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname], [t].[SquadId]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Nickname]");
         }
 
         public override async Task Accessing_derived_property_using_hard_and_soft_cast(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTInheritanceQuerySqlServerTest.cs
@@ -64,7 +64,7 @@ LEFT JOIN (
     LEFT JOIN [Eagle] AS [e] ON [a].[Species] = [e].[Species]
     LEFT JOIN [Kiwi] AS [k] ON [a].[Species] = [k].[Species]
 ) AS [t] ON [c].[Id] = [t].[CountryId]
-ORDER BY [c].[Name], [c].[Id], [t].[Species]");
+ORDER BY [c].[Name], [c].[Id]");
         }
 
         public override async Task Can_include_prey(bool async)
@@ -89,7 +89,7 @@ LEFT JOIN (
     LEFT JOIN [Eagle] AS [e0] ON [a0].[Species] = [e0].[Species]
     LEFT JOIN [Kiwi] AS [k] ON [a0].[Species] = [k].[Species]
 ) AS [t0] ON [t].[Species] = [t0].[EagleId]
-ORDER BY [t].[Species], [t0].[Species]");
+ORDER BY [t].[Species]");
         }
 
         public override void Can_insert_update_delete()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyNoTrackingQuerySqlServerTest.cs
@@ -343,7 +343,7 @@ LEFT JOIN (
         INNER JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[LeafId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]");
         }
 
         public override async Task Skip_navigation_of_type(bool async)
@@ -367,7 +367,7 @@ LEFT JOIN (
     ) AS [t] ON [j].[RootId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -544,7 +544,7 @@ LEFT JOIN (
     FROM [JoinOneSelfPayload] AS [j]
     INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[RightId]
-ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
         }
 
         public override async Task Select_skip_navigation_multiple(bool async)
@@ -569,7 +569,7 @@ LEFT JOIN (
     FROM [JoinTwoToCompositeKeyShared] AS [j1]
     INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
 ) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -611,7 +611,7 @@ LEFT JOIN (
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[RootId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -627,7 +627,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
         }
 
         public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
@@ -652,7 +652,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e0] ON [j0].[EntityOneId] = [e0].[Id]
     ) AS [t0] ON [t].[Id] = [t0].[EntityBranchId]
 ) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId], [t1].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId]");
         }
 
         public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
@@ -673,7 +673,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
     ) AS [t] ON [e0].[Id] = [t].[LeftId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId]");
         }
 
         public override async Task Include_skip_navigation_and_reference(bool async)
@@ -689,7 +689,7 @@ LEFT JOIN (
     FROM [EntityOneEntityTwo] AS [e1]
     INNER JOIN [EntityOnes] AS [e2] ON [e1].[EntityOneId] = [e2].[Id]
 ) AS [t] ON [e].[Id] = [t].[EntityTwoId]
-ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id]");
+ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId]");
         }
 
         public override async Task Filtered_include_skip_navigation_where(bool async)
@@ -705,7 +705,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by(bool async)
@@ -720,7 +720,7 @@ LEFT JOIN (
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[Id], [t].[ThreeId], [t].[TwoId]");
+ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
@@ -739,7 +739,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 2 < [t].[row]
 ) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id], [t0].[RightId]");
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -758,7 +758,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[TwoId]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -777,7 +777,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_where(bool async)
@@ -803,7 +803,7 @@ LEFT JOIN (
         WHERE [e1].[Id] < 10
     ) AS [t] ON [e0].[Id] = [t].[ThreeId]
 ) AS [t0] ON [r].[Id] = [t0].[EntityRootId]
-ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id0]");
+ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -832,7 +832,7 @@ LEFT JOIN (
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
     ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
 ) AS [t1] ON [r].[Id] = [t1].[RootId]
-ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id], [t1].[Id0]");
+ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -855,7 +855,7 @@ LEFT JOIN (
     ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
     WHERE [e].[Key1] < 5
 ) AS [t0] ON [r].[Id] = [t0].[LeafId]
-ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -882,7 +882,7 @@ OUTER APPLY (
         WHERE [e1].[Id] < 10
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
-ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -907,7 +907,7 @@ LEFT JOIN (
     ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
     WHERE [e0].[Id] < 10
 ) AS [t1] ON [e].[Id] = [t1].[OneId]
-ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0], [t1].[ThreeId]");
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined(bool async)
@@ -925,7 +925,7 @@ LEFT JOIN (
     LEFT JOIN [EntityTwos] AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
@@ -963,7 +963,7 @@ LEFT JOIN (
     ) AS [t1] ON [e0].[Id] = [t1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [t3] ON [e].[Id] = [t3].[ThreeId]
-ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId], [t3].[Id1]");
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId]");
         }
 
         public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
@@ -984,7 +984,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
@@ -1005,7 +1005,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[TwoId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
-ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
         }
 
         public override async Task Includes_accessed_via_different_path_are_merged(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTManyToManyQuerySqlServerTest.cs
@@ -342,7 +342,7 @@ LEFT JOIN (
         INNER JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[LeafId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]");
         }
 
         public override async Task Skip_navigation_of_type(bool async)
@@ -366,7 +366,7 @@ LEFT JOIN (
     ) AS [t] ON [j].[RootId] = [t].[Id]
     WHERE [t].[Discriminator] = N'EntityLeaf'
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -543,7 +543,7 @@ LEFT JOIN (
     FROM [JoinOneSelfPayload] AS [j]
     INNER JOIN [EntityOnes] AS [e0] ON [j].[LeftId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[RightId]
-ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
         }
 
         public override async Task Select_skip_navigation_multiple(bool async)
@@ -568,7 +568,7 @@ LEFT JOIN (
     FROM [JoinTwoToCompositeKeyShared] AS [j1]
     INNER JOIN [EntityCompositeKeys] AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
 ) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -610,7 +610,7 @@ LEFT JOIN (
         LEFT JOIN [Leaves] AS [l] ON [r].[Id] = [l].[Id]
     ) AS [t] ON [j].[RootId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[RootId]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -626,7 +626,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     LEFT JOIN [EntityTwos] AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
         }
 
         public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
@@ -651,7 +651,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e0] ON [j0].[EntityOneId] = [e0].[Id]
     ) AS [t0] ON [t].[Id] = [t0].[EntityBranchId]
 ) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId], [t1].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId]");
         }
 
         public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
@@ -672,7 +672,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] AS [e2] ON [j0].[RightId] = [e2].[Id]
     ) AS [t] ON [e0].[Id] = [t].[LeftId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId]");
         }
 
         public override async Task Include_skip_navigation_and_reference(bool async)
@@ -688,7 +688,7 @@ LEFT JOIN (
     FROM [EntityOneEntityTwo] AS [e1]
     INNER JOIN [EntityOnes] AS [e2] ON [e1].[EntityOneId] = [e2].[Id]
 ) AS [t] ON [e].[Id] = [t].[EntityTwoId]
-ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id]");
+ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId]");
         }
 
         public override async Task Filtered_include_skip_navigation_where(bool async)
@@ -704,7 +704,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] AS [e0] ON [j].[OneId] = [e0].[Id]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by(bool async)
@@ -719,7 +719,7 @@ LEFT JOIN (
     FROM [JoinTwoToThree] AS [j]
     INNER JOIN [EntityTwos] AS [e0] ON [j].[TwoId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[Id], [t].[ThreeId], [t].[TwoId]");
+ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
@@ -738,7 +738,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 2 < [t].[row]
 ) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id], [t0].[RightId]");
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -757,7 +757,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[TwoId]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -776,7 +776,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_where(bool async)
@@ -802,7 +802,7 @@ LEFT JOIN (
         WHERE [e1].[Id] < 10
     ) AS [t] ON [e0].[Id] = [t].[ThreeId]
 ) AS [t0] ON [r].[Id] = [t0].[EntityRootId]
-ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id0]");
+ORDER BY [r].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -831,7 +831,7 @@ LEFT JOIN (
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
     ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
 ) AS [t1] ON [r].[Id] = [t1].[RootId]
-ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0], [t1].[Id]");
+ORDER BY [r].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -854,7 +854,7 @@ LEFT JOIN (
     ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
     WHERE [e].[Key1] < 5
 ) AS [t0] ON [r].[Id] = [t0].[LeafId]
-ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+ORDER BY [r].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -881,7 +881,7 @@ OUTER APPLY (
         WHERE [e1].[Id] < 10
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
-ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -906,7 +906,7 @@ LEFT JOIN (
     ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
     WHERE [e0].[Id] < 10
 ) AS [t1] ON [e].[Id] = [t1].[OneId]
-ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0], [t1].[ThreeId]");
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined(bool async)
@@ -924,7 +924,7 @@ LEFT JOIN (
     LEFT JOIN [EntityTwos] AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
@@ -962,7 +962,7 @@ LEFT JOIN (
     ) AS [t1] ON [e0].[Id] = [t1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [t3] ON [e].[Id] = [t3].[ThreeId]
-ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId], [t3].[Id1]");
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId]");
         }
 
         public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
@@ -983,7 +983,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
@@ -1004,7 +1004,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[TwoId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
-ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
         }
 
         public override async Task Includes_accessed_via_different_path_are_merged(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTRelationshipsQuerySqlServerTest.cs
@@ -41,7 +41,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b1]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t0] ON [t].[Id] = [t0].[BaseParentId]
-ORDER BY [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t0].[Id]");
+ORDER BY [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_without_inheritance(bool async)
@@ -57,7 +57,7 @@ LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [c].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_without_inheritance_reverse(bool async)
@@ -76,7 +76,7 @@ LEFT JOIN (
 ) AS [t] ON [c].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [c].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [c].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_without_inheritance_with_filter(bool async)
@@ -93,7 +93,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseI
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [CollectionsOnBase] AS [c] ON [b].[Id] = [c].[ParentId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [c].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_without_inheritance_with_filter_reverse(bool async)
@@ -113,7 +113,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 WHERE ([c].[Name] <> N'Bar') OR [c].[Name] IS NULL
-ORDER BY [c].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [c].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance(bool async)
@@ -135,7 +135,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b1]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived1(bool async)
@@ -155,7 +155,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b1]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived2(bool async)
@@ -175,7 +175,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnDerived] AS [b1]
     LEFT JOIN [DerivedCollectionsOnDerived] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[ParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived3(bool async)
@@ -193,7 +193,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnDerived] AS [b1]
     INNER JOIN [DerivedCollectionsOnDerived] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_on_derived_reverse(bool async)
@@ -213,7 +213,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance_reverse(bool async)
@@ -235,7 +235,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_collection_with_inheritance_with_filter(bool async)
@@ -258,7 +258,7 @@ LEFT JOIN (
     LEFT JOIN [DerivedCollectionsOnBase] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_with_filter_reverse(bool async)
@@ -281,7 +281,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance(bool async)
@@ -297,7 +297,7 @@ LEFT JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived1(bool async)
@@ -311,7 +311,7 @@ INNER JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived2(bool async)
@@ -325,7 +325,7 @@ INNER JOIN [DerivedEntities] AS [d] ON [b].[Id] = [d].[Id]
 LEFT JOIN [ReferencesOnDerived] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_on_derived_reverse(bool async)
@@ -342,7 +342,7 @@ LEFT JOIN (
 ) AS [t] ON [r].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_reverse(bool async)
@@ -361,7 +361,7 @@ LEFT JOIN (
 ) AS [t] ON [r].[ParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_with_filter(bool async)
@@ -378,7 +378,7 @@ LEFT JOIN [ReferencesOnBase] AS [r] ON [b].[Id] = [r].[ParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [b].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [b].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [b].[Id], [r].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_without_inheritance_with_filter_reverse(bool async)
@@ -398,7 +398,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b0] ON [t].[Id] = [b0].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d0] ON [t].[Id] = [d0].[DerivedInheritanceRelationshipEntityId]
 WHERE ([r].[Name] <> N'Bar') OR [r].[Name] IS NULL
-ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
+ORDER BY [r].[Id], [t].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance(bool async)
@@ -420,7 +420,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived1(bool async)
@@ -440,7 +440,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived2(bool async)
@@ -460,7 +460,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived4(bool async)
@@ -478,7 +478,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_reverse(bool async)
@@ -498,7 +498,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter1(bool async)
@@ -519,7 +519,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter2(bool async)
@@ -540,7 +540,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter4(bool async)
@@ -559,7 +559,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_on_derived_with_filter_reverse(bool async)
@@ -580,7 +580,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_reverse(bool async)
@@ -602,7 +602,7 @@ LEFT JOIN (
 ) AS [t] ON [b].[BaseParentId] = [t].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_with_filter(bool async)
@@ -625,7 +625,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_reference_with_inheritance_with_filter_reverse(bool async)
@@ -648,7 +648,7 @@ LEFT JOIN (
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 WHERE ([b].[Name] <> N'Bar') OR [b].[Name] IS NULL
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_self_reference_with_inheritance(bool async)
@@ -670,7 +670,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseI
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b2] ON [t].[Id] = [b2].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [b2].[BaseInheritanceRelationshipEntityId], [b2].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [b2].[BaseInheritanceRelationshipEntityId], [b2].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Include_self_reference_with_inheritance_reverse(bool async)
@@ -692,7 +692,7 @@ LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseI
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b2] ON [t].[Id] = [b2].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d2] ON [t].[Id] = [d2].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [b2].[BaseInheritanceRelationshipEntityId], [b2].[Id], [d2].[DerivedInheritanceRelationshipEntityId], [d2].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [b2].[BaseInheritanceRelationshipEntityId], [b2].[Id], [d2].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_collection_reference_on_non_entity_base(bool async)
@@ -707,7 +707,7 @@ LEFT JOIN (
     FROM [PrincipalEntities] AS [p]
     LEFT JOIN [ReferencedEntities] AS [r0] ON [p].[ReferenceId] = [r0].[Id]
 ) AS [t] ON [r].[Id] = [t].[ReferencedEntityId]
-ORDER BY [r].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [r].[Id], [t].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_collection(bool async)
@@ -736,7 +736,7 @@ LEFT JOIN (
         LEFT JOIN [NestedCollectionsDerived] AS [n0] ON [n].[Id] = [n0].[Id]
     ) AS [t] ON [b1].[Id] = [t].[ParentCollectionId]
 ) AS [t0] ON [b].[Id] = [t0].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t0].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_collection_reverse(bool async)
@@ -765,7 +765,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_reference(bool async)
@@ -794,7 +794,7 @@ LEFT JOIN (
         LEFT JOIN [NestedReferencesDerived] AS [n0] ON [n].[Id] = [n0].[Id]
     ) AS [t] ON [b1].[Id] = [t].[ParentCollectionId]
 ) AS [t0] ON [b].[Id] = [t0].[BaseParentId]
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t0].[Id], [t0].[Id0]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t0].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_collection_reference_reverse(bool async)
@@ -823,7 +823,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection(bool async)
@@ -852,7 +852,7 @@ LEFT JOIN (
     FROM [NestedCollections] AS [n]
     LEFT JOIN [NestedCollectionsDerived] AS [n0] ON [n].[Id] = [n0].[Id]
 ) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [t0].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection_on_base(bool async)
@@ -879,7 +879,7 @@ LEFT JOIN (
     FROM [NestedCollections] AS [n]
     LEFT JOIN [NestedCollectionsDerived] AS [n0] ON [n].[Id] = [n0].[Id]
 ) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
-ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id], [t0].[Id]");
+ORDER BY [b].[Id], [t].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_collection_reverse(bool async)
@@ -908,7 +908,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference(bool async)
@@ -937,7 +937,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference_on_base(bool async)
@@ -964,7 +964,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [b].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [b].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [b].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [b].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Nested_include_with_inheritance_reference_reference_reverse(bool async)
@@ -993,7 +993,7 @@ LEFT JOIN (
 ) AS [t0] ON [t].[BaseParentId] = [t0].[Id]
 LEFT JOIN [BaseEntities_OwnedCollectionOnBase] AS [b1] ON [t0].[Id] = [b1].[BaseInheritanceRelationshipEntityId]
 LEFT JOIN [DerivedEntities_OwnedCollectionOnDerived] AS [d1] ON [t0].[Id] = [d1].[DerivedInheritanceRelationshipEntityId]
-ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId], [d1].[Id]");
+ORDER BY [n].[Id], [t].[Id], [t0].[Id], [b1].[BaseInheritanceRelationshipEntityId], [b1].[Id], [d1].[DerivedInheritanceRelationshipEntityId]");
         }
 
         public override async Task Collection_projection_on_base_type(bool async)
@@ -1010,7 +1010,7 @@ LEFT JOIN (
     FROM [BaseCollectionsOnBase] AS [b0]
     LEFT JOIN [DerivedCollectionsOnBase] AS [d0] ON [b0].[Id] = [d0].[Id]
 ) AS [t] ON [b].[Id] = [t].[BaseParentId]
-ORDER BY [b].[Id], [t].[Id]");
+ORDER BY [b].[Id]");
         }
 
         public override async Task Include_on_derived_type_with_queryable_Cast(bool async)
@@ -1031,7 +1031,7 @@ LEFT JOIN (
     INNER JOIN [DerivedCollectionsOnDerived] AS [d1] ON [b1].[Id] = [d1].[Id]
 ) AS [t] ON [b].[Id] = [t].[DerivedInheritanceRelationshipEntityId]
 WHERE [b].[Id] >= 4
-ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id], [t].[Id]");
+ORDER BY [b].[Id], [b0].[BaseInheritanceRelationshipEntityId], [b0].[Id], [d0].[DerivedInheritanceRelationshipEntityId], [d0].[Id]");
         }
 
         public override async Task Include_collection_with_inheritance_split(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -50,7 +50,7 @@ LEFT JOIN (
     FROM [LevelTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
     LEFT JOIN [LevelThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l1] ON [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
 ) AS [t] ON [l].[Id] = [t].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t].[Id], [t].[Id0]");
+ORDER BY [l].[Id], [t].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalGearsOfWarQuerySqlServerTest.cs
@@ -273,12 +273,12 @@ LEFT JOIN (
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
     LEFT JOIN [Gears] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [g0] ON [w].[OwnerFullName] = [g0].[FullName]
 ) AS [t0] ON [g].[FullName] = [t0].[OwnerFullName]
-ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname], [t0].[SquadId]");
+ORDER BY [t].[Note], [t].[Id], [g].[Nickname], [g].[SquadId], [t0].[Id], [t0].[Nickname]");
         }
 
-        public override async Task Acessing_reference_navigation_collection_composition_generates_single_query(bool async)
+        public override async Task Accessing_reference_navigation_collection_composition_generates_single_query(bool async)
         {
-            await base.Acessing_reference_navigation_collection_composition_generates_single_query(async);
+            await base.Accessing_reference_navigation_collection_composition_generates_single_query(async);
 
             AssertSql(
                 @"SELECT [g].[Nickname], [g].[SquadId], [t].[Id], [t].[IsAutomatic], [t].[Name], [t].[Id0]
@@ -288,7 +288,7 @@ LEFT JOIN (
     FROM [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w]
     LEFT JOIN [Weapons] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [w0] ON [w].[SynergyWithId] = [w0].[Id]
 ) AS [t] ON [g].[FullName] = [t].[OwnerFullName]
-ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id], [t].[Id0]");
+ORDER BY [g].[Nickname], [g].[SquadId], [t].[Id]");
         }
 
         public override async Task All_with_optional_navigation_is_translated_to_sql(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalManyToManyQuerySqlServerTest.cs
@@ -356,7 +356,7 @@ LEFT JOIN (
         WHERE [e0].[Discriminator] = N'EntityLeaf'
     ) AS [t] ON [j].[LeafId] = [t].[Id]
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId]");
         }
 
         public override async Task Skip_navigation_of_type(bool async)
@@ -372,7 +372,7 @@ LEFT JOIN (
     INNER JOIN [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[RootId] = [e0].[Id]
     WHERE [e0].[Discriminator] = N'EntityLeaf'
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Join_with_skip_navigation(bool async)
@@ -538,7 +538,7 @@ LEFT JOIN (
     FROM [JoinOneSelfPayload] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [j]
     INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[LeftId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[RightId]
-ORDER BY [e].[Id], [t].[LeftId], [t].[RightId], [t].[Id]");
+ORDER BY [e].[Id], [t].[LeftId], [t].[RightId]");
         }
 
         public override async Task Select_skip_navigation_multiple(bool async)
@@ -563,7 +563,7 @@ LEFT JOIN (
     FROM [JoinTwoToCompositeKeyShared] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [j1]
     INNER JOIN [EntityCompositeKeys] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e2] ON (([j1].[CompositeId1] = [e2].[Key1]) AND ([j1].[CompositeId2] = [e2].[Key2])) AND ([j1].[CompositeId3] = [e2].[Key3])
 ) AS [t1] ON [e].[Id] = [t1].[TwoId]
-ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2], [t1].[Key3]");
+ORDER BY [e].[Id], [t].[ThreeId], [t].[TwoId], [t].[Id], [t0].[LeftId], [t0].[RightId], [t0].[Id], [t1].[TwoId], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[Key1], [t1].[Key2]");
         }
 
         public override async Task Select_skip_navigation_first_or_default(bool async)
@@ -597,7 +597,7 @@ LEFT JOIN (
     FROM [JoinCompositeKeyToRootShared] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [j]
     INNER JOIN [EntityRoots] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[RootId] = [e0].[Id]
 ) AS [t] ON (([e].[Key1] = [t].[CompositeId1]) AND ([e].[Key2] = [t].[CompositeId2])) AND ([e].[Key3] = [t].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId], [t].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t].[CompositeId1], [t].[CompositeId2], [t].[CompositeId3], [t].[RootId]");
         }
 
         public override async Task Include_skip_navigation_then_reference(bool async)
@@ -613,7 +613,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[OneId] = [e0].[Id]
     LEFT JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [e0].[Id] = [e1].[ReferenceInverseId]
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id]");
         }
 
         public override async Task Include_skip_navigation_then_include_skip_navigation(bool async)
@@ -637,7 +637,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [j0].[EntityOneId] = [e1].[Id]
     ) AS [t0] ON [t].[Id] = [t0].[EntityBranchId]
 ) AS [t1] ON (([e].[Key1] = [t1].[CompositeId1]) AND ([e].[Key2] = [t1].[CompositeId2])) AND ([e].[Key3] = [t1].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId], [t1].[Id0]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[LeafId], [t1].[Id], [t1].[EntityBranchId], [t1].[EntityOneId]");
         }
 
         public override async Task Include_skip_navigation_then_include_reference_and_skip_navigation(bool async)
@@ -658,7 +658,7 @@ LEFT JOIN (
         INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e2] ON [j0].[RightId] = [e2].[Id]
     ) AS [t] ON [e0].[Id] = [t].[LeftId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId], [t0].[Id1]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0], [t0].[LeftId], [t0].[RightId]");
         }
 
         public override async Task Include_skip_navigation_and_reference(bool async)
@@ -674,7 +674,7 @@ LEFT JOIN (
     FROM [EntityOneEntityTwo] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1]
     INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e2] ON [e1].[EntityOneId] = [e2].[Id]
 ) AS [t] ON [e].[Id] = [t].[EntityTwoId]
-ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id]");
+ORDER BY [e].[Id], [e0].[Id], [t].[EntityOneId], [t].[EntityTwoId]");
         }
 
         public override async Task Include_skip_navigation_then_include_inverse_works_for_tracking_query(bool async)
@@ -694,7 +694,7 @@ LEFT JOIN (
         INNER JOIN [EntityThrees] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e1] ON [j0].[ThreeId] = [e1].[Id]
     ) AS [t] ON [e0].[Id] = [t].[OneId]
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[OneId0], [t0].[ThreeId0], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[OneId0], [t0].[ThreeId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where(bool async)
@@ -710,7 +710,7 @@ LEFT JOIN (
     INNER JOIN [EntityOnes] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[OneId] = [e0].[Id]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId], [t].[Id]");
+ORDER BY [e].[Id], [t].[OneId], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by(bool async)
@@ -725,7 +725,7 @@ LEFT JOIN (
     FROM [JoinTwoToThree] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [j]
     INNER JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e0] ON [j].[TwoId] = [e0].[Id]
 ) AS [t] ON [e].[Id] = [t].[ThreeId]
-ORDER BY [e].[Id], [t].[Id], [t].[ThreeId], [t].[TwoId]");
+ORDER BY [e].[Id], [t].[Id], [t].[ThreeId]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip(bool async)
@@ -744,7 +744,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE 2 < [t].[row]
 ) AS [t0] ON [e].[Id] = [t0].[LeftId]
-ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id], [t0].[RightId]");
+ORDER BY [e].[Id], [t0].[LeftId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_take(bool async)
@@ -763,7 +763,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE [t].[row] <= 2
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id], [t0].[TwoId]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take(bool async)
@@ -782,7 +782,7 @@ LEFT JOIN (
     ) AS [t]
     WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
 ) AS [t0] ON (([e].[Key1] = [t0].[CompositeId1]) AND ([e].[Key2] = [t0].[CompositeId2])) AND ([e].[Key3] = [t0].[CompositeId3])
-ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0], [t0].[Id]");
+ORDER BY [e].[Key1], [e].[Key2], [e].[Key3], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[Id0]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_where(bool async)
@@ -803,7 +803,7 @@ LEFT JOIN (
         WHERE [e2].[Id] < 10
     ) AS [t] ON [e1].[Id] = [t].[ThreeId]
 ) AS [t0] ON [e].[Id] = [t0].[EntityRootId]
-ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[EntityRootId], [t0].[EntityThreeId], [t0].[Id], [t0].[OneId], [t0].[ThreeId]");
         }
 
         public override async Task Filtered_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -827,7 +827,7 @@ LEFT JOIN (
         WHERE (1 < [t].[row]) AND ([t].[row] <= 3)
     ) AS [t0] ON (([e0].[Key1] = [t0].[CompositeId1]) AND ([e0].[Key2] = [t0].[CompositeId2])) AND ([e0].[Key3] = [t0].[CompositeId3])
 ) AS [t1] ON [e].[Id] = [t1].[RootId]
-ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0], [t1].[Id]");
+ORDER BY [e].[Id], [t1].[CompositeId1], [t1].[CompositeId2], [t1].[CompositeId3], [t1].[RootId], [t1].[Key1], [t1].[Key2], [t1].[Key3], [t1].[CompositeId10], [t1].[CompositeId20], [t1].[CompositeId30], [t1].[Id0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation(bool async)
@@ -849,7 +849,7 @@ LEFT JOIN (
     WHERE [e0].[Key1] < 5
 ) AS [t0] ON [e].[Id] = [t0].[LeafId]
 WHERE [e].[Discriminator] = N'EntityLeaf'
-ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30], [t0].[Id]");
+ORDER BY [e].[Id], [t0].[CompositeId1], [t0].[CompositeId2], [t0].[CompositeId3], [t0].[LeafId], [t0].[Key1], [t0].[Key2], [t0].[Key3], [t0].[TwoId], [t0].[CompositeId10], [t0].[CompositeId20], [t0].[CompositeId30]");
         }
 
         public override async Task Filtered_include_skip_navigation_order_by_skip_take_then_include_skip_navigation_where(bool async)
@@ -876,7 +876,7 @@ OUTER APPLY (
         WHERE [e1].[Id] < 10
     ) AS [t0] ON [t].[Id] = [t0].[TwoId]
 ) AS [t1]
-ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0], [t1].[Id0]");
+ORDER BY [e].[Id], [t1].[Id], [t1].[OneId], [t1].[TwoId], [t1].[ThreeId], [t1].[TwoId0]");
         }
 
         public override async Task Filtered_include_skip_navigation_where_then_include_skip_navigation_order_by_skip_take(bool async)
@@ -901,7 +901,7 @@ LEFT JOIN (
     ) AS [t0] ON [e0].[Id] = [t0].[TwoId]
     WHERE [e0].[Id] < 10
 ) AS [t1] ON [e].[Id] = [t1].[OneId]
-ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0], [t1].[ThreeId]");
+ORDER BY [e].[Id], [t1].[OneId], [t1].[TwoId], [t1].[Id], [t1].[TwoId0], [t1].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined(bool async)
@@ -919,7 +919,7 @@ LEFT JOIN (
     LEFT JOIN [EntityTwos] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [e2] ON [e0].[Id] = [e2].[CollectionInverseId]
     WHERE [e0].[Id] < 10
 ) AS [t] ON [e].[Id] = [t].[TwoId]
-ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0], [t].[Id1]");
+ORDER BY [e].[Id], [t].[OneId], [t].[TwoId], [t].[Id], [t].[Id0]");
         }
 
         public override async Task Filter_include_on_skip_navigation_combined_with_filtered_then_includes(bool async)
@@ -954,7 +954,7 @@ LEFT JOIN (
     ) AS [t1] ON [e0].[Id] = [t1].[EntityOneId]
     WHERE [e0].[Id] < 10
 ) AS [t3] ON [e].[Id] = [t3].[ThreeId]
-ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId], [t3].[Id1]");
+ORDER BY [e].[Id], [t3].[OneId], [t3].[ThreeId], [t3].[Id], [t3].[OneId0], [t3].[Id0], [t3].[TwoId], [t3].[EntityBranchId], [t3].[EntityOneId]");
         }
 
         public override async Task Filtered_include_on_skip_navigation_then_filtered_include_on_navigation(bool async)
@@ -975,7 +975,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[CollectionInverseId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[ThreeId]
-ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[OneId], [t0].[ThreeId], [t0].[Id]");
         }
 
         public override async Task Filtered_include_on_navigation_then_filtered_include_on_skip_navigation(bool async)
@@ -996,7 +996,7 @@ LEFT JOIN (
     ) AS [t] ON [e0].[Id] = [t].[TwoId]
     WHERE [e0].[Id] > 15
 ) AS [t0] ON [e].[Id] = [t0].[CollectionInverseId]
-ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId], [t0].[Id0]");
+ORDER BY [e].[Id], [t0].[Id], [t0].[ThreeId], [t0].[TwoId]");
         }
 
         public override async Task Includes_accessed_via_different_path_are_merged(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -542,7 +542,7 @@ ORDER BY [g].[Year]");
 FROM [Customers] AS [c]
 OUTER APPLY [dbo].[GetOrdersWithMultipleProducts]([dbo].[AddValues]([c].[Id], 1)) AS [g]
 WHERE [c].[Id] = 1
-ORDER BY [c].[Id], [g].[OrderId]");
+ORDER BY [c].[Id]");
         }
 
         public override void QF_Select_Correlated_Subquery_In_Anonymous()
@@ -557,7 +557,7 @@ OUTER APPLY (
     FROM [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [g]
     WHERE DATEPART(day, [g].[OrderDate]) = 21
 ) AS [t]
-ORDER BY [c].[Id], [t].[OrderId]");
+ORDER BY [c].[Id]");
         }
 
         public override void QF_Select_Correlated_Subquery_In_Anonymous_Nested_With_QF()
@@ -582,7 +582,7 @@ INNER JOIN (
                 @"SELECT [c].[Id], [c].[LastName], [g].[OrderId], [g].[CustomerId], [g].[OrderDate]
 FROM [Customers] AS [c]
 OUTER APPLY [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [g]
-ORDER BY [c].[Id], [g].[OrderId]");
+ORDER BY [c].[Id]");
         }
 
         public override void QF_CrossApply_Correlated_Select_Result()
@@ -728,7 +728,7 @@ OUTER APPLY (
     FROM [dbo].[GetOrdersWithMultipleProducts]([c].[Id]) AS [g]
     INNER JOIN [Customers] AS [c0] ON [g].[CustomerId] = [c0].[Id]
 ) AS [t]
-ORDER BY [c].[Id], [t].[OrderId], [t].[Id]");
+ORDER BY [c].[Id], [t].[OrderId]");
         }
 
         public override void DbSet_mapped_to_function()


### PR DESCRIPTION
Here's a draft attempt, probably wrong in various ways :rofl: I've tested and modified the baselines in ComplexNavigationsQuerySqlServerTest only for now, if it's a good start, I can continue.

The approach is simple - just have a pending ordering which gets applied only when another ordering is about to be applied (we already like pending things so much).

After implementing the above, I realized something - can't we drop all orderings on any collection joins which doesn't have a deeper join referring back to it? For example, in the following:

```sql
SELECT * FROM a
LEFT JOIN b ON b.a_id = a.id
LEFT JOIN c ON c.a_id = a.id
```

Since b and c are both at the same level (dependents of a), don't we only need to order on a.id in this query?

Fixes #19828