### PR TITLE
Fix table casing to be the expected default (Pascal casing)

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore
         [MemberData(nameof(IsAsyncData))]
         public virtual Task FromSql(bool async)
             => ConcurrencyDetectorTest(async c => async
-                ? await c.Products.FromSqlRaw("select * from products").ToListAsync()
-                : c.Products.FromSqlRaw("select * from products").ToList());
+                ? await c.Products.FromSqlRaw("select * from Products").ToListAsync()
+                : c.Products.FromSqlRaw("select * from Products").ToList());
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorDisabledRelationalTestBase.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -18,11 +17,14 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        protected string NormalizeDelimitersInRawString(string sql)
+            => (Fixture.TestStore as RelationalTestStore)?.NormalizeDelimitersInRawString(sql) ?? sql;
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task FromSql(bool async)
             => ConcurrencyDetectorTest(async c => async
-                ? await c.Products.FromSqlRaw("select * from Products").ToListAsync()
-                : c.Products.FromSqlRaw("select * from Products").ToList());
+                ? await c.Products.FromSqlRaw(NormalizeDelimitersInRawString("select * from [Products]")).ToListAsync()
+                : c.Products.FromSqlRaw(NormalizeDelimitersInRawString("select * from [Products]")).ToList());
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         [MemberData(nameof(IsAsyncData))]
         public virtual Task FromSql(bool async)
             => ConcurrencyDetectorTest(async c => async
-                ? await c.Products.FromSqlRaw("select * from products").ToListAsync()
-                : c.Products.FromSqlRaw("select * from products").ToList());
+                ? await c.Products.FromSqlRaw("select * from Products").ToListAsync()
+                : c.Products.FromSqlRaw("select * from Products").ToList());
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/ConcurrencyDetectorEnabledRelationalTestBase.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -16,11 +17,14 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+        protected string NormalizeDelimitersInRawString(string sql)
+            => (Fixture.TestStore as RelationalTestStore)?.NormalizeDelimitersInRawString(sql) ?? sql;
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task FromSql(bool async)
             => ConcurrencyDetectorTest(async c => async
-                ? await c.Products.FromSqlRaw("select * from Products").ToListAsync()
-                : c.Products.FromSqlRaw("select * from Products").ToList());
+                ? await c.Products.FromSqlRaw(NormalizeDelimitersInRawString("select * from [Products]")).ToListAsync()
+                : c.Products.FromSqlRaw(NormalizeDelimitersInRawString("select * from [Products]")).ToList());
     }
 }


### PR DESCRIPTION
<!--
Please check if the PR fulfills these requirements

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code follows the same patterns and style as existing code in this repo

Review the guidelines for [contributing](CONTRIBUTING.md) for more details.
-->
For databases with case sensitive object names, the object name casing in `FromSqlRaw()` calls should be the expected default one, which is Pascal casing.