### PR TITLE
Add Math translators for Cosmos DB provider

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosMethodCallTranslatorProvider.cs
@@ -39,7 +39,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     new EqualsTranslator(sqlExpressionFactory),
                     new StringMethodTranslator(sqlExpressionFactory),
                     new ContainsTranslator(sqlExpressionFactory),
-                    new RandomTranslator(sqlExpressionFactory)
+                    new RandomTranslator(sqlExpressionFactory),
+                    new MathTranslator(sqlExpressionFactory)
                     //new LikeTranslator(sqlExpressionFactory),
                     //new EnumHasFlagTranslator(sqlExpressionFactory),
                     //new GetValueOrDefaultTranslator(sqlExpressionFactory),

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -710,7 +710,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
             }
 
-            /* TODO
             if (expression is MethodCallExpression methodCallExpression)
             {
                 var innerType = methodCallExpression.Arguments[0].Type.UnwrapNullableType();
@@ -734,7 +733,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     return TryRemoveImplicitConvert(methodCallExpression.Arguments[0]);
                 }
             }
-            */
 
             return expression;
         }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -710,6 +710,32 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
             }
 
+            /* TODO
+            if (expression is MethodCallExpression methodCallExpression)
+            {
+                var innerType = methodCallExpression.Arguments[0].Type.UnwrapNullableType();
+                if (innerType.IsEnum)
+                {
+                    innerType = Enum.GetUnderlyingType(innerType);
+                }
+
+                var convertedType = methodCallExpression.Type.UnwrapNullableType();
+
+                if (innerType == convertedType
+                    || (convertedType == typeof(int)
+                        && (innerType == typeof(byte)
+                            || innerType == typeof(sbyte)
+                            || innerType == typeof(char)
+                            || innerType == typeof(short)
+                            || innerType == typeof(ushort)))
+                    || (convertedType == typeof(double)
+                        && (innerType == typeof(float))))
+                {
+                    return TryRemoveImplicitConvert(methodCallExpression.Arguments[0]);
+                }
+            }
+            */
+
             return expression;
         }
 

--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -710,30 +710,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 }
             }
 
-            if (expression is MethodCallExpression methodCallExpression)
-            {
-                var innerType = methodCallExpression.Arguments[0].Type.UnwrapNullableType();
-                if (innerType.IsEnum)
-                {
-                    innerType = Enum.GetUnderlyingType(innerType);
-                }
-
-                var convertedType = methodCallExpression.Type.UnwrapNullableType();
-
-                if (innerType == convertedType
-                    || (convertedType == typeof(int)
-                        && (innerType == typeof(byte)
-                            || innerType == typeof(sbyte)
-                            || innerType == typeof(char)
-                            || innerType == typeof(short)
-                            || innerType == typeof(ushort)))
-                    || (convertedType == typeof(double)
-                        && (innerType == typeof(float))))
-                {
-                    return TryRemoveImplicitConvert(methodCallExpression.Arguments[0]);
-                }
-            }
-
             return expression;
         }
 

--- a/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class MathTranslator : IMethodCallTranslator
+    {
+        private static readonly Dictionary<MethodInfo, string> _supportedMethodTranslations = new()
+        {
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(decimal) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(double) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(float) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(int) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(long) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(sbyte) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Abs), new[] { typeof(short) }), "ABS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(decimal) }), "CEILING" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Ceiling), new[] { typeof(double) }), "CEILING" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Floor), new[] { typeof(decimal) }), "FLOOR" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Floor), new[] { typeof(double) }), "FLOOR" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) }), "POWER" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Exp), new[] { typeof(double) }), "EXP" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Log10), new[] { typeof(double) }), "LOG10" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Log), new[] { typeof(double) }), "LOG" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) }), "LOG" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sqrt), new[] { typeof(double) }), "SQRT" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Acos), new[] { typeof(double) }), "ACOS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Asin), new[] { typeof(double) }), "ASIN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Atan), new[] { typeof(double) }), "ATAN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) }), "ATN2" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Cos), new[] { typeof(double) }), "COS" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sin), new[] { typeof(double) }), "SIN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Tan), new[] { typeof(double) }), "TAN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(decimal) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(double) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(float) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(int) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(long) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(sbyte) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Sign), new[] { typeof(short) }), "SIGN" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }), "TRUNC" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) }), "TRUNC" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }), "ROUND" },
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), "ROUND" }
+        };
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public MathTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual SqlExpression? Translate(
+            SqlExpression? instance,
+            MethodInfo method,
+            IReadOnlyList<SqlExpression> arguments,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            Check.NotNull(method, nameof(method));
+            Check.NotNull(arguments, nameof(arguments));
+            Check.NotNull(logger, nameof(logger));
+
+            if (_supportedMethodTranslations.TryGetValue(method, out var sqlFunctionName))
+            {
+                var typeMapping = arguments.Count == 1
+                    ? ExpressionExtensions.InferTypeMapping(arguments[0])
+                    : ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1]);
+
+                var newArguments = new SqlExpression[arguments.Count];
+                newArguments[0] = _sqlExpressionFactory.ApplyTypeMapping(arguments[0], typeMapping!);
+
+                if (arguments.Count == 2)
+                {
+                    newArguments[1] = _sqlExpressionFactory.ApplyTypeMapping(arguments[1], typeMapping!);
+                }
+
+                return _sqlExpressionFactory.Function(
+                    sqlFunctionName,
+                    newArguments,
+                    method.ReturnType,
+                    typeMapping);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
@@ -54,7 +54,26 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Truncate), new[] { typeof(decimal) }), "TRUNC" },
             { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Truncate), new[] { typeof(double) }), "TRUNC" },
             { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Round), new[] { typeof(decimal) }), "ROUND" },
