### PR TITLE
Fix NaN in Query Cache Hit Rate calculation (25142)

### DIFF
--- a/src/EFCore/Infrastructure/EntityFrameworkEventSource.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkEventSource.cs
@@ -178,7 +178,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             internal double CalculateAndReset()
             {
                 var clone = new CacheInfo { _all = Interlocked.Exchange(ref _all, 0) };
-                return ((double)clone.Hits / (clone.Hits + clone.Misses)) * 100;
+
+                var hitsAndMisses = clone.Hits + clone.Misses;
+                if (hitsAndMisses == 0)
+                {
+                    return 0;
+                }
+
+                return ((double)clone.Hits / hitsAndMisses) * 100;
             }
         }
     }


### PR DESCRIPTION
Fixed calculation formula for dotnet counters Query Cache Hit Rate to avoid division by zero.

Fixes #25142 

