### PR TITLE
Add a convention that builds a read-optimized model to be used at runtime

### DIFF
--- a/EFCore.Runtime.slnf
+++ b/EFCore.Runtime.slnf
@@ -36,7 +36,7 @@
       "test\\EFCore.SqlServer.Tests\\EFCore.SqlServer.Tests.csproj",
       "test\\EFCore.Sqlite.FunctionalTests\\EFCore.Sqlite.FunctionalTests.csproj",
       "test\\EFCore.Sqlite.Tests\\EFCore.Sqlite.Tests.csproj",
-      "test\\EFCore.Tests\\EFCore.Tests.csproj",
+      "test\\EFCore.Tests\\EFCore.Tests.csproj"
     ]
   }
 }

--- a/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Design/DesignTimeServiceCollectionExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 .AddTransient(_ => context.GetService<IMigrationsModelDiffer>())
                 .AddTransient(_ => context.GetService<IMigrator>())
                 .AddTransient(_ => context.GetService<IRelationalTypeMappingSource>())
-                .AddTransient(_ => context.GetService<IModel>())
+                .AddTransient(_ => context.DesignTimeModel)
                 .AddTransient(_ => context.GetService<IModelRuntimeInitializer>());
     }
 }

--- a/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
+++ b/src/EFCore.Design/Migrations/Internal/SnapshotModelProcessor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 model = mutableModel.FinalizeModel();
             }
 
-            return _modelRuntimeInitializer.Initialize((IModel)model, validationLogger: null);
+            return _modelRuntimeInitializer.Initialize((IModel)model, designTime: true, validationLogger: null);
         }
 
         private void ProcessCollection(IEnumerable<IReadOnlyAnnotatable> metadata, string version)

--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             VisitDatabaseModel(modelBuilder, databaseModel);
 
-            return _modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), null);
+            return _modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime: true, null);
         }
 
         /// <summary>

--- a/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/EFCore.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         /// </summary>
         bool EnsureCreated(
             IUpdateAdapterFactory updateAdapterFactory,
+            IModel designModel,
             IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger);
 
         /// <summary>

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -32,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         private readonly IInMemoryStore _store;
         private readonly IUpdateAdapterFactory _updateAdapterFactory;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger;
+        private readonly Func<IModel> _getDesignModel;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -43,6 +46,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             DatabaseDependencies dependencies,
             IInMemoryStoreCache storeCache,
             IDbContextOptions options,
+            ICurrentDbContext context,
             IUpdateAdapterFactory updateAdapterFactory,
             IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger)
             : base(dependencies)
@@ -53,6 +57,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             Check.NotNull(updateLogger, nameof(updateLogger));
 
             _store = storeCache.GetStore(options);
+            _getDesignModel = () => context.Context.DesignTimeModel;
             _updateAdapterFactory = updateAdapterFactory;
             _updateLogger = updateLogger;
         }
@@ -93,6 +98,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool EnsureDatabaseCreated()
-            => _store.EnsureCreated(_updateAdapterFactory, _updateLogger);
+            => _store.EnsureCreated(_updateAdapterFactory, _getDesignModel(), _updateLogger);
     }
 }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilder.cs
@@ -109,6 +109,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
                 (QueryFilterRewritingConvention)new RelationalQueryFilterRewritingConvention(
                     Dependencies, RelationalDependencies));
 
+            ReplaceConvention(
+                conventionSet.ModelFinalizedConventions,
+                (SlimModelConvention)new RelationalSlimModelConvention(Dependencies, RelationalDependencies));
+
             return conventionSet;
         }
     }

--- a/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilderDependencies.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Infrastructure/RelationalConventionSetBuilderDependencies.cs
@@ -71,7 +71,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
         /// <summary>
         ///     The relational annotation provider.
         /// </summary>
-        [Obsolete("This is now part of RelationalModelRuntimeInitializerDependencies")]
         public IRelationalAnnotationProvider RelationalAnnotationProvider { get; init; }
     }
 }