-            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), "ROUND" }
+            { typeof(Math).GetRequiredRuntimeMethod(nameof(Math.Round), new[] { typeof(double) }), "ROUND" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Abs), new[] { typeof(float) }), "ABS" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Ceiling), new[] { typeof(float) }), "CEILING" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Floor), new[] { typeof(float) }), "FLOOR" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Pow), new[] { typeof(float), typeof(float) }), "POWER" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Exp), new[] { typeof(float) }), "EXP" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Log10), new[] { typeof(float) }), "LOG10" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Log), new[] { typeof(float) }), "LOG" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Log), new[] { typeof(float), typeof(float) }), "LOG" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Sqrt), new[] { typeof(float) }), "SQRT" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Acos), new[] { typeof(float) }), "ACOS" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Asin), new[] { typeof(float) }), "ASIN" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Atan), new[] { typeof(float) }), "ATAN" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Atan2), new[] { typeof(float), typeof(float) }), "ATN2" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Cos), new[] { typeof(float) }), "COS" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Sin), new[] { typeof(float) }), "SIN" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Tan), new[] { typeof(float) }), "TAN" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Sign), new[] { typeof(float) }), "SIGN" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Truncate), new[] { typeof(float) }), "TRUNC" },
+            { typeof(MathF).GetRequiredRuntimeMethod(nameof(MathF.Round), new[] { typeof(float) }), "ROUND" }
         };
 
         private readonly ISqlExpressionFactory _sqlExpressionFactory;

--- a/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/MathTranslator.cs
@@ -111,13 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                     ? ExpressionExtensions.InferTypeMapping(arguments[0])
                     : ExpressionExtensions.InferTypeMapping(arguments[0], arguments[1]);
 
-                var newArguments = new SqlExpression[arguments.Count];
-                newArguments[0] = _sqlExpressionFactory.ApplyTypeMapping(arguments[0], typeMapping!);
-
-                if (arguments.Count == 2)
-                {
-                    newArguments[1] = _sqlExpressionFactory.ApplyTypeMapping(arguments[1], typeMapping!);
-                }
+                var newArguments = arguments.Select(e => _sqlExpressionFactory.ApplyTypeMapping(e, typeMapping!));
 
                 return _sqlExpressionFactory.Function(
                     sqlFunctionName,

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -290,7 +290,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_abs1(bool async)
         {
             await base.Where_math_abs1(async);
@@ -298,10 +297,9 @@ WHERE (c[""Discriminator""] = ""Customer"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE ((c[""Discriminator""] = ""Product"") AND (ABS(c[""ProductID""]) > 10))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_abs2(bool async)
         {
             await base.Where_math_abs2(async);
@@ -309,10 +307,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""UnitPrice""] < 7.0)) AND (ABS(c[""Quantity""]) > 10))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_abs3(bool async)
         {
             await base.Where_math_abs3(async);
@@ -320,7 +317,7 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (ABS(c[""UnitPrice""]) > 10.0))");
         }
 
         public override async Task Where_math_abs_uncorrelated(bool async)
