### PR TITLE
Query: Lift projections from single result query rather than applying…

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -1091,7 +1091,7 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t].[Id1]");
             AssertSql(
                 @"@__p_0='25'
 
-SELECT [t].[Id], [t0].[Id], [t0].[c], [l1].[Id]
+SELECT [t].[Id], [t0].[Id], [l1].[Id], [t0].[c]
 FROM (
     SELECT TOP(@__p_0) [l].[Id]
     FROM [LevelOne] AS [l]
@@ -1142,22 +1142,21 @@ ORDER BY [l].[Id], [l0].[Id], [l1].[Id]");
             await base.Select_subquery_single_nested_subquery(async);
 
             AssertSql(
-                @"SELECT [t1].[Id], [t1].[Id0], [t1].[c]
+                @"SELECT [l].[Id], [t0].[Id], [t1].[Id], [t0].[c]
 FROM [LevelOne] AS [l]
-OUTER APPLY (
-    SELECT [t].[Id], [t0].[Id] AS [Id0], [t].[c]
+LEFT JOIN (
+    SELECT [t].[c], [t].[Id], [t].[OneToMany_Optional_Inverse2Id]
     FROM (
-        SELECT TOP(1) 1 AS [c], [l0].[Id]
+        SELECT 1 AS [c], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE [l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]
-        ORDER BY [l0].[Id]
     ) AS [t]
-    LEFT JOIN (
-        SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id]
-        FROM [LevelThree] AS [l1]
-    ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
-) AS [t1]
-ORDER BY [l].[Id]");
+    WHERE [t].[row] <= 1
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
+LEFT JOIN (
+    SELECT [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id]
+    FROM [LevelThree] AS [l1]
+) AS [t1] ON [t0].[Id] = [t1].[OneToMany_Optional_Inverse3Id]
+ORDER BY [l].[Id], [t0].[Id], [t1].[Id]");
         }
 
         public override async Task Select_subquery_single_nested_subquery2(bool async)
@@ -1165,26 +1164,25 @@ ORDER BY [l].[Id]");
             await base.Select_subquery_single_nested_subquery2(async);
 
             AssertSql(
-                @"SELECT [l].[Id], [t2].[Id], [t2].[Id0], [t2].[c], [t2].[Id1]
+                @"SELECT [l].[Id], [t2].[Id], [t2].[Id0], [t2].[Id1], [t2].[c]
 FROM [LevelOne] AS [l]
 LEFT JOIN (
-    SELECT [t1].[Id], [t1].[Id0], [t1].[c], [l0].[Id] AS [Id1], [l0].[OneToMany_Optional_Inverse2Id]
+    SELECT [l0].[Id], [t0].[Id] AS [Id0], [t1].[Id] AS [Id1], [t0].[c], [l0].[OneToMany_Optional_Inverse2Id]
     FROM [LevelTwo] AS [l0]
-    OUTER APPLY (
-        SELECT [t].[Id], [t0].[Id] AS [Id0], [t].[c]
+    LEFT JOIN (
+        SELECT [t].[c], [t].[Id], [t].[OneToMany_Optional_Inverse3Id]
         FROM (
-            SELECT TOP(1) 1 AS [c], [l1].[Id]
+            SELECT 1 AS [c], [l1].[Id], [l1].[OneToMany_Optional_Inverse3Id], ROW_NUMBER() OVER(PARTITION BY [l1].[OneToMany_Optional_Inverse3Id] ORDER BY [l1].[Id]) AS [row]
             FROM [LevelThree] AS [l1]
-            WHERE [l0].[Id] = [l1].[OneToMany_Optional_Inverse3Id]
-            ORDER BY [l1].[Id]
         ) AS [t]
-        LEFT JOIN (
-            SELECT [l2].[Id], [l2].[OneToMany_Optional_Inverse4Id]
-            FROM [LevelFour] AS [l2]
-        ) AS [t0] ON [t].[Id] = [t0].[OneToMany_Optional_Inverse4Id]
-    ) AS [t1]
+        WHERE [t].[row] <= 1
+    ) AS [t0] ON [l0].[Id] = [t0].[OneToMany_Optional_Inverse3Id]
+    LEFT JOIN (
+        SELECT [l2].[Id], [l2].[OneToMany_Optional_Inverse4Id]
+        FROM [LevelFour] AS [l2]
+    ) AS [t1] ON [t0].[Id] = [t1].[OneToMany_Optional_Inverse4Id]
 ) AS [t2] ON [l].[Id] = [t2].[OneToMany_Optional_Inverse2Id]
-ORDER BY [l].[Id], [t2].[Id1], [t2].[Id], [t2].[Id0]");
+ORDER BY [l].[Id], [t2].[Id], [t2].[Id0], [t2].[Id1]");
         }
 
         public override async Task Filtered_include_basic_Where(bool async)
@@ -1710,25 +1708,26 @@ ORDER BY [l].[Id], [t].[Id], [t].[Id0], [t0].[Id], [t0].[Id0]");
             await base.Complex_query_with_let_collection_projection_FirstOrDefault(async);
 
             AssertSql(
-                @"SELECT [t1].[Id], [t1].[Name], [t1].[Id0], [t1].[c]
+                @"SELECT [l].[Id], [t0].[Id], [t1].[Name], [t1].[Id], [t0].[c]
 FROM [LevelOne] AS [l]
-OUTER APPLY (
-    SELECT [t].[Id], [t0].[Name], [t0].[Id] AS [Id0], [t].[c]
+LEFT JOIN (
+    SELECT [t].[c], [t].[Id], [t].[OneToMany_Optional_Inverse2Id]
     FROM (
-        SELECT TOP(1) 1 AS [c], [l0].[Id]
+        SELECT 1 AS [c], [l0].[Id], [l0].[OneToMany_Optional_Inverse2Id], ROW_NUMBER() OVER(PARTITION BY [l0].[OneToMany_Optional_Inverse2Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE ([l].[Id] = [l0].[OneToMany_Optional_Inverse2Id]) AND (([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL)
+        WHERE ([l0].[Name] <> N'Foo') OR [l0].[Name] IS NULL
     ) AS [t]
-    OUTER APPLY (
-        SELECT [l1].[Name], [l1].[Id]
-        FROM [LevelOne] AS [l1]
-        WHERE EXISTS (
-            SELECT 1
-            FROM [LevelTwo] AS [l2]
-            WHERE ([l1].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Id] = [t].[Id]))
-    ) AS [t0]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [l].[Id] = [t0].[OneToMany_Optional_Inverse2Id]
+OUTER APPLY (
+    SELECT [l1].[Name], [l1].[Id]
+    FROM [LevelOne] AS [l1]
+    WHERE EXISTS (
+        SELECT 1
+        FROM [LevelTwo] AS [l2]
+        WHERE ([l1].[Id] = [l2].[OneToMany_Optional_Inverse2Id]) AND ([l2].[Id] = [t0].[Id]))
 ) AS [t1]
-ORDER BY [l].[Id]");
+ORDER BY [l].[Id], [t0].[Id], [t1].[Id]");
         }
 
         public override async Task SelectMany_DefaultIfEmpty_multiple_times_with_joins_projecting_a_collection(bool async)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3108,34 +3108,32 @@ ORDER BY [l].[Id]");
             base.Member_pushdown_chain_3_levels_deep_entity();
 
             AssertSql(
-                @"SELECT [t4].[Id], [t4].[Level3_Optional_Id], [t4].[Level3_Required_Id], [t4].[Name], [t4].[OneToMany_Optional_Inverse4Id], [t4].[OneToMany_Optional_Self_Inverse4Id], [t4].[OneToMany_Required_Inverse4Id], [t4].[OneToMany_Required_Self_Inverse4Id], [t4].[OneToOne_Optional_PK_Inverse4Id], [t4].[OneToOne_Optional_Self4Id], [t4].[c], [t4].[c0]
+                @"SELECT [t0].[c], [t1].[c], [t3].[Id], [t3].[Level3_Optional_Id], [t3].[Level3_Required_Id], [t3].[Name], [t3].[OneToMany_Optional_Inverse4Id], [t3].[OneToMany_Optional_Self_Inverse4Id], [t3].[OneToMany_Required_Inverse4Id], [t3].[OneToMany_Required_Self_Inverse4Id], [t3].[OneToOne_Optional_PK_Inverse4Id], [t3].[OneToOne_Optional_Self4Id]
 FROM [LevelOne] AS [l]
-OUTER APPLY (
-    SELECT [t2].[Id], [t2].[Level3_Optional_Id], [t2].[Level3_Required_Id], [t2].[Name], [t2].[OneToMany_Optional_Inverse4Id], [t2].[OneToMany_Optional_Self_Inverse4Id], [t2].[OneToMany_Required_Inverse4Id], [t2].[OneToMany_Required_Self_Inverse4Id], [t2].[OneToOne_Optional_PK_Inverse4Id], [t2].[OneToOne_Optional_Self4Id], [t2].[c], [t].[c] AS [c0]
+LEFT JOIN (
+    SELECT [t].[c], [t].[Id], [t].[Level1_Optional_Id]
     FROM (
-        SELECT TOP(1) 1 AS [c], [l0].[Id]
+        SELECT 1 AS [c], [l0].[Id], [l0].[Level1_Optional_Id], ROW_NUMBER() OVER(PARTITION BY [l0].[Level1_Optional_Id] ORDER BY [l0].[Id]) AS [row]
         FROM [LevelTwo] AS [l0]
-        WHERE [l0].[Level1_Optional_Id] = [l].[Id]
-        ORDER BY [l0].[Id]
     ) AS [t]
-    OUTER APPLY (
-        SELECT [t1].[Id], [t1].[Level3_Optional_Id], [t1].[Level3_Required_Id], [t1].[Name], [t1].[OneToMany_Optional_Inverse4Id], [t1].[OneToMany_Optional_Self_Inverse4Id], [t1].[OneToMany_Required_Inverse4Id], [t1].[OneToMany_Required_Self_Inverse4Id], [t1].[OneToOne_Optional_PK_Inverse4Id], [t1].[OneToOne_Optional_Self4Id], [t0].[c]
-        FROM (
-            SELECT TOP(1) 1 AS [c], [l1].[Id]
-            FROM [LevelThree] AS [l1]
-            WHERE [l1].[Level2_Required_Id] = [t].[Id]
-            ORDER BY [l1].[Id]
-        ) AS [t0]
-        LEFT JOIN (
-            SELECT [t3].[Id], [t3].[Level3_Optional_Id], [t3].[Level3_Required_Id], [t3].[Name], [t3].[OneToMany_Optional_Inverse4Id], [t3].[OneToMany_Optional_Self_Inverse4Id], [t3].[OneToMany_Required_Inverse4Id], [t3].[OneToMany_Required_Self_Inverse4Id], [t3].[OneToOne_Optional_PK_Inverse4Id], [t3].[OneToOne_Optional_Self4Id]
-            FROM (
-                SELECT [l2].[Id], [l2].[Level3_Optional_Id], [l2].[Level3_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse4Id], [l2].[OneToMany_Optional_Self_Inverse4Id], [l2].[OneToMany_Required_Inverse4Id], [l2].[OneToMany_Required_Self_Inverse4Id], [l2].[OneToOne_Optional_PK_Inverse4Id], [l2].[OneToOne_Optional_Self4Id], ROW_NUMBER() OVER(PARTITION BY [l2].[Level3_Required_Id] ORDER BY [l2].[Id]) AS [row]
-                FROM [LevelFour] AS [l2]
-            ) AS [t3]
-            WHERE [t3].[row] <= 1
-        ) AS [t1] ON [t0].[Id] = [t1].[Level3_Required_Id]
+    WHERE [t].[row] <= 1
+) AS [t0] ON [l].[Id] = [t0].[Level1_Optional_Id]
+LEFT JOIN (
+    SELECT [t2].[c], [t2].[Id], [t2].[Level2_Required_Id]
+    FROM (
+        SELECT 1 AS [c], [l1].[Id], [l1].[Level2_Required_Id], ROW_NUMBER() OVER(PARTITION BY [l1].[Level2_Required_Id] ORDER BY [l1].[Id]) AS [row]
+        FROM [LevelThree] AS [l1]
     ) AS [t2]
-) AS [t4]
+    WHERE [t2].[row] <= 1
+) AS [t1] ON [t0].[Id] = [t1].[Level2_Required_Id]
+LEFT JOIN (
+    SELECT [t4].[Id], [t4].[Level3_Optional_Id], [t4].[Level3_Required_Id], [t4].[Name], [t4].[OneToMany_Optional_Inverse4Id], [t4].[OneToMany_Optional_Self_Inverse4Id], [t4].[OneToMany_Required_Inverse4Id], [t4].[OneToMany_Required_Self_Inverse4Id], [t4].[OneToOne_Optional_PK_Inverse4Id], [t4].[OneToOne_Optional_Self4Id]
+    FROM (
+        SELECT [l2].[Id], [l2].[Level3_Optional_Id], [l2].[Level3_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_Inverse4Id], [l2].[OneToMany_Optional_Self_Inverse4Id], [l2].[OneToMany_Required_Inverse4Id], [l2].[OneToMany_Required_Self_Inverse4Id], [l2].[OneToOne_Optional_PK_Inverse4Id], [l2].[OneToOne_Optional_Self4Id], ROW_NUMBER() OVER(PARTITION BY [l2].[Level3_Required_Id] ORDER BY [l2].[Id]) AS [row]
+        FROM [LevelFour] AS [l2]
+    ) AS [t4]
+    WHERE [t4].[row] <= 1
+) AS [t3] ON [t1].[Id] = [t3].[Level3_Required_Id]
 ORDER BY [l].[Id]");
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqliteTest.cs
@@ -81,17 +81,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Skip_Take_Select_collection_Skip_Take(async))).Message);
-
-        public override async Task Select_subquery_single_nested_subquery(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Select_subquery_single_nested_subquery(async))).Message);
-
-        public override async Task Select_subquery_single_nested_subquery2(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Select_subquery_single_nested_subquery2(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqliteTest.cs
@@ -71,17 +71,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Skip_Take_Select_collection_Skip_Take(async))).Message);
-
-        public override async Task Select_subquery_single_nested_subquery(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Select_subquery_single_nested_subquery(async))).Message);
-
-        public override async Task Select_subquery_single_nested_subquery2(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Select_subquery_single_nested_subquery2(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ComplexNavigationsQuerySqliteTest.cs
@@ -20,11 +20,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Let_let_contains_from_outer_let(async))).Message);
-
-        public override void Member_pushdown_chain_3_levels_deep_entity()
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (Assert.Throws<InvalidOperationException>(
-                    () => base.Member_pushdown_chain_3_levels_deep_entity())).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeNoTrackingQuerySqliteTest.cs
@@ -52,11 +52,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Include_collection_with_last_no_orderby(async))).Message);
-
-        public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Include_in_let_followed_by_FirstOrDefault(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindIncludeQuerySqliteTest.cs
@@ -41,11 +41,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Include_collection_with_outer_apply_with_filter_non_equality(async))).Message);
-
-        public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Include_in_let_followed_by_FirstOrDefault(async))).Message);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindSelectQuerySqliteTest.cs
@@ -259,12 +259,6 @@ FROM ""Orders"" AS ""o""");
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Take_on_correlated_collection_in_first(async))).Message);
 
-        public override async Task Collection_include_over_result_of_single_non_scalar(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Collection_include_over_result_of_single_non_scalar(async))).Message);
-
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindStringIncludeQuerySqliteTest.cs
@@ -46,11 +46,5 @@ namespace Microsoft.EntityFrameworkCore.Query
                 RelationalStrings.LastUsedWithoutOrderBy(nameof(Enumerable.Last)),
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Include_collection_with_last_no_orderby(async))).Message);
-
-        public override async Task Include_in_let_followed_by_FirstOrDefault(bool async)
-            => Assert.Equal(
-                SqliteStrings.ApplyNotSupported,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Include_in_let_followed_by_FirstOrDefault(async))).Message);
     }
 }


### PR DESCRIPTION
… nested

This fixes slight regression which was introduced in #24675
We need to lift projections for single result since if there is a split query on it then we need it joined to top level to get proper parent query to clone
