### PR TITLE
Add IInMemoryDbContextOptionsBuilderInfrastructure

### DIFF
--- a/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
+++ b/src/EFCore.Cosmos/Infrastructure/CosmosDbContextOptionsBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class CosmosDbContextOptionsBuilder
+    public class CosmosDbContextOptionsBuilder : ICosmosDbContextOptionsBuilderInfrastructure
     {
         private readonly DbContextOptionsBuilder _optionsBuilder;
 
@@ -35,6 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             _optionsBuilder = optionsBuilder;
         }
+
+        /// <inheritdoc />
+        DbContextOptionsBuilder ICosmosDbContextOptionsBuilderInfrastructure.OptionsBuilder
+            => _optionsBuilder;
 
         /// <summary>
         ///     Configures the context to use the provided <see cref="IExecutionStrategy" />.
@@ -120,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             => WithOption(e => e.WithMaxRequestsPerTcpConnection(Check.NotNull(requestLimit, nameof(requestLimit))));
 
         /// <summary>
-        /// Sets the boolean to only return the headers and status code in the Cosmos DB response for write item operation 
+        /// Sets the boolean to only return the headers and status code in the Cosmos DB response for write item operation
         /// like Create, Upsert, Patch and Replace. Setting the option to false will cause the response to have a null resource.
         /// This reduces networking and CPU load by not sending the resource back over the network and serializing it on the client.
         /// </summary>

--- a/src/EFCore.Cosmos/Infrastructure/ICosmosDbContextOptionsBuilderInfrastructure.cs
+++ b/src/EFCore.Cosmos/Infrastructure/ICosmosDbContextOptionsBuilderInfrastructure.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     Explicitly implemented by <see cref="CosmosDbContextOptionsBuilder" /> to hide
+    ///     methods that are used by database provider extension methods but not intended to be called by application
+    ///     developers.
+    /// </summary>
+    public interface ICosmosDbContextOptionsBuilderInfrastructure
+    {
+        /// <summary>
+        ///     Gets the core options builder.
+        /// </summary>
+        DbContextOptionsBuilder OptionsBuilder { get; }
+    }
+}

--- a/src/EFCore.InMemory/Infrastructure/IInMemoryDbContextOptionsBuilderInfrastructure.cs
+++ b/src/EFCore.InMemory/Infrastructure/IInMemoryDbContextOptionsBuilderInfrastructure.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure
+{
+    /// <summary>
+    ///     Explicitly implemented by <see cref="InMemoryDbContextOptionsBuilder" /> to hide
+    ///     methods that are used by database provider extension methods but not intended to be called by application
+    ///     developers.
+    /// </summary>
+    public interface IInMemoryDbContextOptionsBuilderInfrastructure
+    {
+        /// <summary>
+        ///     Gets the core options builder.
+        /// </summary>
+        DbContextOptionsBuilder OptionsBuilder { get; }
+    }
+}

--- a/src/EFCore.InMemory/Infrastructure/InMemoryDbContextOptionsBuilder.cs
+++ b/src/EFCore.InMemory/Infrastructure/InMemoryDbContextOptionsBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class InMemoryDbContextOptionsBuilder
+    public class InMemoryDbContextOptionsBuilder : IInMemoryDbContextOptionsBuilderInfrastructure
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="InMemoryDbContextOptionsBuilder" /> class.
@@ -36,6 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <returns> The cloned configuration. </returns>
         protected virtual DbContextOptionsBuilder OptionsBuilder { get; }
+
+        /// <inheritdoc />
+        DbContextOptionsBuilder IInMemoryDbContextOptionsBuilderInfrastructure.OptionsBuilder
+            => OptionsBuilder;
 
         /// <summary>
         ///     <para>


### PR DESCRIPTION
This is the moral equivalent of IRelationalDbContextOptionsBuilderInfrastructure which lets extension methods access the core options builder.

Fixes #23669
