### PR TITLE
Implement DateOnly/TimeOnly support for Sqlite 

### DIFF
--- a/src/EFCore.Relational/Storage/DateOnlyTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateOnlyTypeMapping.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents the mapping between a .NET <see cref="DateOnly" /> type and a database type.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class DateOnlyTypeMapping : RelationalTypeMapping
+    {
+        private const string DateOnlyFormatConst = @"{0:yyyy-MM-dd}";
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DateOnlyTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public DateOnlyTypeMapping(
+            string storeType,
+            DbType? dbType = null)
+            : base(storeType, typeof(DateOnly), dbType)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DateOnlyTypeMapping" /> class.
+        /// </summary>
+        /// <param name="parameters"> Parameter object for <see cref="RelationalTypeMapping" />. </param>
+        protected DateOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a copy of this mapping.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new DateOnlyTypeMapping(parameters);
+
+        /// <summary>
+        ///     Gets the string format to be used to generate SQL literals of this type.
+        /// </summary>
+        protected override string SqlLiteralFormatString
+            => "DATE '" + DateOnlyFormatConst + "'";
+    }
+}

--- a/src/EFCore.Relational/Storage/TimeOnlyTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/TimeOnlyTypeMapping.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Globalization;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         Represents the mapping between a .NET <see cref="TimeOnly" /> type and a database type.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class TimeOnlyTypeMapping : RelationalTypeMapping
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TimeOnlyTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public TimeOnlyTypeMapping(
+            string storeType,
+            DbType? dbType = null)
+            : base(storeType, typeof(TimeOnly), dbType)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TimeOnlyTypeMapping" /> class.
+        /// </summary>
+        /// <param name="parameters"> Parameter object for <see cref="RelationalTypeMapping" />. </param>
+        protected TimeOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a copy of this mapping.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new TimeOnlyTypeMapping(parameters);
+
+        /// <inheritdoc />
+        protected override string GenerateNonNullSqlLiteral(object value)
+        {
+            var timeOnly = (TimeOnly)value;
+
+            return timeOnly.Ticks % TimeSpan.TicksPerSecond == 0
+                ? FormattableString.Invariant($@"TIME '{value:HH\:mm\:ss}'")
+                : FormattableString.Invariant($@"TIME '{value:HH\:mm\:ss\.FFFFFFF}'");
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateOnlyMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteDateOnlyMemberTranslator.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class SqliteDateOnlyMemberTranslator : IMemberTranslator
+    {
+        private static readonly Dictionary<string, string> _datePartMapping
+            = new()
+            {
+                { nameof(DateOnly.Year), "%Y" },
+                { nameof(DateOnly.Month), "%m" },
+                { nameof(DateOnly.DayOfYear), "%j" },
+                { nameof(DateOnly.Day), "%d" },
+                { nameof(DateOnly.DayOfWeek), "%w" }
+            };
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqliteDateOnlyMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual SqlExpression? Translate(
+            SqlExpression? instance,
+            MemberInfo member,
+            Type returnType,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            Check.NotNull(member, nameof(member));
+            Check.NotNull(returnType, nameof(returnType));
+            Check.NotNull(logger, nameof(logger));
+
+            return member.DeclaringType == typeof(DateOnly) && _datePartMapping.TryGetValue(member.Name, out var datePart)
+                ? _sqlExpressionFactory.Convert(
+                    SqliteExpression.Strftime(
+                        _sqlExpressionFactory,
+                        typeof(string),
+                        datePart,
+                        instance!),
+                    returnType)
+                : null;
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteMemberTranslatorProvider.cs
@@ -27,7 +27,9 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
             AddTranslators(
                 new IMemberTranslator[]
                 {
-                    new SqliteDateTimeMemberTranslator(sqlExpressionFactory), new SqliteStringLengthTranslator(sqlExpressionFactory)
+                    new SqliteDateTimeMemberTranslator(sqlExpressionFactory),
+                    new SqliteStringLengthTranslator(sqlExpressionFactory),
+                    new SqliteDateOnlyMemberTranslator(sqlExpressionFactory)
                 });
         }
     }

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateOnlyTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateOnlyTypeMapping.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class SqliteDateOnlyTypeMapping : DateOnlyTypeMapping
+    {
+        private const string DateOnlyFormatConst = @"'{0:yyyy\-MM\-dd}'";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqliteDateOnlyTypeMapping(
+            string storeType,
+            DbType? dbType = null)
+            : base(storeType, dbType)
+        {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected SqliteDateOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a copy of this mapping.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new SqliteDateOnlyTypeMapping(parameters);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override string SqlLiteralFormatString
+            => DateOnlyFormatConst;
+    }
+}

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTimeOnlyTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTimeOnlyTypeMapping.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class SqliteTimeOnlyTypeMapping : TimeOnlyTypeMapping
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqliteTimeOnlyTypeMapping(
+            string storeType,
+            DbType? dbType = null)
+            : base(storeType, dbType)
+        {
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected SqliteTimeOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a copy of this mapping.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        /// <returns> The newly created mapping. </returns>
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new SqliteTimeOnlyTypeMapping(parameters);
+
+        /// <inheritdoc />
+        protected override string GenerateNonNullSqlLiteral(object value)
+        {
+            var timeOnly = (TimeOnly)value;
+
+            return timeOnly.Ticks % TimeSpan.TicksPerSecond == 0
+                ? FormattableString.Invariant($@"'{value:HH\:mm\:ss}'")
+                : FormattableString.Invariant($@"'{value:HH\:mm\:ss\.fffffff}'");
+        }
+    }
+}

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -88,6 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
             { typeof(DateTime), new SqliteDateTimeTypeMapping(TextTypeName) },
             { typeof(DateTimeOffset), new SqliteDateTimeOffsetTypeMapping(TextTypeName) },
             { typeof(TimeSpan), new TimeSpanTypeMapping(TextTypeName) },