@@ -333,7 +330,6 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""UnitPrice""] < 7.0)) AND (10 < c[""ProductID""]))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_ceiling1(bool async)
         {
             await base.Where_math_ceiling1(async);
@@ -355,7 +351,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""OrderDetail"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_floor(bool async)
         {
             await base.Where_math_floor(async);
@@ -363,10 +358,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (FLOOR(c[""UnitPrice""]) > 10.0))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_power(bool async)
         {
             await base.Where_math_power(async);
@@ -377,7 +371,6 @@ FROM root c
 WHERE (c[""Discriminator""] = ""OrderDetail"")");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_round(bool async)
         {
             await base.Where_math_round(async);
@@ -385,7 +378,7 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (ROUND(c[""UnitPrice""]) > 10.0))");
         }
 
         public override async Task Select_math_round_int(bool async)
@@ -416,10 +409,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (ROUND(c[""UnitPrice""]) > 100.0))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_truncate(bool async)
         {
             await base.Where_math_truncate(async);
@@ -427,10 +419,9 @@ WHERE (c[""Discriminator""] = ""OrderDetail"")");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE (c[""Discriminator""] = ""OrderDetail"")");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (TRUNC(c[""UnitPrice""]) > 10.0))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_exp(bool async)
         {
             await base.Where_math_exp(async);
@@ -441,7 +432,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log10(bool async)
         {
             await base.Where_math_log10(async);
@@ -452,7 +442,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log(bool async)
         {
             await base.Where_math_log(async);
@@ -463,7 +452,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log_new_base(bool async)
         {
             await base.Where_math_log_new_base(async);
@@ -474,7 +462,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_sqrt(bool async)
         {
             await base.Where_math_sqrt(async);
@@ -485,7 +472,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_acos(bool async)
         {
             await base.Where_math_acos(async);
@@ -496,7 +482,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_asin(bool async)
         {
             await base.Where_math_asin(async);
@@ -507,7 +492,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_atan(bool async)
         {
             await base.Where_math_atan(async);
@@ -518,7 +502,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_atan2(bool async)
         {
             await base.Where_math_atan2(async);
@@ -529,7 +512,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_cos(bool async)
         {
             await base.Where_math_cos(async);
@@ -540,7 +522,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_sin(bool async)
         {
             await base.Where_math_sin(async);
@@ -551,7 +532,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_tan(bool async)
         {
             await base.Where_math_tan(async);
@@ -562,7 +542,6 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
-        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_sign(bool async)
         {
             await base.Where_math_sign(async);
@@ -570,7 +549,7 @@ WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
             AssertSql(
                 @"SELECT c
 FROM root c
-WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077)) AND (SIGN(c[""Discount""]) > 0))");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -330,6 +330,7 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""UnitPrice""] < 7.0)) AND (10 < c[""ProductID""]))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_ceiling1(bool async)
         {
             await base.Where_math_ceiling1(async);
@@ -361,6 +362,7 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (FLOOR(c[""UnitPrice""]) > 10.0))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_power(bool async)
         {
             await base.Where_math_power(async);
@@ -422,6 +424,7 @@ FROM root c
 WHERE (((c[""Discriminator""] = ""OrderDetail"") AND (c[""Quantity""] < 5)) AND (TRUNC(c[""UnitPrice""]) > 10.0))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_exp(bool async)
         {
             await base.Where_math_exp(async);
@@ -432,6 +435,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log10(bool async)
         {
             await base.Where_math_log10(async);
@@ -442,6 +446,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log(bool async)
         {
             await base.Where_math_log(async);
@@ -452,6 +457,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_log_new_base(bool async)
         {
             await base.Where_math_log_new_base(async);
@@ -462,6 +468,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 11077) AND (c[""Discount""] > 0.0)))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_sqrt(bool async)
         {
             await base.Where_math_sqrt(async);
@@ -472,6 +479,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_acos(bool async)
         {
             await base.Where_math_acos(async);
@@ -482,6 +490,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_asin(bool async)
         {
             await base.Where_math_asin(async);
@@ -492,6 +501,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_atan(bool async)
         {
             await base.Where_math_atan(async);
@@ -502,6 +512,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_atan2(bool async)
         {
             await base.Where_math_atan2(async);
@@ -512,6 +523,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_cos(bool async)
         {
             await base.Where_math_cos(async);
@@ -522,6 +534,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_sin(bool async)
         {
             await base.Where_math_sin(async);
@@ -532,6 +545,7 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
         }
 
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override async Task Where_math_tan(bool async)
         {
             await base.Where_math_tan(async);

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -546,7 +546,7 @@ ORDER BY c[""OrderID""]");
             await base.Select_non_matching_value_types_from_method_call_introduces_explicit_cast(async);
 
             AssertSql(
-                @"SELECT c[""OrderID""]
+                @"SELECT ABS(c[""OrderID""]) AS c
 FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))
 ORDER BY c[""OrderID""]");


### PR DESCRIPTION
Added Math for Cosmos:
ABS, CEILING, FLOOR, POWER, EXP, LOG10, LOG, SQRT, ACOS, ASIN, ATAN, ATN2, COS, SIN, TAN, SIGN, TRUNC, ROUND

Issue: #16143

Need your help with translation methods with converting.
Example:

```
.Where(od => Math.Tan(od.Discount) > 0)
```
here `od.Discount` is `float`. `Math.Tan` requires `double`. So, the following expression will be generated:

```
Tan(Convert([Microsoft.EntityFrameworkCore.Query.EntityShaperExpression].Discount, Double))
```
In this case the `TryRemoveImplicitConvert` will be called and return `null`

https://github.com/Marusyk/efcore/blob/e23cdc0128851a8760bbcd57696f4001ae3b3a60/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs#L685

Could you please suggest how to improve that?