### PR TITLE
Only null non-overlapping FK properties on delete/fixup, if possible

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -1194,10 +1194,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             InternalEntityEntry? principalEntry,
             IForeignKey foreignKey)
         {
-            var principalProperties = foreignKey.PrincipalKey.Properties;
-            var dependentProperties = foreignKey.Properties;
-            var hasOnlyKeyProperties = true;
-
             var currentPrincipal = dependentEntry.StateManager.FindPrincipal(dependentEntry, foreignKey);
             if (currentPrincipal != null
                 && currentPrincipal != principalEntry)
@@ -1205,10 +1201,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 return;
             }
 
+            var hasOnlyKeyProperties = true;
+            foreignKey.GetPropertiesWithMinimalOverlap(out var dependentProperties, out var principalProperties);
+            
             if (principalEntry != null
                 && principalEntry.EntityState != EntityState.Detached)
             {
-                for (var i = 0; i < foreignKey.Properties.Count; i++)
+                for (var i = 0; i < dependentProperties.Count; i++)
                 {
                     if (!PrincipalValueEqualsDependentValue(
                         principalProperties[i],
@@ -1225,7 +1224,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
 
-            for (var i = 0; i < foreignKey.Properties.Count; i++)
+            for (var i = 0; i < dependentProperties.Count; i++)
             {
                 if (!dependentProperties[i].IsKey())
                 {

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -158,8 +158,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         if (inverse != null
                             && ReferenceEquals(oldTargetEntry[inverse], entry.Entity)
                             && (entry.EntityType.GetNavigations().All(
-                                    n => n == navigation
-                                        || !ReferenceEquals(oldTargetEntry.Entity, entry[n]))))
+                                n => n == navigation
+                                    || !ReferenceEquals(oldTargetEntry.Entity, entry[n]))))
                         {
                             SetNavigation(oldTargetEntry, inverse, null, fromQuery: false);
                         }
@@ -1202,8 +1202,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             var hasOnlyKeyProperties = true;
-            foreignKey.GetPropertiesWithMinimalOverlap(out var dependentProperties, out var principalProperties);
-            
+            foreignKey.GetPropertiesWithMinimalOverlapIfPossible(out var dependentProperties, out var principalProperties);
+
             if (principalEntry != null
                 && principalEntry.EntityState != EntityState.Detached)
             {

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -178,7 +178,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IModel Model => _model;
+        public virtual IModel Model
+            => _model;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -675,7 +676,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
-        /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
+        /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken" /> is canceled. </exception>
         public virtual Task ResetStateAsync(CancellationToken cancellationToken = default)
         {
             ResetState();
@@ -887,6 +888,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             return ((IEnumerable<object>)navigationValue)
+                // ReSharper disable once RedundantEnumerableCastCall
                 .Select(v => TryGetEntry(v, foreignKey.DeclaringEntityType)).Where(e => e != null).Cast<IUpdateEntry>();
         }
 
@@ -1029,7 +1031,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         }
                         else if (!principalIsDetached)
                         {
-                            fk.GetPropertiesWithMinimalOverlap(out var fkProperties, out _);
+                            fk.GetPropertiesWithMinimalOverlapIfPossible(out var fkProperties, out _);
 
                             foreach (var dependentProperty in fkProperties)
                             {
@@ -1127,9 +1129,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public virtual int SaveChanges(bool acceptAllChangesOnSuccess)
             => Context.Database.AutoTransactionsEnabled
                 ? Dependencies.ExecutionStrategyFactory.Create().Execute(
-                        (StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
-                        (_, t) => SaveChanges(t.StateManager, t.AcceptAllChangesOnSuccess),
-                        null)
+                    (StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
+                    (_, t) => SaveChanges(t.StateManager, t.AcceptAllChangesOnSuccess),
+                    null)
                 : SaveChanges(this, acceptAllChangesOnSuccess);
 
         private static int SaveChanges(StateManager stateManager, bool acceptAllChangesOnSuccess)

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1029,7 +1029,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         }
                         else if (!principalIsDetached)
                         {
-                            foreach (var dependentProperty in fk.Properties)
+                            fk.GetPropertiesWithMinimalOverlap(out var fkProperties, out _);
+
+                            foreach (var dependentProperty in fkProperties)
                             {
                                 dependent.SetProperty(
                                     dependentProperty, null, isMaterialization: false, setModified: true, isCascadeDelete: true);

--- a/src/EFCore/Metadata/IForeignKey.cs
+++ b/src/EFCore/Metadata/IForeignKey.cs
@@ -90,39 +90,54 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IDependentKeyValueFactory<TKey>? GetDependentKeyValueFactory<TKey>();
 
         /// <summary>
-        ///     Finds the list of properties of this foreign key that are not also properties of another foreign key, if possible,
-        ///     otherwise returns all properties.
+        ///     <para>
+        ///         Finds the foreign key properties (and their associated principal key properties) of this foreign key where those
+        ///         properties are not overlapping with any other foreign key, or all properties of the foreign key if there is not
+        ///         a smaller set of non-overlapping properties.
+        ///     </para>
+        ///     <para>
+        ///         This is the full list of key properties for
+        ///         - For non-composite keys
+        ///         - Composite keys with no overlap
+        ///         - Composite keys where all properties overlap
+        ///     </para>
         /// </summary>
-        /// <param name="fkProperties"> The foreign key properties. </param>
-        /// <param name="pkProperties"> The principal key properties. </param>
-        void GetPropertiesWithMinimalOverlap(
-            out IReadOnlyList<IProperty> fkProperties,
-            out IReadOnlyList<IProperty> pkProperties)
+        /// <param name="foreignKeyProperties"> The foreign key properties. </param>
+        /// <param name="principalKeyProperties"> The corresponding principal key properties. </param>
+        void GetPropertiesWithMinimalOverlapIfPossible(
+            out IReadOnlyList<IProperty> foreignKeyProperties,
+            out IReadOnlyList<IProperty> principalKeyProperties)
         {
-            fkProperties = Properties;
-            pkProperties = PrincipalKey.Properties;
+            foreignKeyProperties = Properties;
+            principalKeyProperties = PrincipalKey.Properties;
 
-            var count = fkProperties.Count;
+            var count = foreignKeyProperties.Count;
             if (count == 1)
             {
                 return;
             }
-            
+
             for (var i = 0; i < count; i++)
             {
                 var dependentProperty = Properties[i];
 
                 if (dependentProperty.GetContainingForeignKeys().Count() > 1)
                 {
-                    if (ReferenceEquals(fkProperties, Properties))
+                    if (ReferenceEquals(foreignKeyProperties, Properties))
                     {
-                        fkProperties = Properties.ToList();
-                        pkProperties = PrincipalKey.Properties.ToList();
+                        foreignKeyProperties = Properties.ToList();
+                        principalKeyProperties = PrincipalKey.Properties.ToList();
                     }
-                    
-                    ((List<IProperty>)fkProperties).Remove(dependentProperty);
-                    ((List<IProperty>)pkProperties).Remove(PrincipalKey.Properties[i]);
+
+                    ((List<IProperty>)foreignKeyProperties).Remove(dependentProperty);
+                    ((List<IProperty>)principalKeyProperties).Remove(PrincipalKey.Properties[i]);
                 }
+            }
+
+            if (!foreignKeyProperties.Any())
+            {
+                foreignKeyProperties = Properties;
+                principalKeyProperties = PrincipalKey.Properties;
             }
         }
     }

--- a/src/EFCore/Metadata/IForeignKey.cs
+++ b/src/EFCore/Metadata/IForeignKey.cs
@@ -88,57 +88,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <typeparam name="TKey"> The type of key instances. </typeparam>
         /// <returns> A new factory. </returns>
         IDependentKeyValueFactory<TKey>? GetDependentKeyValueFactory<TKey>();
-
-        /// <summary>
-        ///     <para>
-        ///         Finds the foreign key properties (and their associated principal key properties) of this foreign key where those
-        ///         properties are not overlapping with any other foreign key, or all properties of the foreign key if there is not
-        ///         a smaller set of non-overlapping properties.
-        ///     </para>
-        ///     <para>
-        ///         This is the full list of key properties for
-        ///         - For non-composite keys
-        ///         - Composite keys with no overlap
-        ///         - Composite keys where all properties overlap
-        ///     </para>
-        /// </summary>
-        /// <param name="foreignKeyProperties"> The foreign key properties. </param>
-        /// <param name="principalKeyProperties"> The corresponding principal key properties. </param>
-        void GetPropertiesWithMinimalOverlapIfPossible(
-            out IReadOnlyList<IProperty> foreignKeyProperties,
-            out IReadOnlyList<IProperty> principalKeyProperties)
-        {
-            foreignKeyProperties = Properties;
-            principalKeyProperties = PrincipalKey.Properties;
-
-            var count = foreignKeyProperties.Count;
-            if (count == 1)
-            {
-                return;
-            }
-
-            for (var i = 0; i < count; i++)
-            {
-                var dependentProperty = Properties[i];
-
-                if (dependentProperty.GetContainingForeignKeys().Count() > 1)
-                {
-                    if (ReferenceEquals(foreignKeyProperties, Properties))
-                    {
-                        foreignKeyProperties = Properties.ToList();
-                        principalKeyProperties = PrincipalKey.Properties.ToList();
-                    }
-
-                    ((List<IProperty>)foreignKeyProperties).Remove(dependentProperty);
-                    ((List<IProperty>)principalKeyProperties).Remove(PrincipalKey.Properties[i]);
-                }
-            }
-
-            if (!foreignKeyProperties.Any())
-            {
-                foreignKeyProperties = Properties;
-                principalKeyProperties = PrincipalKey.Properties;
-            }
-        }
     }
 }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
@@ -18,6 +18,197 @@ namespace Microsoft.EntityFrameworkCore
         where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
     {
         [ConditionalFact]
+        public virtual void Avoid_nulling_shared_FK_property_when_deleting()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Same(dependent, parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Equal(dependent.Id, parent.DependantId);
+
+                    context.Remove(dependent);
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    if (Fixture.ForceClientNoAction)
+                    {
+                        Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                        Assert.Equal(EntityState.Unchanged, context.Entry(parent).State);
+                        Assert.Equal(EntityState.Deleted, context.Entry(dependent).State);
+
+                        Assert.Same(root, dependent.Root);
+                        Assert.Same(parent, dependent.Parent);
+                        Assert.Same(root, parent.Root);
+                        Assert.Same(dependent, parent.Dependant);
+
+                        Assert.Equal(root.Id, dependent.RootId);
+                        Assert.Equal(root.Id, parent.RootId);
+                        Assert.Equal(parent.Id, parent.DependantId);
+
+                        Assert.Throws<DbUpdateException>(() => context.SaveChanges());
+                    }
+                    else
+                    {
+                        Assert.Same(root, dependent.Root);
+                        Assert.Same(parent, dependent.Parent);
+                        Assert.Same(root, parent.Root);
+                        Assert.Null(parent.Dependant);
+
+                        Assert.Equal(root.Id, dependent.RootId);
+                        Assert.Equal(root.Id, parent.RootId);
+                        Assert.Null(parent.DependantId);
+
+                        context.SaveChanges();
+
+                        Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                        Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                        Assert.Equal(EntityState.Unchanged, context.Entry(parent).State);
+                        Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+
+                        Assert.Same(root, dependent.Root);
+                        Assert.Same(parent, dependent.Parent);
+                        Assert.Same(root, parent.Root);
+                        Assert.Null(parent.Dependant);
+
+                        Assert.Equal(root.Id, dependent.RootId);
+                        Assert.Equal(root.Id, parent.RootId);
+                        Assert.Null(parent.DependantId);
+                    }
+                },
+                context =>
+                {
+                    if (!Fixture.ForceClientNoAction)
+                    {
+                        var root = context
+                            .Set<SharedFkRoot>()
+                            .Include(e => e.Parents)
+                            .Include(e => e.Dependants)
+                            .Single();
+
+                        Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                        Assert.Empty(root.Dependants);
+                        var parent = root.Parents.Single();
+
+                        Assert.Same(root, parent.Root);
+                        Assert.Null(parent.Dependant);
+
+                        Assert.Equal(root.Id, parent.RootId);
+                        Assert.Null(parent.DependantId);
+                    }
+                });
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Avoid_nulling_shared_FK_property_when_nulling_navigation(bool nullPrincipal)
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Same(dependent, parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Equal(dependent.Id, parent.DependantId);
+
+                    if (nullPrincipal)
+                    {
+                        dependent.Parent = null;
+                    }
+                    else
+                    {
+                        parent.Dependant = null;
+                    }
+
+                    context.ChangeTracker.DetectChanges();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                    Assert.Equal(EntityState.Modified, context.Entry(parent).State);
+                    Assert.Equal(EntityState.Unchanged, context.Entry(dependent).State);
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+
+                    context.SaveChanges();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                },
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                });
+        }
+
+        [ConditionalFact]
         public virtual void Mutating_discriminator_value_throws_by_convention()
         {
             ExecuteWithStrategyInTransaction(

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
@@ -14,6 +14,176 @@ namespace Microsoft.EntityFrameworkCore
         where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
     {
         [ConditionalFact]
+        public virtual void Avoid_nulling_shared_FK_property_when_deleting()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Same(dependent, parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Equal(dependent.Id, parent.DependantId);
+
+                    context.Remove(dependent);
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                    Assert.Equal(EntityState.Modified, context.Entry(parent).State);
+                    Assert.Equal(EntityState.Deleted, context.Entry(dependent).State);
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+
+                    context.SaveChanges();
+
+                    Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                    Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                    Assert.Equal(EntityState.Unchanged, context.Entry(parent).State);
+                    Assert.Equal(EntityState.Detached, context.Entry(dependent).State);
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                },
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(2, context.ChangeTracker.Entries().Count());
+
+                    Assert.Empty(root.Dependants);
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                });
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Avoid_nulling_shared_FK_property_when_nulling_navigation(bool nullPrincipal)
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Same(parent, dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Same(dependent, parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Equal(dependent.Id, parent.DependantId);
+
+                    if (nullPrincipal)
+                    {
+                        dependent.Parent = null;
+                    }
+                    else
+                    {
+                        parent.Dependant = null;
+                    }
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    Assert.Equal(EntityState.Unchanged, context.Entry(root).State);
+                    Assert.Equal(EntityState.Modified, context.Entry(parent).State);
+                    Assert.Equal(EntityState.Unchanged, context.Entry(dependent).State);
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+
+                    context.SaveChanges();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                },
+                context =>
+                {
+                    var root = context
+                        .Set<SharedFkRoot>()
+                        .Include(e => e.Parents)
+                        .Include(e => e.Dependants)
+                        .Single();
+
+                    Assert.Equal(3, context.ChangeTracker.Entries().Count());
+
+                    var dependent = root.Dependants.Single();
+                    var parent = root.Parents.Single();
+
+                    Assert.Same(root, dependent.Root);
+                    Assert.Null(dependent.Parent);
+                    Assert.Same(root, parent.Root);
+                    Assert.Null(parent.Dependant);
+
+                    Assert.Equal(root.Id, dependent.RootId);
+                    Assert.Equal(root.Id, parent.RootId);
+                    Assert.Null(parent.DependantId);
+                });
+        }
+
+        [ConditionalFact]
         public virtual void No_fixup_to_Deleted_entities()
         {
             using var context = CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -603,6 +603,29 @@ namespace Microsoft.EntityFrameworkCore
                     modelBuilder.Entity<Produce>()
                         .HasIndex(e => e.BarCode)
                         .IsUnique();
+
+                    modelBuilder.Entity<SharedFkRoot>(builder =>
+                    {
+                        builder.HasMany(x => x.Dependants).WithOne(x => x.Root)
+                            .HasForeignKey(x => new { x.RootId })
+                            .HasPrincipalKey(x => x.Id)
+                            .OnDelete(DeleteBehavior.Cascade);
+
+                        builder.HasMany(x => x.Parents).WithOne(x => x.Root)
+                            .HasForeignKey(x => new { x.RootId })
+                            .HasPrincipalKey(x => x.Id)
+                            .OnDelete(DeleteBehavior.Cascade);
+                    });
+
+                    modelBuilder.Entity<SharedFkParent>(builder =>
+                    {
+                        builder.HasOne(x => x.Dependant).WithOne(x => x!.Parent).IsRequired(false)
+                            .HasForeignKey<SharedFkParent>(x => new { x.RootId, x.DependantId })
+                            .HasPrincipalKey<SharedFkDependant>(x => new { x.RootId, x.Id })
+                            .OnDelete(DeleteBehavior.ClientSetNull);
+                    });
+
+                    modelBuilder.Entity<SharedFkDependant>();
                 }
             }
         }


### PR DESCRIPTION
Fixes #23883

This is only relevant for overlapping composite foreign keys, where nulling all FK values can also sever other relationships. Since a composite FK is null if any part is null, we avoid nulling the properties that are also shared with another foreign key.
