### PR TITLE
Fix missing code generation output for custom data annotation attributes

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -158,6 +158,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
+                
+                _sb.AppendLine(attributeWriter.ToString());
             }
         }
 
@@ -316,6 +318,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
+                
+                _sb.AppendLine(attributeWriter.ToString());
             }
         }
 


### PR DESCRIPTION
* Fixes missing code generation output for custom data annotation attributes.
* Adds regression tests.

The two regression tests currently skip the assembly build process, because the two custom data annotation attributes do not exist in the generated assembly. If necessary, the `Microsoft.EntityFrameworkCore.Design.Tests` assembly could be added as a reference or additional source code files (containing the attributes) could be added to the build process.

Should be considered as a 5.0 backport.

(Feel free to directly change/edit this PR, if less time consuming than writing a review.)

Fixes #25127