### PR TITLE
[release/5.0] Fix missing code generation output for custom data annotation attributes

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -151,6 +151,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
+
+                _sb.AppendLine(attributeWriter.ToString());
             }
         }
 
@@ -300,6 +302,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
+
+                _sb.AppendLine(attributeWriter.ToString());
             }
         }
 

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -1,8 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
@@ -1401,6 +1410,278 @@ namespace TestNamespace
                     Assert.Equal("TestNamespace.Blog", originalInverseNavigation.DeclaringEntityType.Name);
                     Assert.Equal("OriginalPosts", originalInverseNavigation.Name);
                 });
+        }
+
+        [ConditionalFact]
+        public void Entity_with_custom_annotation()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "EntityWithAnnotation",
+                        x =>
+                        {
+                            x.HasAnnotation("Custom:EntityAnnotation", "first argument");
+                            x.Property<int>("Id");
+                            x.HasKey("Id");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    [CustomEntityDataAnnotation(""first argument"")]
+    public partial class EntityWithAnnotation
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "EntityWithAnnotation.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<EntityWithAnnotation> EntityWithAnnotation { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EntityWithAnnotation>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                assertModel: null,
+                skipBuild: true);
+        }
+
+        [ConditionalFact]
+        public void Entity_property_with_custom_annotation()
+        {
+            Test(
+                modelBuilder => modelBuilder
+                    .Entity(
+                        "EntityWithPropertyAnnotation",
+                        x =>
+                        {
+                            x.Property<int>("Id")
+                                .HasAnnotation("Custom:PropertyAnnotation", "first argument");
+                            x.HasKey("Id");
+                        }),
+                new ModelCodeGenerationOptions { UseDataAnnotations = true },
+                code =>
+                {
+                    AssertFileContents(
+                        @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class EntityWithPropertyAnnotation
+    {
+        [Key]
+        [CustomPropertyDataAnnotation(""first argument"")]
+        public int Id { get; set; }
+    }
+}
+",
+                        code.AdditionalFiles.Single(f => f.Path == "EntityWithPropertyAnnotation.cs"));
+
+                    AssertFileContents(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<EntityWithPropertyAnnotation> EntityWithPropertyAnnotation { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning "
+                        + DesignStrings.SensitiveInformationWarning
+                        + @"
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EntityWithPropertyAnnotation>(entity =>
+            {
+                entity.Property(e => e.Id).UseIdentityColumn();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                        code.ContextFile);
+                },
+                assertModel: null,
+                skipBuild: true);
+        }
+
+        protected override void AddModelServices(IServiceCollection services)
+        {
+            services.Replace(ServiceDescriptor.Singleton<IRelationalAnnotationProvider, ModelAnnotationProvider>());
+        }
+
+        protected override void AddScaffoldingServices(IServiceCollection services)
+        {
+            services.Replace(ServiceDescriptor.Singleton<IAnnotationCodeGenerator, ModelAnnotationCodeGenerator>());
+        }
+
+        public class ModelAnnotationProvider : SqlServerAnnotationProvider
+        {
+            public ModelAnnotationProvider(RelationalAnnotationProviderDependencies dependencies)
+                : base(dependencies)
+            {
+            }
+
+            /// <inheritdoc />
+            public override IEnumerable<IAnnotation> For(ITable table)
+            {
+                foreach (var annotation in base.For(table))
+                {
+                    yield return annotation;
+                }
+
+                var entityType = table.EntityTypeMappings.First().EntityType;
+
+                foreach (var annotation in entityType.GetAnnotations().Where(a => a.Name == "Custom:EntityAnnotation"))
+                {
+                    yield return annotation;
+                }
+            }
+
+            /// <inheritdoc />
+            public override IEnumerable<IAnnotation> For(IColumn column)
+            {
+                foreach (var annotation in base.For(column))
+                {
+                    yield return annotation;
+                }
+
+                var properties = column.PropertyMappings.Select(m => m.Property);
+                var annotations = properties.SelectMany(p => p.GetAnnotations()).GroupBy(a => a.Name).Select(g => g.First());
+
+                foreach (var annotation in annotations.Where(a => a.Name == "Custom:PropertyAnnotation"))
+                {
+                    yield return annotation;
+                }
+            }
+        }
+
+        public class ModelAnnotationCodeGenerator : SqlServerAnnotationCodeGenerator
+        {
+            public ModelAnnotationCodeGenerator(AnnotationCodeGeneratorDependencies dependencies)
+                : base(dependencies)
+            {
+            }
+
+            protected override AttributeCodeFragment GenerateDataAnnotation(IEntityType entityType, IAnnotation annotation)
+                => annotation.Name switch
+                {
+                    "Custom:EntityAnnotation" => new AttributeCodeFragment(
+                        typeof(CustomEntityDataAnnotationAttribute), new object[] { annotation.Value as string }),
+                    _ => base.GenerateDataAnnotation(entityType, annotation)
+                };
+
+            protected override AttributeCodeFragment GenerateDataAnnotation(IProperty property, IAnnotation annotation)
+                => annotation.Name switch
+                {
+                    "Custom:PropertyAnnotation" => new AttributeCodeFragment(typeof(CustomPropertyDataAnnotationAttribute), new object[] {annotation.Value as string}),
+                    _ => base.GenerateDataAnnotation(property, annotation)
+                };
+        }
+
+        [AttributeUsage(AttributeTargets.Class)]
+        public class CustomEntityDataAnnotationAttribute : Attribute
+        {
+            public CustomEntityDataAnnotationAttribute(string argument)
+                => Argument = argument;
+
+            public virtual string Argument { get; }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+        public class CustomPropertyDataAnnotationAttribute : Attribute
+        {
+            public CustomPropertyDataAnnotationAttribute(string argument)
+                => Argument = argument;
+
+            public virtual string Argument { get; }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -135,9 +135,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             return builder.Model;
         }
 
-        public ModelBuilder CreateConventionBuilder(bool skipValidation = false)
+        public ModelBuilder CreateConventionBuilder(
+            bool skipValidation = false,
+            IServiceCollection customServices = null)
         {
-            var conventionSet = CreateConventionSetBuilder().CreateConventionSet();
+            customServices ??= new ServiceCollection();
+            var contextServices = CreateContextServices(customServices);
+            var conventionSet = contextServices.GetRequiredService<IConventionSetBuilder>().CreateConventionSet();
 
             if (skipValidation)
             {


### PR DESCRIPTION
Fixes #25156

Port of https://github.com/dotnet/efcore/pull/25128

**Description**

When scaffolding code from a database provider-specific data annotation attributes are not generated.

**Customer Impact**

Users need to add the provider-specific data annotation attributes manually, this could be unfeasible for large schemas. In particular this affects the data annotations added in 5.0 to the Pomelo MySQL provider

**How found**

Reported by a customer.

**Test coverage**

Test coverage for this case has been added in this PR.

**Regression?**

No.

**Risk**

Low. The change only affect design-time tooling that generate source code. No quirk as it's unfeasible to turn it on when using the tools.
