### PR TITLE
Don't detect public service properties in hierarchy as duplicates

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -186,7 +186,9 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         }
 
         private InstantiationBinding UpdateConstructorBindings(
-            IConventionEntityType entityType, Type proxyType, InstantiationBinding binding)
+            IConventionEntityType entityType,
+            Type proxyType,
+            InstantiationBinding binding)
         {
             if (_options?.UseLazyLoadingProxies == true)
             {
@@ -212,31 +214,29 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                 }
 
                 return new FactoryMethodBinding(
-                        _proxyFactory,
-                        _createLazyLoadingProxyMethod,
-                        new List<ParameterBinding>
-                        {
-                            new ContextParameterBinding(typeof(DbContext)),
-                            new EntityTypeParameterBinding(),
-                            new DependencyInjectionParameterBinding(
-                                typeof(ILazyLoader), typeof(ILazyLoader), (IPropertyBase)serviceProperty),
-                            new ObjectArrayParameterBinding(binding.ParameterBindings)
-                        },
-                        proxyType);
+                    _proxyFactory,
+                    _createLazyLoadingProxyMethod,
+                    new List<ParameterBinding>
+                    {
+                        new ContextParameterBinding(typeof(DbContext)),
+                        new EntityTypeParameterBinding(),
+                        new DependencyInjectionParameterBinding(
+                            typeof(ILazyLoader), typeof(ILazyLoader), new[] { (IPropertyBase)serviceProperty }),
+                        new ObjectArrayParameterBinding(binding.ParameterBindings)
+                    },
+                    proxyType);
             }
-            else
-            {
-                return new FactoryMethodBinding(
-                        _proxyFactory,
-                        _createProxyMethod,
-                        new List<ParameterBinding>
-                        {
-                            new ContextParameterBinding(typeof(DbContext)),
-                            new EntityTypeParameterBinding(),
-                            new ObjectArrayParameterBinding(binding.ParameterBindings)
-                        },
-                        proxyType);
-            }
+
+            return new FactoryMethodBinding(
+                _proxyFactory,
+                _createProxyMethod,
+                new List<ParameterBinding>
+                {
+                    new ContextParameterBinding(typeof(DbContext)),
+                    new EntityTypeParameterBinding(),
+                    new ObjectArrayParameterBinding(binding.ParameterBindings)
+                },
+                proxyType);
         }
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1188,6 +1188,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                     var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
                                     _storeGeneratedValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
                                 }
+
                                 break;
                             case CurrentValueType.Temporary:
                                 if (!_temporaryValues.IsEmpty)
@@ -1196,6 +1197,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                     var storeGeneratedIndex = asProperty.GetStoreGeneratedIndex();
                                     _temporaryValues.SetValue(asProperty, defaultValue, storeGeneratedIndex);
                                 }
+
                                 break;
                         }
                     }
@@ -1742,8 +1744,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             _stateData.FlagProperty(navigation.GetIndex(), PropertyFlag.IsLoaded, isFlagged: loaded);
 
-            var lazyLoaderProperty = EntityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == typeof(ILazyLoader));
-            if (lazyLoaderProperty != null)
+            foreach (var lazyLoaderProperty in EntityType.GetServiceProperties().Where(p => p.ClrType == typeof(ILazyLoader)))
             {
                 ((ILazyLoader?)this[lazyLoaderProperty])?.SetLoaded(Entity, navigation.Name, loaded);
             }

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -20,11 +20,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Creates a new <see cref="ServiceParameterBinding" /> instance for the given service type.
         /// </summary>
         /// <param name="contextType"> The <see cref="DbContext" /> CLR type. </param>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or <see langword="null" />. </param>
+        /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
         public ContextParameterBinding(
             Type contextType,
-            IPropertyBase? serviceProperty = null)
-            : base(contextType, contextType, serviceProperty)
+            IPropertyBase[]? serviceProperties = null)
+            : base(contextType, contextType, serviceProperties)
         {
         }
 

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -57,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
-            => new ContextParameterBinding(ParameterType, consumedProperties.SingleOrDefault());
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
+            => new ContextParameterBinding(ParameterType, consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -100,7 +100,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.EntityTypeMemberIgnoredConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(foreignKeyPropertyDiscoveryConvention);
-            conventionSet.EntityTypeMemberIgnoredConventions.Add(servicePropertyDiscoveryConvention);
 
             var keyAttributeConvention = new KeyAttributeConvention(Dependencies);
             var backingFieldConvention = new BackingFieldConvention(Dependencies);
@@ -231,7 +230,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ModelFinalizingConventions.Add(new ConstructorBindingConvention(Dependencies));
             conventionSet.ModelFinalizingConventions.Add(foreignKeyIndexConvention);
             conventionSet.ModelFinalizingConventions.Add(foreignKeyPropertyDiscoveryConvention);
-            conventionSet.ModelFinalizingConventions.Add(servicePropertyDiscoveryConvention);
             conventionSet.ModelFinalizingConventions.Add(nonNullableReferencePropertyConvention);
             conventionSet.ModelFinalizingConventions.Add(nonNullableNavigationConvention);
             conventionSet.ModelFinalizingConventions.Add(new QueryFilterRewritingConvention(Dependencies));

--- a/src/EFCore/Metadata/Conventions/ServicePropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ServicePropertyDiscoveryConvention.cs
@@ -1,16 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -19,9 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     /// </summary>
     public class ServicePropertyDiscoveryConvention :
         IEntityTypeAddedConvention,
-        IEntityTypeBaseTypeChangedConvention,
-        IEntityTypeMemberIgnoredConvention,
-        IModelFinalizingConvention
+        IEntityTypeBaseTypeChangedConvention
     {
         /// <summary>
         ///     Creates a new instance of <see cref="ServicePropertyDiscoveryConvention" />.
@@ -90,138 +82,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     continue;
                 }
 
-                var duplicateMap = GetDuplicateServiceProperties(entityType);
-                if (duplicateMap != null
-                    && duplicateMap.TryGetValue(propertyInfo.PropertyType, out var duplicateServiceProperties))
-                {
-                    duplicateServiceProperties.Add(name);
-
-                    return;
-                }
-
-                var otherServicePropertySameType = entityType.GetServiceProperties()
-                    .FirstOrDefault(p => p.ClrType == propertyInfo.PropertyType);
-                if (otherServicePropertySameType != null
-                    && otherServicePropertySameType.Name != name)
-                {
-                    if (ConfigurationSource.Convention.Overrides(otherServicePropertySameType.GetConfigurationSource()))
-                    {
-                        otherServicePropertySameType.DeclaringEntityType.RemoveServiceProperty(otherServicePropertySameType.Name);
-                    }
-
-                    AddDuplicateServiceProperty(entityTypeBuilder, propertyInfo.PropertyType, name);
-                    AddDuplicateServiceProperty(entityTypeBuilder, propertyInfo.PropertyType, otherServicePropertySameType.Name);
-
-                    return;
-                }
-
                 entityTypeBuilder.ServiceProperty(propertyInfo)?.HasParameterBinding(
                     (ServiceParameterBinding)factory.Bind(entityType, propertyInfo.PropertyType, name));
             }
         }
