### PR TITLE
Implements events/callbacks for leasing and returning a context to the pool

### DIFF
--- a/src/EFCore.Relational/Metadata/RuntimeRelationalPropertyOverrides.cs
+++ b/src/EFCore.Relational/Metadata/RuntimeRelationalPropertyOverrides.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// Initializes a new instance of the <see cref="RuntimeRelationalPropertyOverrides"/> class.
         /// </summary>
         /// <param name="property"> The property for which the overrides are applied. </param>
-        /// <param name="columnNameOverriden"> Whether the column name is overriden. </param>
+        /// <param name="columnNameOverriden"> Whether the column name is overridden. </param>
         /// <param name="columnName"> The column name. </param>
         public RuntimeRelationalPropertyOverrides(
             RuntimeProperty property,

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.EnlistTransaction" /> but can be overriden
+        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.EnlistTransaction" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         /// <param name="transaction"> The transaction to be used. </param>
@@ -351,7 +351,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.BeginDbTransaction" /> but can be overriden
+        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.BeginDbTransaction" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         /// <param name="isolationLevel"> The isolation level to use for the transaction. </param>
@@ -407,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         /// <summary>
         ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.BeginDbTransactionAsync" /> but can be
-        ///     overriden by providers to make a different call instead.
+        ///     overridden by providers to make a different call instead.
         /// </summary>
         /// <param name="isolationLevel"> The isolation level to use for the transaction. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
@@ -728,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.Open" /> but can be overriden
+        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.Open" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         /// <param name="errorsExpected"> Indicates if the connection errors are expected and should be logged as debug message. </param>
@@ -782,7 +782,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.OpenAsync" /> but can be overriden
+        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.OpenAsync" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         /// <param name="errorsExpected"> Indicates if the connection errors are expected and should be logged as debug message. </param>
@@ -899,7 +899,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.Close" /> but can be overriden
+        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.Close" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         protected virtual void CloseDbConnection()
@@ -975,14 +975,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.CloseAsync" /> but can be overriden
+        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.CloseAsync" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         protected virtual Task CloseDbConnectionAsync()
             => DbConnection.CloseAsync();
 
         /// <summary>
-        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.State" /> but can be overriden
+        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.State" /> but can be overridden
         ///     by providers to make a different call instead.
         /// </summary>
         protected virtual ConnectionState DbConnectionState => DbConnection.State;
@@ -1080,14 +1080,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.Dispose" /> but can be overriden by
+        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.Dispose" /> but can be overridden by
         ///     providers to make a different call instead.
         /// </summary>
         protected virtual void DisposeDbConnection()
             => DbConnection.Dispose();
 
         /// <summary>
-        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.DisposeAsync" /> but can be overriden by
+        ///     Template method that by default calls <see cref="System.Data.Common.DbConnection.DisposeAsync" /> but can be overridden by
         ///     providers to make a different call instead.
         /// </summary>
         protected virtual ValueTask DisposeDbConnectionAsync()

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -717,43 +717,25 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>.
         ///     </para>
         /// </summary>
-        public event Action<DbContext>? LeasedFromPool;
+        public event EventHandler<EventArgs>? LeasedFromPool;
 
         /// <summary>
         ///     Called to fire the <see cref="LeasedFromPool"/> event. Can be overriden in a derived context to intercept this event.
         /// </summary>
         protected virtual void OnLeasedFromPool()
-            => LeasedFromPool?.Invoke(this);
+            => LeasedFromPool?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
-        ///     <para>
-        ///         An event fired when this context instance is leased from the context pool.
-        ///     </para>
-        ///     <para>
-        ///         This event is only fired when 'DbContext' pooling is enabled through use of
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>
-        ///         or
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>.
-        ///     </para>
-        /// </summary>
-        public event Func<DbContext, CancellationToken, Task>? LeasedFromPoolAsync;
-
-        /// <summary>
-        ///     Called to fire the <see cref="OnLeasedFromPoolAsync"/> event. Can be overriden in a derived context to intercept this event.
+        ///     Called to fire the <see cref="LeasedFromPool"/> event. Can be overriden in a derived context to intercept this event.
         /// </summary>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> A task that represents the asynchronous operation. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken" /> is canceled. </exception>
-        protected virtual async Task OnLeasedFromPoolAsync(CancellationToken cancellationToken)
+        protected virtual Task OnLeasedFromPoolAsync(CancellationToken cancellationToken)
         {
-            var handler = LeasedFromPoolAsync;
-            if (handler != null)
-            {
-                foreach (var func in handler.GetInvocationList())
-                {
-                    await ((Func<DbContext, CancellationToken, Task>)func)(this, cancellationToken);
-                }
-            }
+            LeasedFromPool?.Invoke(this, EventArgs.Empty);
+            
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -767,26 +749,13 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>.
         ///     </para>
         /// </summary>
-        public event Action<DbContext>? ReturnedToPool;
+        public event EventHandler<EventArgs>? ReturnedToPool;
 
         /// <summary>
         ///     Called to fire the <see cref="ReturnedToPool"/> event. Can be overriden in a derived context to intercept this event.
         /// </summary>
         protected virtual void OnReturnedToPool()
-            => ReturnedToPool?.Invoke(this);
-
-        /// <summary>
-        ///     <para>
-        ///         An event fired when this context instance is returned to the context pool.
-        ///     </para>
-        ///     <para>
-        ///         This event is only fired when 'DbContext' pooling is enabled through use of
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContextPool{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>
-        ///         or
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddPooledDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},int)"/>.
-        ///     </para>
-        /// </summary>
-        public event Func<DbContext, CancellationToken, Task>? ReturnedToPoolAsync;
+            => ReturnedToPool?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
         ///     Called to fire the <see cref="ReturnedToPool"/> event. Can be overriden in a derived context to intercept this event.
@@ -794,16 +763,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> A task that represents the asynchronous operation. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken" /> is canceled. </exception>
-        protected virtual async Task OnReturnedToPoolAsync(CancellationToken cancellationToken)
+        protected virtual Task OnReturnedToPoolAsync(CancellationToken cancellationToken)
         {
-            var handler = ReturnedToPoolAsync;
-            if (handler != null)
-            {
-                foreach (var func in handler.GetInvocationList())
-                {
-                    await ((Func<DbContext, CancellationToken, Task>)func)(this, cancellationToken);
-                }
-            }
+            ReturnedToPool?.Invoke(this, EventArgs.Empty);
+            
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/EFCore/IDbContextFactory.cs
+++ b/src/EFCore/IDbContextFactory.cs
@@ -1,13 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
     ///     Defines a factory for creating <see cref="DbContext" /> instances.
     /// </summary>
     /// <typeparam name="TContext"> The <see cref="DbContext" /> type to create. </typeparam>
-    public interface IDbContextFactory<out TContext>
+    public interface IDbContextFactory<TContext>
         where TContext : DbContext
     {
         /// <summary>
@@ -20,5 +24,19 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <returns> A new context instance. </returns>
         TContext CreateDbContext();
+
+        /// <summary>
+        ///     <para>
+        ///         Creates a new <see cref="DbContext" /> instance in an async context.
+        ///     </para>
+        ///     <para>
+        ///         The caller is responsible for disposing the context; it will not be disposed by any dependency injection container.
+        ///     </para>
+        /// </summary>
+        /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
+        /// <returns> A task containing the created context that represents the asynchronous operation. </returns>
+        /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken" /> is canceled. </exception>
+        Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateDbContext());
     }
 }

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///     Instances of this class are typically obtained from <see cref="DbContext.Database" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
-    public class DatabaseFacade : IInfrastructure<IServiceProvider>, IDatabaseFacadeDependenciesAccessor
+    public class DatabaseFacade : IInfrastructure<IServiceProvider>, IDatabaseFacadeDependenciesAccessor, IResettableService
     {
         private readonly DbContext _context;
         private IDatabaseFacadeDependencies? _dependencies;
@@ -377,6 +377,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         [EntityFrameworkInternal]
         DbContext IDatabaseFacadeDependenciesAccessor.Context
             => _context;
+
+        /// <inheritdoc />
+        void IResettableService.ResetState()
+        {
+            AutoTransactionsEnabled = true;
+            AutoSavepointsEnabled = true;
+        }
+
+        Task IResettableService.ResetStateAsync(CancellationToken cancellationToken)
+        {
+            ((IResettableService)this).ResetState();
+
+            return Task.CompletedTask;
+        }
 
         #region Hidden System.Object members
 

--- a/src/EFCore/Infrastructure/PooledDbContextFactory.cs
+++ b/src/EFCore/Infrastructure/PooledDbContextFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             return (TContext)lease.Context;
         }
