### PR TITLE
Use Random.Shared

### DIFF
--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -93,7 +93,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     A pseudo-random number generator that can be used to vary the delay between retries.
         /// </summary>
+#if NET6_0_OR_GREATER
+        protected virtual Random Random { get; } = Random.Shared;
+#else
         protected virtual Random Random { get; } = new();
+#endif
 
         /// <summary>
         ///     The maximum number of retry attempts.

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -93,11 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     A pseudo-random number generator that can be used to vary the delay between retries.
         /// </summary>
-#if NET6_0_OR_GREATER
-        protected virtual Random Random { get; } = Random.Shared;
-#else
         protected virtual Random Random { get; } = new();
-#endif
 
         /// <summary>
         ///     The maximum number of retry attempts.

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -3644,7 +3644,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Order>().Where(o => o.OrderID < (new Random().Next() - 2147483647)));
+                ss => ss.Set<Order>().Where(o => o.OrderID < (Random.Shared.Next() - 2147483647)));
         }
 
         [ConditionalTheory]
@@ -3653,7 +3653,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(5)),
+                ss => ss.Set<Order>().Where(o => o.OrderID > Random.Shared.Next(5)),
                 entryCount: 830);
         }
 
@@ -3663,7 +3663,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Order>().Where(o => o.OrderID > new Random().Next(0, 10)),
+                ss => ss.Set<Order>().Where(o => o.OrderID > Random.Shared.Next(0, 10)),
                 entryCount: 830);
         }
 

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
@@ -308,7 +308,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
 
         public void Execute<TElement>(IQueryable<TElement> query, DbContext context, string testMethodName)
         {
-            var seed = ProceduralQueryExpressionGenerator.Seed ?? new Random().Next();
+            var seed = ProceduralQueryExpressionGenerator.Seed ?? Random.Shared.Next();
             var random = new Random(seed);
             var depth = 2;
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -442,7 +442,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             var builder = new SqlConnectionStringBuilder(TestEnvironment.DefaultConnection)
             {
-                MultipleActiveResultSets = multipleActiveResultSets ?? new Random().Next(0, 2) == 1, InitialCatalog = name
+                MultipleActiveResultSets = multipleActiveResultSets ?? Random.Shared.Next(0, 2) == 1, InitialCatalog = name
             };
             if (fileName != null)
             {

--- a/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
@@ -541,7 +541,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 NullableInt = i;
                 String = i.ToString();
                 XNode = new NotXText(i.ToString());
-                Random = new Random();
+                Random = Random.Shared;
                 ByteArray = new[] { (byte)i, (byte)i, (byte)i, (byte)i };
             }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Int = i;
                 NullableInt = i;
                 String = i.ToString();
-                Random = new Random();
+                Random = Random.Shared;
                 ByteArray = new[] { (byte)i, (byte)i, (byte)i, (byte)i };
             }
 


### PR DESCRIPTION
Use the new [`Random.Shared`](https://github.com/dotnet/runtime/blob/3c1f5b380e6704f9d14de02a4a22adaec5095cd1/src/libraries/System.Private.CoreLib/src/System/Random.cs#L50-L51) property to remove the need to allocate a new instance when targeting `net6.0`.

<!--
Please check if the PR fulfills these requirements

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

Review the guidelines for [contributing](CONTRIBUTING.md) for more details.
-->