-
-        /// <summary>
-        ///     Called after an entity type member is ignored.
-        /// </summary>
-        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
-        /// <param name="name"> The name of the ignored member. </param>
-        /// <param name="context"> Additional information associated with convention execution. </param>
-        public virtual void ProcessEntityTypeMemberIgnored(
-            IConventionEntityTypeBuilder entityTypeBuilder,
-            string name,
-            IConventionContext<string> context)
-        {
-            var entityType = entityTypeBuilder.Metadata;
-            var duplicateMap = GetDuplicateServiceProperties(entityType);
-            if (duplicateMap == null)
-            {
-                return;
-            }
-
-            var member = (MemberInfo?)entityType.GetRuntimeProperties().Find(name)
-                ?? entityType.GetRuntimeFields().Find(name)!;
-            var type = member.GetMemberType();
-            if (duplicateMap.TryGetValue(type, out var duplicateServiceProperties)
-                && duplicateServiceProperties.Remove(member.Name))
-            {
-                if (duplicateServiceProperties.Count != 1)
-                {
-                    return;
-                }
-
-                var otherName = duplicateServiceProperties.First();
-                var otherMember = (MemberInfo?)entityType.GetRuntimeProperties().Find(otherName)
-                    ?? entityType.GetRuntimeFields().Find(name)!;
-                var factory = Dependencies.ParameterBindingFactories.FindFactory(type, otherName)!;
-                entityType.Builder.ServiceProperty(otherMember)?.HasParameterBinding(
-                    (ServiceParameterBinding)factory.Bind(entityType, type, otherName));
-                duplicateMap.Remove(type);
-                if (duplicateMap.Count == 0)
-                {
-                    SetDuplicateServiceProperties(entityType.Builder, null);
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public virtual void ProcessModelFinalizing(
-            IConventionModelBuilder modelBuilder,
-            IConventionContext<IConventionModelBuilder> context)
-        {
-            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
-            {
-                var duplicateMap = GetDuplicateServiceProperties(entityType);
-                if (duplicateMap == null)
-                {
-                    continue;
-                }
-
-                foreach (var duplicateServiceProperties in duplicateMap)
-                {
-                    foreach (var duplicateServicePropertyName in duplicateServiceProperties.Value)
-                    {
-                        if (entityType.FindProperty(duplicateServicePropertyName) == null
-                            && entityType.FindNavigation(duplicateServicePropertyName) == null)
-                        {
-                            throw new InvalidOperationException(
-                                CoreStrings.AmbiguousServiceProperty(
-                                    duplicateServicePropertyName,
-                                    duplicateServiceProperties.Key.ShortDisplayName(),
-                                    entityType.DisplayName()));
-                        }
-                    }
-                }
-
-                SetDuplicateServiceProperties(entityType.Builder, null);
-            }
-        }
-
-        private static void AddDuplicateServiceProperty(
-            IConventionEntityTypeBuilder entityTypeBuilder,
-            Type propertyType,
-            string propertyName)
-        {
-            var duplicateMap = GetDuplicateServiceProperties(entityTypeBuilder.Metadata)
-                ?? new Dictionary<Type, HashSet<string>>(1);
-
-            if (!duplicateMap.TryGetValue(propertyType, out var duplicateServiceProperties))
-            {
-                duplicateServiceProperties = new HashSet<string>();
-                duplicateMap[propertyType] = duplicateServiceProperties;
-            }
-
-            duplicateServiceProperties.Add(propertyName);
-
-            SetDuplicateServiceProperties(entityTypeBuilder, duplicateMap);
-        }
-
-        private static Dictionary<Type, HashSet<string>>? GetDuplicateServiceProperties(IConventionEntityType entityType)
-            => entityType.FindAnnotation(CoreAnnotationNames.DuplicateServiceProperties)?.Value
-                as Dictionary<Type, HashSet<string>>;
-
-        private static void SetDuplicateServiceProperties(
-            IConventionEntityTypeBuilder entityTypeBuilder,
-            Dictionary<Type, HashSet<string>>? duplicateServiceProperties)
-            => entityTypeBuilder.HasAnnotation(CoreAnnotationNames.DuplicateServiceProperties, duplicateServiceProperties);
     }
 }

--- a/src/EFCore/Metadata/Conventions/SlimModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/SlimModelConvention.cs
@@ -222,7 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             (entityType.FindProperty(property.Name)
                 ?? entityType.FindServiceProperty(property.Name)
                 ?? entityType.FindNavigation(property.Name)
-                ?? (IPropertyBase?)entityType.FindSkipNavigation(property.Name))!).ToList());
+                ?? (IPropertyBase?)entityType.FindSkipNavigation(property.Name))!).ToArray());
 
         private InstantiationBinding? Create(InstantiationBinding? instantiationBinding, SlimEntityType entityType)
             => instantiationBinding?.With(instantiationBinding.ParameterBindings.Select(binding => Create(binding, entityType)).ToList());

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
-            => new DependencyInjectionMethodParameterBinding(ParameterType, ServiceType, Method, consumedProperties.SingleOrDefault());
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
+            => new DependencyInjectionMethodParameterBinding(ParameterType, ServiceType, Method, consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -24,13 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="parameterType"> The parameter CLR type. </param>
         /// <param name="serviceType"> The service CLR types, as resolved from dependency injection </param>
         /// <param name="method"> The method of the service to bind to. </param>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
+        /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
         public DependencyInjectionMethodParameterBinding(
             Type parameterType,
             Type serviceType,
             MethodInfo method,
-            IPropertyBase? serviceProperty = null)
-            : base(parameterType, serviceType, serviceProperty)
+            IPropertyBase[]? serviceProperties = null)
+            : base(parameterType, serviceType, serviceProperties)
         {
             Check.NotNull(method, nameof(method));
 

--- a/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
@@ -28,12 +28,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="parameterType"> The parameter CLR type. </param>
         /// <param name="serviceType"> The service CLR types, as resolved from dependency injection </param>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
+        /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
         public DependencyInjectionParameterBinding(
             Type parameterType,
             Type serviceType,
-            IPropertyBase? serviceProperty = null)
-            : base(parameterType, serviceType, serviceProperty)
+            IPropertyBase[]? serviceProperties = null)
+            : base(parameterType, serviceType, serviceProperties)
         {
         }
 

