### PR TITLE
Query: Update column references in pending collections

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -538,6 +538,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         return ExpandInclude(ownedNavigationReference, ownedNavigationReference.EntityReference);
 
                     case MaterializeCollectionNavigationExpression _:
+                    case IncludeExpression _:
                         return extensionExpression;
                 }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1284,6 +1284,24 @@ ORDER BY c[""OrderID""]");
             return base.Collection_include_over_result_of_single_non_scalar(async);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
+        {
+            return base.Collection_projection_selecting_outer_element_followed_by_take(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
+        {
+            return base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async);
+        }
+
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Take_on_correlated_collection_in_first(bool async)
+        {
+            return base.Take_on_correlated_collection_in_first(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -6093,5 +6093,81 @@ namespace Microsoft.EntityFrameworkCore.Query
                     AssertEqual(e.Property, a.Property);
                 });
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Take_Select_collection_Take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().OrderBy(l1 => l1.Id).Take(1)
+                    .Select(l1 => new
+                    {
+                        Id = l1.Id,
+                        Name = l1.Name,
+                        Level2s = l1.OneToMany_Required1.OrderBy(l2 => l2.Id).Take(3)
+                            .Select(l2 => new
+                            {
+                                Id = l2.Id,
+                                Name = l2.Name,
+                                Level1Id = EF.Property<int>(l2, "OneToMany_Required_Inverse2Id"),
+                                Level2Id = l2.Level1_Required_Id,
+                                Level2 = l2.OneToOne_Required_FK_Inverse2
+                            })
+                    }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+                    Assert.Equal(e.Name, a.Name);
+                    AssertCollection(e.Level2s, a.Level2s, ordered: true,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.Level1Id, aa.Level1Id);
+                            Assert.Equal(ee.Level2Id, aa.Level2Id);
+                            AssertEqual(ee.Level2, aa.Level2);
+                        });
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_Take_Select_collection_Skip_Take(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().OrderBy(l1 => l1.Id).Skip(1).Take(1)
+                    .Select(l1 => new
+                    {
+                        Id = l1.Id,
+                        Name = l1.Name,
+                        Level2s = l1.OneToMany_Required1.OrderBy(l2 => l2.Id).Skip(1).Take(3)
+                            .Select(l2 => new
+                            {
+                                Id = l2.Id,
+                                Name = l2.Name,
+                                Level1Id = EF.Property<int>(l2, "OneToMany_Required_Inverse2Id"),
+                                Level2Id = l2.Level1_Required_Id,
+                                Level2 = l2.OneToOne_Required_FK_Inverse2
+                            })
+                    }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+                    Assert.Equal(e.Name, a.Name);
+                    AssertCollection(e.Level2s, a.Level2s, ordered: true,
+                        elementAsserter: (ee, aa) =>
+                        {
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.Level1Id, aa.Level1Id);
+                            Assert.Equal(ee.Level2Id, aa.Level2Id);
+                            AssertEqual(ee.Level2, aa.Level2);
+                        });
+                });
+        }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -32,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Concat(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Concat(ss.Set<Customer>().Where(c => c.City == "London")),
                 entryCount: 7);
@@ -43,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Concat_nested(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "México D.F.")
                     .Concat(ss.Set<Customer>().Where(s => s.City == "Berlin"))
                     .Concat(ss.Set<Customer>().Where(e => e.City == "London")),
@@ -55,7 +57,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Concat_non_entity(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "México D.F.")
                     .Select(c => c.CustomerID)
                     .Concat(
@@ -69,7 +72,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Except(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "London")
                     .Except(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))),
                 entryCount: 5);
@@ -80,7 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Except_simple_followed_by_projecting_constant(bool async)
         {
             return AssertQueryScalar(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Except(ss.Set<Customer>())
                     .Select(e => 1));
         }
@@ -90,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Except_nested(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(s => s.ContactTitle == "Owner")
                     .Except(ss.Set<Customer>().Where(s => s.City == "México D.F."))
                     .Except(ss.Set<Customer>().Where(e => e.City == "Seattle")),
@@ -102,7 +108,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Except_non_entity(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(s => s.ContactTitle == "Owner")
                     .Select(c => c.CustomerID)
                     .Except(
@@ -116,7 +123,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Intersect(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "London")
                     .Intersect(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))),
                 entryCount: 1);
@@ -127,7 +135,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Intersect_nested(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "México D.F.")
                     .Intersect(ss.Set<Customer>().Where(s => s.ContactTitle == "Owner"))
                     .Intersect(ss.Set<Customer>().Where(e => e.Fax != null)),
@@ -139,7 +148,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Intersect_non_entity(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "México D.F.")
                     .Select(c => c.CustomerID)
                     .Intersect(
@@ -153,7 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London")),
                 entryCount: 7);
