### PR TITLE
Fix order of arguments passed to log messages

### DIFF
--- a/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
+++ b/src/EFCore/Diagnostics/CoreLoggerExtensions.cs
@@ -672,7 +672,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             var definition = CoreResources.LogInvalidIncludePath(diagnostics);
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, navigationChain, navigationName);
+                definition.Log(diagnostics, navigationName, navigationChain);
             }
 
             if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -692,7 +692,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             var d = (EventDefinition<object, object>)definition;
             var p = (InvalidIncludePathEventData)payload;
 
-            return d.GenerateMessage(p.NavigationChain, p.NavigationName);
+            return d.GenerateMessage(p.NavigationName, p.NavigationChain);
         }
 
         /// <summary>
@@ -938,7 +938,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, navigationName, entityType.GetType().ShortDisplayName());
+                definition.Log(diagnostics, entityType.GetType().ShortDisplayName(), navigationName);
             }
 
             if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -958,7 +958,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var d = (EventDefinition<string, string>)definition;
             var p = (LazyLoadingEventData)payload;
-            return d.GenerateMessage(p.NavigationPropertyName, p.Entity.GetType().ShortDisplayName());
+            return d.GenerateMessage(p.Entity.GetType().ShortDisplayName(), p.NavigationPropertyName);
         }
 
         /// <summary>
@@ -978,7 +978,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, navigationName, entityType.GetType().ShortDisplayName());
+                definition.Log(diagnostics, entityType.GetType().ShortDisplayName(), navigationName);
             }
 
             if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -998,7 +998,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var d = (EventDefinition<string, string>)definition;
             var p = (LazyLoadingEventData)payload;
-            return d.GenerateMessage(p.NavigationPropertyName, p.Entity.GetType().ShortDisplayName());
+            return d.GenerateMessage(p.Entity.GetType().ShortDisplayName(), p.NavigationPropertyName);
         }
 
         /// <summary>
@@ -1081,7 +1081,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.DeclaringEntityType.DisplayName(), property.Name);
             }
 
             if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -1099,7 +1099,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var d = (EventDefinition<string, string>)definition;
             var p = (PropertyEventData)payload;
-            return d.GenerateMessage(p.Property.Name, p.Property.DeclaringEntityType.DisplayName());
+            return d.GenerateMessage(p.Property.DeclaringEntityType.DisplayName(), p.Property.Name);
         }
 
         /// <summary>
@@ -1115,7 +1115,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
             if (diagnostics.ShouldLog(definition))
             {
-                definition.Log(diagnostics, property.Name, property.DeclaringEntityType.DisplayName());
+                definition.Log(diagnostics, property.DeclaringEntityType.DisplayName(), property.Name);
             }
 
             if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
