### PR TITLE
Allow execution strategy bypass

### DIFF
--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Indicates whether this <see cref="IExecutionStrategy" /> might retry the execution after a failure.
         /// </summary>
         public virtual bool RetriesOnFailure
-            => !Suspended;
+            => !Suspended && MaxRetryCount > 0;
 
         /// <summary>
         ///     Executes the specified operation and returns the result.
@@ -325,20 +325,23 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual void OnFirstExecution()
         {
-            if (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
-                || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
-                || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies.TransactionManager as
-                    ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null)
+            if (RetriesOnFailure)
             {
-                throw new InvalidOperationException(
-                    CoreStrings.ExecutionStrategyExistingTransaction(
-                        GetType().Name,
-                        nameof(DbContext)
-                        + "."
-                        + nameof(DbContext.Database)
-                        + "."
-                        + nameof(DatabaseFacade.CreateExecutionStrategy)
-                        + "()"));
+                if (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
+                    || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
+                    || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies.TransactionManager as
+                        ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.ExecutionStrategyExistingTransaction(
+                            GetType().Name,
+                            nameof(DbContext)
+                            + "."
+                            + nameof(DbContext.Database)
+                            + "."
+                            + nameof(DatabaseFacade.CreateExecutionStrategy)
+                            + "()"));
+                }
             }
 
             ExceptionsEncountered.Clear();

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -325,23 +325,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual void OnFirstExecution()
         {
-            if (RetriesOnFailure)
+            if (RetriesOnFailure &&
+                (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
+                 || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
+                 || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies.TransactionManager as
+                     ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null))
             {
-                if (Dependencies.CurrentContext.Context.Database.CurrentTransaction is not null
-                    || Dependencies.CurrentContext.Context.Database.GetEnlistedTransaction() is not null
-                    || (((IDatabaseFacadeDependenciesAccessor)Dependencies.CurrentContext.Context.Database).Dependencies.TransactionManager as
-                        ITransactionEnlistmentManager)?.CurrentAmbientTransaction is not null)
-                {
-                    throw new InvalidOperationException(
-                        CoreStrings.ExecutionStrategyExistingTransaction(
-                            GetType().Name,
-                            nameof(DbContext)
-                            + "."
-                            + nameof(DbContext.Database)
-                            + "."
-                            + nameof(DatabaseFacade.CreateExecutionStrategy)
-                            + "()"));
-                }
+                throw new InvalidOperationException(
+                    CoreStrings.ExecutionStrategyExistingTransaction(
+                        GetType().Name,
+                        nameof(DbContext)
+                        + "."
+                        + nameof(DbContext.Database)
+                        + "."
+                        + nameof(DatabaseFacade.CreateExecutionStrategy)
+                        + "()"));
             }
 
             ExceptionsEncountered.Clear();


### PR DESCRIPTION
Do not throw an exception on the first execution of an execution strategy if a transaction is pending when `MaxRetryCount` is zero.

This follows the suggested implementation in https://github.com/dotnet/efcore/issues/24922#issuecomment-843490061.

I've added a unit test for the async and sync execution paths using the example code in #24922 as the starting point.