-        
+
         /// <inheritdoc />
         public virtual async Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
         {

--- a/src/EFCore/Infrastructure/PooledDbContextFactory.cs
+++ b/src/EFCore/Infrastructure/PooledDbContextFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -49,6 +51,20 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
         /// <inheritdoc />
         public virtual TContext CreateDbContext()
-            => (TContext)new DbContextLease(_pool, standalone: true).Context;
+        {
+            var lease = new DbContextLease(_pool, standalone: true);
+            lease.Context.SetLease(lease);
+
+            return (TContext)lease.Context;
+        }
+        
+        /// <inheritdoc />
+        public virtual async Task<TContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        {
+            var lease = new DbContextLease(_pool, standalone: true);
+            await lease.Context.SetLeaseAsync(lease, cancellationToken);
+
+            return (TContext)lease.Context;
+        }
     }
 }

--- a/src/EFCore/Internal/DbContextLease.cs
+++ b/src/EFCore/Internal/DbContextLease.cs
@@ -114,7 +114,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public ValueTask ReleaseAsync()
-            => Release(out var pool, out var context) ? pool.ReturnAsync(context) : default;
+            => Release(out var pool, out var context)
+                ? pool.ReturnAsync(context)
+                : default;
 
         private bool Release([NotNullWhen(true)] out IDbContextPool? pool, [NotNullWhen(true)] out IDbContextPoolable? context)
         {

--- a/src/EFCore/Internal/DbContextLease.cs
+++ b/src/EFCore/Internal/DbContextLease.cs
@@ -38,8 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             var context = _contextPool.Rent();
             Context = context;
-
-            context.SetLease(this);
         }
 
         /// <summary>