--- a/src/EFCore.Relational/Metadata/Conventions/RelationalSlimModelConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalSlimModelConvention.cs
@@ -1,0 +1,388 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that creates an optimized copy of the mutable model. This convention is typically
+    ///     implemented by database providers to update provider annotations when creating a read-only model.
+    /// </summary>
+    public class RelationalSlimModelConvention : SlimModelConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="RelationalModelConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        /// <param name="relationalDependencies">  Parameter object containing relational dependencies for this convention. </param>
+        public RelationalSlimModelConvention(
+            ProviderConventionSetBuilderDependencies dependencies,
+            RelationalConventionSetBuilderDependencies relationalDependencies)
+            : base(dependencies)
+        {
+            RelationalDependencies = relationalDependencies;
+        }
+
+        /// <summary>
+        ///     The service dependencies for <see cref="RelationalConventionSetBuilder" />
+        /// </summary>
+        protected virtual RelationalConventionSetBuilderDependencies RelationalDependencies { get; }
+
+        /// <summary>
+        ///     Updates the model annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="model"> The source model. </param>
+        /// <param name="slimModel"> The target model that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessModelAnnotations(
+            Dictionary<string, object?> annotations, IModel model, SlimModel slimModel, bool runtime)
+        {
+            base.ProcessModelAnnotations(annotations, model, slimModel, runtime);
+
+            if (runtime)
+            {
+                annotations[RelationalAnnotationNames.RelationalModel] =
+                    RelationalModel.Create(slimModel, RelationalDependencies.RelationalAnnotationProvider);
+            }
+            else
+            {
+                if (annotations.TryGetValue(RelationalAnnotationNames.DbFunctions, out var functions))
+                {
+                    var slimFunctions = new SortedDictionary<string, IDbFunction>();
+                    foreach (var functionPair in (SortedDictionary<string, IDbFunction>)functions!)
+                    {
+                        var slimFunction = Create(functionPair.Value, slimModel);
+                        slimFunctions[functionPair.Key] = slimFunction;
+
+                        foreach (var parameter in functionPair.Value.Parameters)
+                        {
+                            var slimParameter = Create(parameter, slimFunction);
+
+                            CreateAnnotations(parameter, slimParameter, static (convention, annotations, source, target, runtime) =>
+                                convention.ProcessFunctionParameterAnnotations(annotations, source, target, runtime));
+                        }
+
+                        CreateAnnotations(functionPair.Value, slimFunction, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessFunctionAnnotations(annotations, source, target, runtime));
+                    }
+
+                    annotations[RelationalAnnotationNames.DbFunctions] = slimFunctions;
+                }
+
+                if (annotations.TryGetValue(RelationalAnnotationNames.Sequences, out var sequences))
+                {
+                    var slimSequences = new SortedDictionary<(string, string?), ISequence>();
+                    foreach (var sequencePair in (SortedDictionary<(string, string?), ISequence>)sequences!)
+                    {
+                        var slimSequence = Create(sequencePair.Value, slimModel);
+                        slimSequences[sequencePair.Key] = slimSequence;
+
+                        CreateAnnotations(sequencePair.Value, slimSequence, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessSequenceAnnotations(annotations, source, target, runtime));
+                    }
+
+                    annotations[RelationalAnnotationNames.Sequences] = slimSequences;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Updates the entity type annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="entityType"> The source entity type. </param>
+        /// <param name="slimEntityType"> The target entity type that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessEntityTypeAnnotations(
+            IDictionary<string, object?> annotations, IEntityType entityType, SlimEntityType slimEntityType, bool runtime)
+        {
+            base.ProcessEntityTypeAnnotations(annotations, entityType, slimEntityType, runtime);
+
+            if (runtime)
+            {
+                annotations.Remove(RelationalAnnotationNames.TableMappings);
+                annotations.Remove(RelationalAnnotationNames.ViewMappings);
+                annotations.Remove(RelationalAnnotationNames.SqlQueryMappings);
+                annotations.Remove(RelationalAnnotationNames.FunctionMappings);
+                annotations.Remove(RelationalAnnotationNames.DefaultMappings);
+            }
+            else
+            {
+                if (annotations.TryGetValue(RelationalAnnotationNames.CheckConstraints, out var constraints))
+                {
+                    var slimCheckConstraints = new Dictionary<string, ICheckConstraint>();
+                    foreach (var constraintPair in (Dictionary<string, ICheckConstraint>?)constraints!)
+                    {
+                        var slimCheckConstraint = Create(constraintPair.Value, slimEntityType);
+                        slimCheckConstraints[constraintPair.Key] = slimCheckConstraint;
+
+                        CreateAnnotations(constraintPair.Value, slimCheckConstraint, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessCheckConstraintAnnotations(annotations, source, target, runtime));
+                    }
+
+                    annotations[RelationalAnnotationNames.CheckConstraints] = slimCheckConstraints;
+                }
+
+                // These need to be set explicitly to prevent default values from being generated
+                annotations[RelationalAnnotationNames.TableName] = entityType.GetTableName();
+                annotations[RelationalAnnotationNames.Schema] = entityType.GetSchema();
+                annotations[RelationalAnnotationNames.ViewName] = entityType.GetViewName();
+                annotations[RelationalAnnotationNames.ViewSchema] = entityType.GetViewSchema();
+                annotations[RelationalAnnotationNames.SqlQuery] = entityType.GetSqlQuery();
+                annotations[RelationalAnnotationNames.FunctionName] = entityType.GetFunctionName();
+            }
+        }
+
+        private void CreateAnnotations<TSource, TTarget>(
+            TSource source,
+            TTarget target,
+            Action<RelationalSlimModelConvention, Dictionary<string, object?>, TSource, TTarget, bool> process)
+            where TSource : IAnnotatable
+            where TTarget : AnnotatableBase
+        {
+            var annotations = source.GetAnnotations().ToDictionary(a => a.Name, a => a.Value);
+            process(this, annotations, source, target, false);
+            target.AddAnnotations(annotations);
+
+            annotations = source.GetRuntimeAnnotations().ToDictionary(a => a.Name, a => a.Value);
+            process(this, annotations, source, target, true);
+            target.AddRuntimeAnnotations(annotations);
+        }
+
+        private SlimDbFunction Create(IDbFunction function, SlimModel slimModel)
+            => new SlimDbFunction(
+                function.ModelName,
+                slimModel,
+                function.MethodInfo,
+                function.ReturnType,
+                function.IsScalar,
+                function.IsAggregate,
+                function.IsNullable,
+                function.IsBuiltIn,
+                function.Name,
+                function.Schema,
+                function.StoreType,
+                function.TypeMapping,
+                function.Translation);
+
+        /// <summary>
+        ///     Updates the function annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="function"> The source function. </param>
+        /// <param name="slimFunction"> The target function that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessFunctionAnnotations(
+            Dictionary<string, object?> annotations,
+            IDbFunction function,
+            SlimDbFunction slimFunction,
+            bool runtime)
+        {
+        }
+
+        private SlimDbFunctionParameter Create(IDbFunctionParameter parameter, SlimDbFunction slimFunction)
+            => slimFunction.AddParameter(
+                parameter.Name,
+                parameter.ClrType,
+                parameter.PropagatesNullability,
+                parameter.StoreType,
+                parameter.TypeMapping);
+
+        /// <summary>
+        ///     Updates the function parameter annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="parameter"> The source function parameter. </param>
+        /// <param name="slimParameter"> The target function parameter that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessFunctionParameterAnnotations(
+            Dictionary<string, object?> annotations,
+            IDbFunctionParameter parameter,
+            SlimDbFunctionParameter slimParameter,
+            bool runtime)
+        {
+        }
+
+        private SlimSequence Create(ISequence sequence, SlimModel slimModel)
+            => new SlimSequence(
+                sequence.Name,
+                sequence.Schema,
+                slimModel,
+                sequence.Type,
+                sequence.StartValue,
+                sequence.IncrementBy,
+                sequence.IsCyclic,
+                sequence.MinValue,
+                sequence.MaxValue);
+
+        /// <summary>
+        ///     Updates the sequence annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="sequence"> The source sequence. </param>
+        /// <param name="slimSequence"> The target sequence that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessSequenceAnnotations(
+            Dictionary<string, object?> annotations,
+            ISequence sequence,
+            SlimSequence slimSequence,
+            bool runtime)
+        {
+        }
+
+        private SlimCheckConstraint Create(ICheckConstraint checkConstraint, SlimEntityType slimEntityType)
+            => new SlimCheckConstraint(
+                checkConstraint.Name,
+                slimEntityType,
+                checkConstraint.Sql);
+
+        /// <summary>
+        ///     Updates the check constraint annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="checkConstraint"> The source check constraint. </param>
+        /// <param name="slimCheckConstraint"> The target check constraint that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessCheckConstraintAnnotations(
+            Dictionary<string, object?> annotations,
+            ICheckConstraint checkConstraint,
+            SlimCheckConstraint slimCheckConstraint,
+            bool runtime)
+        {
+        }
+
+        /// <summary>
+        ///     Updates the property annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="property"> The source property. </param>
+        /// <param name="slimProperty"> The target property that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessPropertyAnnotations(
+            Dictionary<string, object?> annotations, IProperty property, SlimProperty slimProperty, bool runtime)
+        {
+            base.ProcessPropertyAnnotations(annotations, property, slimProperty, runtime);
+
+            if (runtime)
+            {
+                annotations.Remove(RelationalAnnotationNames.TableColumnMappings);
+                annotations.Remove(RelationalAnnotationNames.ViewColumnMappings);
+                annotations.Remove(RelationalAnnotationNames.SqlQueryColumnMappings);
+                annotations.Remove(RelationalAnnotationNames.FunctionColumnMappings);
+                annotations.Remove(RelationalAnnotationNames.DefaultColumnMappings);
+            }
+            else
+            {
+                if (annotations.TryGetValue(RelationalAnnotationNames.RelationalOverrides, out var overrides))
+                {
+                    var slimPropertyOverrides = new SortedDictionary<StoreObjectIdentifier, IRelationalPropertyOverrides>();
+                    foreach (var overridesPair in (SortedDictionary<StoreObjectIdentifier, IRelationalPropertyOverrides>?)overrides!)
+                    {
+                        var slimOverrides = Create(overridesPair.Value, slimProperty);
+                        slimPropertyOverrides[overridesPair.Key] = slimOverrides;
+
+                        CreateAnnotations(overridesPair.Value, slimOverrides, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessPropertyOverridesAnnotations(annotations, source, target, runtime));
+                    }
+
+                    annotations[RelationalAnnotationNames.RelationalOverrides] = slimPropertyOverrides;
+                }
+            }
+        }
+
+        private SlimRelationalPropertyOverrides Create(
+            IRelationalPropertyOverrides propertyOverrides,
+            SlimProperty slimProperty)
+            => new SlimRelationalPropertyOverrides(
+                slimProperty,
+                propertyOverrides.ColumnName,
+                propertyOverrides.ColumnNameOverriden);
+
+        /// <summary>
+        ///     Updates the relational property overrides annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="propertyOverrides"> The source relational property overrides. </param>
+        /// <param name="slimPropertyOverrides"> The target relational property overrides that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessPropertyOverridesAnnotations(
+            Dictionary<string, object?> annotations,
+            IRelationalPropertyOverrides propertyOverrides,
+            SlimRelationalPropertyOverrides slimPropertyOverrides,
+            bool runtime)
+        {
+        }
+
+        /// <summary>
+        ///     Updates the key annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="key"> The source key. </param>
+        /// <param name="slimKey"> The target key that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessKeyAnnotations(
+            IDictionary<string, object?> annotations,
+            IKey key,
+            SlimKey slimKey,
+            bool runtime)
+        {
+            base.ProcessKeyAnnotations(annotations, key, slimKey, runtime);
+
+            if (runtime)
+            {
+                annotations.Remove(RelationalAnnotationNames.UniqueConstraintMappings);
+            }
+        }
+
+        /// <summary>
+        ///     Updates the index annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="index"> The source index. </param>
+        /// <param name="slimIndex"> The target index that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessIndexAnnotations(
+            Dictionary<string, object?> annotations,
+            IIndex index,
+            SlimIndex slimIndex,
+            bool runtime)
+        {
+            base.ProcessIndexAnnotations(annotations, index, slimIndex, runtime);
+
+            if (runtime)
+            {
+                annotations.Remove(RelationalAnnotationNames.TableIndexMappings);
+            }
+        }
+
+        /// <summary>
+        ///     Updates the foreign key annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="foreignKey"> The source foreign key. </param>
+        /// <param name="slimForeignKey"> The target foreign key that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessForeignKeyAnnotations(
+            Dictionary<string, object?> annotations,
+            IForeignKey foreignKey,
+            SlimForeignKey slimForeignKey,
+            bool runtime)
+        {
+            base.ProcessForeignKeyAnnotations(annotations, foreignKey, slimForeignKey, runtime);
+
+            if (runtime)
+            {
+                annotations.Remove(RelationalAnnotationNames.ForeignKeyMappings);
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModel.cs
@@ -180,9 +180,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         constraint.AddAnnotations(relationalAnnotationProvider.For(constraint));
                     }
 
-                    foreach (CheckConstraint checkConstraint in ((ITable)table).CheckConstraints)
+                    foreach (var checkConstraint in ((ITable)table).CheckConstraints)
                     {
-                        checkConstraint.AddAnnotations(relationalAnnotationProvider.For(checkConstraint));
+                        ((AnnotatableBase)checkConstraint).AddAnnotations(relationalAnnotationProvider.For(checkConstraint));
                     }
 
                     table.AddAnnotations(relationalAnnotationProvider.For(table));
@@ -232,9 +232,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (relationalAnnotationProvider != null)
             {
-                foreach (Sequence sequence in ((IRelationalModel)databaseModel).Sequences)
+                foreach (var sequence in ((IRelationalModel)databaseModel).Sequences)
                 {
-                    sequence.AddAnnotations(relationalAnnotationProvider.For(sequence));
+                    ((AnnotatableBase)sequence).AddAnnotations(relationalAnnotationProvider.For(sequence));
                 }
 
                 databaseModel.AddAnnotations(relationalAnnotationProvider.For(databaseModel));

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         x.ToTable(TableName, TableSchema);
                     });
 
-                _model = Dependencies.ModelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), validationLogger: null);
+                _model = Dependencies.ModelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
             }
 
             return _model;

--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -502,7 +502,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 model = mutableModel.FinalizeModel();
             }
 
-            return _modelRuntimeInitializer.Initialize(model, validationLogger: null);
+            return _modelRuntimeInitializer.Initialize(model, designTime: true, validationLogger: null);
         }
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreator.cs
@@ -144,7 +144,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         protected virtual IReadOnlyList<MigrationCommand> GetCreateTablesCommands(
             MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
             => Dependencies.MigrationsSqlGenerator.Generate(
-                Dependencies.ModelDiffer.GetDifferences(null, Dependencies.Model.GetRelationalModel()), Dependencies.Model, options);
+                Dependencies.ModelDiffer.GetDifferences(null, Dependencies.CurrentContext.Context.DesignTimeModel.GetRelationalModel()),
+                Dependencies.CurrentContext.Context.DesignTimeModel,
+                options);
 
         /// <summary>
         ///     Determines whether the database contains any tables. No attempt is made to determine if

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -82,7 +83,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(currentContext, nameof(currentContext));
             Check.NotNull(commandLogger, nameof(commandLogger));
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Model = model;
+#pragma warning restore CS0618 // Type or member is obsolete
             Connection = connection;
             ModelDiffer = modelDiffer;
             MigrationsSqlGenerator = migrationsSqlGenerator;