+            { typeof(DateOnly), new SqliteDateOnlyTypeMapping(TextTypeName) },
+            { typeof(TimeOnly), new SqliteTimeOnlyTypeMapping(TextTypeName) },
             { typeof(decimal), new SqliteDecimalTypeMapping(TextTypeName) },
             { typeof(double), _real },
             { typeof(float), new FloatTypeMapping(RealTypeName) },

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
@@ -68,6 +68,25 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+#if NET6_0_OR_GREATER
+        public virtual DateOnly GetDateOnly(int ordinal)
+        {
+            var sqliteType = GetSqliteType(ordinal);
+            switch (sqliteType)
+            {
+                case SQLITE_FLOAT:
+                case SQLITE_INTEGER:
+                    return DateOnly.FromDateTime(FromJulianDate(GetDouble(ordinal)));
+
+                default:
+                    return DateOnly.Parse(GetString(ordinal), CultureInfo.InvariantCulture);
+            }
+        }
+
+        public virtual TimeOnly GetTimeOnly(int ordinal)
+            => TimeOnly.Parse(GetString(ordinal), CultureInfo.InvariantCulture);
+#endif
+
         public virtual decimal GetDecimal(int ordinal)
             => decimal.Parse(GetString(ordinal), NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
 
@@ -168,6 +187,18 @@ namespace Microsoft.Data.Sqlite
             {
                 return (T)(object)GetDateTimeOffset(ordinal);
             }
+
+#if NET6_0_OR_GREATER
+            if (type == typeof(DateOnly))
+            {
+                return (T)(object)GetDateOnly(ordinal);
+            }
+
+            if (type == typeof(TimeOnly))
+            {
+                return (T)(object)GetTimeOnly(ordinal);
+            }
+#endif
 
             if (type == typeof(DBNull))
             {

--- a/test/EFCore.OData.FunctionalTests/Query/GearsOfWarODataContext.cs
+++ b/test/EFCore.OData.FunctionalTests/Query/GearsOfWarODataContext.cs
@@ -92,6 +92,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<LocustHighCommand>().Property(l => l.Id).ValueGeneratedNever();
 
             modelBuilder.Entity<City>().Property(g => g.Location).HasColumnType("varchar(100)");
+
+            // No support yet for DateOnly/TimeOnly (#24507)
+            modelBuilder.Entity<Mission>(
+                b =>
+                {
+                    b.Ignore(m => m.Date);
+                    b.Ignore(m => m.Time);
+                });
         }
     }
 }

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -407,6 +407,33 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         [ConditionalFact]
+        public virtual void DateOnly_literal_generated_correctly()
+        {
+            Test_GenerateSqlLiteral_helper(
+                new DateOnlyTypeMapping("DateOnly"),
+                new DateOnly(2015, 3, 12),
+                "DATE '2015-03-12'");
+        }
+
+        [ConditionalFact]
+        public virtual void TimeOnly_literal_generated_correctly()
+        {
+            Test_GenerateSqlLiteral_helper(
+                new TimeOnlyTypeMapping("TimeOnly"),
+                new TimeOnly(13, 10, 15),
+                "TIME '13:10:15'");
+        }
+
+        [ConditionalFact]
+        public virtual void TimeOnly_literal_generated_correctly_with_milliseconds()
+        {
+            Test_GenerateSqlLiteral_helper(
+                new TimeOnlyTypeMapping("TimeOnly"),
+                new TimeOnly(13, 10, 15, 500),
+                "TIME '13:10:15.5'");
+        }
+
+        [ConditionalFact]
         public virtual void Decimal_literal_generated_correctly()
         {
             var typeMapping = new DecimalTypeMapping("decimal", DbType.Decimal);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -8796,6 +8796,176 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_Year(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Year == 1990).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_Month(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Month == 11).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_Day(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Day == 10).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_DayOfYear(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.DayOfYear == 314).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_DayOfWeek(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.DayOfWeek == DayOfWeek.Saturday).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_AddYears(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddYears(3) == new DateOnly(1993, 11, 10)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_AddMonths(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddMonths(3) == new DateOnly(1991, 2, 10)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_DateOnly_AddDays(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddDays(3) == new DateOnly(1990, 11, 13)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_Hour(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Hour == 10).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_Minute(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Minute == 15).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_Second(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Second == 50).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_Millisecond(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Millisecond == 500).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_AddHours(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.AddHours(3) == new TimeOnly(13, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.AddMinutes(3) == new TimeOnly(10, 18, 50, 500)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Add(new TimeSpan(3, 0, 0)) == new TimeOnly(13, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_IsBetween(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.IsBetween(new TimeOnly(10, 0, 0), new TimeOnly(11, 0, 0))).AsTracking(),
+                entryCount: 1);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time - new TimeOnly(10, 0, 0) == new TimeSpan(0, 0, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+        }
+
         protected GearsOfWarContext CreateContext()
             => Fixture.CreateContext();
 

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -132,7 +132,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                     CodeName = "Lightmass Offensive",
                     Rating = 2.1,
                     Timeline = new DateTimeOffset(599898024001234567, new TimeSpan(1, 30, 0)),
-                    Duration = new TimeSpan(1, 2, 3)
+                    Duration = new TimeSpan(1, 2, 3),
+                    Date = new DateOnly(2020, 1, 1),
+                    Time = new TimeOnly(15, 30, 10)
                 },
                 new()
                 {
@@ -140,7 +142,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                     CodeName = "Hollow Storm",
                     Rating = 4.2,
                     Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)),
-                    Duration = new TimeSpan(0, 1, 2, 3, 456)
+                    Duration = new TimeSpan(0, 1, 2, 3, 456),
+                    Date = new DateOnly(1990, 11, 10),
+                    Time = new TimeOnly(10, 15, 50, 500)
                 },
                 new()
                 {
@@ -148,7 +152,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                     CodeName = "Halvo Bay defense",
                     Rating = null,
                     Timeline = new DateTimeOffset(10, 5, 3, 12, 0, 0, new TimeSpan()),
-                    Duration = new TimeSpan(0, 1, 0, 15, 456)
+                    Duration = new TimeSpan(0, 1, 0, 15, 456),
+                    Date = new DateOnly(1, 1, 1),
+                    Time = new TimeOnly(0, 0, 0)
                 }
             };
 

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public double? Rating { get; set; }
         public DateTimeOffset Timeline { get; set; }
         public TimeSpan Duration { get; set; }
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
 
         public virtual ICollection<SquadMission> ParticipatingSquads { get; set; }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerFixture.cs
@@ -17,13 +17,21 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             modelBuilder.Entity<City>().Property(g => g.Location).HasColumnType("varchar(100)");
 
-            // Full-text binary search
-            modelBuilder.Entity<Mission>()
-                .Property<byte[]>("BriefingDocument");
+            modelBuilder.Entity<Mission>(
+                b =>
+                {
+                    // Full-text binary search
+                    b.Property<byte[]>("BriefingDocument");
+                    b.Property<string>("BriefingDocumentFileExtension").HasColumnType("nvarchar(16)");
+                });
 
-            modelBuilder.Entity<Mission>()
-                .Property<string>("BriefingDocumentFileExtension")
-                .HasColumnType("nvarchar(16)");
+            // No support yet for DateOnly/TimeOnly (#24507)
+            modelBuilder.Entity<Mission>(
+                b =>
+                {
+                    b.Ignore(m => m.Date);
+                    b.Ignore(m => m.Time);
+                });
         }
 
         protected override void Seed(GearsOfWarContext context)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7897,7 +7897,7 @@ OUTER APPLY (
 ) AS [t]
 ORDER BY [g].[Nickname], [g].[SquadId], [t].[IsAutomatic], [t].[Name]");
         }
