### PR TITLE
Fix to #23302 - Query: IQueryable in subquery sometimes triggers validation which prevents IQueryables in the final projection

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsQueryRelationalTestBase.cs
@@ -545,6 +545,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
+        public override async Task Join_with_result_selector_returning_queryable_throws_validation_error(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                base.Join_with_result_selector_returning_queryable_throws_validation_error(async))).Message;
+
+            Assert.Equal(CoreStrings.QueryInvalidMaterializationType(@"(l1, l2) => DbSet<Level3>()
+    .Where(x => x.Id < 5)", typeof(IQueryable<Level3>).DisplayName(false)), message);
+        }
+
+
         public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
         {
             return AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));

--- a/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedQueryTypeRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsSharedQueryTypeRelationalTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -510,6 +511,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override Task Complex_query_with_optional_navigations_and_client_side_evaluation(bool async)
         {
             return AssertTranslationFailed(() => base.Complex_query_with_optional_navigations_and_client_side_evaluation(async));
+        }
+
+        public override async Task Join_with_result_selector_returning_queryable_throws_validation_error(bool async)
+        {
+            var message = (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                base.Join_with_result_selector_returning_queryable_throws_validation_error(async))).Message;
+
+            Assert.Equal(CoreStrings.QueryInvalidMaterializationType(@"(l1, l2) => DbSet<Level1>()
+    .Select(t => t.OneToOne_Required_PK1)
+    .Where(t => t != null)
+    .Select(t => t.OneToOne_Required_PK2)
+    .Where(t => t != null)
+    .Where(x => x.Id < 5)", typeof(IQueryable<Level3>).DisplayName(false)), message);
         }
 
         protected virtual bool CanExecuteQueryString

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -5877,7 +5878,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => (e.Foo, e.Bar, e.Baz));
         }
 
