### PR TITLE
EFCore.Design.IDesignTimeDbContextFactory

### DIFF
--- a/src/EFCore/Design/IDesignTimeDbContextFactory.cs
+++ b/src/EFCore/Design/IDesignTimeDbContextFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.Design
 {
@@ -19,6 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// </summary>
         /// <param name="args"> Arguments provided by the design-time service. </param>
         /// <returns> An instance of <typeparamref name="TContext" />. </returns>
-        TContext CreateDbContext(string[] args);
+        TContext CreateDbContext([NotNull] string args);
     }
 }

--- a/src/EFCore/Design/IDesignTimeDbContextFactory.cs
+++ b/src/EFCore/Design/IDesignTimeDbContextFactory.cs
@@ -21,5 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="args"> Arguments provided by the design-time service. </param>
         /// <returns> An instance of <typeparamref name="TContext" />. </returns>
         TContext CreateDbContext([NotNull] string args);
+        /// <summary>
+        ///     Creates a new instance of a derived context, where args is an array of connection strings.
+        /// </summary>
+        /// <param name="args"> Arguments provided by the design-time service. </param>
+        /// <returns> An instance of <typeparamref name="TContext" />. </returns>
+        TContext CreateDbContexts([NotNull] string[] args);
     }
 }


### PR DESCRIPTION
Changed parameter type to string for CreateDbContext. Added CreateDbContexts method, which allows for an array of string from appsettings.json, which defines the ConnectionStrings

