### PR TITLE
Draft: Mapping a single property to multiple columns

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalForeignKeyExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Append('_')
                 .Append(principalTableName)
                 .Append('_')
-                .AppendJoin(foreignKey.Properties.Select(p => p.GetColumnBaseName()), "_")
+                .AppendJoin(foreignKey.Properties.Select(p => p.GetColumnBaseName())!, "_")
                 .ToString();
 
             return Uniquifier.Truncate(name, foreignKey.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalIndexExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore
                 .Append("IX_")
                 .Append(tableName)
                 .Append('_')
-                .AppendJoin(index.Properties.Select(p => p.GetColumnBaseName()), "_")
+                .AppendJoin(index.Properties.Select(p => p.GetColumnBaseName())!, "_")
                 .ToString();
 
             return Uniquifier.Truncate(baseName, index.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalKeyExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore
                     .Append("AK_")
                     .Append(tableName)
                     .Append('_')
-                    .AppendJoin(key.Properties.Select(p => p.GetColumnBaseName()), "_")
+                    .AppendJoin(key.Properties.Select(p => p.GetColumnBaseName())!, "_")
                     .ToString();
 
             return Uniquifier.Truncate(name, key.DeclaringEntityType.Model.GetMaxIdentifierLength());

--- a/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalPropertyExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The base name of the column to which the property would be mapped. </returns>
-        public static string GetColumnBaseName(this IReadOnlyProperty property)
+        public static string? GetColumnBaseName(this IReadOnlyProperty property)
             => (string?)property.FindAnnotation(RelationalAnnotationNames.ColumnName)?.Value ?? property.GetDefaultColumnBaseName();
 
         /// <summary>

--- a/src/EFCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/EFCore.Relational/Migrations/HistoryRepository.cs
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => _migrationIdColumnName ??= EnsureModel()
                 .FindEntityType(typeof(HistoryRow))!
                 .FindProperty(nameof(HistoryRow.MigrationId))!
-                .GetColumnBaseName();
+                .GetColumnBaseName()!;
 
         private IModel EnsureModel()
         {
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => _productVersionColumnName ??= EnsureModel()
                 .FindEntityType(typeof(HistoryRow))!
                 .FindProperty(nameof(HistoryRow.ProductVersion))!
-                .GetColumnBaseName();
+                .GetColumnBaseName()!;
 
         /// <summary>
         ///     Overridden by database providers to generate SQL that tests for existence of the history table.

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -808,9 +808,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public object? ReadPropertyValue(IPropertyBase propertyBase)
-            => propertyBase.IsShadowProperty()
-                ? _shadowValues[propertyBase.GetShadowIndex()]
-                : propertyBase.GetGetter().GetClrValue(Entity);
+            => propertyBase.IsPseudoProperty
+                ? ((IPseudoProperty)propertyBase).ValueExtractor(
+                    ReadPropertyValue(((IPseudoProperty)propertyBase).OuterProperty))
+                : propertyBase.IsShadowProperty()
+                    ? _shadowValues[propertyBase.GetShadowIndex()]
+                    : propertyBase.GetGetter().GetClrValue(Entity);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -65,6 +65,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     var runtimeProperty = Create(property, runtimeEntityType);
                     CreateAnnotations(property, runtimeProperty, static (convention, annotations, source, target, runtime) =>
                         convention.ProcessPropertyAnnotations(annotations, source, target, runtime));
+
+                    foreach (var pseudoProperty in property.GetPseudoProperties())
+                    {
+                        var nestedRuntimeProperty = Create(pseudoProperty, runtimeProperty);
+                        CreateAnnotations(pseudoProperty, nestedRuntimeProperty, static (convention, annotations, source, target, runtime) =>
+                            convention.ProcessPropertyAnnotations(annotations, source, target, runtime));
+                    }
                 }
 
                 foreach (var serviceProperty in entityType.GetDeclaredServiceProperties())
@@ -268,6 +275,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 property.ClrType,
                 property.PropertyInfo,
                 property.FieldInfo,
+                property.GetPropertyAccessMode(),
+                property.IsNullable,
+                property.IsConcurrencyToken,
+                property.ValueGenerated,
+                property.GetBeforeSaveBehavior(),
+                property.GetAfterSaveBehavior(),
+                property.GetMaxLength(),
+                property.IsUnicode(),
+                property.GetPrecision(),
+                property.GetScale(),
+                property.GetProviderClrType(),
+                property.GetValueGeneratorFactory(),
+                property.GetValueConverter(),
+                property.GetValueComparer(),
+                property.GetKeyValueComparer(),
+                property.GetTypeMapping());
+
+        private RuntimeProperty Create(IPseudoProperty property, RuntimeProperty runtimeProperty)
+            => runtimeProperty.AddPseudoProperty(
+                property.Name,
+                property.ClrType,
+                property.PropertyInfo,
+                property.FieldInfo,
+                runtimeProperty,
+                property.ValueExtractor,
                 property.GetPropertyAccessMode(),
                 property.IsNullable,
                 property.IsConcurrencyToken,

--- a/src/EFCore/Metadata/IConventionProperty.cs
+++ b/src/EFCore/Metadata/IConventionProperty.cs
@@ -142,6 +142,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IConventionIndex> GetContainingIndexes();
 
         /// <summary>
+        ///     Adds a pseudo-property below this property. For relational databases, pseudo-properties represent
+        ///     the columns in the database when a single property maps to multiple columns.
+        /// </summary>
+        /// <param name="property"> The pseudo-property. </param>
+        void AddPseudoProperty(IConventionPseudoProperty property);
+
+        /// <summary>
+        ///     Gets any pseudo-properties inside this property. For relational providers, each of these
+        ///     pseudo-properties maps to a column when the top-level property maps to multiple columns.
+        /// </summary>
+        /// <returns> The list of pseudo-properties. </returns>
+        new IReadOnlyList<IConventionProperty> GetPseudoProperties();
+        
+        /// <summary>
         ///     Gets the primary key that uses this property (including a composite primary key in which this property
         ///     is included).
         /// </summary>

--- a/src/EFCore/Metadata/IConventionPseudoProperty.cs
+++ b/src/EFCore/Metadata/IConventionPseudoProperty.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents a property mapped to the database, but fully accessed through an outer property.
+    ///         For relational databases, pseudo-properties represent the columns in the database when a single
+    ///         property maps to multiple columns.
+    ///     </para>
+    ///     <para>
+    ///         This interface is used during model creation and allows the metadata to be modified.
+    ///         Once the model is built, <see cref="IProperty" /> represents a read-only view of the same metadata.
+    ///     </para>
+    /// </summary>
+    public interface IConventionPseudoProperty : IConventionProperty, IPseudoProperty
+    {
+        /// <summary>
+        ///     The outer property used to access values of this pseudo-property.
+        /// </summary>
+        new IMutableProperty OuterProperty { get; }
+    }
+}

--- a/src/EFCore/Metadata/IMutableProperty.cs
+++ b/src/EFCore/Metadata/IMutableProperty.cs
@@ -85,6 +85,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IMutableIndex> GetContainingIndexes();
 
         /// <summary>
+        ///     Adds a pseudo-property below this property. For relational databases, pseudo-properties represent
+        ///     the columns in the database when a single property maps to multiple columns.
+        /// </summary>
+        /// <param name="property"> The pseudo-property. </param>
+        void AddPseudoProperty(IMutablePseudoProperty property);
+
+        /// <summary>
+        ///     Gets any pseudo-properties inside this property. For relational providers, each of these
+        ///     pseudo-properties maps to a column when the top-level property maps to multiple columns.
+        /// </summary>
+        /// <returns> The list of pseudo-properties. </returns>
+        new IReadOnlyList<IMutablePseudoProperty> GetPseudoProperties();
+
+        /// <summary>
         ///     Gets the primary key that uses this property (including a composite primary key in which this property
         ///     is included).
         /// </summary>

--- a/src/EFCore/Metadata/IMutablePseudoProperty.cs
+++ b/src/EFCore/Metadata/IMutablePseudoProperty.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents a property mapped to the database, but fully accessed through an outer property.
+    ///         For relational databases, pseudo-properties represent the columns in the database when a single
+    ///         property maps to multiple columns.
+    ///     </para>
+    ///     <para>
+    ///         This interface is used during model creation and allows the metadata to be modified.
+    ///         Once the model is built, <see cref="IPseudoProperty" /> represents a read-only view of the same metadata.
+    ///     </para>
+    /// </summary>
+    public interface IMutablePseudoProperty : IMutableProperty, IPseudoProperty
+    {
+        /// <summary>
+        ///     The outer property used to access values of this pseudo-property.
+        /// </summary>
+        new IMutableProperty OuterProperty { get; }
+    }
+}

