### PR TITLE
throw exception when migration has error in table changes

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -42,6 +42,21 @@ namespace Microsoft.EntityFrameworkCore
             => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>().Migrate();
 
         /// <summary>
+        ///     <para>
+        ///         Applies any pending migrations for the context to the database. Will create the database
+        ///         if it does not already exist.
+        ///     </para>
+        ///     <para>
+        ///         Note that this API is mutually exclusive with <see cref="DatabaseFacade.EnsureCreated" />. EnsureCreated does not use migrations
+        ///         to create the database and therefore the database that is created cannot be later updated using migrations.
+        ///     </para>
+        /// </summary>
+        /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
+        /// <param name="throwWhenHasError">If you set this true, this will check and throw exception when you change models and forgot to add-migration</param>
+        public static void Migrate([NotNull] this DatabaseFacade databaseFacade, bool throwWhenHasError)
+            => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>().Migrate(throwWhenHasError: throwWhenHasError);
+
+        /// <summary>
         ///     Gets all the migrations that are defined in the configured migrations assembly.
         /// </summary>
         /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context.</param>
@@ -113,6 +128,28 @@ namespace Microsoft.EntityFrameworkCore
             => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>()
                 .MigrateAsync(cancellationToken: cancellationToken);
 
+        /// <summary>
+        ///     <para>
+        ///         Asynchronously applies any pending migrations for the context to the database. Will create the database
+        ///         if it does not already exist.
+        ///     </para>
+        ///     <para>
+        ///         Note that this API is mutually exclusive with <see cref="DatabaseFacade.EnsureCreated" />.
+        ///         <see cref="DatabaseFacade.EnsureCreated" /> does not use migrations to create the database and therefore the database
+        ///         that is created cannot be later updated using migrations.
+        ///     </para>
+        /// </summary>
+        /// <param name="databaseFacade"> The <see cref="DatabaseFacade" /> for the context. </param>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
+        /// <param name="throwWhenHasError">If you set this true, this will check and throw exception when you change models and forgot to add-migration</param>
+        /// <returns> A task that represents the asynchronous migration operation. </returns>
+        /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
+        public static Task MigrateAsync(
+            [NotNull] this DatabaseFacade databaseFacade,
+            bool throwWhenHasError,
+            CancellationToken cancellationToken = default)
+            => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetRelationalService<IMigrator>()
+                .MigrateAsync(throwWhenHasError: throwWhenHasError, cancellationToken: cancellationToken);
         /// <summary>
         ///     <para>
         ///         Executes the given SQL against the database and returns the number of rows affected.

--- a/src/EFCore.Relational/Migrations/IMigrator.cs
+++ b/src/EFCore.Relational/Migrations/IMigrator.cs
@@ -38,6 +38,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///     Migrates the database to either a specified target migration or up to the latest
         ///     migration that exists in the <see cref="IMigrationsAssembly" />.
         /// </summary>
+        /// <param name="throwWhenHasError">
+        ///     If you set this true, this will check and throw exception when you change models and forgot to add-migration
+        /// </param>
+        /// <param name="targetMigration">
+        ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
+        /// </param>
+        void Migrate(bool throwWhenHasError, [CanBeNull] string? targetMigration = null);
+
+        /// <summary>
+        ///     Migrates the database to either a specified target migration or up to the latest
+        ///     migration that exists in the <see cref="IMigrationsAssembly" />.
+        /// </summary>
         /// <param name="targetMigration">
         ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
         /// </param>
@@ -48,6 +60,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] string? targetMigration = null,
             CancellationToken cancellationToken = default);
 
