### PR TITLE
Add support for `InfiniteTimeSpan` in `SetCommandTimeout`.

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -687,6 +687,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="timeout"> The timeout to use. </param>
         public static void SetCommandTimeout(this DatabaseFacade databaseFacade, TimeSpan timeout)
         {
+            if(timeout == Timeout.InfiniteTimeSpan)
+            {
+                SetCommandTimeout(databaseFacade, null);
+                return;
+            }
+            
             if (timeout < TimeSpan.Zero)
             {
                 throw new ArgumentException(RelationalStrings.TimeoutTooSmall(timeout.TotalSeconds));

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -689,7 +689,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             if (timeout == Timeout.InfiniteTimeSpan)
             {
-                SetCommandTimeout(databaseFacade, null);
+                SetCommandTimeout(databaseFacade, 0);
                 return;
             }
             

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -687,7 +687,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="timeout"> The timeout to use. </param>
         public static void SetCommandTimeout(this DatabaseFacade databaseFacade, TimeSpan timeout)
         {
-            if(timeout == Timeout.InfiniteTimeSpan)
+            if (timeout == Timeout.InfiniteTimeSpan)
             {
                 SetCommandTimeout(databaseFacade, null);
                 return;

--- a/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.EntityFrameworkCore
 
                 context.Database.SetCommandTimeout(TimeSpan.FromSeconds(66));
                 Assert.Equal(66, context.Database.GetCommandTimeout());
+            }
+
+            [ConditionalFact]
+            public void Setting_CommandTimeout_to_infinite_sets_to_zero()
+            {
+                using var context = new TimeoutContext();
 
                 context.Database.SetCommandTimeout(Timeout.InfiniteTimeSpan);
                 Assert.Equal(0, context.Database.GetCommandTimeout());

--- a/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Xunit;
 
@@ -26,6 +27,9 @@ namespace Microsoft.EntityFrameworkCore
 
                 context.Database.SetCommandTimeout(TimeSpan.FromSeconds(66));
                 Assert.Equal(66, context.Database.GetCommandTimeout());
+
+                context.Database.SetCommandTimeout(Timeout.InfiniteTimeSpan);
+                Assert.Equal(0, context.Database.GetCommandTimeout());
             }
 
             [ConditionalFact]


### PR DESCRIPTION
Add support for `InfiniteTimeSpan` In `Context.Database.SetCommandTimeout()`.

resolves #25068 Comment [858547728](https://github.com/dotnet/efcore/issues/25068#issuecomment-858547728)