@@ -70,6 +68,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
             if (_standalone)
             {
                 Release();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public async ValueTask<bool> ContextDisposedAsync()
+        {
+            if (_standalone)
+            {
+                await ReleaseAsync();
 
                 return true;
             }

--- a/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
+++ b/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -11,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class DbContextPoolConfigurationSnapshot
+    public sealed class DbContextPoolConfigurationSnapshot
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,13 +21,16 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public DbContextPoolConfigurationSnapshot(
-            bool? autoDetectChangesEnabled,
-            QueryTrackingBehavior? queryTrackingBehavior,
-            bool? autoTransactionsEnabled,
-            bool? autoSavepointsEnabled,
-            bool? lazyLoadingEnabled,
-            CascadeTiming? cascadeDeleteTiming,
-            CascadeTiming? deleteOrphansTiming)
+            bool autoDetectChangesEnabled,
+            QueryTrackingBehavior queryTrackingBehavior,
+            bool autoTransactionsEnabled,
+            bool autoSavepointsEnabled,
+            bool lazyLoadingEnabled,
+            CascadeTiming cascadeDeleteTiming,
+            CascadeTiming deleteOrphansTiming,
+            EventHandler<SavingChangesEventArgs>? savingChanges,
+            EventHandler<SavedChangesEventArgs>? savedChanges,
+            EventHandler<SaveChangesFailedEventArgs>? saveChangesFailed)
         {
             AutoDetectChangesEnabled = autoDetectChangesEnabled;
             QueryTrackingBehavior = queryTrackingBehavior;
@@ -35,6 +39,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
             LazyLoadingEnabled = lazyLoadingEnabled;
             CascadeDeleteTiming = cascadeDeleteTiming;
             DeleteOrphansTiming = deleteOrphansTiming;
+            SavingChanges = savingChanges;
+            SavedChanges = savedChanges;
+            SaveChangesFailed = saveChangesFailed;
         }
 
         /// <summary>
@@ -43,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool? AutoDetectChangesEnabled { get; }
+        public bool AutoDetectChangesEnabled { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -51,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool? LazyLoadingEnabled { get; }
+        public bool LazyLoadingEnabled { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -59,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual CascadeTiming? CascadeDeleteTiming { get; }
+        public CascadeTiming CascadeDeleteTiming { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -67,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual CascadeTiming? DeleteOrphansTiming { get; }
+        public CascadeTiming DeleteOrphansTiming { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -75,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual QueryTrackingBehavior? QueryTrackingBehavior { get; }
+        public QueryTrackingBehavior QueryTrackingBehavior { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -83,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool? AutoTransactionsEnabled { get; }
+        public bool AutoTransactionsEnabled { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -91,6 +98,30 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool? AutoSavepointsEnabled { get; }
+        public bool AutoSavepointsEnabled { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public EventHandler<SavingChangesEventArgs>? SavingChanges { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public EventHandler<SavedChangesEventArgs>? SavedChanges { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public EventHandler<SaveChangesFailedEventArgs>? SaveChangesFailed { get; }
     }
 }

--- a/src/EFCore/Internal/IDbContextPoolable.cs
+++ b/src/EFCore/Internal/IDbContextPoolable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Internal
@@ -21,6 +23,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         void SetLease(DbContextLease lease);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        Task SetLeaseAsync(DbContextLease lease, CancellationToken cancellationToken);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Internal/ScopedDbContextLease.cs
+++ b/src/EFCore/Internal/ScopedDbContextLease.cs
@@ -24,7 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public ScopedDbContextLease(IDbContextPool<TContext> contextPool)
-            => _lease = new DbContextLease(contextPool, standalone: false);
+        {
+            _lease = new DbContextLease(contextPool, standalone: false);
+            _lease.Context.SetLease(_lease);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -132,6 +132,8 @@ namespace Microsoft.EntityFrameworkCore
 
                 LeasedFromPool += OnLeasedFromPool;
                 ReturnedToPool += OnReturnedToPool;
+                LeasedFromPoolAsync += OnLeasedFromPoolAsync;
+                ReturnedToPoolAsync += OnReturnedToPoolAsync;
             }
 
             public int LeasedCount { get; private set; }
@@ -141,11 +143,33 @@ namespace Microsoft.EntityFrameworkCore
             public bool? AsyncReturn { get; private set; }
             public bool? SyncReturn { get; private set; }
 
-            private void OnLeasedFromPool(object sender, EventArgs e)
-                => LeasedCount++;
+            private void OnLeasedFromPool(object sender)
+            {
+                SyncLease = true;
+                LeasedCount++;
+            }
 
-            private void OnReturnedToPool(object sender, EventArgs e)
-                => ReturnedCount++;
+            private async Task OnLeasedFromPoolAsync(DbContext sender, CancellationToken cancellationToken)
+            {
+                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
+
+                AsyncLease = true;
+                LeasedCount++;
+            }
+
+            private void OnReturnedToPool(object sender)
+            {
+                SyncReturn = true;
+                ReturnedCount++;
+            }
+
+            private async Task OnReturnedToPoolAsync(DbContext sender, CancellationToken cancellationToken)
+            {
+                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
+
+                AsyncReturn = true;
+                ReturnedCount++;
+            }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
@@ -245,6 +269,8 @@ namespace Microsoft.EntityFrameworkCore
             {
                 LeasedFromPool += OnLeasedFromPool;
                 ReturnedToPool += OnReturnedToPool;
+                LeasedFromPoolAsync += OnLeasedFromPoolAsync;
+                ReturnedToPoolAsync += OnReturnedToPoolAsync;
             }
 
             public int LeasedCount { get; private set; }
@@ -254,11 +280,33 @@ namespace Microsoft.EntityFrameworkCore
             public bool? AsyncReturn { get; private set; }
             public bool? SyncReturn { get; private set; }
 
-            private void OnLeasedFromPool(object sender, EventArgs e)
-                => LeasedCount++;
+            private void OnLeasedFromPool(object sender)
+            {
+                SyncLease = true;
+                LeasedCount++;
+            }
 
-            private void OnReturnedToPool(object sender, EventArgs e)
-                => ReturnedCount++;
+            private async Task OnLeasedFromPoolAsync(DbContext sender, CancellationToken cancellationToken)
+            {
+                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
+
+                AsyncLease = true;
+                LeasedCount++;
+            }
+
+            private void OnReturnedToPool(object sender)
+            {
+                SyncReturn = true;
+                ReturnedCount++;
+            }
+
+            private async Task OnReturnedToPoolAsync(DbContext sender, CancellationToken cancellationToken)
+            {
+                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
+
+                AsyncReturn = true;
+                ReturnedCount++;
+            }
         }
 
         private class SecondContextWithOverrides : DbContext, ISecondContext
@@ -731,6 +779,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1!.LeasedCount);
             Assert.Equal(0, context1.ReturnedCount);
             Assert.Equal(0, secondContext1.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Null(context1.SyncReturn);
+            Assert.Null(context1.AsyncReturn);
 
             var serviceScope2 = serviceProvider.CreateScope();
             var scopedProvider2 = serviceScope2.ServiceProvider;
@@ -745,6 +797,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, context1.ReturnedCount);
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Null(context1.SyncReturn);
+            Assert.Null(context1.AsyncReturn);
 
             var secondContext2 = useInterface
                 ? scopedProvider2.GetService<ISecondContext>()
@@ -761,6 +817,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Null(context1.SyncReturn);
+            Assert.Null(context1.AsyncReturn);
 
             await Dispose(serviceScope1, async);
 
@@ -772,6 +832,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope2, async);
 
@@ -783,6 +847,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var serviceScope3 = serviceProvider.CreateScope();
             var scopedProvider3 = serviceScope3.ServiceProvider;
@@ -806,6 +874,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var serviceScope4 = serviceProvider.CreateScope();
             var scopedProvider4 = serviceScope4.ServiceProvider;
@@ -829,6 +901,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope3, async);
 
@@ -840,6 +916,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope4, async);
 
@@ -851,6 +931,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(2, context2.ReturnedCount);
             Assert.Equal(2, secondContext2.ReturnedCount);
+            Assert.True(context1.SyncLease);
+            Assert.Null(context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
         }
 
         [ConditionalTheory]
@@ -879,6 +963,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
+            Assert.Equal(!async ? true : null, context1.SyncLease);
+            Assert.Equal(async ? true : null, context1.AsyncLease);
+            Assert.Null(context1.SyncReturn);
+            Assert.Null(context1.AsyncReturn);
 
             await Dispose(context1, async);
             await Dispose(secondContext1, async);
@@ -893,6 +981,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
+            Assert.Equal(!async ? true : null, context1.SyncLease);
+            Assert.Equal(async ? true : null, context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var context3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
             var secondContext3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
@@ -928,6 +1020,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(2, context2.ReturnedCount);
             Assert.Equal(2, secondContext2.ReturnedCount);
+            Assert.Equal(!async ? true : null, context1.SyncLease);
+            Assert.Equal(async ? true : null, context1.AsyncLease);
+            Assert.Equal(!async ? true : null, context1.SyncReturn);
+            Assert.Equal(async ? true : null, context1.AsyncReturn);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -132,8 +132,6 @@ namespace Microsoft.EntityFrameworkCore
 
                 LeasedFromPool += OnLeasedFromPool;
                 ReturnedToPool += OnReturnedToPool;
-                LeasedFromPoolAsync += OnLeasedFromPoolAsync;
-                ReturnedToPoolAsync += OnReturnedToPoolAsync;
             }
 
             public int LeasedCount { get; private set; }
@@ -143,33 +141,11 @@ namespace Microsoft.EntityFrameworkCore
             public bool? AsyncReturn { get; private set; }
             public bool? SyncReturn { get; private set; }
 
-            private void OnLeasedFromPool(object sender)
-            {
-                SyncLease = true;
-                LeasedCount++;
-            }
+            private void OnLeasedFromPool(object sender, EventArgs e)
+                => LeasedCount++;
 
-            private async Task OnLeasedFromPoolAsync(DbContext sender, CancellationToken cancellationToken)
-            {
-                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
-
-                AsyncLease = true;
-                LeasedCount++;
-            }
-
-            private void OnReturnedToPool(object sender)
-            {
-                SyncReturn = true;
-                ReturnedCount++;
-            }
-
-            private async Task OnReturnedToPoolAsync(DbContext sender, CancellationToken cancellationToken)
-            {
-                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
-
-                AsyncReturn = true;
-                ReturnedCount++;
-            }
+            private void OnReturnedToPool(object sender, EventArgs e)
+                => ReturnedCount++;
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
@@ -269,8 +245,6 @@ namespace Microsoft.EntityFrameworkCore
             {
                 LeasedFromPool += OnLeasedFromPool;
                 ReturnedToPool += OnReturnedToPool;
-                LeasedFromPoolAsync += OnLeasedFromPoolAsync;
-                ReturnedToPoolAsync += OnReturnedToPoolAsync;
             }
 
             public int LeasedCount { get; private set; }
@@ -280,33 +254,11 @@ namespace Microsoft.EntityFrameworkCore
             public bool? AsyncReturn { get; private set; }
             public bool? SyncReturn { get; private set; }
 
-            private void OnLeasedFromPool(object sender)
-            {
-                SyncLease = true;
-                LeasedCount++;
-            }
+            private void OnLeasedFromPool(object sender, EventArgs e)
+                => LeasedCount++;
 
-            private async Task OnLeasedFromPoolAsync(DbContext sender, CancellationToken cancellationToken)
-            {
-                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
-
-                AsyncLease = true;
-                LeasedCount++;
-            }
-
-            private void OnReturnedToPool(object sender)
-            {
-                SyncReturn = true;
-                ReturnedCount++;
-            }
-
-            private async Task OnReturnedToPoolAsync(DbContext sender, CancellationToken cancellationToken)
-            {
-                await sender.Database.CanConnectAsync(cancellationToken); // Just something async
-
-                AsyncReturn = true;
-                ReturnedCount++;
-            }
+            private void OnReturnedToPool(object sender, EventArgs e)
+                => ReturnedCount++;
         }
 
         private class SecondContextWithOverrides : DbContext, ISecondContext
@@ -779,10 +731,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1!.LeasedCount);
             Assert.Equal(0, context1.ReturnedCount);
             Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
 
             var serviceScope2 = serviceProvider.CreateScope();
             var scopedProvider2 = serviceScope2.ServiceProvider;
@@ -797,10 +745,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, context1.ReturnedCount);
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
 
             var secondContext2 = useInterface
                 ? scopedProvider2.GetService<ISecondContext>()