@@ -106,6 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Gets the model for the context this creator is being used with.
         /// </summary>
+        [Obsolete("Use CurrentContext.Context.DesignTimeModel instead")]
         public IModel Model { get; init; }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -178,7 +178,7 @@ SELECT 1 ELSE SELECT 0");
                     {
                         Name = builder.InitialCatalog,
                         FileName = builder.AttachDBFilename,
-                        Collation = Dependencies.Model.GetCollation()
+                        Collation = Dependencies.CurrentContext.Context.DesignTimeModel.GetCollation()
                     }
                 },
                 null);

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -138,11 +138,22 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     The metadata about the shape of entities, the relationships between them, and how they map to the database.
+        ///     May not include all the information necessary to initialize the database.
         /// </summary>
         public virtual IModel Model
         {
             [DebuggerStepThrough]
-            get => DbContextDependencies.Model;
+            get => ContextServices.Model;
+        }
+
+        /// <summary>
+        ///     The metadata about the shape of entities, the relationships between them, and how they map to the database.
+        ///     Also includes all the information necessary to initialize the database.
+        /// </summary>
+        public virtual IModel DesignTimeModel
+        {
+            [DebuggerStepThrough]
+            get => ContextServices.DesignTimeModel;
         }
 
         /// <summary>
@@ -331,7 +342,9 @@ namespace Microsoft.EntityFrameworkCore
             return DbContextDependencies.EntityFinderFactory.Create(entityType);
         }
 
-        private IServiceProvider InternalServiceProvider
+        private IServiceProvider InternalServiceProvider => ContextServices.InternalServiceProvider;
+
+        private IDbContextServices ContextServices
         {
             get
             {
@@ -339,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (_contextServices != null)
                 {
-                    return _contextServices.InternalServiceProvider;
+                    return _contextServices;
                 }
 
                 if (_initializing)
@@ -382,7 +395,7 @@ namespace Microsoft.EntityFrameworkCore
                     _initializing = false;
                 }
 
-                return _contextServices.InternalServiceProvider;
+                return _contextServices;
             }
         }
 

--- a/src/EFCore/Infrastructure/IModelCacheKeyFactory.cs
+++ b/src/EFCore/Infrastructure/IModelCacheKeyFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -29,6 +30,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     The context to get the model cache key for.
         /// </param>
         /// <returns> The created key. </returns>
+        [Obsolete("Use the overload with most parameters")]
         object Create(DbContext context);
+
+        /// <summary>
+        ///     Gets the model cache key for a given context.
+        /// </summary>
+        /// <param name="context">
+        ///     The context to get the model cache key for.
+        /// </param>
+        /// <param name="designTime"> Whether the model should contain design-time configuration.</param>
+        /// <returns> The created key. </returns>
+        object Create(DbContext context, bool designTime)
+#pragma warning disable CS0618 // Type or member is obsolete
+            => Create(context);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/EFCore/Infrastructure/IModelRuntimeInitializer.cs
+++ b/src/EFCore/Infrastructure/IModelRuntimeInitializer.cs
@@ -29,10 +29,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Validates and initializes the given model with runtime dependencies.
         /// </summary>
         /// <param name="model"> The model to initialize. </param>
-        /// <param name="validationLogger"> The validation logger. </param>
+        /// <param name="designTime"> Whether the model should contain design-time configuration.</param>
+        /// <param name="validationLogger">
+        ///     The validation logger. If <see langword="null"/> is provided validation will not be performed.
+        ///     </param>
         /// <returns> The initialized model. </returns>
         IModel Initialize(
             IModel model,
-            IDiagnosticsLogger<DbLoggerCategory.Model.Validation>? validationLogger);
+            bool designTime = true,
+            IDiagnosticsLogger<DbLoggerCategory.Model.Validation>? validationLogger = null);
     }
 }

--- a/src/EFCore/Infrastructure/IModelSource.cs
+++ b/src/EFCore/Infrastructure/IModelSource.cs
@@ -54,9 +54,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <param name="context"> The context the model is being produced for. </param>
         /// <param name="modelCreationDependencies"> The dependencies object used during the creation of the model. </param>
+        /// <param name="designTime"> Whether the model should contain design-time configuration.</param>
         /// <returns> The model to be used. </returns>
         IModel GetModel(
             DbContext context,
-            ModelCreationDependencies modelCreationDependencies);
+            ModelCreationDependencies modelCreationDependencies,
+            bool designTime);
     }
 }

--- a/src/EFCore/Infrastructure/ModelCacheKey.cs
+++ b/src/EFCore/Infrastructure/ModelCacheKey.cs
@@ -18,6 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     /// </summary>
     public class ModelCacheKey
     {
+        private readonly Type _dbContextType;
+        private readonly bool _designTime;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ModelCacheKey" /> class.
         /// </summary>
@@ -29,7 +32,18 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _dbContextType = context.GetType();
         }
 
-        private readonly Type _dbContextType;
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ModelCacheKey" /> class.
+        /// </summary>
+        /// <param name="context">
+        ///     The context instance that this key is for.
+        /// </param>
+        /// <param name="designTime"> Whether the model should contain design-time configuration.</param>
+        public ModelCacheKey(DbContext context, bool designTime)
+        {
+            _dbContextType = context.GetType();
+            _designTime = designTime;
+        }
 
         /// <summary>
         ///     Determines if this key is equivalent to a given key (i.e. if they are for the same context type).
@@ -41,7 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     <see langword="true" /> if the key is for the same context type, otherwise <see langword="false" />.
         /// </returns>
         protected virtual bool Equals(ModelCacheKey other)
-            => _dbContextType == other._dbContextType;
+            => _dbContextType == other._dbContextType
+                && _designTime == other._designTime;
 
         /// <summary>
         ///     Determines if this key is equivalent to a given object (i.e. if they are keys for the same context type).
@@ -63,6 +78,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     The hash code for the key.
         /// </returns>
         public override int GetHashCode()
-            => _dbContextType.GetHashCode();
+        {
+            var hash = new HashCode();
+            hash.Add(_dbContextType);
+            hash.Add(_designTime);
+            return hash.ToHashCode();
+        }
     }
 }

--- a/src/EFCore/Infrastructure/ModelCacheKeyFactory.cs
+++ b/src/EFCore/Infrastructure/ModelCacheKeyFactory.cs
@@ -42,5 +42,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <returns> The created key. </returns>
         public virtual object Create(DbContext context)
             => new ModelCacheKey(context);
+
+        /// <summary>
+        ///     Gets the model cache key for a given context.
+        /// </summary>
+        /// <param name="context">
+        ///     The context to get the model cache key for.
+        /// </param>
+        /// <param name="designTime"> Whether the model should contain design-time configuration.</param>
+        /// <returns> The created key. </returns>
+        public virtual object Create(DbContext context, bool designTime)
+            => new ModelCacheKey(context, designTime);
     }
 }

--- a/src/EFCore/Internal/DbContextDependencies.cs
+++ b/src/EFCore/Internal/DbContextDependencies.cs
@@ -4,7 +4,6 @@
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -41,7 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             IDbSetSource setSource,
             IEntityFinderSource entityFinderSource,
             IEntityGraphAttacher entityGraphAttacher,
-            IModel model,
             IAsyncQueryProvider queryProvider,
             IStateManager stateManager,
             IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
@@ -50,21 +48,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
             ChangeDetector = changeDetector;
             SetSource = setSource;
             EntityGraphAttacher = entityGraphAttacher;
-            Model = model;
             QueryProvider = queryProvider;
             StateManager = stateManager;
             UpdateLogger = updateLogger;
             InfrastructureLogger = infrastructureLogger;
             EntityFinderFactory = new EntityFinderFactory(entityFinderSource, stateManager, setSource, currentContext.Context);
         }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public IModel Model { get; init; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/IDbContextDependencies.cs
+++ b/src/EFCore/Internal/IDbContextDependencies.cs
@@ -31,14 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        IModel Model { get; }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         IDbSetSource SetSource { get; }
 
         /// <summary>

--- a/src/EFCore/Internal/IDbContextServices.cs
+++ b/src/EFCore/Internal/IDbContextServices.cs
@@ -57,6 +57,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        IModel DesignTimeModel { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         IDbContextOptions ContextOptions { get; }
 
         /// <summary>

--- a/src/EFCore/Metadata/ConstructorBinding.cs
+++ b/src/EFCore/Metadata/ConstructorBinding.cs
@@ -51,5 +51,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         public override Type RuntimeType
             => Constructor.DeclaringType!;
+
+        /// <summary>
+        ///     Creates a copy that contains the given parameter bindings.
+        /// </summary>
+        /// <param name="parameterBindings"> The new parameter bindings. </param>
+        /// <returns> A copy with replaced parameter bindings. </returns>
+        public override InstantiationBinding With(IReadOnlyList<ParameterBinding> parameterBindings)
+            => new ConstructorBinding(Constructor, parameterBindings);
     }
 }

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -49,5 +51,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 ? (Expression)Expression.TypeAs(propertyExpression, ServiceType)
                 : propertyExpression;
         }
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+            => new ContextParameterBinding(ParameterType, consumedProperties.SingleOrDefault());
     }
 }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -238,6 +238,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizingConventions.Add(inversePropertyAttributeConvention);
             conventionSet.ModelFinalizingConventions.Add(backingFieldConvention);
 
