### PR TITLE
Microsfot.Data.Sqlite: Multi-target .NET Standard 2.1

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -15,7 +15,7 @@ Microsoft.Data.Sqlite.SqliteException
 Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <MinClientVersion>3.6</MinClientVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.Data.Sqlite.Core.ruleset</CodeAnalysisRuleSet>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
@@ -167,6 +167,28 @@ namespace Microsoft.Data.Sqlite
                 throw new ArgumentException(Resources.InvalidOffsetAndCount);
             }
 
+            return Read(buffer.AsSpan(offset, count));
+        }
+
+        /// <summary>
+        ///     Reads a sequence of bytes from the current stream and advances the position within the stream by the
+        ///     number of bytes read.
+        /// </summary>
+        /// <param name="buffer">
+        ///     A region of memory. When this method returns, the contents of this region are replaced by the bytes read
+        ///     from the current source.
+        /// </param>
+        /// <returns>
+        ///     The total number of bytes read into the buffer. This can be less than the number of bytes allocated in
+        ///     the buffer if that many bytes are not currently available, or zero (0) if the end of the stream has been
+        ///     reached.
+        /// </returns>
+#if NET
+        public override int Read(Span<byte> buffer)
+#else
+        public virtual int Read(Span<byte> buffer)
+#endif
+        {
             if (_blob == null)
             {
                 throw new ObjectDisposedException(objectName: null);
@@ -178,12 +200,13 @@ namespace Microsoft.Data.Sqlite
                 position = Length;
             }
 
+            var count = buffer.Length;
             if (position + count > Length)
             {
                 count = (int)(Length - position);
             }
 
-            var rc = sqlite3_blob_read(_blob, buffer.AsSpan(offset, count), (int)position);
+            var rc = sqlite3_blob_read(_blob, buffer.Slice(0, count), (int)position);
             SqliteException.ThrowExceptionForRC(rc, _db);
             _position += count;
             return count;
@@ -198,11 +221,6 @@ namespace Microsoft.Data.Sqlite
         /// <param name="count">The number of bytes to be written to the current stream.</param>
         public override void Write(byte[] buffer, int offset, int count)
         {
-            if (!CanWrite)
-            {
-                throw new NotSupportedException(Resources.WriteNotSupported);
-            }
-
             if (buffer == null)
             {
                 throw new ArgumentNullException(nameof(buffer));
@@ -229,18 +247,40 @@ namespace Microsoft.Data.Sqlite
                 throw new ObjectDisposedException(objectName: null);
             }
 
+            Write(buffer.AsSpan(offset, count));
+        }
+
+        /// <summary>
+        ///     Writes a sequence of bytes to the current stream and advances the current position within this stream by
+        ///     the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">
+        ///     A region of memory. This method copies the contents of this region to the current stream.
+        /// </param>
+#if NET
+        public override void Write(ReadOnlySpan<byte> buffer)
+#else
+        public virtual void Write(ReadOnlySpan<byte> buffer)
+#endif
+        {
+            if (!CanWrite)
+            {
+                throw new NotSupportedException(Resources.WriteNotSupported);
+            }
+
             var position = _position;
             if (position > Length)
             {
                 position = Length;
             }
 
+            var count = buffer.Length;
             if (position + count > Length)
             {
                 throw new NotSupportedException(Resources.ResizeNotSupported);
             }
 
-            var rc = sqlite3_blob_write(_blob, buffer.AsSpan(offset, count), (int)position);
+            var rc = sqlite3_blob_write(_blob, buffer.Slice(0, count), (int)position);
             SqliteException.ThrowExceptionForRC(rc, _db);
             _position += count;
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Data.Sqlite
         ///     the buffer if that many bytes are not currently available, or zero (0) if the end of the stream has been
         ///     reached.
         /// </returns>
-#if NET
+#if NETSTANDARD2_1 || NET
         public override int Read(Span<byte> buffer)
 #else
         public virtual int Read(Span<byte> buffer)
@@ -257,7 +257,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="buffer">
         ///     A region of memory. This method copies the contents of this region to the current stream.
         /// </param>
-#if NET
+#if NETSTANDARD2_1 || NET
         public override void Write(ReadOnlySpan<byte> buffer)
 #else
         public virtual void Write(ReadOnlySpan<byte> buffer)

--- a/src/Microsoft.Data.Sqlite.Core/Utilities/AllowNullAttribute.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Utilities/AllowNullAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if !NET
+#if NETSTANDARD2_0
 
 namespace System.Diagnostics.CodeAnalysis
 {


### PR DESCRIPTION
This only matters if you're using `SqliteBlob` polymorphically as a `Stream` on older platforms. Everything is functional, you just get the perf/memory characteristics of the API before PR #24503. To illustrate, here's a stack trace:

```
   at Microsoft.Data.Sqlite.SqliteBlob.Write(ReadOnlySpan`1 buffer)
   at Microsoft.Data.Sqlite.SqliteBlob.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.Write(ReadOnlySpan`1 buffer)
```

Platforms where this will matter:

* .NET Core 2.1-3.1
* Mono ~6.4+
* Xamarin.iOS ~12.16+ (< .NET 6)
* Xamarin.Mac ~5.16+ (< .NET 6)
* Xamarin.Android ~10.0+ (< .NET 6)

Multi-targeting .NET Standard 2.1 mitigates most of these, but (IMHO) this probably isn't worth it.