### PR TITLE
Don't remove default table mapping for TVF return entity types.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -825,28 +825,43 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 || entityType.BaseType == null)
             {
                 var tableName = (string?)tableNameAnnotation?.Value ?? entityType.GetTableName();
-                if (tableName != null)
+                if (tableName != null
+                    || tableNameAnnotation != null)
                 {
+                    var schemaAnnotation = annotations.Find(RelationalAnnotationNames.Schema);
                     stringBuilder
                         .AppendLine()
                         .Append(builderName)
-                        .Append(".ToTable(")
-                        .Append(Code.Literal(tableName));
+                        .Append(".ToTable(");
+
+                    if (tableName == null
+                        && schemaAnnotation == null)
+                    {
+                        stringBuilder.Append("(string)");
+                    }
+
+                    stringBuilder.Append(Code.UnknownLiteral(tableName));
+
                     if (tableNameAnnotation != null)
                     {
                         annotations.Remove(tableNameAnnotation.Name);
                     }
 
-                    var schemaAnnotation = annotations.Find(RelationalAnnotationNames.Schema);
-                    if (schemaAnnotation?.Value != null)
+                    var isExcludedAnnotation = annotations.Find(RelationalAnnotationNames.IsTableExcludedFromMigrations);
+                    if (schemaAnnotation != null)
                     {
                         stringBuilder
-                            .Append(", ")
-                            .Append(Code.Literal((string)schemaAnnotation.Value));
-                        annotations.Remove(schemaAnnotation.Name);
+                            .Append(", ");
+
+                        if (schemaAnnotation.Value == null
+                            && ((bool?)isExcludedAnnotation?.Value) != true)
+                        {
+                            stringBuilder.Append("(string)");
+                        }
+
+                        stringBuilder.Append(Code.UnknownLiteral(schemaAnnotation.Value));
                     }
 
-                    var isExcludedAnnotation = annotations.Find(RelationalAnnotationNames.IsTableExcludedFromMigrations);
                     if (isExcludedAnnotation != null)
                     {
                         if (((bool?)isExcludedAnnotation.Value) == true)
@@ -870,19 +885,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     stringBuilder.AppendLine(");");
                 }
             }
+            annotations.Remove(RelationalAnnotationNames.Schema);
 
             var viewNameAnnotation = annotations.Find(RelationalAnnotationNames.ViewName);
             if (viewNameAnnotation?.Value != null
                 || entityType.BaseType == null)
             {
                 var viewName = (string?)viewNameAnnotation?.Value ?? entityType.GetViewName();
-                if (viewName != null)
+                if (viewName != null
+                    || viewNameAnnotation != null)
                 {
                     stringBuilder
                         .AppendLine()
                         .Append(builderName)
                         .Append(".ToView(")
-                        .Append(Code.Literal(viewName));
+                        .Append(Code.UnknownLiteral(viewName));
                     if (viewNameAnnotation != null)
                     {
                         annotations.Remove(viewNameAnnotation.Name);
@@ -900,25 +917,48 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     stringBuilder.AppendLine(");");
                 }
             }
+            annotations.Remove(RelationalAnnotationNames.ViewSchema);
+            annotations.Remove(RelationalAnnotationNames.ViewDefinitionSql);
 
             var functionNameAnnotation = annotations.Find(RelationalAnnotationNames.FunctionName);
             if (functionNameAnnotation?.Value != null
                 || entityType.BaseType == null)
             {
                 var functionName = (string?)functionNameAnnotation?.Value ?? entityType.GetFunctionName();
-                if (functionName != null)
+                if (functionName != null
+                    || functionNameAnnotation != null)
                 {
                     stringBuilder
                         .AppendLine()
                         .Append(builderName)
                         .Append(".ToFunction(")
-                        .Append(Code.Literal(functionName));
+                        .Append(Code.UnknownLiteral(functionName))
+                        .AppendLine(");");
                     if (functionNameAnnotation != null)
                     {
                         annotations.Remove(functionNameAnnotation.Name);
                     }
+                }
+            }
 
-                    stringBuilder.AppendLine(");");
+            var sqlQueryAnnotation = annotations.Find(RelationalAnnotationNames.SqlQuery);
+            if (sqlQueryAnnotation?.Value != null
+                || entityType.BaseType == null)
+            {
+                var sqlQuery = (string?)sqlQueryAnnotation?.Value ?? entityType.GetSqlQuery();
+                if (sqlQuery != null
+                    || sqlQueryAnnotation != null)
+                {
+                    stringBuilder
+                        .AppendLine()
+                        .Append(builderName)
+                        .Append(".ToSqlQuery(")
+                        .Append(Code.UnknownLiteral(sqlQuery))
+                        .AppendLine(");");
+                    if (sqlQueryAnnotation != null)
+                    {
+                        annotations.Remove(sqlQueryAnnotation.Name);
+                    }
                 }
             }
 

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -215,6 +215,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private IEnumerable<string> GetAnnotationNamespaces(IEnumerable<IAnnotatable> items)
             => items.SelectMany(
                 i => Dependencies.AnnotationCodeGenerator.FilterIgnoredAnnotations(i.GetAnnotations())
+                    .Where(a => a.Value != null)
                     .Select(a => new { Annotatable = i, Annotation = a })
                     .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value!.GetType()).GetNamespaces()));
 

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -54,9 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <inheritdoc />
         public virtual IEnumerable<IAnnotation> FilterIgnoredAnnotations(IEnumerable<IAnnotation> annotations)
             => annotations.Where(
-                a => !(
-                    a.Value is null
-                    || CoreAnnotationNames.AllNames.Contains(a.Name)
+                a => !(CoreAnnotationNames.AllNames.Contains(a.Name)
                     || _ignoredRelationalAnnotations.Contains(a.Name)));
 
         /// <inheritdoc />
@@ -676,12 +674,14 @@ namespace Microsoft.EntityFrameworkCore.Design
             string methodName,
             List<MethodCallCodeFragment> methodCallCodeFragments)
         {
-            if (annotations.TryGetValue(annotationName, out var annotation)
-                && annotation.Value is object annotationValue)
+            if (annotations.TryGetValue(annotationName, out var annotation))
             {
                 annotations.Remove(annotationName);
-                methodCallCodeFragments.Add(
-                    new MethodCallCodeFragment(methodName, annotationValue));
+                if (annotation.Value is object annotationValue)
+                {
+                    methodCallCodeFragments.Add(
+                        new MethodCallCodeFragment(methodName, annotationValue));
+                }
             }
         }
 

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -691,10 +691,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
         /// <param name="query"> The SQL query that will provide the underlying data for the entity type. </param>
         /// <returns> The same builder instance so that multiple calls can be chained. </returns>