--- a/src/EFCore/Metadata/IProperty.cs
+++ b/src/EFCore/Metadata/IProperty.cs
@@ -85,6 +85,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IIndex> GetContainingIndexes();
 
         /// <summary>
+        ///     Gets any pseudo-properties inside this property. For relational providers, each of these
+        ///     pseudo-properties maps to a column when the top-level property maps to multiple columns.
+        /// </summary>
+        /// <returns> The list of pseudo-properties. </returns>
+        new IReadOnlyList<IPseudoProperty> GetPseudoProperties();
+
+        /// <summary>
         ///     Gets the primary key that uses this property (including a composite primary key in which this property
         ///     is included).
         /// </summary>

--- a/src/EFCore/Metadata/IPseudoProperty.cs
+++ b/src/EFCore/Metadata/IPseudoProperty.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents a property mapped to the database, but fully accessed through an outer property.
+    ///         For relational databases, pseudo-properties represent the columns in the database when a single
+    ///         property maps to multiple columns.
+    ///     </para>
+    /// </summary>
+    public interface IPseudoProperty : IProperty
+    {
+        /// <summary>
+        ///     The outer property used to access values of this pseudo-property.
+        /// </summary>
+        IProperty OuterProperty { get; }
+
+        /// <summary>
+        ///     A delegate that accepts a value from the <see cref="OuterProperty"/> and generates the value
+        ///     for this pseudo-property.
+        /// </summary>
+        Func<object?, object?> ValueExtractor { get; }
+    }
+}