@@ -817,10 +761,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
 
             await Dispose(serviceScope1, async);
 
@@ -832,10 +772,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope2, async);
 
@@ -847,10 +783,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var serviceScope3 = serviceProvider.CreateScope();
             var scopedProvider3 = serviceScope3.ServiceProvider;
@@ -874,10 +806,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var serviceScope4 = serviceProvider.CreateScope();
             var scopedProvider4 = serviceScope4.ServiceProvider;
@@ -901,10 +829,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope3, async);
 
@@ -916,10 +840,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             await Dispose(serviceScope4, async);
 
@@ -931,10 +851,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(2, context2.ReturnedCount);
             Assert.Equal(2, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
         }
 
         [ConditionalTheory]
@@ -963,10 +879,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(0, secondContext1.ReturnedCount);
             Assert.Equal(0, context2.ReturnedCount);
             Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
 
             await Dispose(context1, async);
             await Dispose(secondContext1, async);
@@ -981,10 +893,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, secondContext1.ReturnedCount);
             Assert.Equal(1, context2.ReturnedCount);
             Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
 
             var context3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
             var secondContext3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
@@ -1020,10 +928,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, secondContext1.ReturnedCount);
             Assert.Equal(2, context2.ReturnedCount);
             Assert.Equal(2, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -16,6 +16,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
+// ReSharper disable MethodHasAsyncOverload
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -95,12 +96,6 @@ namespace Microsoft.EntityFrameworkCore
 
         private interface IPooledContext
         {
-            int LeasedCount { get;  }
-            int ReturnedCount { get; }
-            public bool? AsyncLease { get; }
-            public bool? SyncLease { get; }
-            public bool? AsyncReturn { get; }
-            public bool? SyncReturn { get; }
         }
 
         private class DefaultOptionsPooledContext : DbContext
@@ -129,23 +124,7 @@ namespace Microsoft.EntityFrameworkCore
                 Database.AutoSavepointsEnabled = false;
                 ChangeTracker.CascadeDeleteTiming = CascadeTiming.Never;
                 ChangeTracker.DeleteOrphansTiming = CascadeTiming.Never;
-
-                LeasedFromPool += OnLeasedFromPool;
-                ReturnedToPool += OnReturnedToPool;
             }