-        public static EntityTypeBuilder<TEntity> ToSqlQuery<TEntity>(
-            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        public static EntityTypeBuilder ToSqlQuery(
+            this EntityTypeBuilder entityTypeBuilder,
             string query)
-            where TEntity : class
         {
             Check.NotNull(query, nameof(query));
 
@@ -702,6 +701,18 @@ namespace Microsoft.EntityFrameworkCore
 
             return entityTypeBuilder;
         }
+
+        /// <summary>
+        ///     Configures a SQL string used to provide data for the entity type.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="query"> The SQL query that will provide the underlying data for the entity type. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static EntityTypeBuilder<TEntity> ToSqlQuery<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            string query)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)ToSqlQuery((EntityTypeBuilder)entityTypeBuilder, query);
 
         /// <summary>
         ///     Configures a SQL string used to provide data for the entity type.

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -547,7 +547,7 @@ namespace Microsoft.EntityFrameworkCore
             string? name,
             bool fromDataAnnotation = false)
             => (string?)entityType.SetAnnotation(
-                RelationalAnnotationNames.ViewName,
+                RelationalAnnotationNames.FunctionName,
                 Check.NullButNotEmpty(name, nameof(name)),
                 fromDataAnnotation)?.Value;
 

--- a/src/EFCore.Relational/Metadata/Conventions/TableValuedDbFunctionConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableValuedDbFunctionConvention.cs
@@ -90,11 +90,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
                 entityType = entityTypeBuilder.Metadata;
             }
-
-            if (entityType.GetFunctionName() == null)
-            {
-                entityTypeBuilder.ToTable(null);
-            }
         }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -8,11 +8,11 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
@@ -536,7 +536,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             nameof(GetCountByYear),
                             BindingFlags.NonPublic | BindingFlags.Static));
 
-                    builder.Entity<TestKeylessType>().HasNoKey();
+                    builder.Entity<TestKeylessType>().HasNoKey().ToTable((string)null);
                 },
                 AddBoilerPlate(
                     GetHeading()
@@ -545,6 +545,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<string>(""Something"")
                         .HasColumnType(""nvarchar(max)"");
+
+                    b.ToTable(null, (string)null);
                 });"),
                 o => Assert.Null(o.GetEntityTypes().Single().GetFunctionName()));
         }
@@ -571,6 +573,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.ToFunction(""GetCount"");
                 });"),
                 o => Assert.Equal("GetCount", o.GetEntityTypes().Single().GetFunctionName()));
+        }
+
+        [ConditionalFact]
+        public void Entity_types_mapped_to_queries_are_stored_in_the_model_snapshot()
+        {
+            Test(
+                builder => builder.Entity<EntityWithOneProperty>().Ignore(e => e.EntityWithTwoProperties).ToSqlQuery("query"),
+                AddBoilerPlate(
+                    GetHeading()
+                    + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    b.HasKey(""Id"");
+
+                    b.ToSqlQuery(""query"");
+                });"),
+                o => Assert.Equal("query", o.GetEntityTypes().Single().GetSqlQuery()));
         }
 
         [ConditionalFact]
@@ -792,7 +815,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -1419,7 +1442,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasIndex(""RightsId"");
 
-                    b.ToTable(""MyJoinTable"");
+                    b.ToTable(""MyJoinTable"", (string)null);
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+ManyToManyLeft"", b =>
@@ -1605,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"");
+                    b.ToTable(""EntityWithProperties"", (string)null);
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -1620,7 +1643,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithProperties"");
+                    b.ToTable(""EntityWithProperties"", (string)null);
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2130,7 +2153,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
 