+            conventionSet.ModelFinalizedConventions.Add(new SlimModelConvention(Dependencies));
+
             return conventionSet;
         }
 

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilderDependencies.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilderDependencies.cs
@@ -159,8 +159,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
         public ProviderConventionSetBuilderDependencies With(ICurrentDbContext currentContext)
 #pragma warning disable CS0618 // Type or member is obsolete
             => new(
-                TypeMappingSource, ConstructorBindingFactory, ParameterBindingFactories, MemberClassifier, Logger, ValidationLogger,
-                SetFinder, currentContext, ModelValidator);
+                TypeMappingSource,
+                ConstructorBindingFactory,
+                ParameterBindingFactories,
+                MemberClassifier,
+                Logger,
+                ValidationLogger,
+                SetFinder,
+                currentContext,
+                ModelValidator);
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/EFCore/Metadata/Conventions/SlimModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/SlimModelConvention.cs
@@ -1,0 +1,538 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+#nullable enable
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that creates an optimized copy of the mutable model. This convention is typically
+    ///     implemented by database providers to update provider annotations when creating a read-only model.
+    /// </summary>
+    public class SlimModelConvention : IModelFinalizedConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="SlimModelConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public SlimModelConvention(
+            ProviderConventionSetBuilderDependencies dependencies)
+        {
+            Dependencies = dependencies;
+        }
+
+        /// <summary>
+        ///     Parameter object containing service dependencies.
+        /// </summary>
+        protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     Called after a model is finalized and can no longer be mutated.
+        /// </summary>
+        /// <param name="model"> The model. </param>
+        public virtual IModel ProcessModelFinalized(IModel model)
+            => Create(model);
+
+        /// <summary>
+        ///     Creates an optimized model base on the supplied one.
+        /// </summary>
+        /// <param name="model"> The source model. </param>
+        /// <returns> An optimized model. </returns>
+        protected virtual SlimModel Create(IModel model)
+        {
+            var slimModel = new SlimModel(model.ModelDependencies!, ((IRuntimeModel)model).SkipDetectChanges);
+
+            var entityTypes = Sort(model.GetEntityTypes());
+            var entityTypePairs = new List<(IEntityType Source, SlimEntityType Target)>(entityTypes.Count);
+
+            foreach (var entityType in entityTypes)
+            {
+                var slimEntityType = Create(entityType, slimModel);
+                entityTypePairs.Add((entityType, slimEntityType));
+
+                foreach (var property in entityType.GetDeclaredProperties())
+                {
+                    var slimProperty = Create(property, slimEntityType);
+                    CreateAnnotations(property, slimProperty, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessPropertyAnnotations(annotations, source, target, runtime));
+                }
+
+                foreach (var serviceProperty in entityType.GetDeclaredServiceProperties())
+                {
+                    var slimServiceProperty = Create(serviceProperty, slimEntityType);
+                    CreateAnnotations(serviceProperty, slimServiceProperty, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessServicePropertyAnnotations(annotations, source, target, runtime));
+                    slimServiceProperty.ParameterBinding =
+                        (ServiceParameterBinding)Create(serviceProperty.ParameterBinding, slimEntityType);
+                }
+
+                foreach (var key in entityType.GetDeclaredKeys())
+                {
+                    var slimKey = Create(key, slimEntityType);
+                    if (key.IsPrimaryKey())
+                    {
+                        slimEntityType.SetPrimaryKey(slimKey);
+                    }
+
+                    CreateAnnotations(key, slimKey, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessKeyAnnotations(annotations, source, target, runtime));
+                }
+
+                foreach (var index in entityType.GetDeclaredIndexes())
+                {
+                    var slimIndex = Create(index, slimEntityType);
+                    CreateAnnotations(index, slimIndex, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessIndexAnnotations(annotations, source, target, runtime));
+                }
+
+                slimEntityType.ConstructorBinding = Create(entityType.ConstructorBinding, slimEntityType);
+                slimEntityType.ServiceOnlyConstructorBinding =
+                    Create(((IRuntimeEntityType)entityType).ServiceOnlyConstructorBinding, slimEntityType);
+            }
+
+            foreach (var (entityType, slimEntityType) in entityTypePairs)
+            {
+                foreach (var foreignKey in entityType.GetDeclaredForeignKeys())
+                {
+                    var slimForeignKey = Create(foreignKey, slimEntityType);
+
+                    var navigation = foreignKey.DependentToPrincipal;
+                    if (navigation != null)
+                    {
+                        var slimNavigation = Create(navigation, slimForeignKey);
+                        CreateAnnotations(navigation, slimNavigation, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessNavigationAnnotations(annotations, source, target, runtime));
+                    }
+
+                    navigation = foreignKey.PrincipalToDependent;
+                    if (navigation != null)
+                    {
+                        var slimNavigation = Create(navigation, slimForeignKey);
+                        CreateAnnotations(navigation, slimNavigation, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessNavigationAnnotations(annotations, source, target, runtime));
+                    }
+
+                    CreateAnnotations(foreignKey, slimForeignKey, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessForeignKeyAnnotations(annotations, source, target, runtime));
+                }
+            }
+
+            foreach (var (entityType, slimEntityType) in entityTypePairs)
+            {
+                foreach (var navigation in entityType.GetDeclaredSkipNavigations())
+                {
+                    var slimNavigation = Create(navigation, slimEntityType);
+
+                    var inverse = slimNavigation.TargetEntityType.FindSkipNavigation(navigation.Inverse.Name);
+                    if (inverse != null)
+                    {
+                        slimNavigation.Inverse = inverse;
+                        inverse.Inverse = slimNavigation;
+                    }
+
+                    CreateAnnotations(navigation, slimNavigation, static (convention, annotations, source, target, runtime) =>
+                        convention.ProcessSkipNavigationAnnotations(annotations, source, target, runtime));
+                }
+
+                CreateAnnotations(entityType, slimEntityType, static (convention, annotations, source, target, runtime) =>
+                    convention.ProcessEntityTypeAnnotations(annotations, source, target, runtime));
+            }
+
+            CreateAnnotations(model, slimModel, static (convention, annotations, source, target, runtime) =>
+                convention.ProcessModelAnnotations(annotations, source, target, runtime));
+
+            return slimModel;
+        }
+
+        private void CreateAnnotations<TSource, TTarget>(
+            TSource source,
+            TTarget target,
+            Action<SlimModelConvention, Dictionary<string, object?>, TSource, TTarget, bool> process)
+            where TSource : IAnnotatable
+            where TTarget : AnnotatableBase
+        {
+            var annotations = source.GetAnnotations().ToDictionary(a => a.Name, a => a.Value);
+            process(this, annotations, source, target, false);
+            target.AddAnnotations(annotations);
+
+            annotations = source.GetRuntimeAnnotations().ToDictionary(a => a.Name, a => a.Value);
+            process(this, annotations, source, target, true);
+            target.AddRuntimeAnnotations(annotations);
+        }
+
+        /// <summary>
+        ///     Updates the model annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="model"> The source model. </param>
+        /// <param name="slimModel"> The target model that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessModelAnnotations(
+            Dictionary<string, object?> annotations,
+            IModel model,
+            SlimModel slimModel,
+            bool runtime)
+        {
+            if (runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.ModelDependencies);
+                annotations[CoreAnnotationNames.ReadOnlyModel] = slimModel;
+            }
+            else
+            {
+                annotations.Remove(CoreAnnotationNames.OwnedTypes);
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+            }
+        }
+
+        private static IReadOnlyList<IEntityType> Sort(IEnumerable<IEntityType> entityTypes)
+        {
+            var entityTypeGraph = new Multigraph<IEntityType, int>();
+            entityTypeGraph.AddVertices(entityTypes);
+            foreach (var entityType in entityTypes.Where(et => et.BaseType != null))
+            {
+                entityTypeGraph.AddEdge(entityType.BaseType!, entityType, 0);
+            }
+
+            return entityTypeGraph.TopologicalSort();
+        }
+
+        private SlimEntityType Create(IEntityType entityType, SlimModel model)
+            => model.AddEntityType(entityType.Name,
+                entityType.ClrType,
+                entityType.HasSharedClrType,
+                entityType.BaseType == null ? null : model.FindEntityType(entityType.BaseType.Name)!,
+                entityType.GetDiscriminatorPropertyName(),
+                entityType.GetChangeTrackingStrategy(),
+                entityType.FindIndexerPropertyInfo(),
+                entityType.IsPropertyBag);
+
+        private ParameterBinding Create(ParameterBinding parameterBinding, SlimEntityType entityType)
+            => parameterBinding.With(parameterBinding.ConsumedProperties.Select(property =>
+            (entityType.FindProperty(property.Name)
+                ?? entityType.FindServiceProperty(property.Name)
+                ?? entityType.FindNavigation(property.Name)
+                ?? (IPropertyBase?)entityType.FindSkipNavigation(property.Name))!).ToList());
+
+        private InstantiationBinding? Create(InstantiationBinding? instantiationBinding, SlimEntityType entityType)
+            => instantiationBinding?.With(instantiationBinding.ParameterBindings.Select(binding => Create(binding, entityType)).ToList());
+
+        /// <summary>
+        ///     Updates the entity type annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="entityType"> The source entity type. </param>
+        /// <param name="slimEntityType"> The target entity type that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessEntityTypeAnnotations(
+            IDictionary<string, object?> annotations,
+            IEntityType entityType,
+            SlimEntityType slimEntityType,
+            bool runtime)
+        {
+            if (!runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                annotations.Remove(CoreAnnotationNames.NavigationAccessMode);
+                annotations.Remove(CoreAnnotationNames.DiscriminatorProperty);
+
+                if (annotations.TryGetValue(CoreAnnotationNames.QueryFilter, out var queryFilter))
+                {
+                    annotations[CoreAnnotationNames.QueryFilter] =
+                        new QueryRootRewritingExpressionVisitor(slimEntityType.Model).Rewrite((Expression)queryFilter!);
+                }
+
+#pragma warning disable CS0612 // Type or member is obsolete
+                if (annotations.TryGetValue(CoreAnnotationNames.DefiningQuery, out var definingQuery))
+                {
+                    annotations[CoreAnnotationNames.DefiningQuery] =
+                        new QueryRootRewritingExpressionVisitor(slimEntityType.Model).Rewrite((Expression)definingQuery!);
+                }
+#pragma warning restore CS0612 // Type or member is obsolete
+            }
+        }
+
+        private SlimProperty Create(IProperty property, SlimEntityType slimEntityType)
+            => slimEntityType.AddProperty(
+                property.Name,
+                property.ClrType,
+                property.PropertyInfo,
+                property.FieldInfo,
+                property.GetPropertyAccessMode(),
+                property.IsNullable,
+                property.IsConcurrencyToken,
+                property.ValueGenerated,
+                property.GetBeforeSaveBehavior(),
+                property.GetAfterSaveBehavior(),
+                property.GetMaxLength(),
+                property.IsUnicode(),
+                property.GetPrecision(),
+                property.GetScale(),
+                property.GetProviderClrType(),
+                property.GetValueGeneratorFactory(),
+                property.GetValueConverter(),
+                property.GetValueComparer(),
+                property.GetKeyValueComparer(),
+                property.GetTypeMapping());
+
+        /// <summary>
+        ///     Updates the property annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="property"> The source property. </param>
+        /// <param name="slimProperty"> The target property that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessPropertyAnnotations(
+            Dictionary<string, object?> annotations,
+            IProperty property,
+            SlimProperty slimProperty,
+            bool runtime)
+        {
+            if (!runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                annotations.Remove(CoreAnnotationNames.BeforeSaveBehavior);
+                annotations.Remove(CoreAnnotationNames.AfterSaveBehavior);
+                annotations.Remove(CoreAnnotationNames.MaxLength);
+                annotations.Remove(CoreAnnotationNames.Unicode);
+                annotations.Remove(CoreAnnotationNames.Precision);
+                annotations.Remove(CoreAnnotationNames.Scale);
+                annotations.Remove(CoreAnnotationNames.ProviderClrType);
+                annotations.Remove(CoreAnnotationNames.ValueConverter);
+                annotations.Remove(CoreAnnotationNames.ValueComparer);
+            }
+        }
+
+        private SlimServiceProperty Create(IServiceProperty property, SlimEntityType slimEntityType)
+            => slimEntityType.AddServiceProperty(
+                property.Name,
+                property.PropertyInfo,
+                property.FieldInfo,
+                property.GetPropertyAccessMode());
+
+        /// <summary>
+        ///     Updates the service property annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="property"> The source service property. </param>
+        /// <param name="slimProperty"> The target service property that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessServicePropertyAnnotations(
+            Dictionary<string, object?> annotations,
+            IServiceProperty property,
+            SlimServiceProperty slimProperty,
+            bool runtime)
+        {
+            if (!runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+            }
+        }
+
+        private SlimKey Create(IKey key, SlimEntityType slimEntityType)
+            => slimEntityType.AddKey(slimEntityType.FindProperties(key.Properties.Select(p => p.Name))!);
+
+        /// <summary>
+        ///     Updates the key annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="key"> The source key. </param>
+        /// <param name="slimKey"> The target key that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessKeyAnnotations(
+            IDictionary<string, object?> annotations,
+            IKey key,
+            SlimKey slimKey,
+            bool runtime)
+        {
+        }
+
+        private SlimIndex Create(IIndex index, SlimEntityType slimEntityType)
+            => slimEntityType.AddIndex(
+                slimEntityType.FindProperties(index.Properties.Select(p => p.Name))!,
+                index.Name,
+                index.IsUnique);
+
+        /// <summary>
+        ///     Updates the index annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="index"> The source index. </param>
+        /// <param name="slimIndex"> The target index that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessIndexAnnotations(
+            Dictionary<string, object?> annotations,
+            IIndex index,
+            SlimIndex slimIndex,
+            bool runtime)
+        {
+        }
+
+        private SlimForeignKey Create(IForeignKey foreignKey, SlimEntityType slimEntityType)
+        {
+            var principalEntityType = slimEntityType.Model.FindEntityType(foreignKey.PrincipalEntityType.Name)!;
+            return slimEntityType.AddForeignKey(
+                slimEntityType.FindProperties(foreignKey.Properties.Select(p => p.Name))!,
+                GetKey(foreignKey.PrincipalKey, principalEntityType),
+                principalEntityType,
+                foreignKey.DeleteBehavior,
+                foreignKey.IsUnique,
+                foreignKey.IsRequired,
+                foreignKey.IsRequiredDependent,
+                foreignKey.IsOwnership);
+        }
+
+        /// <summary>
+        ///     Updates the foreign key annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="foreignKey"> The source foreign key. </param>
+        /// <param name="slimForeignKey"> The target foreign key that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessForeignKeyAnnotations(
+            Dictionary<string, object?> annotations,
+            IForeignKey foreignKey,
+            SlimForeignKey slimForeignKey,
+            bool runtime)
+        {
+        }
+
+        private SlimNavigation Create(INavigation navigation, SlimForeignKey slimForeigKey)
+            => (navigation.IsOnDependent ? slimForeigKey.DeclaringEntityType : slimForeigKey.PrincipalEntityType)
+                .AddNavigation(
+                    navigation.Name,
+                    navigation.ClrType,
+                    navigation.PropertyInfo,
+                    navigation.FieldInfo,
+                    slimForeigKey,
+                    navigation.IsOnDependent,
+                    navigation.GetPropertyAccessMode(),
+                    navigation.IsEagerLoaded);
+
+        /// <summary>
+        ///     Updates the navigation annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="navigation"> The source navigation. </param>
+        /// <param name="slimNavigation"> The target navigation that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessNavigationAnnotations(
+            Dictionary<string, object?> annotations,
+            INavigation navigation,
+            SlimNavigation slimNavigation,
+            bool runtime)
+        {
+            if (!runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                annotations.Remove(CoreAnnotationNames.EagerLoaded);
+            }
+        }
+
+        private SlimSkipNavigation Create(ISkipNavigation navigation, SlimEntityType slimEntityType)
+            => slimEntityType.AddSkipNavigation(
+                navigation.Name,
+                navigation.ClrType,
+                navigation.PropertyInfo,
+                navigation.FieldInfo,
+                slimEntityType.Model.FindEntityType(navigation.TargetEntityType.Name)!,
+                GetForeignKey(navigation.ForeignKey, slimEntityType.Model.FindEntityType(navigation.ForeignKey.DeclaringEntityType.Name)!),
+                navigation.IsCollection,
+                navigation.IsOnDependent,
+                navigation.GetPropertyAccessMode(),
+                navigation.IsEagerLoaded);
+
+        /// <summary>
+        ///     Gets the corresponding foreign key in the read-optimized model.
+        /// </summary>
+        /// <param name="foreignKey"> The original foreign key. </param>
+        /// <param name="entityType"> The declaring entity type. </param>
+        /// <returns> The corresponding read-optimized foreign key. </returns>
+        protected virtual SlimForeignKey GetForeignKey(IForeignKey foreignKey, SlimEntityType entityType)
+            => entityType.FindDeclaredForeignKeys(
+                entityType.FindProperties(foreignKey.Properties.Select(p => p.Name))!)
+                .Single(fk => fk.PrincipalEntityType.Name == foreignKey.PrincipalEntityType.Name
+                && fk.PrincipalKey.Properties.Select(p => p.Name).SequenceEqual(
+                    foreignKey.PrincipalKey.Properties.Select(p => p.Name)));
+
+        /// <summary>
+        ///     Gets the corresponding key in the read-optimized model.
+        /// </summary>
+        /// <param name="key"> The original key. </param>
+        /// <param name="entityType"> The declaring entity type. </param>
+        /// <returns> The corresponding read-optimized key. </returns>
+        protected virtual SlimKey GetKey(IKey key, SlimEntityType entityType)
+            => entityType.FindKey(entityType.FindProperties(key.Properties.Select(p => p.Name))!)!;
+
+        /// <summary>
+        ///     Gets the corresponding index in the read-optimized model.
+        /// </summary>
+        /// <param name="index"> The original index. </param>
+        /// <param name="entityType"> The declaring entity type. </param>
+        /// <returns> The corresponding read-optimized index. </returns>
+        protected virtual SlimIndex GetIndex(IIndex index, SlimEntityType entityType)
+            => index.Name == null
+            ? entityType.FindIndex(entityType.FindProperties(index.Properties.Select(p => p.Name))!)!
+            : entityType.FindIndex(index.Name)!;
+
+        /// <summary>
+        ///     Updates the skip navigation annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="skipNavigation"> The source skip navigation. </param>
+        /// <param name="slimSkipNavigation"> The target skip navigation that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected virtual void ProcessSkipNavigationAnnotations(
+            Dictionary<string, object?> annotations,
+            ISkipNavigation skipNavigation,
+            SlimSkipNavigation slimSkipNavigation,
+            bool runtime)
+        {
+            if (!runtime)
+            {
+                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                annotations.Remove(CoreAnnotationNames.EagerLoaded);
+            }
+        }
+
+        /// <summary>
+        ///     A visitor that rewrites <see cref="QueryRootExpression" /> encountered in an expression to use a different entity type.
+        /// </summary>
+        protected class QueryRootRewritingExpressionVisitor : ExpressionVisitor
+        {
+            private readonly IModel _model;
+
+            /// <summary>
+            ///     Creates a new instance of <see cref="QueryRootRewritingExpressionVisitor" />.
+            /// </summary>
+            /// <param name="model"> The model to look for entity types. </param>
+            public QueryRootRewritingExpressionVisitor(IModel model)
+            {
+                _model = model;
+            }
+
+            /// <summary>
+            ///     Rewrites <see cref="QueryRootExpression" /> encountered in an expression to use a different entity type.
+            /// </summary>
+            /// <param name="expression"> The query expression to rewrite. </param>
+            public Expression Rewrite(Expression expression)
+                => Visit(expression);
+
+            /// <inheritdoc />
+            protected override Expression VisitExtension(Expression extensionExpression)
+                => extensionExpression is QueryRootExpression queryRootExpression
+                    ? new QueryRootExpression(_model.FindEntityType(queryRootExpression.EntityType.Name)!)
+                    : base.VisitExtension(extensionExpression);
+        }
+    }
+}

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -83,5 +83,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     delegateVariable
                 });
         }
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+            => new DependencyInjectionMethodParameterBinding(ParameterType, ServiceType, Method, consumedProperties.SingleOrDefault());
     }
 }

