### PR TITLE
Hacky games around DI and context factories

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Extensions.DependencyInjection
             AddPoolingOptions<TContextImplementation>(serviceCollection, optionsAction, poolSize);
 
             serviceCollection.TryAddSingleton<IDbContextPool<TContextImplementation>, DbContextPool<TContextImplementation>>();
-            serviceCollection.AddScoped<IScopedDbContextLease<TContextImplementation>, ScopedDbContextLease<TContextImplementation>>();
+            serviceCollection.AddScoped<IScopedDbContextLease<TContextImplementation>, PoolingScopedDbContextLease<TContextImplementation>>();
 
             serviceCollection.AddScoped<TContextService>(
                 sp => sp.GetRequiredService<IScopedDbContextLease<TContextImplementation>>().Context);
@@ -368,6 +368,13 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
             where TContext : DbContext
             => AddDbContext<TContext, TContext>(serviceCollection, contextLifetime, optionsLifetime);
+
+        // public static IServiceCollection AddDbContext<TContext>(
+        //     this IServiceCollection serviceCollection,
+        //     ServiceLifetime contextLifetime,
+        //     ServiceLifetime optionsLifetime = ServiceLifetime.Scoped)
+        //     where TContext : DbContext
+        //     => AddDbContext<TContext, TContext>(serviceCollection, contextLifetime, optionsLifetime);
 
         /// <summary>
         ///     <para>
@@ -779,6 +786,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     typeof(IDbContextFactory<TContext>),
                     typeof(TFactory),
                     lifetime));
+
+            serviceCollection.AddScoped<IScopedDbContextLease<TContext>, ScopedDbContextLease<TContext>>();
+            serviceCollection.AddScoped(sp => sp.GetRequiredService<IScopedDbContextLease<TContext>>().Context);
 
             return serviceCollection;
         }


### PR DESCRIPTION
Alternative approach to #24768.

This hacky thing modifies AddDbContextFactory to also arrange for direct DbContext injection, via a lease mechanism that's very similar to what we already do for pooling. The user simply specifies the factory they want to use when setting up EF in DI, and do any customizations there.

For multi-tenancy, users would have to implement a factory like the following:

```c#
public class MultiTenantContextFactory : DbContextFactory<BlogContext>
{
    public MultiTenantContextFactory(
        IServiceProvider serviceProvider,
        DbContextOptions<BlogContext> options,
        IDbContextFactorySource<BlogContext> factorySource)
        : base(serviceProvider, options, factorySource)
    {
    }

    public override BlogContext CreateDbContext()
    {
        var context = base.CreateDbContext();
        // Fetch tenant id and inject it into the context
        return context;
    }
}
```

... and register it in DI as usual with AddDbContextFactory.

The big limitation at the moment is that IDbContextFactory manages creation, but not disposal. A bigger refactor could add Dispose or Return methods there, at which point it seems like DbContextPool could also be merged into PooledDbContextFactory (calling DbContext.Dispose would call into its factory's Return).

If we go down this route, users could also extend PooledDbContextFactory, and override the factory's methods to do nothing, as a way of getting rid of config snapshotting/resetting for ultra-high-perf (#24769), without needing a new flag and code path.

(The only thing I personally dislike is the additional ScopedDbContextLease which we need to disposal... if only the DI scope provider allowed us to register the DbContext for disposal instead...)

<details>
<summary>Complete sample user code</summary>

```c#
var serviceCollection = new ServiceCollection();
serviceCollection.AddDbContextFactory<BlogContext, MultiTenantContextFactory>(o =>
    o.UseSqlServer(@"Server=localhost;Database=test;User=SA;Password=Abcd5678;Connect Timeout=60;ConnectRetryCount=0"));
using var serviceProvider = serviceCollection.BuildServiceProvider();
using var scope = serviceProvider.CreateScope();
var scopedServiceProvider = scope.ServiceProvider;

using var ctx = scopedServiceProvider.GetService<BlogContext>();

public class MultiTenantContextFactory : DbContextFactory<BlogContext>
{
    public MultiTenantContextFactory(
        IServiceProvider serviceProvider,
        DbContextOptions<BlogContext> options,
        IDbContextFactorySource<BlogContext> factorySource)
        : base(serviceProvider, options, factorySource)
    {
    }

    public override BlogContext CreateDbContext()
    {
        var context = base.CreateDbContext();
        // Fetch tenant id and inject it into the context
        return context;
    }
}

public class BlogContext : DbContext
{
    public BlogContext(DbContextOptions<BlogContext> options) : base(options) {}

    public DbSet<Blog> Blogs { get; set; }
}

public class Blog
{
    public int Id { get; set; }
    public string Name { get; set; }
}
```

</details>

/cc @ajcvickers