-
-            public int LeasedCount { get; private set; }
-            public int ReturnedCount { get; private set; }
-            public bool? AsyncLease { get; private set; }
-            public bool? SyncLease { get; private set; }
-            public bool? AsyncReturn { get; private set; }
-            public bool? SyncReturn { get; private set; }
-
-            private void OnLeasedFromPool(object sender, EventArgs e)
-                => LeasedCount++;
-
-            private void OnReturnedToPool(object sender, EventArgs e)
-                => ReturnedCount++;
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
@@ -175,49 +154,10 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            public int LeasedCount { get; private set; }
-            public int ReturnedCount { get; private set; }
-            public bool? AsyncLease { get; private set; }
-            public bool? SyncLease { get; private set; }
-            public bool? AsyncReturn { get; private set; }
-            public bool? SyncReturn { get; private set; }
-
             public DbSet<Customer> Customers { get; set; }
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
                 => modelBuilder.Entity<Customer>().ToTable("Customers");
-
-            protected override void OnLeasedFromPool()
-            {
-                LeasedCount++;
-                SyncLease = true;
-
-                base.OnLeasedFromPool();
-            }
-
-            protected override Task OnLeasedFromPoolAsync(CancellationToken cancellationToken)
-            {
-                LeasedCount++;
-                AsyncLease = true;
-
-                return base.OnLeasedFromPoolAsync(cancellationToken);
-            }
-
-            protected override void OnReturnedToPool()
-            {
-                ReturnedCount++;
-                SyncReturn = true;
-
-                base.OnReturnedToPool();
-            }
-
-            protected override Task OnReturnedToPoolAsync(CancellationToken cancellationToken)
-            {
-                ReturnedCount++;
-                AsyncReturn = true;
-
-                return base.OnReturnedToPoolAsync(cancellationToken);
-            }
         }
 
         public class Customer
@@ -228,12 +168,6 @@ namespace Microsoft.EntityFrameworkCore
 
         private interface ISecondContext
         {
-            int LeasedCount { get;  }
-            int ReturnedCount { get; }
-            public bool? AsyncLease { get; }
-            public bool? SyncLease { get; }
-            public bool? AsyncReturn { get; }
-            public bool? SyncReturn { get; }
         }
 
         private class SecondContext : DbContext, ISecondContext