--- a/src/EFCore/Metadata/IReadOnlyProperty.cs
+++ b/src/EFCore/Metadata/IReadOnlyProperty.cs
@@ -249,6 +249,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IEnumerable<IReadOnlyIndex> GetContainingIndexes();
 
         /// <summary>
+        ///     Gets any pseudo-properties inside this property. For relational providers, each of these
+        ///     pseudo-properties maps to a column when the top-level property maps to multiple columns.
+        /// </summary>
+        /// <returns> The list of pseudo-properties. </returns>
+        IReadOnlyList<IReadOnlyProperty> GetPseudoProperties();
+        
+        /// <summary>
         ///     Gets a value indicating whether this property is used as the primary key (or part of a composite primary key).
         /// </summary>
         /// <returns> <see langword="true" /> if the property is used as the primary key, otherwise <see langword="false" />. </returns>

--- a/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
@@ -57,8 +57,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <returns>
         ///     <see langword="true" /> if the property is a shadow property, otherwise <see langword="false" />.
         /// </returns>
-        bool IsShadowProperty() => this.GetIdentifyingMemberInfo() == null;
+        bool IsShadowProperty()
+            => this.GetIdentifyingMemberInfo() == null;
 
+        /// <summary>
+        /// a
+        /// </summary>
+        /// <returns>b</returns>
+        bool IsPseudoProperty { get; }
+        
         /// <summary>
         ///     Gets a value indicating whether this is an indexer property. An indexer property is one that is accessed through
         ///     an indexer on the entity class.