--- a/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -65,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
-            => new DependencyInjectionParameterBinding(ParameterType, ServiceType, consumedProperties.SingleOrDefault());
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
+            => new DependencyInjectionParameterBinding(ParameterType, ServiceType, consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -17,9 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <summary>
         ///     Creates a new <see cref="EntityTypeParameterBinding" /> instance for the given service type.
         /// </summary>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
-        public EntityTypeParameterBinding(IPropertyBase? serviceProperty = null)
-            : base(typeof(IEntityType), typeof(IEntityType), serviceProperty)
+        /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
+        public EntityTypeParameterBinding(IPropertyBase[]? serviceProperties = null)
+            : base(typeof(IEntityType), typeof(IEntityType), serviceProperties)
         {
         }
 

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -40,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
-            => new EntityTypeParameterBinding(consumedProperties.SingleOrDefault());
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
+            => new EntityTypeParameterBinding(consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/Internal/ContextParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ContextParameterBindingFactory.cs
@@ -61,6 +61,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             string parameterName)
             => new ContextParameterBinding(
                 parameterType,
-                (IPropertyBase?)entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+                entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => p.ClrType == parameterType).ToArray());
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -202,7 +202,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        private string DisplayName() => ((IReadOnlyEntityType)this).DisplayName();
+        private string DisplayName()
+            => ((IReadOnlyEntityType)this).DisplayName();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -230,8 +231,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (_keys.Count != 0)
                 {
-                    throw new InvalidOperationException(CoreStrings.KeylessTypeExistingKey(
-                        DisplayName(), _keys.First().Value.Properties.Format()));
+                    throw new InvalidOperationException(
+                        CoreStrings.KeylessTypeExistingKey(
+                            DisplayName(), _keys.First().Value.Properties.Format()));
                 }
             }
 
@@ -537,7 +539,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .Concat(FindSkipNavigationsInHierarchy(name));
 
         #region Primary and Candidate Keys
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -908,11 +909,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IEnumerable<Key> GetKeys()
             => _baseType?.GetKeys().Concat(_keys.Values) ?? _keys.Values;
-
         #endregion
 
         #region Foreign Keys
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1240,7 +1239,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             IReadOnlyEntityType principalEntityType)
             => _directlyDerivedTypes.Count == 0
                 ? Enumerable.Empty<ForeignKey>()
-                : (IEnumerable<ForeignKey>)GetDerivedTypes().Select(et => et.FindDeclaredForeignKey(properties, principalKey, principalEntityType))
+                : (IEnumerable<ForeignKey>)GetDerivedTypes()
+                    .Select(et => et.FindDeclaredForeignKey(properties, principalKey, principalEntityType))
                     .Where(fk => fk != null);
 
         /// <summary>
@@ -1383,11 +1383,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => DeclaredReferencingForeignKeys ?? Enumerable.Empty<ForeignKey>();
 
         private SortedSet<ForeignKey>? DeclaredReferencingForeignKeys { get; set; }
-
         #endregion
 
         #region Navigations
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1896,11 +1894,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : GetDerivedTypes().SelectMany(et => et.GetDeclaredReferencingSkipNavigations());
 
         private SortedSet<SkipNavigation>? DeclaredReferencingSkipNavigations { get; set; }
-
         #endregion
 
         #region Indexes
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2244,11 +2240,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     ? _baseType.GetIndexes()
                     : _baseType.GetIndexes().Concat(GetDeclaredIndexes())
                 : GetDeclaredIndexes();
-
         #endregion
 
         #region Properties
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2341,8 +2335,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (memberInfo.DeclaringType?.IsAssignableFrom(ClrType) != true)
                 {
-                    throw new InvalidOperationException(CoreStrings.PropertyWrongEntityClrType(
-                        memberInfo.Name, DisplayName(), memberInfo.DeclaringType?.ShortDisplayName()));
+                    throw new InvalidOperationException(
+                        CoreStrings.PropertyWrongEntityClrType(
+                            memberInfo.Name, DisplayName(), memberInfo.DeclaringType?.ShortDisplayName()));
                 }
             }
             else if (IsPropertyBag)
@@ -2577,11 +2572,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual PropertyCounts Counts
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _counts, this, static entityType =>
-            {
-                entityType.EnsureReadOnly();
-                return entityType.CalculateCounts();
-            });
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _counts, this, static entityType =>
+                {
+                    entityType.EnsureReadOnly();
+                    return entityType.CalculateCounts();
+                });
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -2737,11 +2733,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     return entityType.GetProperties().Where(p => p.RequiresValueGenerator()).ToArray();
                 });
-
         #endregion
 
         #region Service properties
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2774,18 +2768,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 memberInfo as FieldInfo,
                 this,
                 configurationSource);
