### PR TITLE
Fix to #24569 - TableValuedFunctionExpression does not take the IsBuiltIn option into account (DbFunctions)

### DIFF
--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -312,8 +312,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Append(".");
             }
 
+            var name = tableValuedFunctionExpression.StoreFunction.IsBuiltIn
+                ? tableValuedFunctionExpression.StoreFunction.Name
+                : _sqlGenerationHelper.DelimitIdentifier(tableValuedFunctionExpression.StoreFunction.Name);
+
             _relationalCommandBuilder
-                .Append(_sqlGenerationHelper.DelimitIdentifier(tableValuedFunctionExpression.StoreFunction.Name))
+                .Append(name)
                 .Append("(");
 
             GenerateList(tableValuedFunctionExpression.Arguments, e => Visit(e));


### PR DESCRIPTION
The TableValuedFunctionExpression does not take the IsBuiltIn option into account. This results in brackets being added to build in database functions.

Fixes #24569