### PR TITLE
Unskip `Double_dispose_does_not_enter_pool_twice` Test

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -1041,7 +1041,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Throws<ObjectDisposedException>(() => context.Customers.ToList());
         }
 
-        [ConditionalTheory(Skip = "Issue #24590")]
+        [ConditionalTheory]
         [InlineData(false, false)]
         [InlineData(true, false)]
         [InlineData(false, true)]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/efcore/issues/24590