-
-            var duplicateServiceProperty = GetServiceProperties().FirstOrDefault(p => p.ClrType == serviceProperty.ClrType);
-            if (duplicateServiceProperty != null)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.DuplicateServicePropertyType(
-                        name,
-                        serviceProperty.ClrType.ShortDisplayName(),
-                        DisplayName(),
-                        duplicateServiceProperty.Name,
-                        duplicateServiceProperty.DeclaringEntityType.DisplayName()));
-            }
 
             _serviceProperties[serviceProperty.Name] = serviceProperty;
 
@@ -2937,11 +2919,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => _directlyDerivedTypes.Count == 0
                 ? Enumerable.Empty<ServiceProperty>()
                 : GetDerivedTypes().SelectMany(et => et.GetDeclaredServiceProperties());
-
         #endregion
 
         #region Ignore
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2963,11 +2943,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public override string? OnTypeMemberIgnored(string name)
             => Model.ConventionDispatcher.OnEntityTypeMemberIgnored(Builder, name);
-
         #endregion
 
         #region Data
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2994,7 +2972,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 data.Add(seed);
                 var type = rawSeed.GetType();
 
-                if (ClrType.IsAssignableFrom(type) == true)
+                if (ClrType.IsAssignableFrom(type))
                 {
                     // non-anonymous type
                     foreach (var propertyBase in properties.Values)
@@ -3101,11 +3079,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _data.Add(entity);
             }
         }
-
         #endregion
 
         #region Other
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -3130,7 +3106,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (changeTrackingStrategy != null)
             {
-                var requireFullNotifications = (string?)Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation] == "true";
+                var requireFullNotifications =
+                    (string?)Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation] == "true";
                 var errorMessage = CheckChangeTrackingStrategy(this, changeTrackingStrategy.Value, requireFullNotifications);
                 if (errorMessage != null)
                 {
@@ -3154,7 +3131,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static string? CheckChangeTrackingStrategy(
-            IReadOnlyEntityType entityType, ChangeTrackingStrategy value, bool requireFullNotifications)
+            IReadOnlyEntityType entityType,
+            ChangeTrackingStrategy value,
+            bool requireFullNotifications)
         {
             if (requireFullNotifications)
             {
@@ -3236,7 +3215,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual LambdaExpression? GetQueryFilter() => (LambdaExpression?)this[CoreAnnotationNames.QueryFilter];
+        public virtual LambdaExpression? GetQueryFilter()
+            => (LambdaExpression?)this[CoreAnnotationNames.QueryFilter];
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -3282,8 +3262,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             return ((string?)SetAnnotation(CoreAnnotationNames.DiscriminatorProperty, property?.Name, configurationSource)?.Value)
                 == property?.Name
-                ? property
-                : (Property?)((IReadOnlyEntityType)this).FindDiscriminatorProperty();
+                    ? property
+                    : (Property?)((IReadOnlyEntityType)this).FindDiscriminatorProperty();
         }
 
         private void CheckDiscriminatorProperty(Property? property)
@@ -3375,14 +3355,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InstantiationBinding? ConstructorBinding
         {
-            get => IsReadOnly && !ClrType.IsAbstract
-                    ? NonCapturingLazyInitializer.EnsureInitialized(ref _constructorBinding, this, static entityType =>
-                    {
-                        ((IModel)entityType.Model).GetModelDependencies().ConstructorBindingFactory.GetBindings(
-                            (IReadOnlyEntityType)entityType,
-                            out entityType._constructorBinding,
-                            out entityType._serviceOnlyConstructorBinding);
-                    })
+            get
+                => IsReadOnly && !ClrType.IsAbstract
+                    ? NonCapturingLazyInitializer.EnsureInitialized(
+                        ref _constructorBinding, this, static entityType =>
+                        {
+                            ((IModel)entityType.Model).GetModelDependencies().ConstructorBindingFactory.GetBindings(
+                                (IReadOnlyEntityType)entityType,
+                                out entityType._constructorBinding,
+                                out entityType._serviceOnlyConstructorBinding);
+                        })
                     : _constructorBinding;
 
             set => SetConstructorBinding(value, ConfigurationSource.Explicit);
@@ -3474,12 +3456,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => _serviceOnlyConstructorBindingConfigurationSource;
 
         private void UpdateServiceOnlyConstructorBindingConfigurationSource(ConfigurationSource configurationSource)
-            => _serviceOnlyConstructorBindingConfigurationSource = configurationSource.Max(_serviceOnlyConstructorBindingConfigurationSource);
-
+            => _serviceOnlyConstructorBindingConfigurationSource =
+                configurationSource.Max(_serviceOnlyConstructorBindingConfigurationSource);
         #endregion
 
         #region Explicit interface implementations
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -3630,8 +3611,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         [DebuggerStepThrough]
         IConventionProperty? IConventionEntityType.SetDiscriminatorProperty(
-            IReadOnlyProperty? property, bool fromDataAnnotation)
-            => SetDiscriminatorProperty((Property?)property,
+            IReadOnlyProperty? property,
+            bool fromDataAnnotation)
+            => SetDiscriminatorProperty(
+                (Property?)property,
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -3910,7 +3893,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         IEnumerable<IKey> IEntityType.GetKeys()
             => GetKeys();
-
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -4703,7 +4685,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         IEnumerable<IIndex> IEntityType.GetIndexes()
             => GetIndexes();
 
-
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -5203,7 +5184,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         IConventionServiceProperty? IConventionEntityType.RemoveServiceProperty(string name)
             => RemoveServiceProperty(name);
-
         #endregion
 
         private static IEnumerable<T> ToEnumerable<T>(T? element)

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
@@ -69,6 +69,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Type parameterType,
             string parameterName)
             => new EntityTypeParameterBinding(
-                (IPropertyBase?)entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+                entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => p.ClrType == parameterType).ToArray());
     }
 }

