### PR TITLE
Caching access to virtual properties

### DIFF
--- a/src/EFCore.Relational/Query/Internal/SingleQueryResultCoordinator.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryResultCoordinator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class SingleQueryResultCoordinator
+    public sealed class SingleQueryResultCoordinator
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -20,9 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public SingleQueryResultCoordinator()
-        {
-            ResultContext = new ResultContext();
-        }
+            => ResultContext = new ResultContext();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -30,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ResultContext ResultContext { get; }
+        public ResultContext ResultContext { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -38,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool ResultReady { get; set; }
+        public bool ResultReady { get; set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -46,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool? HasNext { get; set; }
+        public bool? HasNext { get; set; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -54,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IList<SingleQueryCollectionContext?> Collections { get; } = new List<SingleQueryCollectionContext?>();
+        public IList<SingleQueryCollectionContext?> Collections { get; } = new List<SingleQueryCollectionContext?>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -62,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void SetSingleQueryCollectionContext(
+        public void SetSingleQueryCollectionContext(
             int collectionId,
             SingleQueryCollectionContext singleQueryCollectionContext)
         {

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -234,7 +234,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         enumerator._detailedErrorsEnabled));
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
-                var resultCoordinator = enumerator._resultCoordinator = new SingleQueryResultCoordinator();
+                enumerator._resultCoordinator = new SingleQueryResultCoordinator();
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -248,6 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                     _dataReader.Dispose();
                     _dataReader = null;
+                    _dbDataReader = null;
                 }
             }
 
@@ -379,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     .ConfigureAwait(false);
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
-                var resultCoordinator = enumerator._resultCoordinator = new SingleQueryResultCoordinator();
+                enumerator._resultCoordinator = new SingleQueryResultCoordinator();
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -394,6 +395,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     var dataReader = _dataReader;
                     _dataReader = null;
+                    _dbDataReader = null;
 
                     return dataReader.DisposeAsync();
                 }

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -132,7 +132,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private RelationalDataReader? _dataReader;
             private DbDataReader? _dbDataReader;
             private SingleQueryResultCoordinator? _resultCoordinator;
