### PR TITLE
Added named query filters

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterRewritingConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/RelationalQueryFilterRewritingConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
@@ -34,10 +35,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                var queryFilter = entityType.GetQueryFilter();
-                if (queryFilter != null)
+                var queryFilters = entityType.GetQueryFilters();
+                if (queryFilters != null)
                 {
-                    entityType.SetQueryFilter((LambdaExpression)DbSetAccessRewriter.Rewrite(modelBuilder.Metadata, queryFilter));
+                    var rewritedQueryfilters = new Dictionary<string, LambdaExpression>();
+                    foreach (var queryfilter in queryFilters)
+                    {
+                        rewritedQueryfilters.Add(queryfilter.Key,
+                            (LambdaExpression)DbSetAccessRewriter.Rewrite(modelBuilder.Metadata, queryfilter.Value));
+                    }
+
+                    entityType.SetQueryFilters(rewritedQueryfilters);
                 }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2396,6 +2396,36 @@ namespace Microsoft.EntityFrameworkCore
                     : source;
         }
 
+        internal static readonly MethodInfo IgnoreQueryFilterMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetRequiredDeclaredMethod(nameof(IgnoreQueryFilter));
+
+        /// <summary>
+        ///     Specifies that the current Entity Framework LINQ query should not have a specific model-level entity query filters applied.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="name"> The name of the query filter that should not be applied. </param>
+        /// <returns> A new query that will not apply the specified model-level entity query filters. </returns>
+        /// <exception cref="ArgumentNullException"> <paramref name="source" /> is <see langword="null" />. </exception>
+        public static IQueryable<TEntity> IgnoreQueryFilter<TEntity>(
+            this IQueryable<TEntity> source, [NotParameterized] string name)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotEmpty(name, nameof(name));
+
+            return
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: IgnoreQueryFilterMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                            arg0: source.Expression,
+                            arg1: Expression.Constant(name)))
+                    : source;
+        }
+
         #endregion
 
         #region Tracking

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -933,13 +933,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                if (entityType.GetQueryFilter() != null)
+                if (entityType.GetQueryFilters() != null)
                 {
                     if (entityType.BaseType != null)
                     {
                         throw new InvalidOperationException(
                             CoreStrings.BadFilterDerivedType(
-                                entityType.GetQueryFilter(),
+                                entityType.GetQueryFilters(),
                                 entityType.DisplayName(),
                                 entityType.GetRootType().DisplayName()));
                     }
@@ -947,7 +947,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     if (entityType.IsOwned())
                     {
                         throw new InvalidOperationException(
-                            CoreStrings.BadFilterOwnedType(entityType.GetQueryFilter(), entityType.DisplayName()));
+                            CoreStrings.BadFilterOwnedType(entityType.GetQueryFilters(), entityType.DisplayName()));
                     }
                 }
 
@@ -956,8 +956,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         n => !n.IsCollection
                             && n.ForeignKey.IsRequired
                             && n.IsOnDependent