-        [ConditionalTheory(Skip = "issue #23302")]
+        [ConditionalTheory(Skip = "issue #23303")]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Queryable_in_subquery_works_when_final_projection_is_List(bool async)
         {
@@ -5932,6 +5933,68 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select inner,
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Complex_query_with_let_collection_SelectMany(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from l1 in ss.Set<Level1>()
+                      where l1.Name.StartsWith("L1 0")
+                      let inner = from i in ss.Set<Level1>()
+                                  where i.Id == l1.Id && i.Id > 5
+                                  select i
+                      from die in inner.DefaultIfEmpty()
+                      select die ?? l1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task SelectMany_without_collection_selector_returning_queryable(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().SelectMany(x => ss.Set<Level2>().Where(l2 => l2.Id < 10)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_projecting_queryable_followed_by_SelectMany(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Select(x => ss.Set<Level2>().Where(l2 => l2.Id < 10)).SelectMany(x => x));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Join_with_result_selector_returning_queryable_throws_validation_error(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from l1 in ss.Set<Level1>()
+                      join l2 in ss.Set<Level2>() on l1.Id equals l2.Level1_Optional_Id
+                      select ss.Set<Level3>().Where(x => x.Id < 5));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_projecting_queryable_followed_by_Join(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Select(x => ss.Set<Level2>().Where(l2 => l2.Id < 10)).Join(ss.Set<Level3>(), o => 7, i => i.Id, (o, i) => i));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_projecting_queryable_in_anonymous_projection_followed_by_Join(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Level1>().Select(x => new { Subquery = ss.Set<Level2>().Where(l2 => l2.Id < 10) }).Join(ss.Set<Level3>(), o => 7, i => i.Id, (o, i) => i));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -6151,6 +6151,69 @@ OUTER APPLY (
 ORDER BY [l].[Id], [t0].[Id], [t1].[Id]");
         }
 
+        public override async Task Complex_query_with_let_collection_SelectMany(bool async)
+        {
+            await base.Complex_query_with_let_collection_SelectMany(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[Date], [t].[Name], [t].[OneToMany_Optional_Self_Inverse1Id], [t].[OneToMany_Required_Self_Inverse1Id], [t].[OneToOne_Optional_Self1Id], [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_Inverse1Id], [l].[OneToMany_Required_Self_Inverse1Id], [l].[OneToOne_Optional_Self1Id]
+FROM [LevelOne] AS [l]
+LEFT JOIN (
+    SELECT [l0].[Id], [l0].[Date], [l0].[Name], [l0].[OneToMany_Optional_Self_Inverse1Id], [l0].[OneToMany_Required_Self_Inverse1Id], [l0].[OneToOne_Optional_Self1Id]
+    FROM [LevelOne] AS [l0]
+    WHERE [l0].[Id] > 5
+) AS [t] ON [l].[Id] = [t].[Id]
+WHERE [l].[Name] IS NOT NULL AND ([l].[Name] LIKE N'L1 0%')");
+        }
+
+        public override async Task SelectMany_without_collection_selector_returning_queryable(bool async)
+        {
+            await base.SelectMany_without_collection_selector_returning_queryable(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+CROSS JOIN (
+    SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+    FROM [LevelTwo] AS [l0]
+    WHERE [l0].[Id] < 10
+) AS [t]");
+        }
+
+        public override async Task Select_projecting_queryable_followed_by_SelectMany(bool async)
+        {
+            await base.Select_projecting_queryable_followed_by_SelectMany(async);
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Name], [t].[OneToMany_Optional_Inverse2Id], [t].[OneToMany_Optional_Self_Inverse2Id], [t].[OneToMany_Required_Inverse2Id], [t].[OneToMany_Required_Self_Inverse2Id], [t].[OneToOne_Optional_PK_Inverse2Id], [t].[OneToOne_Optional_Self2Id]
+FROM [LevelOne] AS [l]
+CROSS JOIN (
+    SELECT [l0].[Id], [l0].[Date], [l0].[Level1_Optional_Id], [l0].[Level1_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse2Id], [l0].[OneToMany_Optional_Self_Inverse2Id], [l0].[OneToMany_Required_Inverse2Id], [l0].[OneToMany_Required_Self_Inverse2Id], [l0].[OneToOne_Optional_PK_Inverse2Id], [l0].[OneToOne_Optional_Self2Id]
+    FROM [LevelTwo] AS [l0]
+    WHERE [l0].[Id] < 10
+) AS [t]");
+        }
+
+        public override async Task Select_projecting_queryable_followed_by_Join(bool async)
+        {
+            await base.Select_projecting_queryable_followed_by_Join(async);
+
+            AssertSql(
+                @"SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
+FROM [LevelOne] AS [l]
+INNER JOIN [LevelThree] AS [l0] ON 7 = [l0].[Id]");
+        }
+
+        public override async Task Select_projecting_queryable_in_anonymous_projection_followed_by_Join(bool async)
+        {
+            await base.Select_projecting_queryable_in_anonymous_projection_followed_by_Join(async);
+
+            AssertSql(
+                @"SELECT [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_Inverse3Id], [l0].[OneToMany_Optional_Self_Inverse3Id], [l0].[OneToMany_Required_Inverse3Id], [l0].[OneToMany_Required_Self_Inverse3Id], [l0].[OneToOne_Optional_PK_Inverse3Id], [l0].[OneToOne_Optional_Self3Id]
+FROM [LevelOne] AS [l]
+INNER JOIN [LevelThree] AS [l0] ON 7 = [l0].[Id]");
+        }
+
         public override async Task Project_shadow_properties(bool async)
         {
             await base.Project_shadow_properties(async);


### PR DESCRIPTION
Problem was that during queryable method normalization we would validate that Select methods contain no queryable results (we expect enumerable instead). However, we only need to do this for top level projections. Also, there are other methods which act as projections - we were not checking those. Fix is to only validate types for top level projections, and also add validation for other methods (SelectMany, Join, GroupJoin). If those methods have correct result selectors, then Selects that come before can contain queryables without issue.

Fixes #23302