@@ -243,68 +177,6 @@ namespace Microsoft.EntityFrameworkCore
             public SecondContext(DbContextOptions options)
                 : base(options)
             {
-                LeasedFromPool += OnLeasedFromPool;
-                ReturnedToPool += OnReturnedToPool;
-            }
-
-            public int LeasedCount { get; private set; }
-            public int ReturnedCount { get; private set; }
-            public bool? AsyncLease { get; private set; }
-            public bool? SyncLease { get; private set; }
-            public bool? AsyncReturn { get; private set; }
-            public bool? SyncReturn { get; private set; }
-
-            private void OnLeasedFromPool(object sender, EventArgs e)
-                => LeasedCount++;
-
-            private void OnReturnedToPool(object sender, EventArgs e)
-                => ReturnedCount++;
-        }
-
-        private class SecondContextWithOverrides : DbContext, ISecondContext
-        {
-            public SecondContextWithOverrides(DbContextOptions options)
-                : base(options)
-            {
-            }
-
-            public int LeasedCount { get; private set; }
-            public int ReturnedCount { get; private set; }
-            public bool? AsyncLease { get; private set; }
-            public bool? SyncLease { get; private set; }
-            public bool? AsyncReturn { get; private set; }
-            public bool? SyncReturn { get; private set; }
-
-            protected override void OnLeasedFromPool()
-            {
-                LeasedCount++;
-                SyncLease = true;
-
-                base.OnLeasedFromPool();
-            }
-
-            protected override Task OnLeasedFromPoolAsync(CancellationToken cancellationToken)
-            {
-                LeasedCount++;
-                AsyncLease = true;
-
-                return base.OnLeasedFromPoolAsync(cancellationToken);
-            }
-
-            protected override void OnReturnedToPool()
-            {
-                ReturnedCount++;
-                SyncReturn = true;
-
-                base.OnReturnedToPool();
-            }
-
-            protected override Task OnReturnedToPoolAsync(CancellationToken cancellationToken)
-            {
-                ReturnedCount++;
-                AsyncReturn = true;
-
-                return base.OnReturnedToPoolAsync(cancellationToken);
             }
 
             public class Blog
@@ -720,17 +592,9 @@ namespace Microsoft.EntityFrameworkCore
                 ? scopedProvider1.GetService<IPooledContext>()
                 : scopedProvider1.GetService<PooledContext>();
 
-            Assert.Equal(1, context1!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-
             var secondContext1 = useInterface
                 ? scopedProvider1.GetService<ISecondContext>()
                 : scopedProvider1.GetService<SecondContext>();
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
 
             var serviceScope2 = serviceProvider.CreateScope();
             var scopedProvider2 = serviceScope2.ServiceProvider;
@@ -739,13 +603,6 @@ namespace Microsoft.EntityFrameworkCore
                 ? scopedProvider2.GetService<IPooledContext>()
                 : scopedProvider2.GetService<PooledContext>();
 
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-
             var secondContext2 = useInterface
                 ? scopedProvider2.GetService<ISecondContext>()
                 : scopedProvider2.GetService<SecondContext>();
@@ -753,36 +610,9 @@ namespace Microsoft.EntityFrameworkCore
             Assert.NotSame(context1, context2);
             Assert.NotSame(secondContext1, secondContext2);
 
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-
             await Dispose(serviceScope1, async);
 
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-
             await Dispose(serviceScope2, async);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
 
             var serviceScope3 = serviceProvider.CreateScope();
             var scopedProvider3 = serviceScope3.ServiceProvider;
@@ -798,15 +628,6 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(context1, context3);
             Assert.Same(secondContext1, secondContext3);
 
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-
             var serviceScope4 = serviceProvider.CreateScope();
             var scopedProvider4 = serviceScope4.ServiceProvider;
 
@@ -821,36 +642,9 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(context2, context4);
             Assert.Same(secondContext2, secondContext4);
 
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-
             await Dispose(serviceScope3, async);
 
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-
             await Dispose(serviceScope4, async);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(2, context2.ReturnedCount);
-            Assert.Equal(2, secondContext2.ReturnedCount);
         }
 
         [ConditionalTheory]
@@ -871,28 +665,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.NotSame(context1, context2);
             Assert.NotSame(secondContext1, secondContext2);
 
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-
             await Dispose(context1, async);
             await Dispose(secondContext1, async);
             await Dispose(context2, async);
             await Dispose(secondContext2, async);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
 
             var context3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
             var secondContext3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
@@ -906,318 +682,10 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Same(context2, context4);
             Assert.Same(secondContext2, secondContext4);
 
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-
             await Dispose(context1, async);
             await Dispose(secondContext1, async);
             await Dispose(context2, async);
             await Dispose(secondContext2, async);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(2, context2.ReturnedCount);
-            Assert.Equal(2, secondContext2.ReturnedCount);
-        }
-
-        [ConditionalTheory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public async Task Contexts_are_pooled_with_event_overrides(bool useInterface, bool async)
-        {
-            var serviceProvider = useInterface
-                ? new ServiceCollection()
-                    .AddDbContextPool<IPooledContext, PooledContextWithOverrides>(ob => ConfigureOptions(ob))
-                    .AddDbContextPool<ISecondContext, SecondContextWithOverrides>(ob => ConfigureOptions(ob))
-                    .BuildServiceProvider()
-                : new ServiceCollection()
-                    .AddDbContextPool<PooledContextWithOverrides>(ob => ConfigureOptions(ob))
-                    .AddDbContextPool<SecondContextWithOverrides>(ob => ConfigureOptions(ob))
-                    .BuildServiceProvider();
-
-            var serviceScope1 = serviceProvider.CreateScope();
-            var scopedProvider1 = serviceScope1.ServiceProvider;
-
-            var context1 = useInterface
-                ? scopedProvider1.GetService<IPooledContext>()
-                : scopedProvider1.GetService<PooledContextWithOverrides>();
-
-            Assert.Equal(1, context1!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
-
-            var secondContext1 = useInterface
-                ? scopedProvider1.GetService<ISecondContext>()
-                : scopedProvider1.GetService<SecondContextWithOverrides>();
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
-
-            var serviceScope2 = serviceProvider.CreateScope();
-            var scopedProvider2 = serviceScope2.ServiceProvider;
-
-            var context2 = useInterface
-                ? scopedProvider2.GetService<IPooledContext>()
-                : scopedProvider2.GetService<PooledContextWithOverrides>();
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
-
-            var secondContext2 = useInterface
-                ? scopedProvider2.GetService<ISecondContext>()
-                : scopedProvider2.GetService<SecondContextWithOverrides>();
-
-            Assert.NotSame(context1, context2);
-            Assert.NotSame(secondContext1, secondContext2);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
-
-            await Dispose(serviceScope1, async);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            await Dispose(serviceScope2, async);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            var serviceScope3 = serviceProvider.CreateScope();
-            var scopedProvider3 = serviceScope3.ServiceProvider;
-
-            var context3 = useInterface
-                ? scopedProvider3.GetService<IPooledContext>()
-                : scopedProvider3.GetService<PooledContextWithOverrides>();
-
-            var secondContext3 = useInterface
-                ? scopedProvider3.GetService<ISecondContext>()
-                : scopedProvider3.GetService<SecondContextWithOverrides>();
-
-            Assert.Same(context1, context3);
-            Assert.Same(secondContext1, secondContext3);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            var serviceScope4 = serviceProvider.CreateScope();
-            var scopedProvider4 = serviceScope4.ServiceProvider;
-
-            var context4 = useInterface
-                ? scopedProvider4.GetService<IPooledContext>()
-                : scopedProvider4.GetService<PooledContextWithOverrides>();
-
-            var secondContext4 = useInterface
-                ? scopedProvider4.GetService<ISecondContext>()
-                : scopedProvider4.GetService<SecondContextWithOverrides>();
-
-            Assert.Same(context2, context4);
-            Assert.Same(secondContext2, secondContext4);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            await Dispose(serviceScope3, async);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            await Dispose(serviceScope4, async);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(2, context2.ReturnedCount);
-            Assert.Equal(2, secondContext2.ReturnedCount);
-            Assert.True(context1.SyncLease);
-            Assert.Null(context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-        }
-
-        [ConditionalTheory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public async Task Contexts_are_pooled_with_factory_with_event_overrides(bool async, bool withDependencyInjection)
-        {
-            var factory = BuildFactory<PooledContextWithOverrides>(withDependencyInjection);
-
-            var context1 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-            var secondContext1 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-
-            var context2 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-            var secondContext2 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-
-            Assert.NotSame(context1, context2);
-            Assert.NotSame(secondContext1, secondContext2);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, secondContext1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-            Assert.Equal(0, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Null(context1.SyncReturn);
-            Assert.Null(context1.AsyncReturn);
-
-            await Dispose(context1, async);
-            await Dispose(secondContext1, async);
-            await Dispose(context2, async);
-            await Dispose(secondContext2, async);
-
-            Assert.Equal(1, context1.LeasedCount);
-            Assert.Equal(1, secondContext1.LeasedCount);
-            Assert.Equal(1, context2.LeasedCount);
-            Assert.Equal(1, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            var context3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-            var secondContext3 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-
-            Assert.Same(context1, context3);
-            Assert.Same(secondContext1, secondContext3);
-
-            var context4 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-            var secondContext4 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
-
-            Assert.Same(context2, context4);
-            Assert.Same(secondContext2, secondContext4);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, secondContext1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
-            Assert.Equal(1, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
-
-            await Dispose(context1, async);
-            await Dispose(secondContext1, async);
-            await Dispose(context2, async);
-            await Dispose(secondContext2, async);
-
-            Assert.Equal(2, context1.LeasedCount);
-            Assert.Equal(2, secondContext1.LeasedCount);
-            Assert.Equal(2, context2.LeasedCount);
-            Assert.Equal(2, secondContext2!.LeasedCount);
-            Assert.Equal(2, context1.ReturnedCount);
-            Assert.Equal(2, secondContext1.ReturnedCount);
-            Assert.Equal(2, context2.ReturnedCount);
-            Assert.Equal(2, secondContext2.ReturnedCount);
-            Assert.Equal(!async ? true : null, context1.SyncLease);
-            Assert.Equal(async ? true : null, context1.AsyncLease);
-            Assert.Equal(!async ? true : null, context1.SyncReturn);
-            Assert.Equal(async ? true : null, context1.AsyncReturn);
         }
 
         [ConditionalTheory]
@@ -1235,7 +703,7 @@ namespace Microsoft.EntityFrameworkCore
             var scopedProvider = serviceScope.ServiceProvider;
 
             var context1 = useInterface
-                ? (DbContext)scopedProvider.GetService<IPooledContext>()
+                ? (PooledContext)scopedProvider.GetService<IPooledContext>()
                 : scopedProvider.GetService<PooledContext>();
 
             Assert.Null(context1!.Database.GetCommandTimeout());
@@ -1252,24 +720,20 @@ namespace Microsoft.EntityFrameworkCore
             context1.SavedChanges += (sender, args) => { };
             context1.SaveChangesFailed += (sender, args) => { };
 
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavingChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavedChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SaveChangesFailed)));
-
             await Dispose(serviceScope, async);
-
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavingChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavedChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SaveChangesFailed)));
 
             serviceScope = serviceProvider.CreateScope();
             scopedProvider = serviceScope.ServiceProvider;
 
             var context2 = useInterface
-                ? (DbContext)scopedProvider.GetService<IPooledContext>()
+                ? (PooledContext)scopedProvider.GetService<IPooledContext>()
                 : scopedProvider.GetService<PooledContext>();
 
             Assert.Same(context1, context2);
+
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SavingChanges)));
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SavedChanges)));
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SaveChangesFailed)));
 
             Assert.False(context2!.ChangeTracker.AutoDetectChangesEnabled);
             Assert.False(context2.ChangeTracker.LazyLoadingEnabled);