-     
+
         public override async Task Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(bool async)
         {
             await base.Correlated_collection_via_SelectMany_with_Distinct_missing_indentifying_columns_in_projection(async);
@@ -7966,6 +7966,159 @@ OUTER APPLY (
     ) AS [t1]
 ) AS [t2]
 ORDER BY [t].[Length], [t2].[HasSoulPatch], [t2].[CityOfBirthName], [t2].[Id]");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Year(bool async)
+        {
+            await base.Where_DateOnly_Year(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Month(bool async)
+        {
+            await base.Where_DateOnly_Month(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Day(bool async)
+        {
+            await base.Where_DateOnly_Day(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfYear(bool async)
+        {
+            await base.Where_DateOnly_DayOfYear(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfWeek(bool async)
+        {
+            await base.Where_DateOnly_DayOfWeek(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddYears(bool async)
+        {
+            await base.Where_DateOnly_AddYears(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddMonths(bool async)
+        {
+            await base.Where_DateOnly_AddMonths(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddDays(bool async)
+        {
+            await base.Where_DateOnly_AddDays(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Hour(bool async)
+        {
+            await base.Where_TimeOnly_Hour(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Minute(bool async)
+        {
+            await base.Where_TimeOnly_Minute(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Second(bool async)
+        {
+            await base.Where_TimeOnly_Second(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Millisecond(bool async)
+        {
+            await base.Where_TimeOnly_Millisecond(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddHours(bool async)
+        {
+            await base.Where_TimeOnly_AddHours(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            await base.Where_TimeOnly_AddMinutes(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            await base.Where_TimeOnly_Add_TimeSpan(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_IsBetween(bool async)
+        {
+            await base.Where_TimeOnly_IsBetween(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            await base.Where_TimeOnly_subtract_TimeOnly(async);
+
+            AssertSql("");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerFixture.cs
@@ -16,6 +16,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.OnModelCreating(modelBuilder, context);
 
             modelBuilder.Entity<City>().Property(g => g.Location).HasColumnType("varchar(100)");
+
+            // No support yet for DateOnly/TimeOnly (#24507)
+            modelBuilder.Entity<Mission>(
+                b =>
+                {
+                    b.Ignore(m => m.Date);
+                    b.Ignore(m => m.Time);
+                });
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TPTGearsOfWarQuerySqlServerTest.cs
@@ -8912,6 +8912,159 @@ ORDER BY CASE
 END, [t].[Note]");
         }
 
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Year(bool async)
+        {
+            await base.Where_DateOnly_Year(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Month(bool async)
+        {
+            await base.Where_DateOnly_Month(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Day(bool async)
+        {
+            await base.Where_DateOnly_Day(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfYear(bool async)
+        {
+            await base.Where_DateOnly_DayOfYear(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfWeek(bool async)
+        {
+            await base.Where_DateOnly_DayOfWeek(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddYears(bool async)
+        {
+            await base.Where_DateOnly_AddYears(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddMonths(bool async)
+        {
+            await base.Where_DateOnly_AddMonths(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddDays(bool async)
+        {
+            await base.Where_DateOnly_AddDays(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Hour(bool async)
+        {
+            await base.Where_TimeOnly_Hour(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Minute(bool async)
+        {
+            await base.Where_TimeOnly_Minute(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Second(bool async)
+        {
+            await base.Where_TimeOnly_Second(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Millisecond(bool async)
+        {
+            await base.Where_TimeOnly_Millisecond(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddHours(bool async)
+        {
+            await base.Where_TimeOnly_AddHours(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            await base.Where_TimeOnly_AddMinutes(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            await base.Where_TimeOnly_Add_TimeSpan(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_IsBetween(bool async)
+        {
+            await base.Where_TimeOnly_IsBetween(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#24507")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            await base.Where_TimeOnly_subtract_TimeOnly(async);
+
+            AssertSql("");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/GearsOfWarQuerySqliteTest.cs
@@ -341,6 +341,183 @@ WHERE ""s"".""Banner5"" = @__byteArrayParam_0");
             return base.Array_access_on_byte_array(async);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Year(bool async)
+        {
+            await base.Where_DateOnly_Year(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(strftime('%Y', ""m"".""Date"") AS INTEGER) = 1990");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Month(bool async)
+        {
+            await base.Where_DateOnly_Month(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(strftime('%m', ""m"".""Date"") AS INTEGER) = 11");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_Day(bool async)
+        {
+            await base.Where_DateOnly_Day(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(strftime('%d', ""m"".""Date"") AS INTEGER) = 10");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfYear(bool async)
+        {
+            await base.Where_DateOnly_DayOfYear(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(strftime('%j', ""m"".""Date"") AS INTEGER) = 314");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_DayOfWeek(bool async)
+        {
+            await base.Where_DateOnly_DayOfWeek(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE CAST(strftime('%w', ""m"".""Date"") AS INTEGER) = 6");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddYears(bool async)
+        {
+            await base.Where_DateOnly_AddYears(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE date(""m"".""Date"", CAST(3 AS TEXT) || ' years') = '1993-11-10'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddMonths(bool async)
+        {
+            await base.Where_DateOnly_AddMonths(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE date(""m"".""Date"", CAST(3 AS TEXT) || ' months') = '1991-02-10'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_DateOnly_AddDays(bool async)
+        {
+            await base.Where_DateOnly_AddDays(async);
+
+            AssertSql(
+                @"SELECT ""m"".""Id"", ""m"".""CodeName"", ""m"".""Date"", ""m"".""Duration"", ""m"".""Rating"", ""m"".""Time"", ""m"".""Timeline""
+FROM ""Missions"" AS ""m""
+WHERE date(""m"".""Date"", CAST(3 AS TEXT) || ' days') = '1990-11-13'");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Hour(bool async)
+        {
+            await base.Where_TimeOnly_Hour(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Minute(bool async)
+        {
+            await base.Where_TimeOnly_Minute(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Second(bool async)
+        {
+            await base.Where_TimeOnly_Second(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Millisecond(bool async)
+        {
+            await base.Where_TimeOnly_Millisecond(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddHours(bool async)
+        {
+            await base.Where_TimeOnly_AddHours(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            await base.Where_TimeOnly_AddMinutes(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            await base.Where_TimeOnly_Add_TimeSpan(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_IsBetween(bool async)
+        {
+            await base.Where_TimeOnly_IsBetween(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            await base.Where_TimeOnly_subtract_TimeOnly(async);
+
+            AssertSql("");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/TPTGearsOfWarQuerySqliteTest.cs
@@ -342,6 +342,87 @@ WHERE ""s"".""Banner5"" = @__byteArrayParam_0");
             return base.Array_access_on_byte_array(async);
         }
 
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Hour(bool async)
+        {
+            await base.Where_TimeOnly_Hour(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Minute(bool async)
+        {
+            await base.Where_TimeOnly_Minute(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Second(bool async)
+        {
+            await base.Where_TimeOnly_Second(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Millisecond(bool async)
+        {
+            await base.Where_TimeOnly_Millisecond(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddHours(bool async)
+        {
+            await base.Where_TimeOnly_AddHours(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            await base.Where_TimeOnly_AddMinutes(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            await base.Where_TimeOnly_Add_TimeSpan(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_IsBetween(bool async)
+        {
+            await base.Where_TimeOnly_IsBetween(async);
+
+            AssertSql("");
+        }
+
+        [ConditionalTheory(Skip = "Issue#18844")]
+        [MemberData(nameof(IsAsyncData))]
+        public override async Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            await base.Where_TimeOnly_subtract_TimeOnly(async);
+
+            AssertSql("");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -133,6 +133,33 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 "'2015-03-12 13:36:37.371'");
         }
 
+        [ConditionalFact]
+        public override void DateOnly_literal_generated_correctly()
+        {
+            Test_GenerateSqlLiteral_helper(
+                GetMapping(typeof(DateOnly)),
+                new DateOnly(2015, 3, 12),
+                "'2015-03-12'");
+        }
+
+        [ConditionalFact]
+        public override void TimeOnly_literal_generated_correctly()
+        {
+            Test_GenerateSqlLiteral_helper(
+                GetMapping(typeof(TimeOnly)),
+                new TimeOnly(13, 10, 15),
+                "'13:10:15'");
+        }
+
+        [ConditionalFact]
+        public override void TimeOnly_literal_generated_correctly_with_milliseconds()
+        {
+            Test_GenerateSqlLiteral_helper(
+                GetMapping(typeof(TimeOnly)),
+                new TimeOnly(13, 10, 15, 500),
+                "'13:10:15.5000000'");
+        }
+
         public override void Decimal_literal_generated_correctly()
         {
             var typeMapping = new SqliteDecimalTypeMapping("TEXT");

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -688,6 +688,30 @@ namespace Microsoft.Data.Sqlite
         public void GetDateTimeOffset_throws_when_null()
             => GetX_throws_when_null(r => ((SqliteDataReader)r).GetDateTimeOffset(0));
 
+        [Fact]
+        public void GetFieldValue_of_DateOnly_works()
+            => GetFieldValue_works(
+                "SELECT '2014-04-15';",
+                new DateOnly(2014, 4, 15));
+
+        [Fact]
+        public void GetFieldValue_of_DateOnly_works_with_real()
+            => GetFieldValue_works(
+                "SELECT julianday('2014-04-15');",
+                new DateOnly(2014, 4, 15));
+
+        [Fact]
+        public void GetFieldValue_of_TimeOnly_works()
+            => GetFieldValue_works(
+                "SELECT '13:10:15';",
+                new TimeOnly(13, 10, 15));
+
+        [Fact]
+        public void GetFieldValue_of_TimeOnly_works_with_milliseconds()
+            => GetFieldValue_works(
+                "SELECT '13:10:15.5';",
+                new TimeOnly(13, 10, 15, 500));
+
         [Theory]
         [InlineData("SELECT 1;", "INTEGER")]
         [InlineData("SELECT 3.14;", "REAL")]

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -258,6 +258,26 @@ namespace Microsoft.Data.Sqlite
                 SqliteType.Real);
 
         [Fact]
+        public void Bind_works_when_DateOnly()
+            => Bind_works(new DateOnly(2014, 4, 14), "2014-04-14");
+
+        [Fact]
+        public void Bind_works_when_DateOnly_with_SqliteType_Real()
+            => Bind_works(new DateOnly(2014, 4, 14), 2456761.5, SqliteType.Real);
+
+        [Fact]
+        public void Bind_works_when_TimeOnly()
+            => Bind_works(new TimeOnly(13, 10, 15), "13:10:15");
+
+        [Fact]
+        public void Bind_works_when_TimeOnly_with_milliseconds()
+            => Bind_works(new TimeOnly(13, 10, 15, 500), "13:10:15.5000000");
+
+        [Fact]
+        public void Bind_works_when_TimeOnly_with_SqliteType_Real()
+            => Bind_works(new TimeOnly(13, 10, 15), 0.5487847222222222, SqliteType.Real);
+
+        [Fact]
         public void Bind_works_when_DBNull()
             => Bind_works(DBNull.Value, DBNull.Value);
 


### PR DESCRIPTION
Closes #24506

Note: this doesn't add translations for TimeOnly, since none exist for TimeSpan at the moment (and some Sqlite magic needs to be done). Both can be done together as part of #18844.