-            private ResultContext? _resultContext;
 
             public Enumerator(SingleQueryingEnumerable<T> queryingEnumerable)
             {
@@ -178,11 +177,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             {
                                 _resultCoordinator.ResultReady = true;
                                 _resultCoordinator.HasNext = null;
-                                Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                                Current = _shaper(
+                                    _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                                 if (_resultCoordinator.ResultReady)
                                 {
                                     // We generated a result so null out previously stored values
-                                    _resultContext!.Values = null;
+                                    _resultCoordinator.ResultContext.Values = null;
                                     break;
                                 }
 
@@ -191,7 +191,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     _resultCoordinator.HasNext = false;
                                     // Enumeration has ended, materialize last element
                                     _resultCoordinator.ResultReady = true;
-                                    Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                                    Current = _shaper(
+                                        _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
 
                                     break;
                                 }
@@ -234,7 +235,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
                 var resultCoordinator = enumerator._resultCoordinator = new SingleQueryResultCoordinator();
-                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -271,7 +271,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private RelationalDataReader? _dataReader;
             private DbDataReader? _dbDataReader;
             private SingleQueryResultCoordinator? _resultCoordinator;
-            private ResultContext? _resultContext;
 
             public AsyncEnumerator(SingleQueryingEnumerable<T> queryingEnumerable)
             {
@@ -321,11 +320,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             {
                                 _resultCoordinator.ResultReady = true;
                                 _resultCoordinator.HasNext = null;
-                                Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                                Current = _shaper(
+                                    _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                                 if (_resultCoordinator.ResultReady)
                                 {
                                     // We generated a result so null out previously stored values
-                                    _resultContext!.Values = null;
+                                    _resultCoordinator.ResultContext.Values = null;
                                     break;
                                 }
 
@@ -334,7 +334,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     _resultCoordinator.HasNext = false;
                                     // Enumeration has ended, materialize last element
                                     _resultCoordinator.ResultReady = true;
-                                    Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                                    Current = _shaper(
+                                        _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
 
                                     break;
                                 }
@@ -379,7 +380,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
                 var resultCoordinator = enumerator._resultCoordinator = new SingleQueryResultCoordinator();
-                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -169,7 +169,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
 
                         var hasNext = _resultCoordinator!.HasNext ?? _dataReader!.Read();
-                        Current = default!;
 
                         if (hasNext)
                         {
@@ -197,6 +196,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     break;
                                 }
                             }
+                        }
+                        else
+                        {
+                            Current = default!;
                         }
 
                         return hasNext;
@@ -313,7 +316,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         var hasNext = _resultCoordinator!.HasNext
                             ?? await _dataReader!.ReadAsync(_cancellationToken).ConfigureAwait(false);
-                        Current = default!;
 
                         if (hasNext)
                         {
@@ -341,6 +343,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     break;
                                 }
                             }
+                        }
+                        else
+                        {
+                            Current = default!;
                         }
 
                         return hasNext;

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -172,17 +172,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         if (hasNext)
                         {
+                            var resultContext = _resultCoordinator.ResultContext;
                             while (true)
                             {
                                 _resultCoordinator.ResultReady = true;
                                 _resultCoordinator.HasNext = null;
                                 Current = _shaper(
-                                    _relationalQueryContext, _dataReader!.DbDataReader, _resultCoordinator.ResultContext,
+                                    _relationalQueryContext, _dataReader!.DbDataReader, resultContext,
                                     _resultCoordinator);
                                 if (_resultCoordinator.ResultReady)
                                 {
                                     // We generated a result so null out previously stored values
-                                    _resultCoordinator.ResultContext.Values = null;
+                                    resultContext.Values = null;
                                     break;
                                 }
 
@@ -192,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     // Enumeration has ended, materialize last element
                                     _resultCoordinator.ResultReady = true;
                                     Current = _shaper(
-                                        _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext,
+                                        _relationalQueryContext, _dataReader.DbDataReader, resultContext,
                                         _resultCoordinator);
 
                                     break;
@@ -313,17 +314,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         if (hasNext)
                         {
+                            var resultContext = _resultCoordinator.ResultContext;
                             while (true)
                             {
                                 _resultCoordinator.ResultReady = true;
                                 _resultCoordinator.HasNext = null;
                                 Current = _shaper(
-                                    _relationalQueryContext, _dataReader!.DbDataReader, _resultCoordinator.ResultContext,
+                                    _relationalQueryContext, _dataReader!.DbDataReader, resultContext,
                                     _resultCoordinator);
                                 if (_resultCoordinator.ResultReady)
                                 {
                                     // We generated a result so null out previously stored values
-                                    _resultCoordinator.ResultContext.Values = null;
+                                    resultContext.Values = null;
                                     break;
                                 }
 
@@ -333,7 +335,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                     // Enumeration has ended, materialize last element
                                     _resultCoordinator.ResultReady = true;
                                     Current = _shaper(
-                                        _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext,
+                                        _relationalQueryContext, _dataReader.DbDataReader, resultContext,
                                         _resultCoordinator);
 
                                     break;

--- a/src/EFCore.Relational/Query/Internal/SplitQueryResultCoordinator.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryResultCoordinator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public class SplitQueryResultCoordinator
+    public sealed class SplitQueryResultCoordinator
     {
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -21,9 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public SplitQueryResultCoordinator()
-        {
-            ResultContext = new ResultContext();
-        }
+            => ResultContext = new ResultContext();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -31,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual ResultContext ResultContext { get; }
+        public ResultContext ResultContext { get; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -39,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IList<SplitQueryCollectionContext?> Collections { get; } = new List<SplitQueryCollectionContext?>();
+        public IList<SplitQueryCollectionContext?> Collections { get; } = new List<SplitQueryCollectionContext?>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -47,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IList<SplitQueryDataReaderContext?> DataReaders { get; } = new List<SplitQueryDataReaderContext?>();
+        public IList<SplitQueryDataReaderContext?> DataReaders { get; } = new List<SplitQueryDataReaderContext?>();
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -55,9 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void SetDataReader(
-            int collectionId,
-            RelationalDataReader relationalDataReader)
+        public void SetDataReader(int collectionId, RelationalDataReader relationalDataReader)
         {
             while (DataReaders.Count <= collectionId)
             {
@@ -73,9 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual void SetSplitQueryCollectionContext(
-            int collectionId,
-            SplitQueryCollectionContext splitQueryCollectionContext)
+        public void SetSplitQueryCollectionContext(int collectionId, SplitQueryCollectionContext splitQueryCollectionContext)
         {
             while (Collections.Count <= collectionId)
             {

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         enumerator._detailedErrorsEnabled));
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
-                var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                enumerator._resultCoordinator = new SplitQueryResultCoordinator();
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -255,6 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
 
                     _dataReader = null;
+                    _dbDataReader = null;
                 }
             }
 
@@ -378,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     .ConfigureAwait(false);
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
-                var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                enumerator._resultCoordinator = new SplitQueryResultCoordinator();
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -405,6 +406,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _resultCoordinator = null;
                     }
                     _dataReader = null;
+                    _dbDataReader = null;
                 }
             }
         }

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -183,7 +183,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
 
                         var hasNext = _dataReader!.Read();
-                        Current = default!;
 
                         if (hasNext)
                         {
@@ -192,6 +191,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             _relatedDataLoaders?.Invoke(_relationalQueryContext, _executionStrategy!, _resultCoordinator);
                             Current = _shaper(
                                 _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
+                        }
+                        else
+                        {
+                            Current = default!;
                         }
 
                         return hasNext;
@@ -326,7 +329,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
 
                         var hasNext = await _dataReader!.ReadAsync(_cancellationToken).ConfigureAwait(false);
-                        Current = default!;
 
                         if (hasNext)
                         {
@@ -340,6 +342,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                             Current =
                                 _shaper(_relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
+                        }
+                        else
+                        {
+                            Current = default!;
                         }
 
                         return hasNext;

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -140,7 +140,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private RelationalDataReader? _dataReader;
             private DbDataReader? _dbDataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
-            private ResultContext? _resultContext;
             private IExecutionStrategy? _executionStrategy;
 
             public Enumerator(SplitQueryingEnumerable<T> queryingEnumerable)
@@ -189,9 +188,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         if (hasNext)
                         {
                             _resultCoordinator!.ResultContext.Values = null;
-                            _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                            _shaper(_relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                             _relatedDataLoaders?.Invoke(_relationalQueryContext, _executionStrategy!, _resultCoordinator);
-                            Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                            Current = _shaper(
+                                _relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                         }
 
                         return hasNext;
@@ -230,7 +230,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
                 var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
-                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -280,7 +279,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private RelationalDataReader? _dataReader;
             private DbDataReader? _dbDataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
-            private ResultContext? _resultContext;
             private IExecutionStrategy? _executionStrategy;
 
             public AsyncEnumerator(SplitQueryingEnumerable<T> queryingEnumerable)
@@ -332,14 +330,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         if (hasNext)
                         {
                             _resultCoordinator!.ResultContext.Values = null;
-                            _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                            _shaper(_relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                             if (_relatedDataLoaders != null)
                             {
                                 await _relatedDataLoaders(_relationalQueryContext, _executionStrategy!, _resultCoordinator)
                                     .ConfigureAwait(false);
                             }
 
-                            Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
+                            Current =
+                                _shaper(_relationalQueryContext, _dbDataReader!, _resultCoordinator.ResultContext, _resultCoordinator);
                         }
 
                         return hasNext;
@@ -380,7 +379,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 enumerator._dbDataReader = dataReader.DbDataReader;
 
                 var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
-                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -138,7 +138,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
+            private DbDataReader? _dbDataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
+            private ResultContext? _resultContext;
             private IExecutionStrategy? _executionStrategy;
 
             public Enumerator(SplitQueryingEnumerable<T> queryingEnumerable)
@@ -178,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                 _executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
                             }
 
-                            _executionStrategy.Execute(this, (_, enumerator) => InitializeReader(enumerator), null);
+                            _executionStrategy.Execute(this, static (_, enumerator) => InitializeReader(enumerator), null);
                         }
 
                         var hasNext = _dataReader!.Read();
@@ -187,11 +189,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         if (hasNext)
                         {
                             _resultCoordinator!.ResultContext.Values = null;
-                            _shaper(
-                                _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext, _resultCoordinator);
+                            _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
                             _relatedDataLoaders?.Invoke(_relationalQueryContext, _executionStrategy!, _resultCoordinator);
-                            Current = _shaper(
-                                _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext, _resultCoordinator);
+                            Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
                         }
 
                         return hasNext;
@@ -219,7 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
                 relationalCommand.PopulateFrom(relationalCommandTemplate);
 
-                enumerator._dataReader = relationalCommand.ExecuteReader(
+                var dataReader = enumerator._dataReader = relationalCommand.ExecuteReader(
                     new RelationalCommandParameterObject(
                         enumerator._relationalQueryContext.Connection,
                         enumerator._relationalQueryContext.ParameterValues,
@@ -227,8 +227,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         enumerator._relationalQueryContext.Context,
                         enumerator._relationalQueryContext.CommandLogger,
                         enumerator._detailedErrorsEnabled));
+                enumerator._dbDataReader = dataReader.DbDataReader;
 
-                enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 
@@ -272,10 +274,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private readonly bool _standAloneStateManager;
             private readonly bool _detailedErrorEnabled;
             private readonly IConcurrencyDetector? _concurrencyDetector;
+            private readonly CancellationToken _cancellationToken;
 
             private IRelationalCommand? _relationalCommand;
             private RelationalDataReader? _dataReader;
+            private DbDataReader? _dbDataReader;
             private SplitQueryResultCoordinator? _resultCoordinator;
+            private ResultContext? _resultContext;
             private IExecutionStrategy? _executionStrategy;
 
             public AsyncEnumerator(SplitQueryingEnumerable<T> queryingEnumerable)
@@ -288,6 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _queryLogger = queryingEnumerable._queryLogger;
                 _standAloneStateManager = queryingEnumerable._standAloneStateManager;
                 _detailedErrorEnabled = queryingEnumerable._detailedErrorsEnabled;
+                _cancellationToken = _relationalQueryContext.CancellationToken;
                 Current = default!;
 
                 _concurrencyDetector = queryingEnumerable._threadSafetyChecksEnabled
@@ -314,28 +320,26 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                             await _executionStrategy.ExecuteAsync(
                                     this,
-                                    (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
+                                    static (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
                                     null,
-                                    _relationalQueryContext.CancellationToken)
+                                    _cancellationToken)
                                 .ConfigureAwait(false);
                         }
 
-                        var hasNext = await _dataReader!.ReadAsync(_relationalQueryContext.CancellationToken).ConfigureAwait(false);
+                        var hasNext = await _dataReader!.ReadAsync(_cancellationToken).ConfigureAwait(false);
                         Current = default!;
 
                         if (hasNext)
                         {
                             _resultCoordinator!.ResultContext.Values = null;
-                            _shaper(
-                                _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext, _resultCoordinator);
+                            _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
                             if (_relatedDataLoaders != null)
                             {
                                 await _relatedDataLoaders(_relationalQueryContext, _executionStrategy!, _resultCoordinator)
                                     .ConfigureAwait(false);
                             }
 
-                            Current = _shaper(
-                                _relationalQueryContext, _dataReader.DbDataReader, _resultCoordinator.ResultContext, _resultCoordinator);
+                            Current = _shaper(_relationalQueryContext, _dbDataReader!, _resultContext!, _resultCoordinator);
                         }
 
                         return hasNext;
@@ -363,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
                 relationalCommand.PopulateFrom(relationalCommandTemplate);
 
-                enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
+                var dataReader = enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(
                         enumerator._relationalQueryContext.Connection,
                         enumerator._relationalQueryContext.ParameterValues,
@@ -373,8 +377,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         enumerator._detailedErrorEnabled),
                     cancellationToken)
                     .ConfigureAwait(false);
+                enumerator._dbDataReader = dataReader.DbDataReader;
 
-                enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                var resultCoordinator = enumerator._resultCoordinator = new SplitQueryResultCoordinator();
+                enumerator._resultContext = resultCoordinator.ResultContext;
 
                 enumerator._relationalQueryContext.InitializeStateManager(enumerator._standAloneStateManager);
 

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -723,11 +723,12 @@ namespace Microsoft.EntityFrameworkCore
                 Check.DebugAssert(
                     _configurationSnapshot.DeleteOrphansTiming.HasValue, "!configurationSnapshot.DeleteOrphansTiming.HasValue");
 
-                ChangeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled.Value;
-                ChangeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
-                ChangeTracker.LazyLoadingEnabled = _configurationSnapshot.LazyLoadingEnabled.Value;
-                ChangeTracker.CascadeDeleteTiming = _configurationSnapshot.CascadeDeleteTiming.Value;
-                ChangeTracker.DeleteOrphansTiming = _configurationSnapshot.DeleteOrphansTiming.Value;
+                var changeTracker = ChangeTracker;
+                changeTracker.AutoDetectChangesEnabled = _configurationSnapshot.AutoDetectChangesEnabled.Value;
+                changeTracker.QueryTrackingBehavior = _configurationSnapshot.QueryTrackingBehavior.Value;
+                changeTracker.LazyLoadingEnabled = _configurationSnapshot.LazyLoadingEnabled.Value;
+                changeTracker.CascadeDeleteTiming = _configurationSnapshot.CascadeDeleteTiming.Value;
+                changeTracker.DeleteOrphansTiming = _configurationSnapshot.DeleteOrphansTiming.Value;
             }
             else
             {

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -45,13 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(dependencies, nameof(dependencies));
 
             Dependencies = dependencies;
+            Context = dependencies.CurrentContext.Context;
         }
 
         /// <summary>
         ///     The current DbContext in using while executing the query.
         /// </summary>
-        public virtual DbContext Context
-            => Dependencies.CurrentContext.Context;
+        public virtual DbContext Context { get; }
 
         /// <summary>
         ///     Parameter object containing dependencies for this service.


### PR DESCRIPTION
Reading from virtual properties in a cycle/sequentially is very slow because the compiler can't cache the returned value from the property (because there might be side effects). This pr helps to alleviate this problem for some of the properties (the worst offender is `QueryContext.Context`, which is called every time a new `MaterializationContext` is created, but changing this is not trivial). Below is the benchmark results of reading from fields and properties in a cycle of 10.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 5 2400G with Radeon Vega Graphics, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=6.0.100-preview.3.21202.5
  [Host]     : .NET Core 6.0.0 (CoreCLR 6.0.21.20104, CoreFX 6.0.21.20104), X64 RyuJIT
  DefaultJob : .NET Core 6.0.0 (CoreCLR 6.0.21.20104, CoreFX 6.0.21.20104), X64 RyuJIT


```
|                Method |      Mean |     Error |    StdDev |
|---------------------- |----------:|----------:|----------:|
|                 Field |  2.885 ns | 0.0515 ns | 0.0456 ns |
|              Property |  2.895 ns | 0.0644 ns | 0.0537 ns |
|       VirtualProperty | 17.204 ns | 0.3340 ns | 0.2961 ns |
| VirtualPropertyCached |  4.847 ns | 0.0433 ns | 0.0384 ns |

<details>
<summary>benchmark code</summary>

```csharp
public class VirtualPropertyBenchmark
{
	public int ValueField;

	public int ValueProperty { get; set; }

	public virtual int ValuePropertyVirtual { get; set; }

	[GlobalSetup]
	public void Setup()
	{
		ValueField = 42;
		ValueProperty = 42;
		ValuePropertyVirtual = 42;
	}

	[Benchmark]
	public int Field()
	{
		var valueSum = 0;
		for (var i = 0; i < 10; i++)
		{
			valueSum += ValueField;
		}

		return valueSum;
	}

	[Benchmark]
	public int Property()
	{
		var valueSum = 0;
		for (var i = 0; i < 10; i++)
		{
			valueSum += ValueProperty;
		}

		return valueSum;
	}

	[Benchmark]
	public int VirtualProperty()
	{
		var valueSum = 0;
		for (var i = 0; i < 10; i++)
		{
			valueSum += ValuePropertyVirtual;
		}

		return valueSum;
	}

	[Benchmark]
	public int VirtualPropertyCached()
	{
		var valueSum = 0;
		var value = ValuePropertyVirtual;
		for (var i = 0; i < 10; i++)
		{
			valueSum += value;
		}

		return valueSum;
	}
}
```

</details>

On fortunes benchmark this change got me around 50 ms/minute.

cc @roji 