### PR TITLE
Preview 4: Copy instead of reusing the same reference in AnnotatableBase.AddAnnotations

### DIFF
--- a/src/EFCore/Infrastructure/AnnotatableBase.cs
+++ b/src/EFCore/Infrastructure/AnnotatableBase.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             foreach (var annotation in annotations)
             {
-                annotatable.AddAnnotation(annotation.Name, (Annotation)annotation);
+                annotatable.AddAnnotation(annotation.Name, annotation.Value);
             }
         }
 
@@ -429,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The newly created annotation. </returns>
         protected virtual Annotation CreateRuntimeAnnotation(string name, object? value)
-            => new Annotation(name, value);
+            => new (name, value);
 
         private ConcurrentDictionary<string, Annotation> GetOrCreateRuntimeAnnotations()
         {

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -3708,7 +3708,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(3, context.ChangeTracker.Entries<EntityOne>().Count());
                 Assert.Equal(3, context.ChangeTracker.Entries<EntityTwo>().Count());
                 Assert.Equal(5, context.ChangeTracker.Entries<JoinOneToTwo>().Count());
-                Assert.Equal(1, context.ChangeTracker.Entries<JoinOneToTwoExtra>().Count());
+                Assert.Single(context.ChangeTracker.Entries<JoinOneToTwoExtra>());
 
                 Assert.Equal(3, leftEntities[0].TwoSkip.Count);
                 Assert.Single(leftEntities[1].TwoSkip);

--- a/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
+++ b/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
@@ -37,6 +37,22 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [ConditionalFact]
+        public void Added_annotation_type_is_consistent()
+        {
+            var annotatable = new Annotatable();
+
+            annotatable.AddAnnotations(new[] { new ConventionAnnotation("Foo", "Bar", ConfigurationSource.Convention) });
+
+            Assert.Equal(typeof(Annotation), annotatable.FindAnnotation("Foo").GetType());
+
+            var conventionAnnotatable = new Model();
+
+            conventionAnnotatable.AddAnnotations(new[] { new Annotation("Foo", "Bar") });
+
+            Assert.Equal(typeof(ConventionAnnotation), conventionAnnotatable.FindAnnotation("Foo").GetType());
+        }
+
+        [ConditionalFact]
         public void Adding_duplicate_annotation_throws()
         {
             var annotatable = new Annotatable();


### PR DESCRIPTION
Cherry-picking the commit into preview 4.

Fixes #24658

**Description**

An exception is thrown when generating migration SQL when a property is modified which has both a comment and a default value.

**Customer Impact**

The EF Core Power Tools are broken for reverse engineering/scaffolding.

**How found**

Reported by @ErikEJ, author of the Power Tools, while testing.

**Test coverage**

The fix was already in preview 5 with test coverage; this PR brings the fix and tests to preview 4.

**Regression?**

Yes, from preview 2.

**Risk**

Low. This is a feature bug fix that we are bringing forward.