--- a/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -57,5 +59,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                         MaterializationContext.ContextProperty),
                     typeof(IInfrastructure<IServiceProvider>)));
         }
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+            => new DependencyInjectionParameterBinding(ParameterType, ServiceType, consumedProperties.SingleOrDefault());
     }
 }

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -32,5 +34,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Expression materializationExpression,
             Expression entityTypeExpression)
             => Check.NotNull(entityTypeExpression, nameof(entityTypeExpression));
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+            => new EntityTypeParameterBinding(consumedProperties.SingleOrDefault());
     }
 }

--- a/src/EFCore/Metadata/FactoryMethodBinding.cs
+++ b/src/EFCore/Metadata/FactoryMethodBinding.cs
@@ -87,5 +87,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The type that will be created from the expression tree created for this binding.
         /// </summary>
         public override Type RuntimeType { get; }
+
+        /// <summary>
+        ///     Creates a copy that contains the given parameter bindings.
+        /// </summary>
+        /// <param name="parameterBindings"> The new parameter bindings. </param>
+        /// <returns> A copy with replaced parameter bindings. </returns>
+        public override InstantiationBinding With(IReadOnlyList<ParameterBinding> parameterBindings)
+            => _factoryInstance == null
+            ? new FactoryMethodBinding(_factoryMethod, parameterBindings, RuntimeType)
+            : new FactoryMethodBinding(_factoryInstance, _factoryMethod, parameterBindings, RuntimeType);
     }
 }

