### PR TITLE
Fixed an issue with the TableValuedFunctionExpression that it does no…

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -309,8 +309,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Append(".");
             }
 
+            var name = tableValuedFunctionExpression.StoreFunction.IsBuiltIn
+                ? tableValuedFunctionExpression.StoreFunction.Name
+                : _sqlGenerationHelper.DelimitIdentifier(tableValuedFunctionExpression.StoreFunction.Name);
             _relationalCommandBuilder
-                .Append(_sqlGenerationHelper.DelimitIdentifier(tableValuedFunctionExpression.StoreFunction.Name))
+                .Append(name)
                 .Append("(");
 
             GenerateList(tableValuedFunctionExpression.Arguments, e => Visit(e));

--- a/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
@@ -94,6 +94,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 IsDefaultFunctionMapping = true
             };
             entityType[RelationalAnnotationNames.FunctionMappings] = new[] { functionMapping };
+            model.FinalizeModel();
+            entityType.AddRuntimeAnnotation(RelationalAnnotationNames.FunctionMappings, new[] { functionMapping });
             return entityType;
         }
 

--- a/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         [Theory]
         [InlineData(true, "SELECT 1\r\nFROM CustomFunction() AS \"c\"")]
         [InlineData(false, "SELECT 1\r\nFROM \"CustomFunction\"() AS \"c\"")]
-        public void VisitTableValuedFunction(bool isBuiltIn, string sql)
+        public void VisitTableValuedFunction_should_take_IsBuiltIn_option_into_account(bool isBuiltIn, string sql)
         {
             var entityType = CreateFunctionMappingEntityType(isBuiltIn);
             var selectExpression = CreateSelectExpression(entityType);

--- a/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -104,9 +103,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public new void CheckComposableSql(string sql)
                 => base.CheckComposableSql(sql);
-
-            public new void VisitTableValuedFunction(TableValuedFunctionExpression tableValuedFunctionExpression)
-                => base.VisitTableValuedFunction(tableValuedFunctionExpression);
 
             public new IRelationalCommandBuilder Sql
                 => base.Sql;

--- a/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Query/Internal/QuerySqlGeneratorTest.cs
@@ -54,7 +54,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             generator.GetCommand(selectExpression);
             var commandText = generator.Sql.Build().CommandText;
 
-            Assert.Equal(sql, commandText);
+            // Transform new lines for Unix platforms.
+            var expected = sql.Replace("\r\n", Environment.NewLine);
+
+            Assert.Equal(expected, commandText);
         }
 
         private DummyQuerySqlGenerator CreateDummyQuerySqlGenerator()


### PR DESCRIPTION
Fixes #24569

The TableValuedFunctionExpression does not take the IsBuiltIn option into account. This results in brackets being added to build in database functions.