### PR TITLE
Enable value conversion support for identity/sequence properties

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerPropertyExtensions.cs
@@ -534,13 +534,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> <see langword="true" /> if compatible. </returns>
         public static bool IsCompatibleWithValueGeneration(IReadOnlyProperty property)
         {
-            var type = property.ClrType;
+            var valueConverter = property.GetValueConverter()
+                ?? property.FindTypeMapping()?.Converter;
+
+            var type = (valueConverter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
 
             return (type.IsInteger()
-                    || type == typeof(decimal))
-                && (property.GetValueConverter()
-                    ?? property.FindTypeMapping()?.Converter)
-                == null;
+                    || type == typeof(decimal));
         }
 
         private static bool IsCompatibleWithValueGeneration(
@@ -548,14 +548,14 @@ namespace Microsoft.EntityFrameworkCore
             in StoreObjectIdentifier storeObject,
             ITypeMappingSource? typeMappingSource)
         {
-            var type = property.ClrType;
+            var valueConverter = property.GetValueConverter()
+                ?? (property.FindRelationalTypeMapping(storeObject)
+                    ?? typeMappingSource?.FindMapping((IProperty)property))?.Converter;
 
+            var type = (valueConverter?.ProviderClrType ?? property.ClrType).UnwrapNullableType();
+            
             return (type.IsInteger()
-                    || type == typeof(decimal))
-                && (property.GetValueConverter()
-                    ?? (property.FindRelationalTypeMapping(storeObject)
-                        ?? typeMappingSource?.FindMapping((IProperty)property))?.Converter)
-                == null;
+                    || type == typeof(decimal));
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2782,14 +2782,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, propertyType);
 
         /// <summary>
-        ///     Value generation is not supported for property '{entityType}.{property}' because it has a '{converter}' converter configured. Configure the property to not use value generation using 'ValueGenerated.Never' or 'DatabaseGeneratedOption.None' and specify explicit values instead.
-        /// </summary>
-        public static string ValueGenWithConversion(object? entityType, object? property, object? converter)
-            => string.Format(
-                GetString("ValueGenWithConversion", nameof(entityType), nameof(property), nameof(converter)),
-                entityType, property, converter);
-
-        /// <summary>
         ///     Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.
         /// </summary>
         public static string VisitIsNotAllowed(object? visitMethodName)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1499,9 +1499,6 @@
   <data name="ValueCannotBeNull" xml:space="preserve">
     <value>The value for property '{1_entityType}.{0_property}' cannot be set to null because its type is '{propertyType}' which is not a nullable type.</value>
   </data>
-  <data name="ValueGenWithConversion" xml:space="preserve">
-    <value>Value generation is not supported for property '{entityType}.{property}' because it has a '{converter}' converter configured. Configure the property to not use value generation using 'ValueGenerated.Never' or 'DatabaseGeneratedOption.None' and specify explicit values instead.</value>
-  </data>
   <data name="VisitIsNotAllowed" xml:space="preserve">
     <value>Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.</value>
   </data>

--- a/src/EFCore/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EFCore/ValueGeneration/ValueGeneratorSelector.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -67,31 +68,7 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         }
 
         private static ValueGenerator? CreateFromFactory(IProperty property, IEntityType entityType)
-        {
-            var factory = property.GetValueGeneratorFactory();
-
-            if (factory == null)
-            {
-                var mapping = property.GetTypeMapping();
-                factory = mapping.ValueGeneratorFactory;
-
-                if (factory == null)
-                {
-                    var converter = mapping.Converter;
-
-                    if (converter != null)
-                    {
-                        throw new NotSupportedException(
-                            CoreStrings.ValueGenWithConversion(
-                                property.DeclaringEntityType.DisplayName(),
-                                property.Name,
-                                converter.GetType().ShortDisplayName()));
-                    }
-                }
-            }
-
-            return factory?.Invoke(property, entityType);
-        }
+            => (property.GetValueGeneratorFactory() ?? property.GetTypeMapping().ValueGeneratorFactory)?.Invoke(property, entityType);
 
         /// <summary>
         ///     Creates a new value generator for the given property.

--- a/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedTestBase.cs
@@ -26,25 +26,6 @@ namespace Microsoft.EntityFrameworkCore
         protected TFixture Fixture { get; }
 
         [ConditionalFact]
-        public virtual void Value_generation_throws_for_common_cases()
-        {
-            ValueGenerationNegative<int, IntToString, NumberToStringConverter<int>>();
-            ValueGenerationNegative<short, ShortToBytes, NumberToBytesConverter<short>>();
-        }
-
-        private void ValueGenerationNegative<TKey, TEntity, TConverter>()
-            where TEntity : WithConverter<TKey>, new()
-        {
-            using var context = CreateContext();
-            Assert.Equal(
-                CoreStrings.ValueGenWithConversion(
-                    typeof(TEntity).ShortDisplayName(),
-                    nameof(WithConverter<int>.Id),
-                    typeof(TConverter).ShortDisplayName()),
-                Assert.Throws<NotSupportedException>(() => context.Add(new TEntity())).Message);
-        }
-
-        [ConditionalFact]
         public virtual void Value_generation_works_for_common_GUID_conversions()
         {
             ValueGenerationPositive<Guid, GuidToString>();

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -147,6 +147,26 @@ EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSc
 );");
         }
 
+        [ConditionalFact]
+        public virtual async Task Create_table_with_identity_column_value_converter()
+        {
+            await Test(
+                _ => { },
+                builder => builder.UseIdentityColumns()
+                    .Entity("People").Property<int>("IdentityColumn").HasConversion<short>().ValueGeneratedOnAdd(),
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    var column = Assert.Single(table.Columns, c => c.Name == "IdentityColumn");
+                    Assert.Equal(ValueGenerated.OnAdd, column.ValueGenerated);
+                });
+
+            AssertSql(
+                @"CREATE TABLE [People] (
+    [IdentityColumn] smallint NOT NULL IDENTITY
+);");
+        }
+
         public override async Task Drop_table()
         {
             await base.Drop_table();
@@ -2685,7 +2705,7 @@ ALTER SCHEMA [newHistorySchema] TRANSFER [historySchema].[RenamedHistoryTable];"
                         e.Property<string>("Name");
                         e.Property<int>("Number");
                     }),
-                builder => 
+                builder =>
                     {
                     },
                 model =>


### PR DESCRIPTION
Allows to use value converters for identity and sequence columns, within the limitations already established (must be a non-floating point numerical type on the provider side).

Implements https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1118 for SQL Server.

I added an explicit `.UnwrapNullableType()` call, so that a `decimal?` would behave the same way as an `int?` (both are not really supported for identity columns by SQL Server, but they should at least be handled in the same way before SQL Server finally returns an error, and should not lead to different behavior in EF Core).
It would probably be cleaner to check for non-nullable types only in general instead.

Related to #11597 and https://github.com/npgsql/efcore.pg/issues/1439

I don't see any issues with this PR in regards to #11597.
If there are, feel free to add a test or two to demonstrate those.