### PR TITLE
Scaffold SQL Server index fill factor annotation as int

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -1019,7 +1019,7 @@ ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";
 
                     if (indexGroup.Key.FillFactor > 0 && indexGroup.Key.FillFactor <= 100)
                     {
-                        index[SqlServerAnnotationNames.FillFactor] = indexGroup.Key.FillFactor;
+                        index[SqlServerAnnotationNames.FillFactor] = (int)indexGroup.Key.FillFactor;
                     }
 
                     foreach (var dataRecord in indexGroup)

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -2008,6 +2008,33 @@ CREATE INDEX IX_INCLUDE ON IncludeIndexTable(IndexProperty) INCLUDE (IncludeProp
                 "DROP TABLE IncludeIndexTable;");
         }
 
+        [ConditionalFact]
+        public void Index_fill_factor()
+        {
+            Test(
+                @"
+CREATE TABLE IndexFillFactor
+(
+    Id INT IDENTITY,
+    Name NVARCHAR(100)
+);
+
+CREATE NONCLUSTERED INDEX [IX_Name] ON [dbo].[IndexFillFactor]
+(
+     [Name] ASC
+)
+WITH (FILLFACTOR = 80) ON [PRIMARY]",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var index = Assert.Single(dbModel.Tables.Single().Indexes);
+                    Assert.Equal(new[] { "Name" }, index.Columns.Select(ic => ic.Name).ToList());
+                    Assert.Equal(80, index[SqlServerAnnotationNames.FillFactor]);
+                },
+                "DROP TABLE IndexFillFactor;");
+        }
+
         #endregion
 
         #region ForeignKeyFacets


### PR DESCRIPTION
We can also go the other way, i.e. change the metadata APIs to work with byte. This would be more consistent with the internal SQL Server representation (tinyint), but would be a small breaking change.

Fixes #25006