@@ -1133,7 +1133,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         {
             var d = (EventDefinition<string, string>)definition;
             var p = (PropertyEventData)payload;
-            return d.GenerateMessage(p.Property.Name, p.Property.DeclaringEntityType.DisplayName());
+            return d.GenerateMessage(p.Property.DeclaringEntityType.DisplayName(), p.Property.Name);
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2985,7 +2985,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.
+        ///     The property '{entityType}.{property}' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.
         /// </summary>
         public static EventDefinition<string, string> LogCollectionWithoutComparer(IDiagnosticsLogger logger)
         {
@@ -3485,7 +3485,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     Unable to find navigation '{1_navigation}' specified in string based include path '{0_navigationChain}'.
+        ///     Unable to find navigation '{navigation}' specified in string based include path '{navigationChain}'.
         /// </summary>
         public static EventDefinition<object, object> LogInvalidIncludePath(IDiagnosticsLogger logger)
         {
@@ -3510,7 +3510,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     An attempt was made to lazy-load navigation '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.
+        ///     An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed.
         /// </summary>
         public static EventDefinition<string, string> LogLazyLoadOnDisposedContext(IDiagnosticsLogger logger)
         {
@@ -3685,7 +3685,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.
+        ///     The navigation '{entityType}.{navigation}' is being lazy-loaded.
         /// </summary>
         public static EventDefinition<string, string> LogNavigationLazyLoading(IDiagnosticsLogger logger)
         {
@@ -4442,7 +4442,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
         }
 
         /// <summary>
-        ///     The property '{1_entityType}.{0_property}' was created in shadow state because there are no eligible CLR members with a matching name.
+        ///     The property '{entityType}.{property}' was created in shadow state because there are no eligible CLR members with a matching name.
         /// </summary>
         public static EventDefinition<string, string> LogShadowPropertyCreated(IDiagnosticsLogger logger)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -705,7 +705,7 @@
     <comment>Debug CoreEventId.CollectionChangeDetected int int string string string</comment>
   </data>
   <data name="LogCollectionWithoutComparer" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.</value>
+    <value>The property '{entityType}.{property}' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.</value>
     <comment>Warning CoreEventId.CollectionWithoutComparer string string</comment>
   </data>
   <data name="LogConflictingForeignKeyAttributesOnNavigationAndProperty" xml:space="preserve">
@@ -785,11 +785,11 @@
     <comment>Debug CoreEventId.IncompatibleMatchingForeignKeyProperties string string string string</comment>
   </data>
   <data name="LogInvalidIncludePath" xml:space="preserve">
-    <value>Unable to find navigation '{1_navigation}' specified in string based include path '{0_navigationChain}'.</value>
+    <value>Unable to find navigation '{navigation}' specified in string based include path '{navigationChain}'.</value>
     <comment>Error CoreEventId.InvalidIncludePathError object object</comment>
   </data>
   <data name="LogLazyLoadOnDisposedContext" xml:space="preserve">
-    <value>An attempt was made to lazy-load navigation '{1_entityType}.{0_navigation}' after the associated DbContext was disposed.</value>
+    <value>An attempt was made to lazy-load navigation '{entityType}.{navigation}' after the associated DbContext was disposed.</value>
     <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning string string</comment>
   </data>
   <data name="LogManyServiceProvidersCreated" xml:space="preserve">
@@ -817,7 +817,7 @@
     <comment>Error CoreEventId.NavigationBaseIncludeIgnored string</comment>
   </data>
   <data name="LogNavigationLazyLoading" xml:space="preserve">
-    <value>The navigation '{1_entityType}.{0_navigation}' is being lazy-loaded.</value>
+    <value>The navigation '{entityType}.{navigation}' is being lazy-loaded.</value>
     <comment>Debug CoreEventId.NavigationLazyLoading string string</comment>
   </data>
   <data name="LogNonDefiningInverseNavigation" xml:space="preserve">
@@ -937,7 +937,7 @@
     <comment>Debug CoreEventId.ServiceProviderDebugInfo string</comment>
   </data>
   <data name="LogShadowPropertyCreated" xml:space="preserve">
-    <value>The property '{1_entityType}.{0_property}' was created in shadow state because there are no eligible CLR members with a matching name.</value>
+    <value>The property '{entityType}.{property}' was created in shadow state because there are no eligible CLR members with a matching name.</value>
     <comment>Debug CoreEventId.ShadowPropertyCreated string string</comment>
   </data>
   <data name="LogSkipCollectionChangeDetected" xml:space="preserve">

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 CoreStrings.WarningAsErrorTemplate(
                     CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                     CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<InMemoryLoggingDefinitions>())
-                        .GenerateMessage("Nav", "WarningAsErrorEntity"),
+                        .GenerateMessage("WarningAsErrorEntity", "Nav"),
                     "CoreEventId.LazyLoadOnDisposedContextWarning"),
                 Assert.Throws<InvalidOperationException>(
                     () => entity.Nav).Message);
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l => l.Message
                     == CoreResources
                         .LogLazyLoadOnDisposedContext(new TestLogger<InMemoryLoggingDefinitions>())
-                        .GenerateMessage("Nav", "WarningAsErrorEntity"));
+                        .GenerateMessage("WarningAsErrorEntity", "Nav"));
 
             Assert.Equal(LogLevel.Warning, log.Level);
         }
@@ -182,7 +182,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l => l.Message
                     == CoreResources
                         .LogLazyLoadOnDisposedContext(new TestLogger<InMemoryLoggingDefinitions>())
-                        .GenerateMessage("Nav", "WarningAsErrorEntity"));
+                        .GenerateMessage("WarningAsErrorEntity", "Nav"));
 
             Assert.Equal(LogLevel.Debug, log.Level);
         }