--- a/src/EFCore/Metadata/InstantiationBinding.cs
+++ b/src/EFCore/Metadata/InstantiationBinding.cs
@@ -44,5 +44,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The type that will be created from the expression tree created for this binding.
         /// </summary>
         public abstract Type RuntimeType { get; }
+
+        /// <summary>
+        ///     Creates a copy that contains the given parameter bindings.
+        /// </summary>
+        /// <param name="parameterBindings"> The new parameter bindings. </param>
+        /// <returns> A copy with replaced parameter bindings. </returns>
+        public abstract InstantiationBinding With(IReadOnlyList<ParameterBinding> parameterBindings);
     }
 }

--- a/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
+++ b/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
@@ -51,5 +51,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
                         return expression;
                     }));
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+        {
+            var newBindings = new List<ParameterBinding>(_bindings.Count);
+            var propertyCount = 0;
+            foreach (var binding in _bindings)
+            {
+                var newBinding = binding.With(consumedProperties.Skip(propertyCount).Take(binding.ConsumedProperties.Count).ToList());
+                newBindings.Add(newBinding);
+                propertyCount += binding.ConsumedProperties.Count;
+            }
+
+            return new ObjectArrayParameterBinding(newBindings);
+        }
     }
 }

--- a/src/EFCore/Metadata/ParameterBinding.cs
+++ b/src/EFCore/Metadata/ParameterBinding.cs
@@ -47,5 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="bindingInfo"> The binding information. </param>
         /// <returns> The expression tree. </returns>
         public abstract Expression BindToParameter(ParameterBindingInfo bindingInfo);
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public abstract ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/PropertyParameterBinding.cs
+++ b/src/EFCore/Metadata/PropertyParameterBinding.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -35,5 +37,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             return Expression.Call(bindingInfo.MaterializationContextExpression, MaterializationContext.GetValueBufferMethod)
                 .CreateValueBufferReadValueExpression(property.ClrType, bindingInfo.GetValueBufferIndex(property), property);
         }
+
+        /// <summary>
+        ///     Creates a copy that contains the given consumed properties.
+        /// </summary>
+        /// <param name="consumedProperties"> The new consumed properties. </param>
+        /// <returns> A copy with replaced consumed properties. </returns>
+        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+            => new PropertyParameterBinding((IProperty)consumedProperties.Single());
     }
 }

--- a/src/EFCore/Metadata/SlimEntityType.cs
+++ b/src/EFCore/Metadata/SlimEntityType.cs
@@ -436,16 +436,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             _skipNavigations.Add(name, skipNavigation);
 
-            if (targetEntityType.DeclaredReferencingSkipNavigations == null)
-            {
-                targetEntityType.DeclaredReferencingSkipNavigations =
-                    new SortedSet<SlimSkipNavigation>(SkipNavigationComparer.Instance) { skipNavigation };
-            }
-            else
-            {
-                targetEntityType.DeclaredReferencingSkipNavigations.Add(skipNavigation);
-            }
-
             return skipNavigation;
         }
 
@@ -479,18 +469,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     ? _baseType.GetSkipNavigations()
                     : _baseType.GetSkipNavigations().Concat(_skipNavigations.Values)
                 : _skipNavigations.Values;
-
-        private IEnumerable<SlimSkipNavigation> GetReferencingSkipNavigations()
-            => _baseType != null
-                ? (DeclaredReferencingSkipNavigations?.Count ?? 0) == 0
-                    ? _baseType.GetReferencingSkipNavigations()
-                    : _baseType.GetReferencingSkipNavigations().Concat(GetDeclaredReferencingSkipNavigations())
-                : GetDeclaredReferencingSkipNavigations();
-
-        private IEnumerable<SlimSkipNavigation> GetDeclaredReferencingSkipNavigations()
-            => DeclaredReferencingSkipNavigations ?? Enumerable.Empty<SlimSkipNavigation>();
-
-        private SortedSet<SlimSkipNavigation>? DeclaredReferencingSkipNavigations { get; set; }
 
         /// <summary>
         ///     Adds an index to this entity type.
@@ -598,6 +576,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="valueGeneratorFactory"> The factory that has been set to generate values for this property, if any. </param>
         /// <param name="valueConverter"> The custom <see cref="ValueConverter" /> set for this property. </param>
         /// <param name="valueComparer"> The <see cref="ValueComparer" /> for this property. </param>
+        /// <param name="keyValueComparer"> The <see cref="ValueComparer" /> to use with keys for this property. </param>
         /// <param name="typeMapping"> The <see cref="CoreTypeMapping" /> for this property. </param>
         /// <returns> The newly created property. </returns>
         public virtual SlimProperty AddProperty(
@@ -619,6 +598,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory = null,
             ValueConverter? valueConverter = null,
             ValueComparer? valueComparer = null,
+            ValueComparer? keyValueComparer = null,
             CoreTypeMapping? typeMapping = null)
         {
             var property = new SlimProperty(
@@ -641,6 +621,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 valueGeneratorFactory,
                 valueConverter,
                 valueComparer,
+                keyValueComparer,
                 typeMapping);
 
             _properties.Add(property.Name, property);

--- a/src/EFCore/Metadata/SlimProperty.cs
+++ b/src/EFCore/Metadata/SlimProperty.cs
@@ -28,7 +28,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         private readonly PropertySaveBehavior _afterSaveBehavior;
         private readonly Func<IProperty, IEntityType, ValueGenerator>? _valueGeneratorFactory;
         private readonly ValueConverter? _valueConverter;
-        private readonly ValueComparer? _valueComparer;
+        private readonly ValueComparer _valueComparer;
+        private readonly ValueComparer _keyValueComparer;
         private CoreTypeMapping? _typeMapping;
 
         /// <summary>
@@ -58,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory,
             ValueConverter? valueConverter,
             ValueComparer? valueComparer,
+            ValueComparer? keyValueComparer,
             CoreTypeMapping? typeMapping)
             : base(name, propertyInfo, fieldInfo, propertyAccessMode)
         {
@@ -70,7 +72,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             _afterSaveBehavior = afterSaveBehavior;
             _valueGeneratorFactory = valueGeneratorFactory;
             _valueConverter = valueConverter;
-            _valueComparer = valueComparer;
 
             if (maxLength != null)
             {
@@ -94,6 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             }
 
             _typeMapping = typeMapping;
+            _valueComparer = valueComparer ?? TypeMapping.Comparer;
+            _keyValueComparer = keyValueComparer ?? TypeMapping.KeyComparer;
         }
 
         /// <summary>
@@ -258,21 +261,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <inheritdoc/>
         ValueComparer? IReadOnlyProperty.GetValueComparer()
-            => _valueComparer ?? TypeMapping.Comparer;
+            => _valueComparer;
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         ValueComparer IProperty.GetValueComparer()
-            => _valueComparer ?? TypeMapping.Comparer;
+            => _valueComparer;
 
         /// <inheritdoc/>
         ValueComparer? IReadOnlyProperty.GetKeyValueComparer()
-            => _valueComparer ?? TypeMapping.KeyComparer;
+            => _keyValueComparer;
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         ValueComparer IProperty.GetKeyValueComparer()
-            => _valueComparer ?? TypeMapping.KeyComparer;
+            => _keyValueComparer;
 
         /// <inheritdoc/>
         [DebuggerStepThrough]

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -545,6 +545,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
                 public object Create(DbContext context)
                     => Tuple.Create(context.GetType(), _getAdditionalKey());
+
+                public object Create(DbContext context, bool designTime)
+                    => Tuple.Create(context.GetType(), _getAdditionalKey(), designTime);
             }
         }
 

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -292,7 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         ? validAnnotations[annotationName].Value
                         : null);
 
-                    SqlServerTestHelpers.Instance.Finalize(modelBuilder);
+                    SqlServerTestHelpers.Instance.Finalize(modelBuilder, designTime: true);
 
                     var sb = new IndentedStringBuilder();
 