@@ -164,7 +175,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_nested(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(s => s.ContactTitle == "Owner")
                     .Union(ss.Set<Customer>().Where(s => s.City == "México D.F."))
                     .Union(ss.Set<Customer>().Where(e => e.City == "London")),
@@ -176,7 +188,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_non_entity(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(s => s.ContactTitle == "Owner")
                     .Select(c => c.CustomerID)
                     .Union(
@@ -191,7 +204,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_OrderBy_Skip_Take(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .OrderBy(c => c.ContactName)
@@ -207,7 +221,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Where(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .Where(c => c.ContactName.Contains("Thomas")), // pushdown
@@ -220,7 +235,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Skip_Take_OrderBy_ThenBy_Where(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .OrderBy(c => c.Region)
@@ -236,7 +252,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .Union(ss.Set<Customer>().Where(c => c.City == "Mannheim")),
@@ -250,7 +267,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Intersect(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .Intersect(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))),
@@ -262,7 +280,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Take_Union_Take(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .OrderBy(c => c.CustomerID)
@@ -278,7 +297,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Select_Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Select(c => c.Address)
                     .Union(
@@ -292,7 +312,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Select(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .Select(c => c.Address)
@@ -304,7 +325,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Select_scalar(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Except(ss.Set<Customer>())
                     .Select(c => (object)1));
         }
@@ -314,7 +336,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_with_anonymous_type_projection(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.CompanyName.StartsWith("A"))
                     .Union(ss.Set<Customer>().Where(c => c.CompanyName.StartsWith("B")))
                     .Select(c => new CustomerDeets { Id = c.CustomerID }));
@@ -360,7 +383,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Select_Union_different_fields_in_anonymous_with_subquery(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Select(c => new { Foo = c.City, Customer = c }) // Foo is City
                     .Union(
@@ -379,7 +403,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_Include(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                     .Include(c => c.Orders),
@@ -391,7 +416,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Include_Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .Include(c => c.Orders)
                     .Union(
@@ -406,7 +432,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Select_Except_reference_projection(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Order>()
+                async,
+                ss => ss.Set<Order>()
                     .Select(o => o.Customer)
                     .Except(
                         ss.Set<Order>()
@@ -486,7 +513,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task GroupBy_Select_Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Berlin")
                     .GroupBy(c => c.CustomerID)
                     .Select(g => new { CustomerID = g.Key, Count = g.Count() })
@@ -502,7 +530,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Union_over_columns_with_different_nullability(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Select(c => "NonNullableConstant")
                     .Concat(
                         ss.Set<Customer>()
@@ -559,7 +588,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task OrderBy_Take_Union(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .OrderBy(c => c.ContactName)
                     .Take(1)
                     .Union(
@@ -575,7 +605,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Collection_projection_after_set_operation(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>().Where(c => c.City == "Seatte")
+                async,
+                ss => ss.Set<Customer>().Where(c => c.City == "Seatte")
                     .Union(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")))
                     .Select(c => new
                     {
@@ -596,7 +627,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Collection_projection_after_set_operation_fails_if_distinct(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>().Where(c => c.City == "Seatte")
+                async,
+                ss => ss.Set<Customer>().Where(c => c.City == "Seatte")
                     .Concat(ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")))
                     .Select(c => new
                     {
@@ -617,7 +649,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Collection_projection_before_set_operation_fails(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Customer>()
+                async,
+                ss => ss.Set<Customer>()
                     .Where(c => c.City == "Seatte")
                     .Select(c => new
                     {
@@ -642,7 +675,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual Task Concat_with_one_side_being_GroupBy_aggregate(bool async)
         {
             return AssertQuery(
-                async, ss => ss.Set<Order>()
+                async,
+                ss => ss.Set<Order>()
                     .Where(c => c.Customer.City == "Seatte")
                     .Select(c => new
                     {
@@ -659,6 +693,43 @@ namespace Microsoft.EntityFrameworkCore.Query
                 {
                     AssertEqual(e.OrderDate, a.OrderDate);
                 });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_on_entity_with_correlated_collection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(c => c.Customer.City == "Seatte").Select(c => c.Customer)
+                    .Union(ss.Set<Order>().Where(o => o.OrderID < 10250).Select(c => c.Customer))
+                    .OrderBy(c => c.CustomerID)
+                    .Select(c => c.Orders),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertCollection(e, a);
+                },
+                entryCount: 11);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(c => c.Customer.City == "Seatte").Select(c => new { c.Customer, c.OrderDate })
+                    .Union(ss.Set<Order>().Where(o => o.OrderID < 10250).Select(c => new { c.Customer, c.OrderDate }))
+                    .OrderBy(c => c.Customer.CustomerID)
+                    .Select(c => new { c.OrderDate, Orders = ss.Set<Order>().Where(o => o.CustomerID == c.Customer.CustomerID).ToList() }),
+                assertOrder: true,
+                elementAsserter: (e, a) =>
+                {
+                    AssertEqual(e.OrderDate, a.OrderDate);
+                    AssertCollection(e.Orders, a.Orders);
+                },
+                entryCount: 11);
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -6226,6 +6226,60 @@ WHERE ([l11].[Name] <> N'Foo') OR [l11].[Name] IS NULL
 ORDER BY [l12].[Id], [l].[Id], [l0].[Id], [l1].[Id], [l2].[Id], [t].[Id], [t].[Id0], [t].[Id1], [t].[Id2], [t0].[Id], [t0].[Id0], [t0].[Id1], [t0].[Id2], [l11].[Id], [l13].[Id], [l14].[Id], [t1].[Id]");
         }
 
+        public override async Task Take_Select_collection_Take(bool async)
+        {
+            await base.Take_Select_collection_Take(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t].[Id], [t].[Name], [t0].[Id], [t0].[Name], [t0].[Level1Id], [t0].[Level2Id], [t0].[Id0], [t0].[Date], [t0].[Name0], [t0].[OneToMany_Optional_Self_Inverse1Id], [t0].[OneToMany_Required_Self_Inverse1Id], [t0].[OneToOne_Optional_Self1Id]
+FROM (
+    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    FROM [LevelOne] AS [l]
+    ORDER BY [l].[Id]
+) AS [t]
+OUTER APPLY (
+    SELECT [t1].[Id], [t1].[Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l0].[Id] AS [Id0], [l0].[Date], [l0].[Name] AS [Name0], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id]
+    FROM (
+        SELECT TOP(3) [l1].[Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Required_Inverse2Id]
+        FROM [LevelTwo] AS [l1]
+        WHERE [t].[Id] = [l1].[OneToMany_Required_Inverse2Id]
+        ORDER BY [l1].[Id]
+    ) AS [t1]
+    INNER JOIN [LevelOne] AS [l0] ON [t1].[Level1_Required_Id] = [l0].[Id]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id0]");
+        }
+
+        public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
+        {
+            await base.Skip_Take_Select_collection_Skip_Take(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t].[Id], [t].[Name], [t0].[Id], [t0].[Name], [t0].[Level1Id], [t0].[Level2Id], [t0].[Id0], [t0].[Date], [t0].[Name0], [t0].[OneToMany_Optional_Self_Inverse1Id], [t0].[OneToMany_Required_Self_Inverse1Id], [t0].[OneToOne_Optional_Self1Id]
+FROM (
+    SELECT [l].[Id], [l].[Name]
+    FROM [LevelOne] AS [l]
+    ORDER BY [l].[Id]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+) AS [t]
+OUTER APPLY (
+    SELECT [t1].[Id], [t1].[Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l0].[Id] AS [Id0], [l0].[Date], [l0].[Name] AS [Name0], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id]
+    FROM (
+        SELECT [l1].[Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Required_Inverse2Id]
+        FROM [LevelTwo] AS [l1]
+        WHERE [t].[Id] = [l1].[OneToMany_Required_Inverse2Id]
+        ORDER BY [l1].[Id]
+        OFFSET 1 ROWS FETCH NEXT 3 ROWS ONLY
+    ) AS [t1]
+    INNER JOIN [LevelOne] AS [l0] ON [t1].[Level1_Required_Id] = [l0].[Id]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqlServerTest.cs
@@ -324,6 +324,62 @@ LEFT JOIN (
 ORDER BY [l].[Id], [t].[Id], [t].[Name], [t].[FK], [t0].[Id], [t0].[Id0]");
         }
 
+        public override async Task Take_Select_collection_Take(bool async)
+        {
+            await base.Take_Select_collection_Take(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t].[Id], [t].[Name], [t0].[Id], [t0].[Name], [t0].[Level1Id], [t0].[Level2Id], [t0].[Id0], [t0].[Date], [t0].[Name0], [t0].[Id00]
+FROM (
+    SELECT TOP(@__p_0) [l].[Id], [l].[Name]
+    FROM [Level1] AS [l]
+    ORDER BY [l].[Id]
+) AS [t]
+OUTER APPLY (
+    SELECT [t1].[Id], [t1].[Level2_Name] AS [Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [t1].[Id0] AS [Id00]
+    FROM (
+        SELECT TOP(3) [l0].[Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id], [l2].[Id] AS [Id0]
+        FROM [Level1] AS [l0]
+        INNER JOIN [Level1] AS [l2] ON [l0].[Id] = [l2].[Id]
+        WHERE ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
+        ORDER BY [l0].[Id]
+    ) AS [t1]
+    INNER JOIN [Level1] AS [l1] ON [t1].[Level1_Required_Id] = [l1].[Id]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id00], [t0].[Id0]");
+        }
+
+        public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
+        {
+            await base.Skip_Take_Select_collection_Skip_Take(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT [t].[Id], [t].[Name], [t0].[Id], [t0].[Name], [t0].[Level1Id], [t0].[Level2Id], [t0].[Id0], [t0].[Date], [t0].[Name0], [t0].[Id00]
+FROM (
+    SELECT [l].[Id], [l].[Name]
+    FROM [Level1] AS [l]
+    ORDER BY [l].[Id]
+    OFFSET @__p_0 ROWS FETCH NEXT @__p_0 ROWS ONLY
+) AS [t]
+OUTER APPLY (
+    SELECT [t1].[Id], [t1].[Level2_Name] AS [Name], [t1].[OneToMany_Required_Inverse2Id] AS [Level1Id], [t1].[Level1_Required_Id] AS [Level2Id], [l1].[Id] AS [Id0], [l1].[Date], [l1].[Name] AS [Name0], [t1].[Id0] AS [Id00]
+    FROM (
+        SELECT [l0].[Id], [l0].[Level1_Required_Id], [l0].[Level2_Name], [l0].[OneToMany_Required_Inverse2Id], [l2].[Id] AS [Id0]
+        FROM [Level1] AS [l0]
+        INNER JOIN [Level1] AS [l2] ON [l0].[Id] = [l2].[Id]
+        WHERE ([l0].[OneToMany_Required_Inverse2Id] IS NOT NULL AND ([l0].[Level1_Required_Id] IS NOT NULL AND [l0].[OneToOne_Required_PK_Date] IS NOT NULL)) AND ([t].[Id] = [l0].[OneToMany_Required_Inverse2Id])
+        ORDER BY [l0].[Id]
+        OFFSET 1 ROWS FETCH NEXT 3 ROWS ONLY
+    ) AS [t1]
+    INNER JOIN [Level1] AS [l1] ON [t1].[Level1_Required_Id] = [l1].[Id]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id00], [t0].[Id0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSetOperationsQuerySqlServerTest.cs
@@ -576,6 +576,48 @@ FROM [Orders] AS [o0]
 GROUP BY [o0].[CustomerID]");
         }
 
+        public override async Task Union_on_entity_with_correlated_collection(bool async)
+        {
+            await base.Union_on_entity_with_correlated_collection(async);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [c].[City] = N'Seatte'
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+    WHERE [o0].[OrderID] < 10250
+) AS [t]
+LEFT JOIN [Orders] AS [o1] ON [t].[CustomerID] = [o1].[CustomerID]
+ORDER BY [t].[CustomerID], [o1].[OrderID]");
+        }
+
+        public override async Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
+        {
+            await base.Union_on_entity_plus_other_column_with_correlated_collection(async);
+
+            AssertSql(
+                @"SELECT [t].[OrderDate], [t].[CustomerID], [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+FROM (
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+    WHERE [c].[City] = N'Seatte'
+    UNION
+    SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region], [o0].[OrderDate]
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+    WHERE [o0].[OrderID] < 10250
+) AS [t]
+LEFT JOIN [Orders] AS [o1] ON [t].[CustomerID] = [o1].[CustomerID]
+ORDER BY [t].[CustomerID], [t].[OrderDate], [o1].[OrderID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -8377,8 +8377,8 @@ FROM [CycleC] AS [c]");
                 var result = context.Blogs.Select(
                     e => new
                     {
-                        Id = e.Id,
-                        Title = e.Title,
+                        e.Id,
+                        e.Title,
                         FirstPostName = e.Posts.Where(i => i.Name.Contains("2")).ToList()
                     }).ToList();
 
@@ -8399,8 +8399,8 @@ ORDER BY [b].[Id], [t].[Id]");
                 var result = context.Blogs.Select(
                     e => new
                     {
-                        Id = e.Id,
-                        Title = e.Title,
+                        e.Id,
+                        e.Title,
                         FirstPostName = e.Posts.OrderBy(i => i.Id).FirstOrDefault().Name
                     }).ToList();
 
@@ -9405,6 +9405,619 @@ ORDER BY [i].[_Position];");
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Principal23674>();
+            }
+        }
+
+        #endregion
+
+        #region Issue23676
+
+        [ConditionalFact]
+        public virtual async Task Projection_with_multiple_includes_and_subquery_with_set_operation()
+        {
+            var contextFactory = await InitializeAsync<MyContext23676>();
+
+            using var context = contextFactory.CreateContext();
+            var id = 1;
+            var person = await context.Persons
+                            .Include(p => p.Images)
+                            .Include(p => p.Actor)
+                            .ThenInclude(a => a.Movies)
+                            .ThenInclude(p => p.Movie)
+                            .Include(p => p.Director)
+                            .ThenInclude(a => a.Movies)
+                            .ThenInclude(p => p.Movie)
+                            .Select(x => new
+                            {
+                                x.Id,
+                                x.Name,
+                                x.Surname,
+                                x.Birthday,
+                                x.Hometown,
+                                x.Bio,
+                                x.AvatarUrl,
+
+                                Images = x.Images
+                                    .Select(i => new
+                                    {
+                                        i.Id,
+                                        i.ImageUrl,
+                                        i.Height,
+                                        i.Width
+                                    }).ToList(),
+
+                                KnownByFilms = x.Actor.Movies
+                                    .Select(m => m.Movie)
+                                    .Union(x.Director.Movies
+                                    .Select(m => m.Movie))
+                                    .Select(m => new
+                                    {
+                                        m.Id,
+                                        m.Name,
+                                        m.PosterUrl,
+                                        m.Rating
+                                    }).ToList()
+
+                            })
+                            .FirstOrDefaultAsync(x => x.Id == id);
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"@__id_0='1'
+
+SELECT [t].[Id], [t].[Name], [t].[Surname], [t].[Birthday], [t].[Hometown], [t].[Bio], [t].[AvatarUrl], [t].[Id0], [t].[Id1], [p0].[Id], [p0].[ImageUrl], [p0].[Height], [p0].[Width], [t0].[Id], [t0].[Name], [t0].[PosterUrl], [t0].[Rating]
+FROM (
+    SELECT TOP(1) [p].[Id], [p].[Name], [p].[Surname], [p].[Birthday], [p].[Hometown], [p].[Bio], [p].[AvatarUrl], [a].[Id] AS [Id0], [d].[Id] AS [Id1]
+    FROM [Persons] AS [p]
+    LEFT JOIN [ActorEntity] AS [a] ON [p].[Id] = [a].[PersonId]
+    LEFT JOIN [DirectorEntity] AS [d] ON [p].[Id] = [d].[PersonId]
+    WHERE [p].[Id] = @__id_0
+) AS [t]
+LEFT JOIN [PersonImageEntity] AS [p0] ON [t].[Id] = [p0].[PersonId]
+OUTER APPLY (
+    SELECT [m0].[Id], [m0].[Budget], [m0].[Description], [m0].[DurationInMins], [m0].[Name], [m0].[PosterUrl], [m0].[Rating], [m0].[ReleaseDate], [m0].[Revenue]
+    FROM [MovieActorEntity] AS [m]
+    INNER JOIN [MovieEntity] AS [m0] ON [m].[MovieId] = [m0].[Id]
+    WHERE [t].[Id0] IS NOT NULL AND ([t].[Id0] = [m].[ActorId])
+    UNION
+    SELECT [m2].[Id], [m2].[Budget], [m2].[Description], [m2].[DurationInMins], [m2].[Name], [m2].[PosterUrl], [m2].[Rating], [m2].[ReleaseDate], [m2].[Revenue]
+    FROM [MovieDirectorEntity] AS [m1]
+    INNER JOIN [MovieEntity] AS [m2] ON [m1].[MovieId] = [m2].[Id]
+    WHERE [t].[Id1] IS NOT NULL AND ([t].[Id1] = [m1].[DirectorId])
+) AS [t0]
+ORDER BY [t].[Id], [t].[Id0], [t].[Id1], [p0].[Id], [t0].[Id]");
+        }
+
+        private class PersonEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Surname { get; set; }
+            public DateTime Birthday { get; set; }
+            public string Hometown { get; set; }
+            public string Bio { get; set; }
+            public string AvatarUrl { get; set; }
+
+            public ActorEntity Actor { get; set; }
+            public DirectorEntity Director { get; set; }
+            public IList<PersonImageEntity> Images { get; set; } = new List<PersonImageEntity>();
+        }
+        private class PersonImageEntity
+        {
+            public int Id { get; set; }
+            public string ImageUrl { get; set; }
+            public int Height { get; set; }
+            public int Width { get; set; }
+            public PersonEntity Person { get; set; }
+        }
+
+        private class ActorEntity
+        {
+            public int Id { get; set; }
+            public int PersonId { get; set; }
+            public PersonEntity Person { get; set; }
+
+            public IList<MovieActorEntity> Movies { get; set; } = new List<MovieActorEntity>();
+        }
+
+        private class MovieActorEntity
+        {
+            public int Id { get; set; }
+            public int ActorId { get; set; }
+            public ActorEntity Actor { get; set; }
+
+            public int MovieId { get; set; }
+            public MovieEntity Movie { get; set; }
+
+            public string RoleInFilm { get; set; }
+
+            public int Order { get; set; }
+        }
+
+        private class DirectorEntity
+        {
+            public int Id { get; set; }
+            public int PersonId { get; set; }
+            public PersonEntity Person { get; set; }
+
+            public IList<MovieDirectorEntity> Movies { get; set; } = new List<MovieDirectorEntity>();
+        }
+
+        private class MovieDirectorEntity
+        {
+            public int Id { get; set; }
+            public int DirectorId { get; set; }
+            public DirectorEntity Director { get; set; }
+
+            public int MovieId { get; set; }
+            public MovieEntity Movie { get; set; }
+        }
+
+        private class MovieEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public double Rating { get; set; }
+            public string Description { get; set; }
+            public DateTime ReleaseDate { get; set; }
+            public int DurationInMins { get; set; }
+            public int Budget { get; set; }
+            public int Revenue { get; set; }
+            public string PosterUrl { get; set; }
+
+            public IList<MovieDirectorEntity> Directors { get; set; } = new List<MovieDirectorEntity>();
+            public IList<MovieActorEntity> Actors { get; set; } = new List<MovieActorEntity>();
+        }
+
+        private class MyContext23676 : DbContext
+        {
+            public MyContext23676(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<PersonEntity> Persons { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+            }
+        }
+
+        #endregion
+
+        #region Issue19947
+
+        [ConditionalFact]
+        public virtual async Task Multiple_select_many_in_projection()
+        {
+            var contextFactory = await InitializeAsync<MyContext19947>();
+
+            using var context = contextFactory.CreateContext();
+            var query = context.Users.Select(captain => new
+            {
+                CaptainRateDtos = captain.Cars
+                    .SelectMany(car0 => car0.Taxis)
+                    .OrderByDescending(taxi => taxi.DateArrived).Take(12)
+                    .Select(taxi => new
+                    {
+                        Rate = taxi.UserRate.Value,
+                        UserRateText = taxi.UserTextRate,
+                        UserId = taxi.UserEUser.Id,
+                    }).ToList(),
+
+                ReportCount = captain.Cars
+                    .SelectMany(car1 => car1.Taxis).Count(taxi0 => taxi0.ReportText != ""),
+            }).SingleOrDefault();
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"SELECT [t0].[c], [t0].[Id], [t1].[Rate], [t1].[UserRateText], [t1].[UserId], [t1].[Id], [t1].[Id0]
+FROM (
+    SELECT TOP(2) (
+        SELECT COUNT(*)
+        FROM [Cars] AS [c]
+        INNER JOIN [Taxis] AS [t] ON [c].[Id] = [t].[CarId]
+        WHERE ([u].[Id] = [c].[EUserId]) AND (([t].[ReportText] <> N'') OR [t].[ReportText] IS NULL)) AS [c], [u].[Id]
+    FROM [Users] AS [u]
+) AS [t0]
+OUTER APPLY (
+    SELECT [t2].[UserRate] AS [Rate], [t2].[UserTextRate] AS [UserRateText], [u0].[Id] AS [UserId], [t2].[Id], [t2].[Id0], [t2].[DateArrived]
+    FROM (
+        SELECT TOP(12) [c0].[Id], [t3].[Id] AS [Id0], [t3].[DateArrived], [t3].[UserEUserId], [t3].[UserRate], [t3].[UserTextRate]
+        FROM [Cars] AS [c0]
+        INNER JOIN [Taxis] AS [t3] ON [c0].[Id] = [t3].[CarId]
+        WHERE [t0].[Id] = [c0].[EUserId]
+        ORDER BY [t3].[DateArrived] DESC
+    ) AS [t2]
+    LEFT JOIN [Users] AS [u0] ON [t2].[UserEUserId] = [u0].[Id]
+) AS [t1]
+ORDER BY [t0].[Id], [t1].[DateArrived] DESC, [t1].[Id], [t1].[Id0], [t1].[UserId]");
+        }
+
+        [ConditionalFact]
+        public virtual async Task Single_select_many_in_projection_with_take()
+        {
+            var contextFactory = await InitializeAsync<MyContext19947>();
+
+            using var context = contextFactory.CreateContext();
+            var query = context.Users.Select(captain => new
+            {
+                CaptainRateDtos = captain.Cars
+                    .SelectMany(car0 => car0.Taxis)
+                    .OrderByDescending(taxi => taxi.DateArrived).Take(12)
+                    .Select(taxi => new
+                    {
+                        Rate = taxi.UserRate.Value,
+                        UserRateText = taxi.UserTextRate,
+                        UserId = taxi.UserEUser.Id,
+                    }).ToList()
+            }).SingleOrDefault();
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"SELECT [t].[Id], [t0].[Rate], [t0].[UserRateText], [t0].[UserId], [t0].[Id], [t0].[Id0]
+FROM (
+    SELECT TOP(2) [u].[Id]
+    FROM [Users] AS [u]
+) AS [t]
+OUTER APPLY (
+    SELECT [t1].[UserRate] AS [Rate], [t1].[UserTextRate] AS [UserRateText], [u0].[Id] AS [UserId], [t1].[Id], [t1].[Id0], [t1].[DateArrived]
+    FROM (
+        SELECT TOP(12) [c].[Id], [t2].[Id] AS [Id0], [t2].[DateArrived], [t2].[UserEUserId], [t2].[UserRate], [t2].[UserTextRate]
+        FROM [Cars] AS [c]
+        INNER JOIN [Taxis] AS [t2] ON [c].[Id] = [t2].[CarId]
+        WHERE [t].[Id] = [c].[EUserId]
+        ORDER BY [t2].[DateArrived] DESC
+    ) AS [t1]
+    LEFT JOIN [Users] AS [u0] ON [t1].[UserEUserId] = [u0].[Id]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[DateArrived] DESC, [t0].[Id], [t0].[Id0], [t0].[UserId]");
+        }
+
+        private class EUser
+        {
+            public int Id { get; set; }
+
+            public ICollection<Car> Cars { get; set; }
+        }
+
+        private class Taxi
+        {
+            public int Id { get; set; }
+            public DateTime? DateArrived { get; set; }
+            public int? UserRate { get; set; }
+            public string UserTextRate { get; set; }
+            public string ReportText { get; set; }
+            public EUser UserEUser { get; set; }
+        }
+
+        private class Car
+        {
+            public int Id { get; set; }
+            public ICollection<Taxi> Taxis { get; set; }
+        }
+
+        private class MyContext19947 : DbContext
+        {
+            public MyContext19947(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<EUser> Users { get; set; }
+            public DbSet<Car> Cars { get; set; }
+            public DbSet<Taxi> Taxis { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+            }
+        }
+
+        #endregion
+
+        #region Issue20813
+
+        [ConditionalFact]
+        public virtual async Task SelectMany_and_collection_in_projection_in_FirstOrDefault()
+        {
+            var contextFactory = await InitializeAsync<MyContext20813>();
+
+            using var context = contextFactory.CreateContext();
+            var referenceId = "a";
+            var customerId = new Guid("1115c816-6c4c-4016-94df-d8b60a22ffa1");
+            var query = context.Orders
+                .Where(o => o.ExternalReferenceId == referenceId && o.CustomerId == customerId)
+                .Select(o => new
+                {
+                    IdentityDocuments = o.IdentityDocuments.Select(id => new
+                    {
+                        Images = o.IdentityDocuments
+                            .SelectMany(id => id.Images)
+                            .Select(i => new
+                            {
+                                Image = i.Image
+                            }),
+                    })
+                }).SingleOrDefault();
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"@__referenceId_0='a' (Size = 4000)
+@__customerId_1='1115c816-6c4c-4016-94df-d8b60a22ffa1'
+
+SELECT [t].[Id], [t0].[Id], [t0].[Image], [t0].[Id0], [t0].[Id00]
+FROM (
+    SELECT TOP(2) [o].[Id]
+    FROM [Orders] AS [o]
+    WHERE ([o].[ExternalReferenceId] = @__referenceId_0) AND ([o].[CustomerId] = @__customerId_1)
+) AS [t]
+OUTER APPLY (
+    SELECT [i].[Id], [t1].[Image], [t1].[Id] AS [Id0], [t1].[Id0] AS [Id00]
+    FROM [IdentityDocument] AS [i]
+    OUTER APPLY (
+        SELECT [i1].[Image], [i0].[Id], [i1].[Id] AS [Id0]
+        FROM [IdentityDocument] AS [i0]
+        INNER JOIN [IdentityDocumentImage] AS [i1] ON [i0].[Id] = [i1].[IdentityDocumentId]
+        WHERE [t].[Id] = [i0].[OrderId]
+    ) AS [t1]
+    WHERE [t].[Id] = [i].[OrderId]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Id], [t0].[Id0], [t0].[Id00]");
+        }
+
+        private class Order
+        {
+            private ICollection<IdentityDocument> _identityDocuments;
+
+            public Guid Id { get; set; }
+
+            public Guid CustomerId { get; set; }
+
+            public string ExternalReferenceId { get; set; }
+
+            public ICollection<IdentityDocument> IdentityDocuments
+            {
+                get => _identityDocuments = _identityDocuments ?? new Collection<IdentityDocument>();
+                set => _identityDocuments = value;
+            }
+        }
+
+        private class IdentityDocument
+        {
+            private ICollection<IdentityDocumentImage> _images;
+
+            public Guid Id { get; set; }
+
+            [ForeignKey(nameof(Order))]
+            public Guid OrderId { get; set; }
+
+            public Order Order { get; set; }
+
+            public ICollection<IdentityDocumentImage> Images
+            {
+                get => _images = _images ?? new Collection<IdentityDocumentImage>();
+                set => _images = value;
+            }
+        }
+
+        private class IdentityDocumentImage
+        {
+            public Guid Id { get; set; }
+
+            [ForeignKey(nameof(IdentityDocument))]
+            public Guid IdentityDocumentId { get; set; }
+
+            public byte[] Image { get; set; }
+
+            public IdentityDocument IdentityDocument { get; set; }
+        }
+
+        private class MyContext20813 : DbContext
+        {
+            public MyContext20813(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Order> Orders { get; set; }
+        }
+
+        #endregion
+
+        #region Issue18738
+
+        [ConditionalFact]
+        public virtual async Task Set_operation_in_pending_collection()
+        {
+            var contextFactory = await InitializeAsync<MyContext18738>();
+
+            using var context = contextFactory.CreateContext();
+            var resultCollection = context.StudentGameMapper
+                .OrderBy(s => s.Id)
+                .Select(s => new StudentGameResult
+                {
+                    SportsList = (
+                             from inDoorSports in context.InDoorSports
+                             where inDoorSports.Id == s.InCategoryId
+                             select inDoorSports.Name)
+                         .Union(
+                             from outDoorSports in context.OutDoorSports
+                             where outDoorSports.Id == s.OutCategoryId
+                             select outDoorSports.Name)
+                         .ToList()
+                })
+                .Take(5)  // Without this line the query works
+                .ToList();
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"@__p_0='5'
+
+SELECT [t].[Id], [t0].[Name]
+FROM (
+    SELECT TOP(@__p_0) [s].[Id], [s].[InCategoryId], [s].[OutCategoryId]
+    FROM [StudentGameMapper] AS [s]
+    ORDER BY [s].[Id]
+) AS [t]
+OUTER APPLY (
+    SELECT [i].[Name]
+    FROM [InDoorSports] AS [i]
+    WHERE [i].[Id] = [t].[InCategoryId]
+    UNION
+    SELECT [o].[Name]
+    FROM [OutDoorSports] AS [o]
+    WHERE [o].[Id] = [t].[OutCategoryId]
+) AS [t0]
+ORDER BY [t].[Id], [t0].[Name]");
+        }
+
+        private class StudentGameMapper
+        {
+            public int Id { get; set; }
+            public int InCategoryId { get; set; }
+            public int OutCategoryId { get; set; }
+        }
+
+        private class InDoorSports
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class OutDoorSports
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class StudentGameResult
+        {
+            public int GroupId { get; set; }
+            public int StudentId { get; set; }
+            public List<string> SportsList { get; set; }
+        }
+
+        private class MyContext18738 : DbContext
+        {
+            public MyContext18738(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<StudentGameMapper> StudentGameMapper { get; set; }
+            public DbSet<InDoorSports> InDoorSports { get; set; }
+            public DbSet<OutDoorSports> OutDoorSports { get; set; }
+        }
+
+        #endregion
+
+        #region Issue24216
+
+        [ConditionalFact]
+        public virtual async Task Subquery_take_SelectMany_with_TVF()
+        {
+            var contextFactory = await InitializeAsync<MyContext24216>();
+
+            using var context = contextFactory.CreateContext();
+
+            context.Database.ExecuteSqlRaw(
+                @"create function [dbo].[GetPersonStatusAsOf] (@personId bigint, @timestamp datetime2)
+                    returns @personStatus table
+                                    (
+                                        Id bigint not null,
+                                        PersonId bigint not null,
+                                        GenderId bigint not null,
+                                        StatusMessage nvarchar(max)
+                                    )
+                                    as
+                                    begin
+                                        insert into @personStatus
+                                        select [m].[Id], [m].[PersonId], [m].[PersonId], null
+                                        from [Message] as [m]
+                                        where [m].[PersonId] = @personId and [m].[TimeStamp] = @timestamp
+                                        return
+                                    end");
+
+            ClearLog();
+
+            var q = from m in context.Message
+                    orderby m.Id
+                    select m;
+
+            var q2 =
+                from m in q.Take(10)
+                from asof in context.GetPersonStatusAsOf(m.PersonId, m.Timestamp)
+                select new
+                {
+                    Gender = (from g in context.Gender where g.Id == asof.GenderId select g.Description).Single()
+                };
+
+            q2.ToList();
+
+            // Verify the valid generated SQL
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT (
+    SELECT TOP(1) [g0].[Description]
+    FROM [Gender] AS [g0]
+    WHERE [g0].[Id] = [g].[GenderId]) AS [Gender]
+FROM (
+    SELECT TOP(@__p_0) [m].[Id], [m].[PersonId], [m].[Timestamp]
+    FROM [Message] AS [m]
+    ORDER BY [m].[Id]
+) AS [t]
+CROSS APPLY [dbo].[GetPersonStatusAsOf]([t].[PersonId], [t].[Timestamp]) AS [g]
+ORDER BY [t].[Id]");
+        }
+
+        private class Gender
+        {
+            public long Id { get; set; }
+
+            public string Description { get; set; }
+        }
+
+        private class Message
+        {
+            public long Id { get; set; }
+
+            public long PersonId { get; set; }
+
+            public DateTime Timestamp { get; set; }
+        }
+
+        private class PersonStatus
+        {
+            public long Id { get; set; }
+
+            public long PersonId { get; set; }
+
+            public long GenderId { get; set; }
+
+            public string StatusMessage { get; set; }
+        }
+
+        private class MyContext24216 : DbContext
+        {
+            public MyContext24216(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Gender> Gender { get; set; }
+
+            public DbSet<Message> Message { get; set; }
+
+            public IQueryable<PersonStatus> GetPersonStatusAsOf(long personId, DateTime asOf)
+                => FromExpression(() => GetPersonStatusAsOf(personId, asOf));
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.HasDbFunction(typeof(MyContext24216).GetMethod(nameof(GetPersonStatusAsOf),
+                    new[] { typeof(long), typeof(DateTime) }));
             }
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -94,5 +94,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Complex_query_with_let_collection_projection_FirstOrDefault(async))).Message);
+
+        public override async Task Take_Select_collection_Take(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Take_Select_collection_Take(async))).Message);
+
+        public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_Take_Select_collection_Skip_Take(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsSharedTypeQuerySqliteTest.cs
@@ -84,5 +84,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Filtered_include_same_filter_set_on_same_navigation_twice_followed_by_ThenIncludes_split(async))).Message);
+
+        public override async Task Take_Select_collection_Take(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Take_Select_collection_Take(async))).Message);
+
+        public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Skip_Take_Select_collection_Skip_Take(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -241,6 +241,24 @@ FROM ""Orders"" AS ""o""");
             return base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async);
         }
 
+        public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Collection_projection_selecting_outer_element_followed_by_take(async))).Message);
+
+        public override async Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async))).Message);
+
+        public override async Task Take_on_correlated_collection_in_first(bool async)
+            => Assert.Equal(
+                SqliteStrings.ApplyNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => base.Take_on_correlated_collection_in_first(async))).Message);
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }


### PR DESCRIPTION
- Don't apply Include on entities with Include already applied
- Update table references when pushing down select into left for set operation
- Update identifiers after applying set operation if the projection removed exiting identifiers
- Update SQL references in pending collection during push down

Fix for the repro in #17337
Resolves #18738
Resolves #19763
Resolves #19947
Resolves #20813
Resolves #21026
Resolves #22222
Resolves #23676
Resolves #23720
Resolves #24216