### PR TITLE
Cosmos: Filter out the partition key property when it is the same as id

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
@@ -106,7 +106,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     if (partitionKey != null)
                     {
                         var partitionKeyProperty = entityType.FindProperty(partitionKey);
-                        if (partitionKeyProperty == null)
+                        if (partitionKeyProperty == null
+                            || partitionKeyProperty == idProperty)
                         {
                             newKey = entityTypeBuilder.HasKey(new[] { idProperty })?.Metadata;
                         }


### PR DESCRIPTION
Fixes #24872