--- a/src/EFCore/Metadata/LazyLoaderParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/LazyLoaderParameterBindingFactory.cs
@@ -134,18 +134,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 ? new DependencyInjectionParameterBinding(
                     typeof(ILazyLoader),
                     typeof(ILazyLoader),
-                    entityType.GetServiceProperties().FirstOrDefault(p => IsLazyLoader(p.ClrType)))
+                    entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => IsLazyLoader(p.ClrType)).ToArray())
                 : parameterType == typeof(Action<object, string>)
                     ? new DependencyInjectionMethodParameterBinding(
                         typeof(Action<object, string>),
                         typeof(ILazyLoader),
                         _loadMethod,
-                        entityType.GetServiceProperties().FirstOrDefault(p => IsLazyLoaderMethod(p.ClrType, p.Name)))
+                        entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => IsLazyLoaderMethod(p.ClrType, p.Name)).ToArray())
                     : new DependencyInjectionMethodParameterBinding(
                         typeof(Func<object, CancellationToken, string, Task>),
                         typeof(ILazyLoader),
                         _loadAsyncMethod,
-                        entityType.GetServiceProperties().FirstOrDefault(p => IsLazyLoaderAsyncMethod(p.ClrType, p.Name)));
+                        entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => IsLazyLoaderAsyncMethod(p.ClrType, p.Name))
+                            .ToArray());
 
         private static bool IsLazyLoader(Type type)
             => type == typeof(ILazyLoader);

--- a/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
+++ b/src/EFCore/Metadata/ObjectArrayParameterBinding.cs
@@ -57,13 +57,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
         {
             var newBindings = new List<ParameterBinding>(_bindings.Count);
             var propertyCount = 0;
             foreach (var binding in _bindings)
             {
-                var newBinding = binding.With(consumedProperties.Skip(propertyCount).Take(binding.ConsumedProperties.Count).ToList());
+                var newBinding = binding.With(consumedProperties.Skip(propertyCount).Take(binding.ConsumedProperties.Count).ToArray());
                 newBindings.Add(newBinding);
                 propertyCount += binding.ConsumedProperties.Count;
             }

--- a/src/EFCore/Metadata/ParameterBinding.cs
+++ b/src/EFCore/Metadata/ParameterBinding.cs
@@ -21,13 +21,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="consumedProperties"> The properties that are handled by this binding and so do not need to be set in some other way. </param>
         protected ParameterBinding(
             Type parameterType,
-            params IPropertyBase[] consumedProperties)
+            params IPropertyBase[]? consumedProperties)
         {
             Check.NotNull(parameterType, nameof(parameterType));
-            Check.NotNull(consumedProperties, nameof(consumedProperties));
 
             ParameterType = parameterType;
-            ConsumedProperties = consumedProperties;
+            ConsumedProperties = consumedProperties ?? Array.Empty<IPropertyBase>();
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/ParameterBinding.cs
+++ b/src/EFCore/Metadata/ParameterBinding.cs
@@ -52,6 +52,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public abstract ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties);
+        public abstract ParameterBinding With(IPropertyBase[] consumedProperties);
     }
 }

--- a/src/EFCore/Metadata/PropertyParameterBinding.cs
+++ b/src/EFCore/Metadata/PropertyParameterBinding.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -43,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="consumedProperties"> The new consumed properties. </param>
         /// <returns> A copy with replaced consumed properties. </returns>
-        public override ParameterBinding With(IReadOnlyList<IPropertyBase> consumedProperties)
+        public override ParameterBinding With(IPropertyBase[] consumedProperties)
             => new PropertyParameterBinding((IProperty)consumedProperties.Single());
     }
 }

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -24,15 +24,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="parameterType"> The parameter CLR type. </param>
         /// <param name="serviceType"> The service or metadata CLR type. </param>
-        /// <param name="serviceProperty"> The associated <see cref="IServiceProperty" />, or null. </param>
+        /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> instances, or null. </param>
         protected ServiceParameterBinding(
             Type parameterType,
             Type serviceType,
-            IPropertyBase? serviceProperty = null)
-            : base(
-                parameterType, serviceProperty != null
-                    ? new[] { serviceProperty }
-                    : Array.Empty<IPropertyBase>())
+            IPropertyBase[]? serviceProperties = null)
+            : base(parameterType, serviceProperties)
         {
             Check.NotNull(serviceType, nameof(serviceType));
 

--- a/src/EFCore/Metadata/ServiceParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/ServiceParameterBindingFactory.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             return new DependencyInjectionParameterBinding(
                 _serviceType,
                 _serviceType,
-                (IPropertyBase?)entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == _serviceType));
+                entityType.GetServiceProperties().Cast<IPropertyBase>().Where(p => p.ClrType == _serviceType).ToArray());
         }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -99,14 +99,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityTypeNavigationSpecification, otherEntityType);
 
         /// <summary>
-        ///     The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
-        /// </summary>
-        public static string AmbiguousServiceProperty(object? property, object? serviceType, object? entityType)
-            => string.Format(
-                GetString("AmbiguousServiceProperty", nameof(property), nameof(serviceType), nameof(entityType)),
-                property, serviceType, entityType);
-
-        /// <summary>
         ///     The shared type entity type '{entityType}' cannot be added to the model because its name is the same as the CLR type name. This usually indicates an error, either add it as a non-shared entity type or choose a different name.
         /// </summary>
         public static string AmbiguousSharedTypeEntityTypeName(object? entityType)
@@ -728,14 +720,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("DuplicatePropertyInKey", nameof(propertyList), nameof(property)),
                 propertyList, property);
-
-        /// <summary>
-        ///     The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string DuplicateServicePropertyType(object? property, object? serviceType, object? entityType, object? duplicateName, object? duplicateEntityType)
-            => string.Format(
-                GetString("DuplicateServicePropertyType", nameof(property), nameof(serviceType), nameof(entityType), nameof(duplicateName), nameof(duplicateEntityType)),
-                property, serviceType, entityType, duplicateName, duplicateEntityType);
 
         /// <summary>
         ///     Cannot translate '{comparisonOperator}' on a subquery expression of entity type '{entityType}' because it has a composite primary key. See https://go.microsoft.com/fwlink/?linkid=2141942 for information on how to rewrite your query.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -144,9 +144,6 @@
   <data name="AmbiguousOwnedNavigation" xml:space="preserve">
     <value>Unable to determine the owner for the relationship between '{entityTypeNavigationSpecification}' and '{otherEntityType}' as both types have been marked as owned. Either manually configure the ownership, or ignore the corresponding navigations using the [NotMapped] attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