@@ -387,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     eb.Property<RawEnum>("EnumDiscriminator").HasConversion<int>();
                 });
 
-            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder);
+            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder, designTime: true);
 
             var modelSnapshotCode = generator.GenerateSnapshot(
                 "MyNamespace",
@@ -649,7 +649,7 @@ namespace MyNamespace
 
             entityType.SetPrimaryKey(property2);
 
-            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder);
+            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder, designTime: true);
 
             var modelSnapshotCode = generator.GenerateSnapshot(
                 "MyNamespace",
@@ -765,7 +765,7 @@ namespace MyNamespace
                     eb.HasKey(e => e.Boolean);
                 });
 
-            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder);
+            var finalizedModel = SqlServerTestHelpers.Instance.Finalize(modelBuilder, designTime: true);
 
             var modelSnapshotCode = generator.GenerateSnapshot(
                 "MyNamespace",

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var processor = new SnapshotModelProcessor(reporter, modelRuntimeInitializer);
             var model = processor.Process(snapshot.Model);
 
-            var differences = differ.GetDifferences(model.GetRelationalModel(), context.Model.GetRelationalModel());
+            var differences = differ.GetDifferences(model.GetRelationalModel(), context.DesignTimeModel.GetRelationalModel());
 
             Assert.Empty(differences);
         }
@@ -283,6 +283,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             }
 
             public IModel Initialize(IModel model, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger)
+                => model;
+
+            public IModel Initialize(
+                IModel model, bool designTime = true, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> validationLogger = null)
                 => model;
 
             public static DummyModelRuntimeInitializer Instance { get; } = new();

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -5386,7 +5386,7 @@ namespace RootNamespace
                 new ServiceCollection()
                     .AddEntityFrameworkSqlServerNetTopologySuite());
 
-            serviceProvider.GetService<IModelRuntimeInitializer>().Initialize(model, validationLogger: null);
+            serviceProvider.GetService<IModelRuntimeInitializer>().Initialize(model, designTime: true, validationLogger: null);
 
             var generator = CreateMigrationsGenerator();
             var code = generator.GenerateSnapshot("RootNamespace", typeof(DbContext), "Snapshot", model);

--- a/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = new ChangeContext<ChangeValueEntity>();
 
-            Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, context.Model.GetChangeTrackingStrategy());
+            Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, context.DesignTimeModel.GetChangeTrackingStrategy());
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsInfrastructureTestBase.cs
@@ -307,12 +307,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         protected virtual void DiffSnapshot(ModelSnapshot snapshot, DbContext context)
         {
             var sourceModel = context.GetService<IModelRuntimeInitializer>().Initialize(
-                ((IMutableModel)snapshot.Model).FinalizeModel(), validationLogger: null);
+                ((IMutableModel)snapshot.Model).FinalizeModel(), designTime: true, validationLogger: null);
 
             var modelDiffer = context.GetService<IMigrationsModelDiffer>();
             var operations = modelDiffer.GetDifferences(
                 sourceModel.GetRelationalModel(),
-                context.Model.GetRelationalModel());
+                context.DesignTimeModel.GetRelationalModel());
 
             Assert.Equal(0, operations.Count);
         }

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsSqlGeneratorTestBase.cs
@@ -769,7 +769,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
                 buildAction(modelBuilder);
 
-                model = services.GetService<IModelRuntimeInitializer>().Initialize(modelBuilder.FinalizeModel(), validationLogger: null);
+                model = services.GetService<IModelRuntimeInitializer>().Initialize(
+                    modelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
             }
 
             var batch = services.GetRequiredService<IMigrationsSqlGenerator>().Generate(operation, model, options);

--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -11,9 +11,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
@@ -1612,13 +1610,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var sourceModelBuilder = CreateConventionlessModelBuilder();
             buildCommonAction(sourceModelBuilder);
             buildSourceAction(sourceModelBuilder);
-            var sourceModel = modelRuntimeInitializer.Initialize(sourceModelBuilder.FinalizeModel(), validationLogger: null);
+            var sourceModel = modelRuntimeInitializer.Initialize(sourceModelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
 
             var targetModelBuilder = CreateConventionlessModelBuilder();
             buildCommonAction(targetModelBuilder);
             buildTargetAction(targetModelBuilder);
 
-            var targetModel = modelRuntimeInitializer.Initialize(targetModelBuilder.FinalizeModel(), validationLogger: null); // CreateValidationLogger()
+            var targetModel = modelRuntimeInitializer.Initialize(targetModelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
 
             var operations = modelDiffer.GetDifferences(sourceModel.GetRelationalModel(), targetModel.GetRelationalModel());
 
@@ -1657,7 +1655,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
             var context = CreateContext();
             var modelRuntimeInitializer = context.GetService<IModelRuntimeInitializer>();
-            var sourceModel = modelRuntimeInitializer.Initialize(sourceModelBuilder.FinalizeModel(), validationLogger: null);
+            var sourceModel = modelRuntimeInitializer.Initialize(sourceModelBuilder.FinalizeModel(), designTime: true, validationLogger: null);
 
             return Test(sourceModel, targetModel: null, operations, asserter);
         }

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public virtual void Finds_DbFunctions_on_DbContext()
         {
             var model = RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelRuntimeInitializer>()
-                .Initialize(GetModelBuilder(new MyDerivedContext()).FinalizeModel(), validationLogger: null);
+                .Initialize(GetModelBuilder(new MyDerivedContext()).FinalizeModel(), designTime: false, validationLogger: null);
 
             foreach (var function in MyBaseContext.FunctionNames)
             {
@@ -680,7 +680,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var functionName = modelBuilder.HasDbFunction(queryableNoParams).Metadata.ModelName;
 
             var model = RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelRuntimeInitializer>()
-                .Initialize(modelBuilder.FinalizeModel(), validationLogger: null);
+                .Initialize(modelBuilder.FinalizeModel(), designTime: false, validationLogger: null);
 
             var function = model.FindDbFunction(functionName);
             var entityType = model.FindEntityType(typeof(Foo));

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -79,8 +79,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             }
 
             var modelRuntimeInitializer = TestHelpers.CreateContextServices().GetService<IModelRuntimeInitializer>();
-            sourceModel = modelRuntimeInitializer.Initialize(sourceModel, validationLogger: null);
-            targetModel = modelRuntimeInitializer.Initialize(targetModel, validationLogger: null);
+            sourceModel = modelRuntimeInitializer.Initialize(sourceModel, designTime: true, validationLogger: null);
+            targetModel = modelRuntimeInitializer.Initialize(targetModel, designTime: true, validationLogger: null);
 
             var modelDiffer = CreateModelDiffer(targetOptionsBuilder.Options);
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             property.IsNullable = nullable;
 
             RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<IModelRuntimeInitializer>()
-                .Initialize(model.FinalizeModel(), validationLogger: null);
+                .Initialize(model.FinalizeModel(), designTime: false, validationLogger: null);
 
             var parameterBuilder = new RelationalCommandBuilder(
                 new RelationalCommandBuilderDependencies(typeMapper));

--- a/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -19,13 +19,14 @@ namespace Microsoft.EntityFrameworkCore.Update
         [ConditionalFact]
         public void Compare_returns_0_only_for_commands_that_are_equal()
         {
-            IMutableModel model = new Model(TestRelationalConventionSetBuilder.Build());
+            var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());
+            var model = modelBuilder.Model;
             var entityType = model.AddEntityType(typeof(object));
             var key = entityType.AddProperty("Id", typeof(int));
             entityType.SetPrimaryKey(key);
 
             var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model.FinalizeModel())
+                .UseModel(RelationalTestHelpers.Instance.Finalize(modelBuilder))
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
@@ -159,7 +160,8 @@ namespace Microsoft.EntityFrameworkCore.Update
 
         private void Compare_returns_0_only_for_entries_that_have_same_key_values_generic<T>(T value1, T value2)
         {
-            IMutableModel model = new Model(TestRelationalConventionSetBuilder.Build());
+            var modelBuilder = new ModelBuilder(TestRelationalConventionSetBuilder.Build());
+            var model = modelBuilder.Model;
             var entityType = model.AddEntityType(typeof(object));
 
             var keyProperty = entityType.AddProperty("Id", typeof(T));
@@ -168,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Update
 
             var optionsBuilder = new DbContextOptionsBuilder()
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
-                .UseModel(model.FinalizeModel())
+                .UseModel(RelationalTestHelpers.Instance.Finalize(modelBuilder))
                 .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             var stateManager = new DbContext(optionsBuilder.Options).GetService<IStateManager>();

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore
             var context = CreateContext();
             var modelRuntimeInitializer = context.GetService<IModelRuntimeInitializer>();
             var logger = context.GetService<IDiagnosticsLogger<DbLoggerCategory.Model.Validation>>();
-            return modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), logger);
+            return modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime: false, logger);
         }
 
         protected class Person

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -2182,7 +2182,7 @@ namespace Microsoft.EntityFrameworkCore
                     context.Add(CreateBlogAndPosts<BlogFullExplicit, PostFullExplicit>(new List<PostFullExplicit>()));
                     context.AddRange(CreatePostsAndBlog<BlogFullExplicit, PostFullExplicit>());
 