--- a/src/EFCore/Metadata/IReadOnlyPseudoProperty.cs
+++ b/src/EFCore/Metadata/IReadOnlyPseudoProperty.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents a property mapped to the database, but fully accessed through an outer property.
+    ///         For relational databases, pseudo-properties represent the columns in the database when a single
+    ///         property maps to multiple columns.
+    ///     </para>
+    ///     <para>
+    ///         This interface is used during model creation and allows the metadata to be modified.
+    ///         Once the model is built, <see cref="IProperty" /> represents a read-only view of the same metadata.
+    ///     </para>
+    /// </summary>
+    public interface IReadOnlyPseudoProperty : IReadOnlyProperty, IPseudoProperty
+    {
+        /// <summary>
+        ///     The outer property used to access values of this pseudo-property.
+        /// </summary>
+        new IReadOnlyProperty OuterProperty { get; }
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -241,6 +241,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     storeGenerationIndex: property.MayBeStoreGenerated() ? storeGenerationIndex++ : -1);
 
                 ((IRuntimePropertyBase)property).PropertyIndexes = indexes;
+
+                foreach (var pseudoProperty in property.GetPseudoProperties())
+                {
+                    indexes = new PropertyIndexes(
+                        index: -1,
+                        originalValueIndex: -1,
+                        shadowIndex: -1,
+                        relationshipIndex: -1,
+                        storeGenerationIndex: -1);
+
+                    ((IRuntimePropertyBase)pseudoProperty).PropertyIndexes = indexes;
+                }
             }
 
             var isNotifying = entityType.GetChangeTrackingStrategy() != ChangeTrackingStrategy.Snapshot;

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -32,6 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private ValueGenerated? _valueGenerated;
         private CoreTypeMapping? _typeMapping;
         private InternalPropertyBuilder? _builder;
+        private List<PseudoProperty>? _pseudoProperties;
 
         private ConfigurationSource? _typeConfigurationSource;
         private ConfigurationSource? _isNullableConfigurationSource;
@@ -940,6 +941,78 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual IEnumerable<Index> GetContainingIndexes()
             => Indexes ?? Enumerable.Empty<Index>();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void AddPseudoProperty(PseudoProperty property)
+            => (_pseudoProperties ??= new()).Add(property);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        void IConventionProperty.AddPseudoProperty(IConventionPseudoProperty property)
+            => AddPseudoProperty((PseudoProperty)property);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        void IMutableProperty.AddPseudoProperty(IMutablePseudoProperty property)
+            => AddPseudoProperty((PseudoProperty)property);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IReadOnlyList<PseudoProperty> GetPseudoProperties()
+            => (_pseudoProperties ?? (IReadOnlyList<PseudoProperty>)Array.Empty<PseudoProperty>());
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IReadOnlyList<IPseudoProperty> IProperty.GetPseudoProperties()
+            => GetPseudoProperties();
+        
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IReadOnlyList<IReadOnlyProperty> IReadOnlyProperty.GetPseudoProperties()
+            => GetPseudoProperties();
+        
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IReadOnlyList<IMutablePseudoProperty> IMutableProperty.GetPseudoProperties()
+            => GetPseudoProperties();
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IReadOnlyList<IConventionProperty> IConventionProperty.GetPseudoProperties()
+            => GetPseudoProperties();
 
         /// <summary>
         ///     Runs the conventions when an annotation was set or removed.

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -235,6 +235,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ?.Value;
 
         /// <summary>
+        ///     Checks whether or not this property is an <see cref="IsPseudoProperty"/>.
+        /// </summary>
+        /// <returns> <see langword="true" /> if the property is a pseudo-property; <see langword="false" /> otherwise. </returns>
+        public virtual bool IsPseudoProperty
+            => false;
+
+        /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that