+        /// <summary>
+        ///     Migrates the database to either a specified target migration or up to the latest
+        ///     migration that exists in the <see cref="IMigrationsAssembly" />.
+        /// </summary>
+        /// <param name="targetMigration">
+        ///     The target migration to migrate the database to, or <see langword="null" /> to migrate to the latest.
+        /// </param>
+        /// <param name="throwWhenHasError">
+        ///     If you set this true, this will check and throw exception when you change models and forgot to add-migration
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns> A task that represents the asynchronous operation </returns>
+        /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
+        Task MigrateAsync(bool throwWhenHasError,
+            [CanBeNull] string targetMigration = null,
+            CancellationToken cancellationToken = default);
         /// <summary>
         ///     Generates a SQL script to migrate a database either in its entirety, or starting and
         ///     ending at specified migrations.

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -141,9 +141,94 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task MigrateAsync(
-            string? targetMigration = null,
+        public virtual void Migrate(bool throwWhenHasError, string? targetMigration = null)
+        {
+            Migrate(targetMigration);
+            if (throwWhenHasError)
+            {
+                //find firstOrDefaultMethod from Queryable
+                var firstOrDefaultMethod = typeof(Queryable).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)
+                     .Where(x => x.Name == nameof(Queryable.FirstOrDefault) && x.GetParameters().Length == 1).FirstOrDefault();
+
+                if (firstOrDefaultMethod != null)
+                {
+                    CheckMigrationWhenHasError<object>(firstOrDefaultMethod, false, CancellationToken.None).ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check the migraiton errors when developer forgot to use Add-Migration
+        /// </summary>
+        private IEnumerable<T> CheckMigrationWhenHasError<T>(MethodInfo firstOrDefaultMethod, bool isAsync, CancellationToken cancellationToken)
+        {
+            var setMethod = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                                                 .Where(method => method.Name == nameof(DbContext.Set) && method.GetParameters().Length == 0)
+                                                 .FirstOrDefault();
+            if (setMethod != null)
+            {
+                foreach (var entityType in _currentContext.Context.Model.GetEntityTypes())
+                {
+                    Type entityClrType = entityType.ClrType;
+                    //Get the generic type definition of Set method in context
+
+                    //Create a method with the genetic
+                    setMethod = setMethod.MakeGenericMethod(entityClrType);
+                    var queryable = (IQueryable?)setMethod.Invoke(_currentContext.Context, new object[] { });
+                    if (queryable == null)
+                        continue;
+                    //Call Set<T> of context to make queryable
+                    var query = setMethod.Invoke(_currentContext.Context, new object[] { });
+                    if (query == null)
+                        continue;
+                    var parameters = isAsync ? (new object[] { query, CancellationToken.None }) : (new object[] { query });
+                    //Call FirstOrDefault method of queryable to check errors of table
+                    var result = firstOrDefaultMethod.MakeGenericMethod(entityClrType).Invoke(null, parameters);
+                    if (result == null)
+                    {
+                        continue;
+                    }
+
+                    yield return (T)result;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual async Task MigrateAsync(bool throwWhenHasError,
+            string? targetMigration,
             CancellationToken cancellationToken = default)
+        {
+            await MigrateAsync(targetMigration, cancellationToken).ConfigureAwait(false);
+            if (throwWhenHasError)
+            {
+                //find firstOrDefaultMethod from Queryable
+                var firstOrDefaultMethod = typeof(EntityFrameworkQueryableExtensions).GetMethods(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)
+                     .Where(x => x.Name == nameof(EntityFrameworkQueryableExtensions.FirstOrDefaultAsync) && x.GetParameters().Length == 2).FirstOrDefault();
+                if (firstOrDefaultMethod != null)
+                {
+                    foreach (var item in CheckMigrationWhenHasError<Task>(firstOrDefaultMethod, true, cancellationToken))
+                    {
+                        await item.ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual async Task MigrateAsync(
+                    string? targetMigration = null,
+                    CancellationToken cancellationToken = default)
         {
             _logger.MigrateUsingConnection(this, _connection);
 

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -151,6 +151,16 @@ namespace Microsoft.EntityFrameworkCore
                 string toMigration = null,
                 MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
                 => throw new NotImplementedException();
+
+            public void Migrate(bool throwWhenHasError, [CanBeNull] string targetMigration = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task MigrateAsync(bool throwWhenHasError, [CanBeNull] string targetMigration = null, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private class FakeMigrationsAssembly : IMigrationsAssembly


### PR DESCRIPTION
I added a boolean throwWhenHasError to the new Migrate method.
What problem we had and this will fix?
The problem happens when Developers change the entities and forgot to use Add-Migration, so the exception will not happen when you use Migrate method or run the application, the exception happens when you run a query in the table.
example error when you use any query in tables in production:
```

Invalid object name 'Transactions'.
or
Invalid column name 'NewField'

```
What if you use context.Migrate(true)?
If you use this new method this will check all of entities changes and show you the error that you forgot to use Add-Migration in the StartUp of your project.

Example Usage:

```csharp
        static async Task CheckMigrationAsync()
        {
            await using ExampleContext context = new ExampleContext();
            await context.Database.MigrateAsync(true);
        }

        static void CheckMigration()
        {
            using ExampleContext context = new ExampleContext();
            context.Database.Migrate(true);
        }
```
#