-                    if (context.Model.GetPropertyAccessMode() != PropertyAccessMode.Property)
+                    if (context.DesignTimeModel.GetPropertyAccessMode() != PropertyAccessMode.Property)
                     {
                         context.Add(CreateBlogAndPosts<BlogReadOnly, PostReadOnly>(new ObservableCollection<PostReadOnly>()));
                         context.AddRange(CreatePostsAndBlog<BlogReadOnly, PostReadOnly>());

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -127,12 +127,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public IServiceProvider CreateContextServices(IServiceCollection customServices)
             => ((IInfrastructure<IServiceProvider>)CreateContext(customServices)).Instance;
 
-        public IModel Finalize(ModelBuilder modelBuilder, bool skipValidation = false)
+        public IModel Finalize(ModelBuilder modelBuilder, bool designTime = false, bool skipValidation = false)
         {
             var contextServices = CreateContextServices();
 
             var modelRuntimeInitializer = contextServices.GetRequiredService<IModelRuntimeInitializer>();
-            return modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), skipValidation
+            return modelRuntimeInitializer.Initialize(modelBuilder.FinalizeModel(), designTime, skipValidation
                 ? null
                 : new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>(LoggingDefinitions));
         }

--- a/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var dependent = new Product { Id = 21, Category = principal };
 
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var dependentEntry = contextServices.GetRequiredService<IStateManager>().GetOrCreateEntry(dependent);
             var property = model.FindEntityType(typeof(Product)).FindProperty("CategoryId");
             var keyPropagator = contextServices.GetRequiredService<IKeyPropagator>();
@@ -47,6 +48,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel(generateTemporary);
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal = new Category { Id = 11 };
@@ -100,6 +102,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var dependent = new ProductDetail { Product = principal };
 
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var dependentEntry = contextServices.GetRequiredService<IStateManager>().GetOrCreateEntry(dependent);
             var property = model.FindEntityType(typeof(ProductDetail)).FindProperty("Id");
             var keyPropagator = contextServices.GetRequiredService<IKeyPropagator>();
@@ -119,6 +122,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel(generateTemporary);
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var dependent = new ProductDetail();
@@ -201,6 +205,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var dependent = new OrderLineDetail { OrderLine = principal };
 
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var dependentEntry = contextServices.GetRequiredService<IStateManager>().GetOrCreateEntry(dependent);
             var property1 = model.FindEntityType(typeof(OrderLineDetail)).FindProperty("OrderId");
             var property2 = model.FindEntityType(typeof(OrderLineDetail)).FindProperty("ProductId");
@@ -224,6 +229,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel(generateTemporary);
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var dependent = new OrderLineDetail();

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -475,6 +475,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal1 = new Category { Id = 11 };
@@ -516,6 +517,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal1 = new Category { Id = 11 };
@@ -557,6 +559,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal1 = new Category { Id = 11 };
@@ -598,6 +601,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal1 = new Product { Id = 21 };
@@ -641,6 +645,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal = new Product { Id = 21 };
@@ -679,6 +684,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var principal = new Product { Id = 21 };
@@ -717,6 +723,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var entity1 = new Product { Id = 21, AlternateProductId = 22 };
@@ -770,6 +777,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var entity1 = new Product { Id = 21, AlternateProductId = 22 };
@@ -825,6 +833,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
             var manager = contextServices.GetRequiredService<IStateManager>();
 
             var photo1 = new ProductPhoto { ProductId = 1, PhotoId = "Photo1" };

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -743,7 +743,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public void Can_get_all_dependent_entries()
         {
             var model = BuildModel();
-            var stateManager = CreateStateManager(model);
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
+            var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var categoryEntry1 = stateManager.StartTracking(
                 stateManager.GetOrCreateEntry(
@@ -791,7 +793,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public void Does_not_throws_when_instance_of_unmapped_derived_type_is_used()
         {
             var model = BuildModel();
-            var stateManager = CreateStateManager(model);
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
+            model = contextServices.GetRequiredService<IModel>();
+            var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var entry = stateManager.GetOrCreateEntry(new SpecialProduct());
 

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -661,7 +661,8 @@ namespace Microsoft.EntityFrameworkCore
 
             public IModel GetModel(
                 DbContext context,
-                ModelCreationDependencies modelCreationDependencies)
+                ModelCreationDependencies modelCreationDependencies,
+                bool designTime)
                 => new Model();
         }
 

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
                 (await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask())).Message);
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 42 + 8;
+            var expectedMethodCount = 51;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "
@@ -778,11 +778,16 @@ namespace Microsoft.EntityFrameworkCore
                 CoreStrings.ContextDisposed,
                 Assert.Throws<ObjectDisposedException>(() => context.Model).Message);
 
+            Assert.StartsWith(
+                CoreStrings.ContextDisposed,
+                Assert.Throws<ObjectDisposedException>(() => context.DesignTimeModel).Message);
+
             var expectedProperties = new List<string>
             {
                 nameof(DbContext.ChangeTracker),
                 nameof(DbContext.ContextId), // By-design, does not throw for disposed context
                 nameof(DbContext.Database),
+                nameof(DbContext.DesignTimeModel),
                 nameof(DbContext.Model)
             };
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -298,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelRuntimeInitializer = serviceProvider.GetRequiredService<IModelRuntimeInitializer>();
             var validationLogger = CreateValidationLogger(sensitiveDataLoggingEnabled);
 
-            return modelRuntimeInitializer.Initialize(model.FinalizeModel(), validationLogger);
+            return modelRuntimeInitializer.Initialize(model.FinalizeModel(), designTime: false, validationLogger);
         }
 
         protected DiagnosticsLogger<DbLoggerCategory.Model.Validation> CreateValidationLogger(bool sensitiveDataLoggingEnabled = false)

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyMappingValidationConventionTest.cs
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 try
                 {
                     m.FinalizeModel();
-                    modelRuntimeInitializer.Initialize(m, validationLogger: null);
+                    modelRuntimeInitializer.Initialize(m, designTime: false, validationLogger: null);
                     validatePropertyMappingMethod.Invoke(
                         validator, new object[] { m, logger });
                 }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -870,7 +870,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var contextServices = InMemoryTestHelpers.Instance.CreateContextServices();
                 var modelRuntimeInitializer = contextServices.GetRequiredService<IModelRuntimeInitializer>();
 
-                model = modelRuntimeInitializer.Initialize(model, new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>());
+                model = modelRuntimeInitializer.Initialize(
+                    model, designTime: false, new TestLogger<DbLoggerCategory.Model.Validation, TestLoggingDefinitions>());
 
                 Assert.Null(failMessage);
             }

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -174,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var manyToManyA = model.FindEntityType(typeof(ImplicitManyToManyA))!;
                 var manyToManyB = model.FindEntityType(typeof(ImplicitManyToManyB))!;
                 var joinEntityType = model.GetEntityTypes()
-                    .Where(et => ((EntityType)et).IsImplicitlyCreatedJoinEntityType)
+                    .Where(et => et.ClrType == Model.DefaultPropertyBagType)
                     .Single();
                 Assert.Equal("ImplicitManyToManyAImplicitManyToManyB", joinEntityType.Name);
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -223,6 +223,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression)
                 => new GenericTestIndexBuilder<TEntity>(EntityTypeBuilder.HasIndex(indexExpression));
 
+            public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression, string name)
+                => new GenericTestIndexBuilder<TEntity>(EntityTypeBuilder.HasIndex(indexExpression, name));
+
             public override TestIndexBuilder<TEntity> HasIndex(params string[] propertyNames)
                 => new GenericTestIndexBuilder<TEntity>(EntityTypeBuilder.HasIndex(propertyNames));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -105,7 +105,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Entity<ComplexCaseParent13108>().HasKey(c => c.Key);
 
-                var model = (IConventionModel)modelBuilder.FinalizeModel();
+                var model = (IConventionModel)modelBuilder.FinalizeModel(designTime: true);
+
                 var property = model
                     .FindEntityType(typeof(ComplexCaseChild13108))!.GetProperties().Single(p => p.Name == "ParentKey");
                 Assert.Equal(typeof(int), property.ClrType);
@@ -265,6 +266,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression)
                 => new NonGenericTestIndexBuilder<TEntity>(
                     EntityTypeBuilder.HasIndex(indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray()));
+
+            public override TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression, string name)
+                => new NonGenericTestIndexBuilder<TEntity>(
+                    EntityTypeBuilder.HasIndex(indexExpression.GetMemberAccessList().Select(p => p.GetSimpleMemberName()).ToArray(), name));
 
             public override TestIndexBuilder<TEntity> HasIndex(params string[] propertyNames)
                 => new NonGenericTestIndexBuilder<TEntity>(EntityTypeBuilder.HasIndex(propertyNames));

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -172,12 +172,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestModelBuilder Ignore<TEntity>()
                 where TEntity : class;
 
-            public virtual IModel FinalizeModel()
+            public virtual IModel FinalizeModel(bool designTime = false)
             {
                 var serviceProvider = TestHelpers.CreateContextServices();
                 var modelRuntimeInitializer = serviceProvider.GetRequiredService<IModelRuntimeInitializer>();
 
-                return modelRuntimeInitializer.Initialize(ModelBuilder.FinalizeModel(), ValidationLogger);
+                return modelRuntimeInitializer.Initialize(ModelBuilder.FinalizeModel(), designTime, ValidationLogger);
             }
 
             public virtual string GetDisplayName(Type entityType)
@@ -227,6 +227,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestEntityTypeBuilder<TEntity> Ignore(string propertyName);
 
             public abstract TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression);
+            public abstract TestIndexBuilder<TEntity> HasIndex(Expression<Func<TEntity, object?>> indexExpression, string name);
             public abstract TestIndexBuilder<TEntity> HasIndex(params string[] propertyNames);
 
             public abstract TestOwnedNavigationBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(string navigationName)

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -1671,6 +1671,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(fk.PrincipalKey, principalType.GetKeys().First(k => !k.IsPrimaryKey()));
+                Assert.Same(fk.PrincipalKey, principalType.GetDeclaredKeys().First(k => !k.IsPrimaryKey()));
                 Assert.Empty(dependentType.GetIndexes());
                 Assert.Empty(principalType.GetIndexes());
                 Assert.True(fk.IsUnique);


### PR DESCRIPTION
Allow the design-time model to be accessed when necessary

Fixes #8258