--- a/src/EFCore/Metadata/Internal/PseudoProperty.cs
+++ b/src/EFCore/Metadata/Internal/PseudoProperty.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class PseudoProperty : Property, IMutablePseudoProperty, IConventionPseudoProperty
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public PseudoProperty(
+            string name, 
+            Type clrType, 
+            PropertyInfo? propertyInfo, 
+            FieldInfo? fieldInfo, 
+            EntityType declaringEntityType, 
+            Property outerProperty,
+            Func<object?, object?> valueExtractor, 
+            ConfigurationSource configurationSource, 
+            ConfigurationSource? typeConfigurationSource)
+            : base(name, clrType, propertyInfo, fieldInfo, declaringEntityType, configurationSource, typeConfigurationSource)
+        {
+            OuterProperty = outerProperty;
+            ValueExtractor = valueExtractor;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Property OuterProperty { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Func<object?, object?> ValueExtractor { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IMutableProperty IConventionPseudoProperty.OuterProperty
+            => OuterProperty;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IMutableProperty IMutablePseudoProperty.OuterProperty
+            => OuterProperty;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        IProperty IPseudoProperty.OuterProperty
+            => OuterProperty;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override bool IsPseudoProperty
+            => true;
+    }
+}

--- a/src/EFCore/Metadata/RuntimePropertyBase.cs
+++ b/src/EFCore/Metadata/RuntimePropertyBase.cs
@@ -64,6 +64,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         protected abstract Type ClrType { get; }
 
+        /// <summary>
+        ///     Checks whether or not this property is an <see cref="IsPseudoProperty"/>.
+        /// </summary>
+        /// <returns> <see langword="true" /> if the property is a pseudo-property; <see langword="false" /> otherwise. </returns>
+        public virtual bool IsPseudoProperty
+            => false;
+
         /// <inheritdoc/>
         PropertyInfo? IReadOnlyPropertyBase.PropertyInfo
         {

--- a/src/EFCore/Metadata/RuntimePseudoProperty.cs
+++ b/src/EFCore/Metadata/RuntimePseudoProperty.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     Represents a property mapped to the database, but fully accessed through an outer property.
+    ///     For relational databases, pseudo-properties represent the columns in the database when a single
+    ///     property maps to multiple columns.
+    /// </summary>
+    public class RuntimePseudoProperty : RuntimeProperty, IPseudoProperty
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [EntityFrameworkInternal]
+        public RuntimePseudoProperty(
+            string name,
+            Type clrType,
+            PropertyInfo? propertyInfo,
+            FieldInfo? fieldInfo,
+            RuntimeProperty outerProperty,
+            Func<object?, object?> valueExtractor,
+            RuntimeEntityType declaringEntityType,
+            PropertyAccessMode propertyAccessMode,
+            bool nullable,
+            bool concurrencyToken,
+            ValueGenerated valueGenerated,
+            PropertySaveBehavior beforeSaveBehavior,
+            PropertySaveBehavior afterSaveBehavior,
+            int? maxLength,
+            bool? unicode,
+            int? precision,
+            int? scale,
+            Type? providerClrType,
+            Func<IProperty, IEntityType, ValueGenerator>? valueGeneratorFactory,
+            ValueConverter? valueConverter,
+            ValueComparer? valueComparer,
+            ValueComparer? keyValueComparer,
+            CoreTypeMapping? typeMapping)
+            : base(
+                name, clrType, propertyInfo, fieldInfo, declaringEntityType, propertyAccessMode, nullable, concurrencyToken, valueGenerated,
+                beforeSaveBehavior, afterSaveBehavior, maxLength, unicode, precision, scale, providerClrType, valueGeneratorFactory,
+                valueConverter, valueComparer, keyValueComparer, typeMapping)
+        {
+            OuterProperty = outerProperty;
+            ValueExtractor = valueExtractor;
+        }
+
+        /// <summary>
+        ///     The outer property used to access values of this pseudo-property.
+        /// </summary>
+        public virtual IProperty OuterProperty { get; }
+
+        /// <summary>
+        ///     A delegate that accepts a value from the <see cref="OuterProperty"/> and generates the value
+        ///     for this pseudo-property.
+        /// </summary>
+        public virtual Func<object?, object?> ValueExtractor { get; }
+
+        /// <summary>
+        ///     Checks whether or not this property is an <see cref="IsPseudoProperty"/>.
+        /// </summary>
+        /// <returns> <see langword="true" />. </returns>
+        public override bool IsPseudoProperty
+            => true;
+    }
+}