-                            && n.ForeignKey.PrincipalEntityType.GetQueryFilter() != null
-                            && n.ForeignKey.DeclaringEntityType.GetQueryFilter() == null).FirstOrDefault();
+                            && n.ForeignKey.PrincipalEntityType.GetQueryFilters() != null
+                            && n.ForeignKey.DeclaringEntityType.GetQueryFilters() == null).FirstOrDefault();
 
                 if (requiredNavigationWithQueryFilter != null)
                 {

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -247,8 +247,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="filter"> The LINQ predicate expression. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual EntityTypeBuilder HasQueryFilter(LambdaExpression? filter)
+            => HasQueryFilter("", filter);
+
+        /// <summary>
+        ///     Specifies a named LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="name"> The name of the LINQ predicate expression. </param>
+        /// <param name="filter"> The LINQ predicate expression. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder HasQueryFilter(string name, LambdaExpression? filter)
         {
-            Builder.HasQueryFilter(filter, ConfigurationSource.Explicit);
+            Builder.HasQueryFilter(name, filter, ConfigurationSource.Explicit);
 
             return this;
         }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -218,7 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="filter"> The LINQ predicate expression. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public new virtual EntityTypeBuilder<TEntity> HasQueryFilter(LambdaExpression? filter)
-            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(filter);
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter("", filter);
 
         /// <summary>
         ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
@@ -227,7 +227,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="filter"> The LINQ predicate expression. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual EntityTypeBuilder<TEntity> HasQueryFilter(Expression<Func<TEntity, bool>>? filter)
-            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(filter);
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter("", filter);
+
+        /// <summary>
+        ///     Specifies a named LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="name">The name of the LINQ predicate expression. </param>
+        /// <param name="filter"> The LINQ predicate expression. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual EntityTypeBuilder<TEntity> HasQueryFilter(string name, LambdaExpression? filter)
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(name, filter);
+
+        /// <summary>
+        ///     Specifies a named LINQ predicate expression that will automatically be applied to any queries targeting
+        ///     this entity type.
+        /// </summary>
+        /// <param name="name">The name of the LINQ predicate expression. </param>
+        /// <param name="filter"> The LINQ predicate expression. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual EntityTypeBuilder<TEntity> HasQueryFilter(string name, Expression<Func<TEntity, bool>>? filter)
+            => (EntityTypeBuilder<TEntity>)base.HasQueryFilter(name, filter);
 
         /// <summary>
         ///     Configures a query used to provide data for a keyless entity type.

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -246,10 +246,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 annotations.Remove(CoreAnnotationNames.NavigationAccessMode);
                 annotations.Remove(CoreAnnotationNames.DiscriminatorProperty);
 
-                if (annotations.TryGetValue(CoreAnnotationNames.QueryFilter, out var queryFilter))
+                if (annotations.TryGetValue(CoreAnnotationNames.QueryFilter, out var queryFilters))
                 {
-                    annotations[CoreAnnotationNames.QueryFilter] =
-                        new QueryRootRewritingExpressionVisitor(runtimeEntityType.Model).Rewrite((Expression)queryFilter!);
+                    var result = new Dictionary<string, LambdaExpression>();
+                    foreach(var queryFilter in (Dictionary<string, LambdaExpression>)queryFilters!)
+                    { 
+                        result.Add(queryFilter.Key, 
+                            (LambdaExpression)new QueryRootRewritingExpressionVisitor(runtimeEntityType.Model).Rewrite(queryFilter.Value!));
+
+                    }
+                    annotations[CoreAnnotationNames.QueryFilter] = result;
                 }
 
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/src/EFCore/Metadata/IConventionEntityType.cs
+++ b/src/EFCore/Metadata/IConventionEntityType.cs
@@ -83,10 +83,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         LambdaExpression? SetQueryFilter(LambdaExpression? queryFilter, bool fromDataAnnotation = false);
 
         /// <summary>
-        ///     Returns the configuration source for <see cref="IReadOnlyEntityType.GetQueryFilter" />.
+        ///     Sets a named LINQ expression filter automatically applied to queries for this entity type.
         /// </summary>
-        /// <returns> The configuration source for <see cref="IReadOnlyEntityType.GetQueryFilter" />. </returns>
+        /// <param name="name"> The name of the expression filter. </param>
+        /// <param name="queryFilter"> The LINQ expression filter. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The configured filter. </returns>
+        LambdaExpression? SetQueryFilter(string name, LambdaExpression? queryFilter, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns the configuration source for <see cref="IReadOnlyEntityType.GetQueryFilter()" />.
+        /// </summary>
+        /// <returns> The configuration source for <see cref="IReadOnlyEntityType.GetQueryFilter()" />. </returns>
         ConfigurationSource? GetQueryFilterConfigurationSource();
+
+        /// <summary>
+        ///     Sets the LINQ expression filters automatically applied to queries for this entity type.
+        /// </summary>
+        /// <param name="queryFilters"> The LINQ expression filters. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The configured filters. </returns>
+        Dictionary<string, LambdaExpression>? SetQueryFilters(Dictionary<string, LambdaExpression>? queryFilters, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Returns the configuration source for <see cref="IReadOnlyEntityType.GetQueryFilters()" />.
+        /// </summary>
+        /// <returns> The configuration source for <see cref="IReadOnlyEntityType.GetQueryFilters()" />. </returns>
+        ConfigurationSource? GetQueryFiltersConfigurationSource();
 
         /// <summary>
         ///     Returns the property that will be used for storing a discriminator value.

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -69,6 +69,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         LambdaExpression? GetQueryFilter();
 
         /// <summary>
+        ///     Gets a named LINQ expression filter automatically applied to queries for this entity type.
+        /// </summary>
+        /// <param name="name">The name of the LINQ expression.</param>
+        /// <returns> The LINQ expression filter. </returns>
+        LambdaExpression? GetQueryFilter(string name);
+
+        /// <summary>
+        ///     Gets the LINQ expression filters automatically applied to queries for this entity type.
+        /// </summary>
+        /// <returns> The LINQ expression filters. </returns>
+        IDictionary<string, LambdaExpression>? GetQueryFilters();
+
+        /// <summary>
         ///     Returns the property that will be used for storing a discriminator value.
         /// </summary>
         /// <returns> The property that will be used for storing a discriminator value. </returns>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -3180,6 +3180,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual LambdaExpression? SetQueryFilter(LambdaExpression? queryFilter, ConfigurationSource configurationSource)
+            => SetQueryFilter("", queryFilter, configurationSource);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual LambdaExpression? SetQueryFilter(string name, LambdaExpression? queryFilter, ConfigurationSource configurationSource)
         {
             var errorMessage = CheckQueryFilter(queryFilter);
             if (errorMessage != null)
@@ -3187,7 +3196,52 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 throw new InvalidOperationException(errorMessage);
             }
 
-            return (LambdaExpression?)SetOrRemoveAnnotation(CoreAnnotationNames.QueryFilter, queryFilter, configurationSource)?.Value;
+            var queryFilters = (Dictionary<string, LambdaExpression>?)FindAnnotation(CoreAnnotationNames.QueryFilter)?.Value
+                ?? new();
+
+            if(queryFilter == null && queryFilters.ContainsKey(name))
+            {
+                queryFilters.Remove(name);
+            }
+            else if (queryFilter != null && !queryFilters.ContainsKey(name))
+            {
+                queryFilters.Add(name, queryFilter);
+            }
+            else
+            {
+                queryFilters[name] = queryFilter!;
+            }
+
+            if(queryFilters.Count == 0)
+            {
+                queryFilters = null;
+            }
+
+            SetOrRemoveAnnotation(CoreAnnotationNames.QueryFilter, queryFilters, configurationSource);
+            return GetQueryFilter(name);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Dictionary<string, LambdaExpression>? SetQueryFilters(Dictionary<string, LambdaExpression>? queryFilters, ConfigurationSource configurationSource)
+        {
+            if (queryFilters != null)
+            {
+                foreach (var queryFilter in queryFilters)
+                {
+                    var errorMessage = CheckQueryFilter(queryFilter.Value);
+                    if (errorMessage != null)
+                    {
+                        throw new InvalidOperationException(errorMessage);
+                    }
+                }
+            }
+
+            return (Dictionary<string, LambdaExpression>?)SetOrRemoveAnnotation(CoreAnnotationNames.QueryFilter, queryFilters, configurationSource)?.Value;
         }
 
         /// <summary>
@@ -3216,7 +3270,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual LambdaExpression? GetQueryFilter()
-            => (LambdaExpression?)this[CoreAnnotationNames.QueryFilter];
+            => GetQueryFilter("");
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual LambdaExpression? GetQueryFilter(string name)
+        {
+            var queryFilters = (Dictionary<string, LambdaExpression>?)this[CoreAnnotationNames.QueryFilter];
+
+            if(queryFilters != null && name != null && queryFilters.ContainsKey(name))
+            {
+                return queryFilters[name];
+            }
+
+            return null;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -3225,6 +3297,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual ConfigurationSource? GetQueryFilterConfigurationSource()
+            => FindAnnotation(CoreAnnotationNames.QueryFilter)?.GetConfigurationSource();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IDictionary<string, LambdaExpression>? GetQueryFilters()
+            => (Dictionary<string, LambdaExpression>?)this[CoreAnnotationNames.QueryFilter];
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual ConfigurationSource? GetQueryFiltersConfigurationSource()
             => FindAnnotation(CoreAnnotationNames.QueryFilter)?.GetConfigurationSource();
 
         /// <summary>
@@ -3659,6 +3749,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         LambdaExpression? IConventionEntityType.SetQueryFilter(LambdaExpression? queryFilter, bool fromDataAnnotation)
             => SetQueryFilter(queryFilter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [DebuggerStepThrough]
+        LambdaExpression? IConventionEntityType.SetQueryFilter(string name, LambdaExpression? queryFilter, bool fromDataAnnotation)
+            => SetQueryFilter(name, queryFilter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [DebuggerStepThrough]
+        Dictionary<string, LambdaExpression>? IConventionEntityType.SetQueryFilters(Dictionary<string, LambdaExpression>? queryFilters, bool fromDataAnnotation)
+            => SetQueryFilters(queryFilters, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1343,12 +1343,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual InternalEntityTypeBuilder? HasQueryFilter(
+            string name,
             LambdaExpression? filter,
             ConfigurationSource configurationSource)
         {
-            if (CanSetQueryFilter(filter, configurationSource))
+            if (CanSetQueryFilter(name, filter, configurationSource))
             {
-                Metadata.SetQueryFilter(filter, configurationSource);
+                Metadata.SetQueryFilter(name, filter, configurationSource);
 
                 return this;
             }
@@ -1362,9 +1363,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool CanSetQueryFilter(LambdaExpression? filter, ConfigurationSource configurationSource)
+        public virtual bool CanSetQueryFilter(string name, LambdaExpression? filter, ConfigurationSource configurationSource)
             => configurationSource.Overrides(Metadata.GetQueryFilterConfigurationSource())
-                || Metadata.GetQueryFilter() == filter;
+                || Metadata.GetQueryFilter(name) == filter;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -5205,7 +5206,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         [DebuggerStepThrough]
         IConventionEntityTypeBuilder? IConventionEntityTypeBuilder.HasQueryFilter(LambdaExpression? filter, bool fromDataAnnotation)
-            => HasQueryFilter(filter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+            => HasQueryFilter("", filter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -5215,7 +5216,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         [DebuggerStepThrough]
         bool IConventionEntityTypeBuilder.CanSetQueryFilter(LambdaExpression? filter, bool fromDataAnnotation)
-            => CanSetQueryFilter(filter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+            => CanSetQueryFilter("", filter, fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/RuntimeEntityType.cs
+++ b/src/EFCore/Metadata/RuntimeEntityType.cs
@@ -817,7 +817,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <inheritdoc/>
         [DebuggerStepThrough]
         LambdaExpression? IReadOnlyEntityType.GetQueryFilter()
-            => (LambdaExpression?)this[CoreAnnotationNames.QueryFilter];
+            => this.GetQueryFilter("");
+
+        /// <inheritdoc/>
+        [DebuggerStepThrough]
+        LambdaExpression? IReadOnlyEntityType.GetQueryFilter(string name)
+            => this.GetQueryFilter(name);
+
+        private LambdaExpression? GetQueryFilter(string name)
+        {
+            var queryFilters = (Dictionary<string, LambdaExpression>?)this[CoreAnnotationNames.QueryFilter];
+
+            if (queryFilters != null && name != null && queryFilters.ContainsKey(name))
+            {
+                return queryFilters[name];
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        [DebuggerStepThrough]
+        IDictionary<string, LambdaExpression>? IReadOnlyEntityType.GetQueryFilters()
+            => (Dictionary<string, LambdaExpression>?)this[CoreAnnotationNames.QueryFilter];
 
         /// <inheritdoc/>
         [DebuggerStepThrough]

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 dependenciesType);
 
         /// <summary>
-        ///     The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type '{rootType}'.
+        ///     Filter expressions cannot be specified for entity type '{entityType}'. Filter may only be applied to the root entity type '{rootType}'.
         /// </summary>
         public static string BadFilterDerivedType(object? filter, object? entityType, object? rootType)
             => string.Format(
@@ -171,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 filter, entityType, clrType);
 
         /// <summary>
-        ///     The filter expression '{filter}' cannot be specified for owned entity type '{entityType}'. A filter may only be applied to an entity type that is not owned.
+        ///     Filter expressions cannot be specified for owned entity type '{entityType}'. Filter may only be applied to an entity type that is not owned.
         /// </summary>
         public static string BadFilterOwnedType(object? filter, object? entityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -166,13 +166,13 @@
     <value>The service dependencies type '{dependenciesType}' has been registered incorrectly in the service collection. Service dependencies types must only be registered by Entity Framework or database providers.</value>
   </data>
   <data name="BadFilterDerivedType" xml:space="preserve">
-    <value>The filter expression '{filter}' cannot be specified for entity type '{entityType}'. A filter may only be applied to the root entity type '{rootType}'.</value>
+    <value>Filter expressions cannot be specified for entity type '{entityType}'. Filter may only be applied to the root entity type '{rootType}'.</value>
   </data>
   <data name="BadFilterExpression" xml:space="preserve">
     <value>The filter expression '{filter}' specified for entity type '{entityType}' is invalid. The expression must accept a single parameter of type '{clrType}' and return bool.</value>
   </data>
   <data name="BadFilterOwnedType" xml:space="preserve">
-    <value>The filter expression '{filter}' cannot be specified for owned entity type '{entityType}'. A filter may only be applied to an entity type that is not owned.</value>
+    <value>Filter expressions cannot be specified for owned entity type '{entityType}'. Filters may only be applied to an entity type that is not owned.</value>
   </data>
   <data name="BadValueComparerType" xml:space="preserve">
     <value>The type '{givenType}' cannot be used as a value comparer because it does not inherit from '{expectedType}'. Make sure to inherit value comparers from '{expectedType}'.</value>

--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -211,6 +211,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 return visitedExpression;
             }
 
+            if (genericMethodDefinition == EntityFrameworkQueryableExtensions.IgnoreQueryFilterMethodInfo)
+            {
+                var visitedExpression = Visit(methodCallExpression.Arguments[0]);
+                _queryCompilationContext.AddIgnoredQueryFilters(methodCallExpression.Arguments[1].GetConstantValue<string>());
+
+                return visitedExpression;
+            }
+
             if (genericMethodDefinition == EntityFrameworkQueryableExtensions.IgnoreQueryFiltersMethodInfo)
             {
                 var visitedExpression = Visit(methodCallExpression.Arguments[0]);

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -137,6 +137,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual bool IgnoreQueryFilters { get; internal set; }
 
         /// <summary>
+        ///     The set of named query filters that are ignored in this query.
+        /// </summary>
+        public virtual ISet<string> IgnoredQueryFilters { get; } = new HashSet<string>();
+
+        /// <summary>
         ///     A value indicating whether eager loaded navigations are ignored in this query.
         /// </summary>
         public virtual bool IgnoreAutoIncludes { get; internal set; }
@@ -165,6 +170,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotEmpty(tag, nameof(tag));
 
             Tags.Add(tag);
+        }
+
+        /// <summary>
+        ///     Adds a query filter the should be ignored <see cref="IgnoredQueryFilters" />.
+        /// </summary>
+        /// <param name="name"> The name of the query filter to ignore. </param>
+        public virtual void AddIgnoredQueryFilters(string name)
+        {
+            Check.NotEmpty(name, nameof(name));
+
+            IgnoredQueryFilters.Add(name);
         }
 
         /// <summary>

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -568,6 +568,14 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 throw new NotImplementedException();
             }
+            public LambdaExpression GetQueryFilter(string name)
+            {
+                throw new NotImplementedException();
+            }
+            public IDictionary<string, LambdaExpression> GetQueryFilters()
+            {
+                throw new NotImplementedException();
+            }
 
             public IEnumerable<IForeignKey> GetReferencingForeignKeys()
                 => throw new NotImplementedException();

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
@@ -165,6 +165,31 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_named_query_opt_out(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<OrderDetail>()
+                    .IgnoreQueryFilter("HasOrder")
+                    .IgnoreQueryFilter("Quantity"),
+                entryCount: 2155);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_single_named_query_opt_out(bool async)
+        {
+            return AssertQuery(
+                async,                
+                ss => ss.Set<OrderDetail>()
+                    .IgnoreQueryFilter("HasOrder"),
+                ss  => ss.Set<OrderDetail>()
+                    .Where(od => od.Quantity > 50),
+                entryCount: 159);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Included_many_to_one_query2(bool async)
         {
             return AssertFilteredQuery(

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
@@ -92,7 +92,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 
             modelBuilder.Entity<Customer>().HasQueryFilter(c => c.CompanyName.StartsWith(TenantPrefix));
             modelBuilder.Entity<Order>().HasQueryFilter(o => o.Customer != null && o.Customer.CompanyName != null);
-            modelBuilder.Entity<OrderDetail>().HasQueryFilter(od => od.Order != null && EF.Property<short>(od, "Quantity") > _quantity);
+            modelBuilder.Entity<OrderDetail>().HasQueryFilter("HasOrder", od => od.Order != null);
+            modelBuilder.Entity<OrderDetail>().HasQueryFilter("Quantity", od => EF.Property<short>(od, "Quantity") > _quantity);
             modelBuilder.Entity<Employee>().HasQueryFilter(e => e.Address.StartsWith("A"));
             modelBuilder.Entity<Product>().HasQueryFilter(p => ClientMethod(p));
             modelBuilder.Entity<CustomerQueryWithQueryFilter>().HasQueryFilter(cq => cq.CompanyName.StartsWith(SearchTerm));

--- a/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
@@ -46,7 +46,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<MethodCallChainFilter>().HasQueryFilter(e => e.Tenant == GetFlag().GetId());
             modelBuilder.Entity<ComplexFilter>().HasQueryFilter(x => x.IsEnabled == Property && (Tenant + GetId() > 0));
             modelBuilder.Entity<ShortCircuitFilter>()
-                .HasQueryFilter(x => !x.IsDeleted && (IsModerated == null || IsModerated == x.IsModerated));
+               .HasQueryFilter("SoftDelete", x => !x.IsDeleted);
+            modelBuilder.Entity<ShortCircuitFilter>()
+                .HasQueryFilter(x => IsModerated == null || IsModerated == x.IsModerated);
             modelBuilder.Entity<PrincipalSetFilter>()
                 .HasQueryFilter(p => Dependents.Any(d => d.PrincipalSetFilterId == p.Id));
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -146,12 +146,34 @@ LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 ORDER BY [c].[CustomerID], [o].[OrderID]");
         }
 
+        public override async Task Include_named_query_opt_out(bool async)
+        {
+            await base.Include_named_query_opt_out(async);
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]");
+        }
+
+        public override async Task Include_single_named_query_opt_out(bool async)
+        {
+            await base.Include_single_named_query_opt_out(async);
+
+            AssertSql(
+                @"@__ef_filter___quantity_0='50'
+
+SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]
+WHERE [o].[Quantity] > @__ef_filter___quantity_0");
+        }
+
+
         public override async Task Included_many_to_one_query(bool async)
         {
             await base.Included_many_to_one_query(async);
 
             AssertSql(
-                @"@__ef_filter__TenantPrefix_0='B' (Size = 4000)
+                @"@__ef_filter__TenantPrefix_0 ='B' (Size = 4000)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
 FROM [Orders] AS [o]


### PR DESCRIPTION
- Configure multiple query filters on a entity referenced by name.
- Ignore individual filters by name.

The current implmentation of query filter is kept but when ignoring the filters using the current extension method will ignore all filters (so also the named).

Fixes #8576 #10275 #21459