@@ -1330,27 +794,24 @@ namespace Microsoft.EntityFrameworkCore
             context1.SavedChanges += (sender, args) => { };
             context1.SaveChangesFailed += (sender, args) => { };
 
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavingChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavedChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SaveChangesFailed)));
-
             await Dispose(context1, async);
-
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavingChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SavedChanges)));
-            Assert.NotNull(GetContextEventField(context1, nameof(DbContext.SaveChangesFailed)));
 
             var context2 = async ? await factory.CreateDbContextAsync() : factory.CreateDbContext();
 
             Assert.Same(context1, context2);
 
-            Assert.False(context2.ChangeTracker.AutoDetectChangesEnabled);
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SavingChanges)));
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SavedChanges)));
+            Assert.Null(GetContextEventField(context2, nameof(DbContext.SaveChangesFailed)));
+
+            Assert.False(context2!.ChangeTracker.AutoDetectChangesEnabled);
             Assert.False(context2.ChangeTracker.LazyLoadingEnabled);
             Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
             Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.CascadeDeleteTiming);
             Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.DeleteOrphansTiming);
             Assert.False(context2.Database.AutoTransactionsEnabled);
             Assert.False(context2.Database.AutoSavepointsEnabled);
+            Assert.Null(context1.Database.GetCommandTimeout());
         }
 
         [ConditionalFact]