--- a/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
@@ -294,7 +294,7 @@ namespace Microsoft.EntityFrameworkCore
                             + $"{readonlyMethod.DeclaringType.Name}.{readonlyMethod.Name}({Format(readonlyMethod.GetParameters())})";
                     }
 
-                    if (mutableMethod.ReturnType.TryGetSequenceType() != expectedReturnTypes.Mutable)
+                    if (!expectedReturnTypes.Mutable.IsAssignableFrom(mutableMethod.ReturnType.TryGetSequenceType()))
                     {
                         return $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})"
                             + $" expected to have a return type that derives from IEnumerable<{expectedReturnTypes.Mutable}>.";

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -168,7 +168,9 @@ namespace Microsoft.EntityFrameworkCore
                 typeof(IMutableModel).GetMethod(nameof(IMutableModel.AddOwned)),
                 typeof(IMutableModel).GetMethod(nameof(IMutableModel.AddShared)),
                 typeof(IMutableEntityType).GetMethod(nameof(IMutableEntityType.AddData)),
-                typeof(IConventionEntityType).GetMethod(nameof(IConventionEntityType.LeastDerivedType))
+                typeof(IConventionEntityType).GetMethod(nameof(IConventionEntityType.LeastDerivedType)),
+                typeof(IMutableProperty).GetMethod(nameof(IMutableProperty.AddPseudoProperty)),
+                typeof(IConventionProperty).GetMethod(nameof(IConventionProperty.AddPseudoProperty))
             };
         }
     }

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -75,6 +75,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public IClrCollectionAccessor GetCollectionAccessor()
                 => throw new NotImplementedException();
 
+            public bool IsPseudoProperty
+                => false;
+
             public PropertyAccessMode GetPropertyAccessMode()
                 => throw new NotImplementedException();
 

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -40,6 +40,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public IEnumerable<IIndex> GetContainingIndexes()
                 => throw new NotImplementedException();
 
+            public IReadOnlyList<IPseudoProperty> GetPseudoProperties()
+                => throw new NotImplementedException();
+
+            IReadOnlyList<IReadOnlyProperty> IReadOnlyProperty.GetPseudoProperties()
+                => GetPseudoProperties();
+
             public IEnumerable<IKey> GetContainingKeys()
                 => throw new NotImplementedException();
 
@@ -105,6 +111,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             IEnumerable<IReadOnlyKey> IReadOnlyProperty.GetContainingKeys()
                 => throw new NotImplementedException();
+
+            public bool IsPseudoProperty
+                => false;
 
             public PropertyAccessMode GetPropertyAccessMode()
                 => throw new NotImplementedException();

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Same(property, new ClrPropertySetterFactory().Create(property));
         }
 
-        private class FakeProperty : Annotatable, IProperty, IClrPropertySetter
+        private class FakeProperty : Annotatable,  IProperty, IClrPropertySetter
         {
             public string Name { get; }
             public ITypeBase DeclaringType { get; }
@@ -54,6 +54,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             public IEnumerable<IIndex> GetContainingIndexes()
                 => throw new NotImplementedException();
+
+            public IReadOnlyList<IPseudoProperty> GetPseudoProperties()
+                => throw new NotImplementedException();
+
+            IReadOnlyList<IReadOnlyProperty> IReadOnlyProperty.GetPseudoProperties()
+                => GetPseudoProperties();
 
             public IEnumerable<IKey> GetContainingKeys()
                 => throw new NotImplementedException();
@@ -120,6 +126,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             IEnumerable<IReadOnlyKey> IReadOnlyProperty.GetContainingKeys()
                 => throw new NotImplementedException();
+
+            public bool IsPseudoProperty
+                => false;
 
             public PropertyAccessMode GetPropertyAccessMode()
                 => throw new NotImplementedException();


### PR DESCRIPTION
Part of #13947

The idea here is that a property can contain pseudo-properties that generally don't act like properties in the model, but form the basis for mapping to a column after extracting a value from the outer property.

Why properties? Because they have all the metadata needed to allow the facets of columns to be configured?

Why not relational only? Cosmos won't use this, but in-memory will be able to understand it.
