### PR TITLE
Relational: Make table reference graph mapping consistent

### DIFF
--- a/src/EFCore.Relational/Query/Internal/SelectExpressionProjectionApplyingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/SelectExpressionProjectionApplyingExpressionVisitor.cs
@@ -42,7 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && shapedQueryExpression.QueryExpression is SelectExpression selectExpression
                 ? shapedQueryExpression.Update(
                     selectExpression,
-                    selectExpression.ApplyProjection(shapedQueryExpression.ShaperExpression, _querySplittingBehavior))
+                    selectExpression.ApplyProjection(
+                        shapedQueryExpression.ShaperExpression, shapedQueryExpression.ResultCardinality,  _querySplittingBehavior))
                 : base.VisitExtension(extensionExpression);
         }
     }

--- a/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryTranslationPostprocessor.cs
@@ -49,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             query = new SelectExpressionProjectionApplyingExpressionVisitor(
                 ((RelationalQueryCompilationContext)QueryCompilationContext).QuerySplittingBehavior).Visit(query);
 #if DEBUG
-            // TODO: 24460 blocks from enabling this
-            //query = new TableAliasVerifyingExpressionVisitor().Visit(query);
+            query = new TableAliasVerifyingExpressionVisitor().Visit(query);
 #endif
             query = new SelectExpressionPruningExpressionVisitor().Visit(query);
             query = new SqlExpressionSimplifyingExpressionVisitor(RelationalDependencies.SqlExpressionFactory, _useRelationalNulls).Visit(query);

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1394,7 +1394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                         var joinPredicate = _sqlTranslator.Translate(Expression.Equal(outerKey, innerKey))!;
                         _selectExpression.AddLeftJoin(innerSelectExpression, joinPredicate);
-                        var leftJoinTable = ((LeftJoinExpression)_selectExpression.Tables.Last()).Table;
+                        var leftJoinTable = _selectExpression.Tables.Last();
 
                         innerShaper = new RelationalEntityShaperExpression(
                             targetEntityType,

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -859,9 +859,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
-#pragma warning disable EF1001 // Internal EF Core API usage.
                     result = new IncludeExpression(result, included, navigationBase, kvp.Value.SetLoaded);
-#pragma warning restore EF1001 // Internal EF Core API usage.
                 }
 
                 return result;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -532,22 +532,22 @@ WHERE (2 & [g].[Rank]) = [g].[Rank]");
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE ([g].[Rank] & COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)) = COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)",
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)) = COALESCE((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE (2 & COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)) = COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)) = COALESCE((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)");
         }
 
         public override async Task Where_enum_has_flag_subquery_with_pushdown(bool async)
@@ -558,28 +558,28 @@ WHERE (2 & COALESCE((
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE (([g].[Rank] & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL",
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE ((2 & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL");
         }
 
         public override async Task Where_enum_has_flag_subquery_client_eval(bool async)
@@ -590,15 +590,15 @@ WHERE ((2 & (
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
 WHERE (([g].[Rank] & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL");
         }
 
         public override async Task Where_enum_has_flag_with_non_nullable_parameter(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -696,14 +696,14 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 WHERE ([g].[Rank] & COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)) = COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)",
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)) = COALESCE((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -711,14 +711,14 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 WHERE (2 & COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)) = COALESCE((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]), 0)");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)) = COALESCE((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]), 0)");
         }
 
         public override async Task Where_enum_has_flag_subquery_with_pushdown(bool async)
@@ -732,22 +732,22 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 WHERE (([g].[Rank] & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR ((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL AND (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL)",
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOfBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], CASE
     WHEN [o].[Nickname] IS NOT NULL THEN N'Officer'
@@ -755,22 +755,22 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 WHERE ((2 & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR ((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL AND (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL)");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
         }
 
         public override async Task Where_enum_has_flag_subquery_client_eval(bool async)
@@ -784,22 +784,22 @@ END AS [Discriminator]
 FROM [Gears] AS [g]
 LEFT JOIN [Officers] AS [o] ON ([g].[Nickname] = [o].[Nickname]) AND ([g].[SquadId] = [o].[SquadId])
 WHERE (([g].[Rank] & (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) = (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId])) OR ((
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL AND (
-    SELECT TOP(1) [g1].[Rank]
-    FROM [Gears] AS [g1]
-    LEFT JOIN [Officers] AS [o1] ON ([g1].[Nickname] = [o1].[Nickname]) AND ([g1].[SquadId] = [o1].[SquadId])
-    ORDER BY [g1].[Nickname], [g1].[SquadId]) IS NULL)");
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) = (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId])) OR ((
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL AND (
+    SELECT TOP(1) [g0].[Rank]
+    FROM [Gears] AS [g0]
+    LEFT JOIN [Officers] AS [o0] ON ([g0].[Nickname] = [o0].[Nickname]) AND ([g0].[SquadId] = [o0].[SquadId])
+    ORDER BY [g0].[Nickname], [g0].[SquadId]) IS NULL)");
         }
 
         public override async Task Where_enum_has_flag_with_non_nullable_parameter(bool async)


### PR DESCRIPTION
Also add a visitor to verify that all table references are proper
Update alias unique-fier to skip already visited expression

Fixes #24473
Fixes #24460
