### PR TITLE
[release/5.0] Preserve the null table mapping in migration snapshot when an entity type is used as a TVF return type.

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -841,13 +841,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 || entityType.BaseType == null)
             {
                 var tableName = (string)tableNameAnnotation?.Value ?? entityType.GetTableName();
-                if (tableName != null)
+                if (tableName != null
+                    || tableNameAnnotation != null)
                 {
                     stringBuilder
                         .AppendLine()
                         .Append(builderName)
                         .Append(".ToTable(")
-                        .Append(Code.Literal(tableName));
+                        .Append(Code.UnknownLiteral(tableName));
                     if (tableNameAnnotation != null)
                     {
                         annotations.Remove(tableNameAnnotation.Name);

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -216,6 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private IEnumerable<string> GetAnnotationNamespaces(IEnumerable<IAnnotatable> items)
             => items.SelectMany(
                 i => Dependencies.AnnotationCodeGenerator.FilterIgnoredAnnotations(i.GetAnnotations())
+                    .Where(a => a.Value != null)
                     .Select(a => new { Annotatable = i, Annotation = a })
                     .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces()));
 

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         public virtual IEnumerable<IAnnotation> FilterIgnoredAnnotations(IEnumerable<IAnnotation> annotations)
             => annotations.Where(
                 a => !(
-                    a.Value is null
+                    (a.Value is null && a.Name != RelationalAnnotationNames.TableName)
                     || CoreAnnotationNames.AllNames.Contains(a.Name)
                     || _ignoredRelationalAnnotations.Contains(a.Name)));
 

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeExtensions.cs
@@ -544,7 +544,7 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] string name,
             bool fromDataAnnotation = false)
             => (string)entityType.SetAnnotation(
-                RelationalAnnotationNames.ViewName,
+                RelationalAnnotationNames.FunctionName,
                 Check.NullButNotEmpty(name, nameof(name)),
                 fromDataAnnotation)?.Value;
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -526,9 +526,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             => throw new NotImplementedException();
 
         [ConditionalFact]
-        public void TVF_types_are_stored_in_the_model_snapshot()
-        {
-            Test(
+        public void TVF_types_are_stored_in_the_model_snapshot() => Test(
                 builder =>
                 {
                     builder.HasDbFunction(
@@ -545,9 +543,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<string>(""Something"")
                         .HasColumnType(""nvarchar(max)"");
+
+                    b.ToTable(null);
                 });"),
-                o => Assert.Null(o.GetEntityTypes().Single().GetFunctionName()));
-        }
+                o =>
+                {
+                    var entityType = o.GetEntityTypes().Single();
+                    Assert.Null(entityType.GetFunctionName());
+                    Assert.Null(entityType.GetTableName());
+                });
 
         [ConditionalFact]
         public void Entity_types_mapped_to_functions_are_stored_in_the_model_snapshot()


### PR DESCRIPTION
Fixes #25133

Part of a larger fix from 6.0: 6b4ee136cea6a9cb360eed10024511f62b1fac0b

**Description**

When an entity type is used as a TVF return type the (lack of) table mapping is not preserved in the model snapshot.

**Customer Impact**

This causes a migration to be generated even without any model changes. And the generated migration produces an error when applied.
Anyone using TVFs (a new feature in 5.0) is affected by this unless they do want to map the entity type to a table.

**How found**

Reported by a customer.

**Test coverage**

Test coverage for this case has been added in this PR.

**Regression?**

No.

**Risk**

Low. The change only affect design-time tooling that generate source code. No quirk as it's unfeasible to turn it on when using the tools.