-                    b.ToTable(""EntityWithOneProperty"", t => t.ExcludeFromMigrations());
+                    b.ToTable(""EntityWithOneProperty"", null, t => t.ExcludeFromMigrations());
 
                     b.HasData(
                         new
@@ -2146,7 +2169,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""EntityWithStringKey"", t => t.ExcludeFromMigrations());
+                    b.ToTable(""EntityWithStringKey"", null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -2223,7 +2246,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                             b1.HasIndex(""EntityWithStringKeyId"");
 
-                            b1.ToTable(""EntityWithStringProperty"", excludedFromMigrations: true);
+                            b1.ToTable(""EntityWithStringProperty"", null, excludedFromMigrations: true);
 
                             b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                                 .WithOne()
@@ -3369,7 +3392,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -3406,7 +3429,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -3446,7 +3469,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -3486,7 +3509,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -3525,7 +3548,7 @@ namespace RootNamespace
 
                     b.HasKey(""Id"");
 
-                    b.ToTable(""Buildings"");
+                    b.ToTable(""Buildings"", (string)null);
                 });"),
                 o =>
                 {
@@ -5456,6 +5479,16 @@ namespace RootNamespace
 
             var modelFromSnapshot = BuildModelFromSnapshotSource(code);
             assert(modelFromSnapshot, model);
+
+            var targetOptionsBuilder = TestHelpers
+                .AddProviderOptions(new DbContextOptionsBuilder())
+                .UseModel(model)
+                .EnableSensitiveDataLogging();
+
+            var modelDiffer = CreateModelDiffer(targetOptionsBuilder.Options);
+
+            var noopOperations = modelDiffer.GetDifferences(modelFromSnapshot.GetRelationalModel(), model.GetRelationalModel());
+            Assert.Empty(noopOperations);
         }
 
         protected IModel BuildModelFromSnapshotSource(string code)
@@ -5484,15 +5517,20 @@ namespace RootNamespace
                 Activator.CreateInstance(factoryType),
                 new object[] { builder });
 
-            var services = SqlServerTestHelpers.Instance.CreateContextServices();
+            var services = TestHelpers.CreateContextServices();
 
             var processor = new SnapshotModelProcessor(new TestOperationReporter(), services.GetService<IModelRuntimeInitializer>());
             return processor.Process(builder.Model);
         }
 
         protected TestHelpers.TestModelBuilder CreateConventionalModelBuilder()
-            => SqlServerTestHelpers.Instance.CreateConventionBuilder(customServices: new ServiceCollection()
+            => TestHelpers.CreateConventionBuilder(customServices: new ServiceCollection()
                     .AddEntityFrameworkSqlServerNetTopologySuite());
+
+        protected virtual MigrationsModelDiffer CreateModelDiffer(DbContextOptions options)
+            => (MigrationsModelDiffer)TestHelpers.CreateContext(options).GetService<IMigrationsModelDiffer>();
+
+        protected TestHelpers TestHelpers => SqlServerTestHelpers.Instance;
 
         protected CSharpMigrationsGenerator CreateMigrationsGenerator()
         {

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/TableValuedDbFunctionConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/TableValuedDbFunctionConventionTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class TableValuedDbFunctionConventionTest
     {
         [ConditionalFact]
-        public void Configures_return_entity_as_not_mapped()
+        public void Does_not_configure_return_entity_as_not_mapped()
         {
             var modelBuilder = CreateModelBuilder();
             modelBuilder.HasDbFunction(
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = model.FindEntityType(typeof(KeylessEntity));
 
             Assert.Null(entityType.FindPrimaryKey());
-            Assert.Empty(entityType.GetViewOrTableMappings());
+            Assert.Equal("KeylessEntity", entityType.GetViewOrTableMappings().Single().Table.Name);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -10557,15 +10557,19 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             => throw new NotImplementedException();
 
         [ConditionalFact]
-        public void Model_differ_does_not_detect_table_valued_function_result_type()
+        public void Model_differ_does_not_detect_entity_type_mapped_to_TVF()
         {
             Execute(
                 _ => { },
                 modelBuilder =>
-                    modelBuilder.HasDbFunction(
+                {
+                    var function = modelBuilder.HasDbFunction(
                         typeof(MigrationsModelDifferTest).GetMethod(
                             nameof(GetCountByYear),
-                            BindingFlags.NonPublic | BindingFlags.Static)),
+                            BindingFlags.NonPublic | BindingFlags.Static)).Metadata;
+
+                    modelBuilder.Entity<TestKeylessType>().ToFunction(function.ModelName);
+                },
                 result => Assert.Equal(0, result.Count),
                 skipSourceConventions: true);
         }


### PR DESCRIPTION
Preserve `null` mappings in the model snapshot.
Add non-generic `ToSqlQuery` overload.
Output Fluent API for `ToSqlQuery` in the model snapshot.
Fix `SetFunctionName` setting incorrect annotation.

Fixes #23408