-  <data name="AmbiguousServiceProperty" xml:space="preserve">
-    <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the [NotMapped] attribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
-  </data>
   <data name="AmbiguousSharedTypeEntityTypeName" xml:space="preserve">
     <value>The shared type entity type '{entityType}' cannot be added to the model because its name is the same as the CLR type name. This usually indicates an error, either add it as a non-shared entity type or choose a different name.</value>
   </data>
@@ -388,9 +385,6 @@
   </data>
   <data name="DuplicatePropertyInKey" xml:space="preserve">
     <value>The properties {propertyList} cannot be used for a key, because they contain a duplicate: '{property}'.</value>
-  </data>
-  <data name="DuplicateServicePropertyType" xml:space="preserve">
-    <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="EntityEqualityOnCompositeKeyEntitySubqueryNotSupported" xml:space="preserve">
     <value>Cannot translate '{comparisonOperator}' on a subquery expression of entity type '{entityType}' because it has a composite primary key. See https://go.microsoft.com/fwlink/?linkid=2141942 for information on how to rewrite your query.</value>

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -18,19 +20,98 @@ using Xunit;
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable ClassNeverInstantiated.Local
 // ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Local
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     public class ServicePropertyDiscoveryConventionTest
     {
+        [ConditionalFact]
+        public void Finds_service_properties_in_hierarchy()
+        {
+            using (var context = new ServicePropertiesContext())
+            {
+                var entityTypes = context.Model.GetEntityTypes().ToList();
+                Assert.Equal(10, entityTypes.Count);
+
+                foreach (var entityType in entityTypes)
+                {
+                    ValidateServiceProperty<DbContext, DbContext>(entityType, "Context");
+                    ValidateServiceProperty<IEntityType, IEntityType>(entityType, "EntityType");
+                    ValidateServiceProperty<ILazyLoader, ILazyLoader>(entityType, "ALazyLoader");
+                    ValidateServiceProperty<Action<object, string>, ILazyLoader>(entityType, "LazyLoader");
+
+                    var clrType = entityType.ClrType;
+                    while (clrType!.BaseType != typeof(object))
+                    {
+                        clrType = clrType.BaseType;
+                    }
+
+                    var contextProperty = clrType.GetAnyProperty("Context");
+                    var entityTypeProperty = clrType.GetAnyProperty("EntityType");
+                    var lazyLoaderProperty = clrType.GetAnyProperty("ALazyLoader");
+                    var lazyLoaderServiceProperty = clrType.GetAnyProperty("LazyLoader");
+
+                    var entity = Activator.CreateInstance(entityType.ClrType);
+
+                    Assert.Null(contextProperty!.GetValue(entity));
+                    Assert.Null(entityTypeProperty!.GetValue(entity));
+                    Assert.Null(lazyLoaderProperty!.GetValue(entity));
+                    Assert.Null(lazyLoaderServiceProperty!.GetValue(entity));
+
+                    context.Add(entity!);
+
+                    Assert.Same(context, contextProperty!.GetValue(entity));
+                    Assert.Same(entityType, entityTypeProperty!.GetValue(entity));
+                    Assert.NotNull(lazyLoaderProperty!.GetValue(entity));
+                    Assert.NotNull(lazyLoaderServiceProperty!.GetValue(entity));
+                }
+
+                context.SaveChanges();
+            }
+
+            using (var context = new ServicePropertiesContext())
+            {
+                context.PrivateUnmappedBaseSupers.Load();
+                context.PrivateMappedBases.Load();
+                context.PublicUnmappedBaseSupers.Load();
+                context.PublicMappedBases.Load();
+
+                Assert.Equal(10, context.ChangeTracker.Entries().Count());
+
+                foreach (var entry in context.ChangeTracker.Entries())
+                {
+                    var clrType = entry.Metadata.ClrType;
+                    while (clrType!.BaseType != typeof(object))
+                    {
+                        clrType = clrType.BaseType;
+                    }
+
+                    Assert.Same(context, clrType.GetAnyProperty("Context")!.GetValue(entry.Entity));
+                    Assert.Same(entry.Metadata, clrType.GetAnyProperty("EntityType")!.GetValue(entry.Entity));
+                    Assert.NotNull(clrType.GetAnyProperty("ALazyLoader")!.GetValue(entry.Entity));
+                    Assert.NotNull(clrType.GetAnyProperty("LazyLoader")!.GetValue(entry.Entity));
+                }
+            }
+        }
+
+        private static void ValidateServiceProperty<TProperty, TService>(IEntityType entityType, string propertyName)
+        {
+            var serviceProperty = entityType!.FindServiceProperty(propertyName);
+            var binding = serviceProperty!.ParameterBinding;
+
+            Assert.Equal(typeof(TProperty), binding.ParameterType);
+            Assert.Equal(typeof(TService), binding.ServiceType);
+        }
+
         [ConditionalFact]
         public void Finds_one_service_property()
         {
             var entityType = RunConvention<BlogOneService>();
 
             var serviceProperty = entityType.FindServiceProperty(nameof(BlogOneService.Loader));
-            var binding = serviceProperty.ParameterBinding;
+            var binding = serviceProperty!.ParameterBinding;
 
-            Assert.Equal(typeof(ILazyLoader), binding.ParameterType);
+            Assert.Equal(typeof(ILazyLoader), binding!.ParameterType);
             Assert.Equal(typeof(ILazyLoader), binding.ServiceType);
         }
 
@@ -38,8 +119,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public void Does_not_find_service_property_configured_as_property()
         {
             var entityType = new Model().AddEntityType(typeof(BlogOneService), ConfigurationSource.Explicit);
-            entityType.Builder.Property(typeof(ILazyLoader), nameof(BlogOneService.Loader), ConfigurationSource.Explicit)
-                .HasConversion(typeof(string), ConfigurationSource.Explicit);
+            entityType!.Builder.Property(typeof(ILazyLoader), nameof(BlogOneService.Loader), ConfigurationSource.Explicit)
+                !.HasConversion(typeof(string), ConfigurationSource.Explicit);
 
             RunConvention(entityType);
 
@@ -52,8 +133,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(BlogOneService), ConfigurationSource.Explicit);
-            entityType.Builder.HasRelationship(
-                model.AddEntityType(typeof(LazyLoader), ConfigurationSource.Explicit),
+            entityType!.Builder.HasRelationship(
+                model.AddEntityType(typeof(LazyLoader), ConfigurationSource.Explicit)!,
                 nameof(BlogOneService.Loader), ConfigurationSource.Explicit);
 
             RunConvention(entityType);
@@ -109,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         private EntityType RunConvention<TEntity>()
-            => RunConvention(new Model().AddEntityType(typeof(TEntity), ConfigurationSource.Explicit));
+            => RunConvention(new Model().AddEntityType(typeof(TEntity), ConfigurationSource.Explicit)!);
 
         private EntityType RunConvention(EntityType entityType)
         {
@@ -118,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var context = new ConventionContext<IConventionEntityTypeBuilder>(entityType.Model.ConventionDispatcher);
             CreateServicePropertyDiscoveryConvention().ProcessEntityTypeAdded(entityType.Builder, context);
 
-            return context.ShouldStopProcessing() ? (EntityType)context.Result.Metadata : entityType;
+            return context.ShouldStopProcessing() ? (EntityType)context.Result!.Metadata : entityType;
         }
 
         private ServicePropertyDiscoveryConvention CreateServicePropertyDiscoveryConvention()
@@ -132,18 +213,137 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         private class BlogOneService : Blog
         {
-            public ILazyLoader Loader { get; set; }
+            public ILazyLoader? Loader { get; set; }
         }
 
         private class BlogDuplicateService : Blog
         {
-            public DbContext ContextOne { get; set; }
-            public DbContext ContextTwo { get; set; }
+            public DbContext? ContextOne { get; set; }
+            public DbContext? ContextTwo { get; set; }
         }
 
         private abstract class Blog
         {
             public int Id { get; set; }
         }
+
+        private class ServicePropertiesContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(GetType().Name);
+
+            public DbSet<PrivateUnmappedBaseSuper> PrivateUnmappedBaseSupers
+                => Set<PrivateUnmappedBaseSuper>();
+
+            public DbSet<PrivateUnmappedBaseSub> PrivateUnmappedBaseSubs
+                => Set<PrivateUnmappedBaseSub>();
+
+            public DbSet<PrivateMappedBase> PrivateMappedBases
+                => Set<PrivateMappedBase>();
+
+            public DbSet<PrivateMappedBaseSuper> PrivateMappedBaseSupers
+                => Set<PrivateMappedBaseSuper>();
+
+            public DbSet<PrivateMappedBaseSub> PrivateMappedBaseSubs
+                => Set<PrivateMappedBaseSub>();
+
+            public DbSet<PublicUnmappedBaseSuper> PublicUnmappedBaseSupers
+                => Set<PublicUnmappedBaseSuper>();
+
+            public DbSet<PublicUnmappedBaseSub> PublicUnmappedBaseSubs
+                => Set<PublicUnmappedBaseSub>();
+
+            public DbSet<PublicMappedBase> PublicMappedBases
+                => Set<PublicMappedBase>();
+
+            public DbSet<PublicMappedBaseSuper> PublicMappedBaseSupers
+                => Set<PublicMappedBaseSuper>();
+
+            public DbSet<PublicMappedBaseSub> PublicMappedBaseSubs
+                => Set<PublicMappedBaseSub>();
+
+            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<PrivateUnmappedBaseSuper>(
+                    b =>
+                    {
+                        // Because private properties on un-mapped base types are not found by convention
+                        b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("Context")!);
+                        b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("EntityType")!);
+                        b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("ALazyLoader")!);
+                        b.Metadata.AddServiceProperty(typeof(PrivateUnmappedBase).GetAnyProperty("LazyLoader")!);
+                    });
+            }
+        }
+
+        protected class PrivateUnmappedBase
+        {
+            public int Id { get; set; }
+            private DbContext? Context { get; set; }
+            private IEntityType? EntityType { get; set; }
+            private ILazyLoader? ALazyLoader { get; set; }
+            private Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PrivateUnmappedBaseSuper : PrivateUnmappedBase
+        {
+        }
+
+        protected class PrivateUnmappedBaseSub : PrivateUnmappedBaseSuper
+        {
+        }
+
+        protected class PrivateMappedBase
+        {
+            public int Id { get; set; }
+            private DbContext? Context { get; set; }
+            private IEntityType? EntityType { get; set; }
+            private ILazyLoader? ALazyLoader { get; set; }
+            private Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PrivateMappedBaseSuper : PrivateMappedBase
+        {
+        }
+
+        protected class PrivateMappedBaseSub : PrivateMappedBaseSuper
+        {
+        }
+
+        protected class PublicUnmappedBase
+        {
+            public int Id { get; set; }
+            public DbContext? Context { get; set; }
+            public IEntityType? EntityType { get; set; }
+            public ILazyLoader? ALazyLoader { get; set; }
+            public Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PublicUnmappedBaseSuper : PublicUnmappedBase
+        {
+        }
+
+        protected class PublicUnmappedBaseSub : PublicUnmappedBaseSuper
+        {
+        }
+
+        protected class PublicMappedBase
+        {
+            public int Id { get; set; }
+            public DbContext? Context { get; set; }
+            public IEntityType? EntityType { get; set; }
+            public ILazyLoader? ALazyLoader { get; set; }
+            public Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PublicMappedBaseSuper : PublicMappedBase
+        {
+        }
+
+        protected class PublicMappedBaseSub : PublicMappedBaseSuper
+        {
+        }
     }
 }
+
+#nullable restore

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             using (var context = new ServicePropertiesContext())
             {
                 var entityTypes = context.Model.GetEntityTypes().ToList();
-                Assert.Equal(10, entityTypes.Count);
+                Assert.Equal(13, entityTypes.Count);
 
                 foreach (var entityType in entityTypes)
                 {
@@ -93,9 +93,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 foreach (var entry in context.ChangeTracker.Entries())
                 {
                     var clrType = entry.Metadata.ClrType;
-                    while (clrType!.BaseType != typeof(object))
+
+                    if (!clrType.Name.StartsWith("PrivateWithDuplicates", StringComparison.Ordinal))
                     {
-                        clrType = clrType.BaseType;
+                        while (clrType!.BaseType != typeof(object))
+                        {
+                            clrType = clrType.BaseType;
+                        }
                     }
 
                     if (clrType == typeof(PublicUnmappedBaseSuper))
@@ -246,6 +250,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             public DbSet<PublicMappedBaseSub> PublicMappedBaseSubs
                 => Set<PublicMappedBaseSub>();
+
+            public DbSet<PrivateWithDuplicatesBase> PrivateWithDuplicatesBases
+                => Set<PrivateWithDuplicatesBase>();
+
+            public DbSet<PrivateWithDuplicatesSuper> PrivateWithDuplicatesSupers
+                => Set<PrivateWithDuplicatesSuper>();
+
+            public DbSet<PrivateWithDuplicatesSub> PrivateWithDuplicatesSubs
+                => Set<PrivateWithDuplicatesSub>();
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
@@ -411,6 +424,40 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         protected class PublicMappedBaseSub : PublicMappedBaseSuper
         {
+        }
+
+        protected class PrivateWithDuplicatesBase
+        {
+            public int Id { get; set; }
+            private DbContext? Context { get; set; }
+            private DbContext? Context2 { get; set; }
+            private IEntityType? EntityType { get; set; }
+            private IEntityType? EntityType2 { get; set; }
+            private ILazyLoader? ALazyLoader { get; set; }
+            private ILazyLoader? ALazyLoader2 { get; set; }
+            private Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PrivateWithDuplicatesSuper : PrivateWithDuplicatesBase
+        {
+            private DbContext? Context { get; set; }
+            private DbContext? Context2 { get; set; }
+            private IEntityType? EntityType { get; set; }
+            private IEntityType? EntityType2 { get; set; }
+            private ILazyLoader? ALazyLoader { get; set; }
+            private ILazyLoader? ALazyLoader2 { get; set; }
+            private Action<object, string>? LazyLoader { get; set; }
+        }
+
+        protected class PrivateWithDuplicatesSub : PrivateWithDuplicatesSuper
+        {
+            private DbContext? Context { get; set; }
+            private DbContext? Context2 { get; set; }
+            private IEntityType? EntityType { get; set; }
+            private IEntityType? EntityType2 { get; set; }
+            private ILazyLoader? ALazyLoader { get; set; }
+            private ILazyLoader? ALazyLoader2 { get; set; }
+            private Action<object, string>? LazyLoader { get; set; }
         }
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -52,7 +52,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.ModelReadOnly,
-                Assert.Throws<InvalidOperationException>(() => entityTypeA.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications)).Message);
+                Assert.Throws<InvalidOperationException>(
+                    () => entityTypeA.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications)).Message);
 
             Assert.Equal(
                 CoreStrings.ModelReadOnly,
@@ -109,11 +110,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Display_name_is_prettified_for_owned_shared_type()
             => Assert.Equal(
                 "Is<Awesome, When>.We#re.Living#Our.Dream",
-                CreateModel().AddEntityType("Everything.Is<Awesome, When>.We#re.Living#Our.Dream", typeof(Dictionary<string, object>)).DisplayName());
+                CreateModel().AddEntityType("Everything.Is<Awesome, When>.We#re.Living#Our.Dream", typeof(Dictionary<string, object>))
+                    .DisplayName());
 
         [ConditionalFact]
         public void Display_name_is_entity_type_name_when_shared_entity_type()
-            => Assert.Equal("Everything.Is+PostTag (Dictionary<string, object>)", CreateModel().AddEntityType("Everything.Is+PostTag", typeof(Dictionary<string, object>)).DisplayName());
+            => Assert.Equal(
+                "Everything.Is+PostTag (Dictionary<string, object>)",
+                CreateModel().AddEntityType("Everything.Is+PostTag", typeof(Dictionary<string, object>)).DisplayName());
 
         [ConditionalFact]
         public void Name_is_prettified_CLR_full_name()
@@ -2107,23 +2111,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [ConditionalFact]
-        public void Adding_a_new_service_property_with_a_type_that_already_exists_throws()
-        {
-            var model = CreateModel();
-            var entityType = model.AddEntityType(typeof(Customer));
-            entityType.AddServiceProperty(Customer.OrdersProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateServicePropertyType(
-                    nameof(Customer.MoreOrders),
-                    "ICollection<Order>",
-                    nameof(Customer),
-                    nameof(Customer.Orders),
-                    nameof(Customer)),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.MoreOrdersProperty)).Message);
-        }
-
-        [ConditionalFact]
         public void Can_add_indexed_property()
         {
             var model = CreateModel();
@@ -2209,12 +2196,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Can_get_property_indexes()
         {
             var modelBuilder = new ModelBuilder();
-            modelBuilder.Entity<Customer>(eb =>
-            {
-                eb.Property(c => c.Name);
-                eb.Property<int>("Id_");
-                eb.Property<int>("Mane_");
-            });
+            modelBuilder.Entity<Customer>(
+                eb =>
+                {
+                    eb.Property(c => c.Name);
+                    eb.Property<int>("Id_");
+                    eb.Property<int>("Mane_");
+                });
 
             var entityType = modelBuilder.FinalizeModel().FindEntityType(typeof(Customer));
 


### PR DESCRIPTION
Fixes #23968

Service properties are most commonly private. We were missing test coverage for public service properties in a type hierarchy, which was hiding this bug where we detect the property reflected from the base type as a duplicate. Fix is to match duplicates by name.
