### PR TITLE
DbContextOptions WithExtensions use TExtension instance type

### DIFF
--- a/src/EFCore/DbContextOptions`.cs
+++ b/src/EFCore/DbContextOptions`.cs
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(extension, nameof(extension));
 
             var extensions = Extensions.ToDictionary(p => p.GetType(), p => p);
-            extensions[typeof(TExtension)] = extension;
+            extensions[extension.GetType()] = extension;
 
             return new DbContextOptions<TContext>(extensions);
         }

--- a/test/EFCore.Tests/DbContextOptionsTest.cs
+++ b/test/EFCore.Tests/DbContextOptionsTest.cs
@@ -106,6 +106,25 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public void Can_update_an_existing_extension_with_base_type()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            var extension1 = new FakeDbContextOptionsExtension1 { Something = "One " };
+
+            IDbContextOptionsExtension extension2 = new FakeDbContextOptionsExtension1 { Something = "Two " };
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension1);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension2);
+
+            Assert.Single(optionsBuilder.Options.Extensions);
+            Assert.DoesNotContain(extension1, optionsBuilder.Options.Extensions);
+            Assert.Contains(extension2, optionsBuilder.Options.Extensions);
+
+            Assert.Same(extension2, optionsBuilder.Options.FindExtension<FakeDbContextOptionsExtension1>());
+        }
+
+        [ConditionalFact]
         public void IsConfigured_returns_true_if_any_provider_extensions_have_been_added()
         {
             var optionsBuilder = new DbContextOptionsBuilder();


### PR DESCRIPTION
This PR fixes #24578 and adds a test case that, without this code changes would fail.

The objective is to be able to call `DbContextOptions.WithExtensions` and it should use the `System.Type` of the provided instance instead of the generic argument.