@@ -1594,18 +1055,8 @@ namespace Microsoft.EntityFrameworkCore
                 ? (PooledContext)scopedProvider2.GetService<IPooledContext>()
                 : scopedProvider2.GetService<PooledContext>();
 
-            Assert.Equal(1, context1!.LeasedCount);
-            Assert.Equal(1, context2!.LeasedCount);
-            Assert.Equal(0, context1.ReturnedCount);
-            Assert.Equal(0, context2.ReturnedCount);
-
             await Dispose(serviceScope1, async);
             await Dispose(serviceScope2, async);
-
-            Assert.Equal(1, context1!.LeasedCount);
-            Assert.Equal(1, context2!.LeasedCount);
-            Assert.Equal(1, context1.ReturnedCount);
-            Assert.Equal(1, context2.ReturnedCount);
 
             Assert.Throws<ObjectDisposedException>(() => context1.Customers.ToList());
             Assert.Throws<ObjectDisposedException>(() => context2.Customers.ToList());
@@ -1674,18 +1125,9 @@ namespace Microsoft.EntityFrameworkCore
             var lease = scope.ServiceProvider.GetRequiredService<IScopedDbContextLease<PooledContext>>();
             var context = lease.Context;
 
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(0, context.ReturnedCount);
-
             await Dispose(scope, async);
 
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(1, context.ReturnedCount);
-
             await Dispose(scope, async);
-
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(1, context.ReturnedCount);
 
             using var scope1 = serviceProvider.CreateScope();
             var lease1 = scope1.ServiceProvider.GetRequiredService<IScopedDbContextLease<PooledContext>>();
@@ -1713,18 +1155,9 @@ namespace Microsoft.EntityFrameworkCore
             var context = (PooledContext)lease.Context;
             ((IDbContextPoolable)context).SetLease(lease);
 
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(0, context.ReturnedCount);
-
             await Dispose(context, async);
 
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(1, context.ReturnedCount);
-
             await Dispose(context, async);
-
-            Assert.Equal(1, context.LeasedCount);
-            Assert.Equal(1, context.ReturnedCount);
 
             using var context1 = new DbContextLease(pool, standalone: true).Context;
             using var context2 = new DbContextLease(pool, standalone: true).Context;

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
                 (await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask())).Message);
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 54;
+            var expectedMethodCount = 58;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
                 (await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask())).Message);
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 50;
+            var expectedMethodCount = 54;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
                 (await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask())).Message);
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 54;
+            var expectedMethodCount = 50;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
                 (await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77).AsTask())).Message);
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 58;
+            var expectedMethodCount = 54;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. "


### PR DESCRIPTION
Fixes #19193
~Fixes #17086~

Notes:
* We now no longer reset context events, as per #19193
* However, I left the code that resets options like QueryTrackingBehavior since that still seems useful, and makes this less of a break
* Added events to DbContext. These are easy and decoupled, but sync only.
* A derived DbContext can override the On... event methods. This allows async hooks.
* DbContextFactory now has a CreateDbContextAsync method such that a context can be rented from the pool and the hook applied in an async context.