@@ -213,14 +213,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.Contains(
                     CoreResources.LogNavigationLazyLoading(new TestLogger<InMemoryLoggingDefinitions>())
-                        .GenerateMessage("Nav", "WarningAsErrorEntity"),
+                        .GenerateMessage("WarningAsErrorEntity", "Nav"),
                     loggerFactory.Log.Select(l => l.Message));
 
                 loggerFactory.Clear();
                 Assert.NotNull(entity.Nav);
                 Assert.DoesNotContain(
                     CoreResources.LogNavigationLazyLoading(new TestLogger<InMemoryLoggingDefinitions>())
-                        .GenerateMessage("Nav", "WarningAsErrorEntity"),
+                        .GenerateMessage("WarningAsErrorEntity", "Nav"),
                     loggerFactory.Log.Select(l => l.Message));
             }
         }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore
                 CoreStrings.WarningAsErrorTemplate(
                     CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                     CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>())
-                        .GenerateMessage("Texts", "PhoneProxy"),
+                        .GenerateMessage("PhoneProxy", "Texts"),
                     "CoreEventId.LazyLoadOnDisposedContextWarning"),
                 Assert.Throws<InvalidOperationException>(
                     () => phone.Texts).Message);

--- a/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -272,7 +272,7 @@ namespace Microsoft.EntityFrameworkCore
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                             CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>())
-                                .GenerateMessage("Children", "MotherProxy"),
+                                .GenerateMessage("MotherProxy", "Children"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Children).Message);
@@ -347,7 +347,7 @@ namespace Microsoft.EntityFrameworkCore
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                             CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>())
-                                .GenerateMessage("Parent", "ChildProxy"),
+                                .GenerateMessage("ChildProxy", "Parent"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => child.Parent).Message);
@@ -424,7 +424,7 @@ namespace Microsoft.EntityFrameworkCore
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                             CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>())
-                                .GenerateMessage("Parent", "SingleProxy"),
+                                .GenerateMessage("SingleProxy", "Parent"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => single.Parent).Message);
@@ -501,7 +501,7 @@ namespace Microsoft.EntityFrameworkCore
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
                             CoreResources.LogLazyLoadOnDisposedContext(new TestLogger<TestLoggingDefinitions>())
-                                .GenerateMessage("Single", "MotherProxy"),
+                                .GenerateMessage("MotherProxy", "Single"),
                             "CoreEventId.LazyLoadOnDisposedContextWarning"),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Single).Message);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3649,7 +3649,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Assert.Contains(
                 CoreResources.LogInvalidIncludePath(new TestLogger<TestLoggingDefinitions>())
-                    .GenerateMessage("Reports.Foo", "Foo"), message);
+                    .GenerateMessage("Foo", "Reports.Foo"), message);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Assert.Contains(
                 CoreResources.LogInvalidIncludePath(new TestLogger<TestLoggingDefinitions>())
-                    .GenerateMessage("Customer.CustomerID", "CustomerID"),
+                    .GenerateMessage("CustomerID", "Customer.CustomerID"),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             VerifyWarning(
                 CoreResources.LogCollectionWithoutComparer(
-                    new TestLogger<TestLoggingDefinitions>()).GenerateMessage("SomeStrings", "WithCollectionConversion"),
+                    new TestLogger<TestLoggingDefinitions>()).GenerateMessage("WithCollectionConversion", "SomeStrings"),
                 convertedProperty.DeclaringEntityType.Model);
         }
 
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ((IConventionEntityType)entityType).AddKey(keyProperty);
 
             VerifyWarning(
-                CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("Key", "A"), model,
+                CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>()).GenerateMessage("A", "Key"), model,
                 LogLevel.Debug);
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             VerifyWarning(
                 CoreResources.LogShadowPropertyCreated(new TestLogger<TestLoggingDefinitions>())
-                    .GenerateMessage("Key", "A"), (IMutableModel)model, LogLevel.Debug);
+                    .GenerateMessage("A", "Key"), (IMutableModel)model, LogLevel.Debug);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Fixes #24264

The mechanism for changing parameter order does not work for log messages since we pass the string directly to the ASP.NET Log method.
