### PR TITLE
Make ownership handling during model building more consistent

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -826,7 +826,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             var rightEntityType = rightEntityReference?.EntityType;
             var entityType = leftEntityType ?? rightEntityType;
 
-            Debug.Assert(entityType != null, "At least either side should be entityReference so entityType should be non-null.");
+            Check.DebugAssert(entityType != null, "At least either side should be entityReference so entityType should be non-null.");
 
             if (leftEntityType != null
                 && rightEntityType != null

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
-                
+
                 _sb.AppendLine(attributeWriter.ToString());
             }
         }
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     attributeWriter.AddParameter(_code.UnknownLiteral(argument));
                 }
-                
+
                 _sb.AppendLine(attributeWriter.ToString());
             }
         }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryExpressionTranslatingExpressionVisitor.cs
@@ -1408,7 +1408,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             var rightEntityType = rightEntityReference?.EntityType;
             var entityType = leftEntityType ?? rightEntityType;
 
-            Debug.Assert(entityType != null, "At least either side should be entityReference so entityType should be non-null.");
+            Check.DebugAssert(entityType != null, "At least either side should be entityReference so entityType should be non-null.");
 
             if (leftEntityType != null
                 && rightEntityType != null

--- a/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalEntityTypeBuilderExtensions.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -1477,8 +1476,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     }
                     else if (overlappingTables.Count == 0)
                     {
-                        Debug.Assert(firstPropertyTables != null, nameof(firstPropertyTables));
-                        Debug.Assert(lastPropertyTables != null, nameof(lastPropertyTables));
+                        Check.DebugAssert(firstPropertyTables != null, nameof(firstPropertyTables));
+                        Check.DebugAssert(lastPropertyTables != null, nameof(lastPropertyTables));
 
                         logger.IndexPropertiesMappedToNonOverlappingTables(
                             entityType,

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -732,22 +732,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 {
                     foreach (var missingColumn in missingConcurrencyTokens)
                     {
-                        var columnFound = false;
-                        foreach (var property in entityType.GetAllBaseTypesAscending().SelectMany(t => t.GetDeclaredProperties()))
-                        {
-                            if (property.GetColumnName(storeObject) == missingColumn)
-                            {
-                                columnFound = true;
-                                break;
-                            }
-                        }
-
-                        if (!columnFound)
-                        {
-                            throw new InvalidOperationException(
-                                RelationalStrings.MissingConcurrencyColumn(
-                                    entityType.DisplayName(), missingColumn, storeObject.DisplayName()));
-                        }
+                        throw new InvalidOperationException(
+                            RelationalStrings.MissingConcurrencyColumn(
+                                entityType.DisplayName(), missingColumn, storeObject.DisplayName()));
                     }
                 }
             }

--- a/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableSharingConcurrencyTokenConvention.cs
@@ -193,21 +193,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IReadOnlyEntityType entityType,
             IReadOnlyList<IReadOnlyEntityType> mappedTypes)
         {
-            if (entityType.FindPrimaryKey() == null)
+            if (entityType.FindPrimaryKey() == null
+                || propertiesMappedToConcurrencyColumn.Count == 0)
             {
                 return false;
             }
 
-            var propertyMissing = false;
+            var propertyMissing = true;
             foreach (var mappedProperty in propertiesMappedToConcurrencyColumn)
             {
                 var declaringEntityType = mappedProperty.DeclaringEntityType;
                 if (declaringEntityType.IsAssignableFrom(entityType)
-                    || entityType.IsAssignableFrom(declaringEntityType)
                     || declaringEntityType.IsInOwnershipPath(entityType)
                     || entityType.IsInOwnershipPath(declaringEntityType))
                 {
-                    // The concurrency token is in the same hierarchy or in the same aggregate
+                    // The concurrency token is on the base type or in the same aggregate
+                    propertyMissing = false;
                     continue;
                 }
 
@@ -222,11 +223,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                             || entityType.IsAssignableFrom(fk.PrincipalEntityType)))
                 {
                     // The concurrency token is on a type that shares the row with a base or derived type
-                    continue;
+                    propertyMissing = false;
                 }
-
-                propertyMissing = true;
-                break;
             }
 
             return propertyMissing;

--- a/src/EFCore.Relational/Metadata/Conventions/TableValuedDbFunctionConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/TableValuedDbFunctionConvention.cs
@@ -70,26 +70,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var entityType = model.FindEntityType(elementType);
             if (entityType?.IsOwned() == true
                 || model.IsOwned(elementType)
-                || (entityType == null && model.GetEntityTypes().Any(e => e.ClrType == elementType)))
+                || (entityType == null && model.FindEntityTypes(elementType).Any()))
             {
                 return;
             }
 
-            IConventionEntityTypeBuilder? entityTypeBuilder;
-            if (entityType != null)
-            {
-                entityTypeBuilder = entityType.Builder;
-            }
-            else
-            {
-                entityTypeBuilder = dbFunctionBuilder.ModelBuilder.Entity(elementType);
-                if (entityTypeBuilder == null)
-                {
-                    return;
-                }
-
-                entityType = entityTypeBuilder.Metadata;
-            }
+            dbFunctionBuilder.ModelBuilder.Entity(elementType);
         }
     }
 }

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1358,7 +1358,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var rightEntityType = rightEntityReference?.EntityType;
             var entityType = leftEntityType ?? rightEntityType;
 
-            Debug.Assert(entityType != null, "At least one side should be entityReference so entityType should be non-null.");
+            Check.DebugAssert(entityType != null, "At least one side should be entityReference so entityType should be non-null.");
 
             if (leftEntityType != null
                 && rightEntityType != null

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -40,7 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private bool _connectionOwned;
         private int _openedCount;
         private bool _openedInternally;
-        private int? _commandTimeout, _defaultCommandTimeout;
+        private int? _commandTimeout;
+        private readonly int? _defaultCommandTimeout;
         private readonly ConcurrentStack<Transaction> _ambientTransactions = new();
         private DbConnection? _connection;
         private readonly IRelationalCommandBuilder _relationalCommandBuilder;

--- a/src/EFCore.SqlServer.NTS/Properties/SqlServerNTSStrings.Designer.cs
+++ b/src/EFCore.SqlServer.NTS/Properties/SqlServerNTSStrings.Designer.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Reflection;
 using System.Resources;
-using JetBrains.Annotations;
 
 #nullable enable
 

--- a/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> A builder to further configure the index. </returns>
         public static IndexBuilder<TEntity> IncludeProperties<TEntity>(
             this IndexBuilder<TEntity> indexBuilder,
-            Expression<Func<TEntity, object>> includeExpression)
+            Expression<Func<TEntity, object?>> includeExpression)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
             Check.NotNull(includeExpression, nameof(includeExpression));

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -325,7 +325,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     </para>
         ///     <para>
         ///         Note that whenever real original property values are not available (e.g. entity was not yet
-        ///         persisted to the database) this will default to the current property values of this entity.
+        ///         persisted to the database or was retrieved in a non-tracking query) this will default to the
+        ///         current property values of this entity.
         ///     </para>
         /// </summary>
         /// <value> The original values. </value>
@@ -338,14 +339,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <summary>
         ///     <para>
         ///         Queries the database for copies of the values of the tracked entity as they currently
-        ///         exist in the database. If the entity is not found in the database, then null is returned.
+        ///         exist in the database. If the entity is not found in the database, then <see langword="null"/> is returned.
         ///     </para>
         ///     <para>
         ///         Note that changing the values in the returned dictionary will not update the values
         ///         in the database.
         ///     </para>
         /// </summary>
-        /// <returns> The store values, or null if the entity does not exist in the database. </returns>
+        /// <returns> The store values, or <see langword="null"/> if the entity does not exist in the database. </returns>
         public virtual PropertyValues? GetDatabaseValues()
         {
             var values = Finder.GetDatabaseValues(InternalEntry);

--- a/src/EFCore/Design/CSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore/Design/CSharpRuntimeAnnotationCodeGenerator.cs
@@ -43,7 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Design
             }
             else
             {
-                parameters.Annotations.Remove(CoreAnnotationNames.OwnedTypes);
                 parameters.Annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
             }
 

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId SaveChangesFailed = MakeUpdateId(Id.SaveChangesFailed);
 
         /// <summary>
-        ///     The same entity is being tracked as a different weak entity type.
+        ///     The same entity is being tracked as a different shared entity entity type.
         ///     This event is in the <see cref="DbLoggerCategory.Update" /> category.
         /// </summary>
         public static readonly EventId DuplicateDependentEntityTypeInstanceWarning =

--- a/src/EFCore/Infrastructure/IModelCacheKeyFactory.cs
+++ b/src/EFCore/Infrastructure/IModelCacheKeyFactory.cs
@@ -31,7 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </param>
         /// <returns> The created key. </returns>
         [Obsolete("Use the overload with most parameters")]
-        object Create(DbContext context);
+        object Create(DbContext context)
+            => Create(context, true);
 
         /// <summary>
         ///     Gets the model cache key for a given context.

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -698,12 +698,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         throw new InvalidOperationException(CoreStrings.OwnedDerivedType(entityType.DisplayName()));
                     }
 
-                    if (ownership.PrincipalToDependent == null)
-                    {
-                        throw new InvalidOperationException(CoreStrings.NavigationlessOwnership(
-                            ownership.PrincipalEntityType.DisplayName(), entityType.DisplayName()));
-                    }
-
                     foreach (var referencingFk in entityType.GetReferencingForeignKeys().Where(
                         fk => !fk.IsOwnership
                             && !Contains(fk.DeclaringEntityType.FindOwnership(), fk)))

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder.cs
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             if (newJoinEntityType == null)
             {
-                newJoinEntityType = ModelBuilder.Entity(joinEntityType, ConfigurationSource.Explicit)!.Metadata;
+                newJoinEntityType = ModelBuilder.Entity(joinEntityType, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata;
             }
 
             var entityTypeBuilder = new EntityTypeBuilder(newJoinEntityType);

--- a/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionCollectionBuilder`.cs
@@ -94,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             if (joinEntityType == null)
             {
-                joinEntityType = ModelBuilder.Entity(typeof(TJoinEntity), ConfigurationSource.Explicit)!.Metadata;
+                joinEntityType = ModelBuilder.Entity(typeof(TJoinEntity), ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata;
             }
 
             var entityTypeBuilder = new EntityTypeBuilder<TJoinEntity>(joinEntityType);

--- a/src/EFCore/Metadata/Builders/DiscriminatorBuilder.cs
+++ b/src/EFCore/Metadata/Builders/DiscriminatorBuilder.cs
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual DiscriminatorBuilder HasValue(Type entityType, object? value)
         {
             var entityTypeBuilder = EntityTypeBuilder.ModelBuilder.Entity(
-                entityType, ConfigurationSource.Explicit, shouldBeOwned: null);
+                entityType, ConfigurationSource.Explicit);
 
             return HasValue(entityTypeBuilder, value, ConfigurationSource.Explicit)!;
         }
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         public virtual DiscriminatorBuilder HasValue(string entityTypeName, object? value)
         {
             var entityTypeBuilder = EntityTypeBuilder.ModelBuilder.Entity(
-                entityTypeName, ConfigurationSource.Explicit, shouldBeOwned: null);
+                entityTypeName, ConfigurationSource.Explicit);
 
             return HasValue(entityTypeBuilder, value, ConfigurationSource.Explicit)!;
         }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -838,13 +838,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             {
                 foreignKey = Builder.HasRelationship(
                     relatedEntityType, navigationId.MemberInfo, ConfigurationSource.Explicit,
-                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : (bool?)null)!.Metadata;
+                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : null)!.Metadata;
             }
             else
             {
                 foreignKey = Builder.HasRelationship(
                     relatedEntityType, navigationId.Name, ConfigurationSource.Explicit,
-                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : (bool?)null)!.Metadata;
+                    targetIsPrincipal: Builder.Metadata == relatedEntityType ? true : null)!.Metadata;
             }
 
             return foreignKey;
@@ -991,7 +991,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (navigationName == null
                     ? null
                     : Builder.ModelBuilder.Metadata.FindEntityType(relatedTypeName, navigationName, Builder.Metadata))
-                ?? Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit)!.Metadata;
+                ?? Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1004,7 +1004,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => (navigationName == null || !Builder.ModelBuilder.Metadata.IsShared(relatedType)
                     ? null
                     : Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, Builder.Metadata))
-                ?? Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit)!.Metadata;
+                ?? Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata;
 
         /// <summary>
         ///     Configures the <see cref="ChangeTrackingStrategy" /> to be used for this entity type.

--- a/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/IConventionEntityTypeBuilder.cs
@@ -553,6 +553,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures a relationship where the target entity is owned by (or part of) this entity.
         /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName"> The name of the navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        IConventionForeignKeyBuilder? HasOwnership(
+            IConventionEntityType targetEntityType,
+            string navigationName,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
         /// <param name="targetEntityType"> The type that this relationship targets. </param>
         /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
@@ -562,6 +574,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </returns>
         IConventionForeignKeyBuilder? HasOwnership(
             Type targetEntityType,
+            MemberInfo navigation,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? HasOwnership(
+            IConventionEntityType targetEntityType,
             MemberInfo navigation,
             bool fromDataAnnotation = false);
 
@@ -588,6 +615,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     Configures a relationship where the target entity is owned by (or part of) this entity.
         /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName"> The name of the navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="inverseNavigationName">
+        ///     The name of the navigation property on the target entity type that is part of the relationship. If <see langword="null" />
+        ///     is specified, the relationship will be configured without a navigation property on the target end.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? HasOwnership(
+            IConventionEntityType targetEntityType,
+            string navigationName,
+            string? inverseNavigationName,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
         /// <param name="targetEntityType"> The type that this relationship targets. </param>
         /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
         /// <param name="inverseNavigation">
@@ -601,6 +648,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </returns>
         IConventionForeignKeyBuilder? HasOwnership(
             Type targetEntityType,
+            MemberInfo navigation,
+            MemberInfo? inverseNavigation,
+            bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="inverseNavigation">
+        ///     The navigation property on the target entity type that is part of the relationship. If <see langword="null" />
+        ///     is specified, the relationship will be configured without a navigation property on the target end.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? HasOwnership(
+            IConventionEntityType targetEntityType,
             MemberInfo navigation,
             MemberInfo? inverseNavigation,
             bool fromDataAnnotation = false);
@@ -654,7 +721,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The same builder instance if the skip navigation was removed,
         ///     <see langword="null" /> otherwise.
         /// </returns>
-        IConventionEntityTypeBuilder? HasNoSkipNavigation(IReadOnlySkipNavigation skipNavigation, bool fromDataAnnotation = false);
+        IConventionEntityTypeBuilder? HasNoSkipNavigation(IConventionSkipNavigation skipNavigation, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns a value indicating whether the skip navigation can be removed from this entity type.
@@ -662,7 +729,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="skipNavigation"> The skip navigation to be removed. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         /// <returns> <see langword="true" /> if the skip navigation can be removed from this entity type. </returns>
-        bool CanRemoveSkipNavigation(IReadOnlySkipNavigation skipNavigation, bool fromDataAnnotation = false);
+        bool CanRemoveSkipNavigation(IConventionSkipNavigation skipNavigation, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Returns a value indicating whether the given navigation can be added to this entity type.

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder.cs
@@ -794,7 +794,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null)!.Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
         }
 
         /// <summary>
@@ -868,7 +868,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null)!.Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
         }
 
         /// <summary>
@@ -930,7 +930,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 }
             }
 
-            return relatedEntityType ?? DependentEntityType.Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit)!.Metadata;
+            return relatedEntityType ?? DependentEntityType.Builder.ModelBuilder.Entity(
+                relatedType, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigationName, ConfigurationSource.Explicit,
-                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null)!.Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/DbSetFindingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DbSetFindingConvention.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -37,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var setInfo in Dependencies.SetFinder.FindSets(Dependencies.ContextType))
             {
-                modelBuilder.Entity(setInfo.Type, fromDataAnnotation: true);
+                ((InternalModelBuilder)modelBuilder).Entity(setInfo.Type, ConfigurationSource.Explicit);
             }
         }
     }

--- a/src/EFCore/Metadata/Conventions/DbSetFindingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DbSetFindingConvention.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -38,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             foreach (var setInfo in Dependencies.SetFinder.FindSets(Dependencies.ContextType))
             {
-                ((InternalModelBuilder)modelBuilder).Entity(setInfo.Type, ConfigurationSource.Explicit);
+                modelBuilder.Entity(setInfo.Type, fromDataAnnotation: true);
             }
         }
     }

--- a/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/DerivedTypeDiscoveryConvention.cs
@@ -34,23 +34,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionContext<IConventionEntityTypeBuilder> context)
         {
             var entityType = entityTypeBuilder.Metadata;
-            var clrType = entityType.ClrType;
-            if (clrType == null
-                || entityType.HasSharedClrType
+            if (entityType.HasSharedClrType
                 || entityType.HasDefiningNavigation()
-                || entityType.Model.IsOwned(clrType)
-                || entityType.FindOwnership() != null)
+                || entityType.IsOwned())
             {
                 return;
             }
 
+            var clrType = entityType.ClrType;
             var model = entityType.Model;
             foreach (var directlyDerivedType in model.GetEntityTypes())
             {
                 if (directlyDerivedType != entityType
                         && !directlyDerivedType.HasSharedClrType
                         && !directlyDerivedType.HasDefiningNavigation()
-                        && !model.IsOwned(directlyDerivedType.ClrType)
+                        && !directlyDerivedType.IsOwned()
                         && directlyDerivedType.FindDeclaredOwnership() == null
                         && ((directlyDerivedType.BaseType == null && clrType.IsAssignableFrom(directlyDerivedType.ClrType))
                             || (directlyDerivedType.BaseType == entityType.BaseType && FindClosestBaseType(directlyDerivedType) == entityType)))

--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -208,7 +208,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                             ?? new List<string> { fkPropertyOnDependent!.GetSimpleMemberName() };
                     }
 
-                    if (fkPropertyOnDependent != null)
+                    if (fkPropertyOnDependent != null
+                        || fkPropertiesOnDependentToPrincipal != null)
                     {
                         upgradeDependentToPrincipalNavigationSource = true;
                     }
@@ -260,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
 
-            return newRelationshipBuilder?.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
+            return newRelationshipBuilder.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
         }
 
         private static IConventionForeignKeyBuilder? SplitNavigationsToSeparateRelationships(

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -61,7 +61,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention(Dependencies);
             var servicePropertyDiscoveryConvention = new ServicePropertyDiscoveryConvention(Dependencies);
             var indexAttributeConvention = new IndexAttributeConvention(Dependencies);
-
             var baseTypeDiscoveryConvention = new BaseTypeDiscoveryConvention(Dependencies);
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention(Dependencies));
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention(Dependencies));
@@ -166,7 +165,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ForeignKeyRequirednessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention(Dependencies));
-            conventionSet.ForeignKeyOwnershipChangedConventions.Add(baseTypeDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(valueGeneratorConvention);

--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -44,13 +44,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionContext<IConventionModelBuilder> context)
         {
             var model = modelBuilder.Metadata;
-            var rootEntityTypes = GetRoots(model, ConfigurationSource.DataAnnotation);
-            using (context.DelayConventions())
+            var rootEntityTypes = GetRoots(model, ConfigurationSource.Explicit);
+
+            foreach (var orphan in new GraphAdapter(model).GetUnreachableVertices(rootEntityTypes))
             {
-                foreach (var orphan in new GraphAdapter(model).GetUnreachableVertices(rootEntityTypes))
-                {
-                    modelBuilder.HasNoEntityType(orphan, fromDataAnnotation: true);
-                }
+                modelBuilder.HasNoEntityType(orphan, fromDataAnnotation: true);
             }
         }
 

--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionContext<IConventionModelBuilder> context)
         {
             var model = modelBuilder.Metadata;
-            var rootEntityTypes = GetRoots(model, ConfigurationSource.Explicit);
+            var rootEntityTypes = GetRoots(model, ConfigurationSource.DataAnnotation);
 
             foreach (var orphan in new GraphAdapter(model).GetUnreachableVertices(rootEntityTypes))
             {

--- a/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
@@ -286,8 +286,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         private Type? FindCandidateNavigationWithAttributePropertyType(PropertyInfo propertyInfo, IConventionModel model)
         {
-            var targetClrType = Dependencies.MemberClassifier.FindCandidateNavigationPropertyType(
-                propertyInfo, ((Model)model).Configuration);
+            var targetClrType = Dependencies.MemberClassifier.FindCandidateNavigationPropertyType(propertyInfo, model, out var _);
             return targetClrType != null
                 && Attribute.IsDefined(propertyInfo, typeof(TAttribute), inherit: true)
                     ? targetClrType
@@ -296,9 +295,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         private Type? FindCandidateNavigationWithAttributePropertyType(PropertyInfo propertyInfo, IConventionEntityType entityType)
             => Dependencies.MemberClassifier.GetNavigationCandidates(entityType)
-                .TryGetValue(propertyInfo, out var targetClrType)
+                .TryGetValue(propertyInfo, out var target)
                 && Attribute.IsDefined(propertyInfo, typeof(TAttribute), inherit: true)
-                    ? targetClrType
+                    ? target.Type
                     : null;
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(inherit: true);
                 foreach (var attribute in attributes)
                 {
-                    ProcessEntityTypeRemoved(modelBuilder, type, navigationPropertyInfo, targetClrType, attribute, context);
+                    ProcessEntityTypeRemoved(modelBuilder, entityType, navigationPropertyInfo, targetClrType, attribute, context);
                     if (((ConventionContext<IConventionEntityType>)context).ShouldStopProcessing())
                     {
                         return;
@@ -379,14 +379,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         ///     Called for every navigation property that has an attribute after an entity type is removed.
         /// </summary>
         /// <param name="modelBuilder"> The builder for the model. </param>
-        /// <param name="type"> The ignored entity type. </param>
+        /// <param name="entityType"> The ignored entity type. </param>
         /// <param name="navigationMemberInfo"> The navigation member info. </param>
         /// <param name="targetClrType"> The CLR type of the target entity type. </param>
         /// <param name="attribute"> The attribute. </param>
         /// <param name="context"> Additional information associated with convention execution. </param>
         public virtual void ProcessEntityTypeRemoved(
             IConventionModelBuilder modelBuilder,
-            Type type,
+            IConventionEntityType entityType,
             MemberInfo navigationMemberInfo,
             Type targetClrType,
             TAttribute attribute,

--- a/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RelationshipDiscoveryConvention.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
@@ -52,52 +51,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             relationshipCandidates = RemoveInheritedInverseNavigations(relationshipCandidates);
             relationshipCandidates = RemoveSingleSidedBaseNavigations(relationshipCandidates, entityTypeBuilder);
 
-            using (context.DelayConventions())
-            {
-                CreateRelationships(relationshipCandidates, entityTypeBuilder);
-            }
+            CreateRelationships(relationshipCandidates, entityTypeBuilder);
         }
 
         private IReadOnlyList<RelationshipCandidate> FindRelationshipCandidates(IConventionEntityTypeBuilder entityTypeBuilder)
         {
             var entityType = entityTypeBuilder.Metadata;
-            var model = entityType.Model;
             var relationshipCandidates = new Dictionary<IConventionEntityType, RelationshipCandidate>();
-            var ownership = entityTypeBuilder.Metadata.FindOwnership();
+            var ownership = entityType.FindOwnership();
             if (ownership == null
-                && model.IsOwned(entityTypeBuilder.Metadata.ClrType))
+                && entityType.IsOwned())
             {
+                // Handled when the ownership is actually added
                 return relationshipCandidates.Values.ToList();
             }
 
             foreach (var candidateTuple in Dependencies.MemberClassifier.GetNavigationCandidates(entityType))
             {
                 var navigationPropertyInfo = candidateTuple.Key;
-                var targetClrType = candidateTuple.Value;
+                var (targetClrType, shouldBeOwned) = candidateTuple.Value;
 
-                if (!IsCandidateNavigationProperty(entityTypeBuilder, navigationPropertyInfo.GetSimpleMemberName(), navigationPropertyInfo)
-                    || (model.IsOwned(targetClrType)
-                        && HasDeclaredAmbiguousNavigationsTo(entityType, targetClrType)))
+                if (!IsCandidateNavigationProperty(entityTypeBuilder, navigationPropertyInfo.GetSimpleMemberName(), navigationPropertyInfo))
                 {
                     continue;
                 }
 
-                IConventionEntityTypeBuilder? candidateTargetEntityTypeBuilder = ((InternalEntityTypeBuilder)entityTypeBuilder)
-                    .GetTargetEntityTypeBuilder(targetClrType, navigationPropertyInfo, ConfigurationSource.Convention);
-
+                var candidateTargetEntityTypeBuilder = TryGetTargetEntityTypeBuilder(
+                    entityTypeBuilder, targetClrType, navigationPropertyInfo, shouldBeOwned);
                 if (candidateTargetEntityTypeBuilder == null)
-                {
-                    continue;
-                }
-
-                var candidateTargetEntityType = candidateTargetEntityTypeBuilder.Metadata;
-                if (candidateTargetEntityType.IsKeyless)
                 {
                     continue;
                 }
 
                 if (!entityType.IsInModel)
                 {
+                    // Current entity type was removed while the target entity type was being added
                     foreach (var relationshipCandidate in relationshipCandidates.Values)
                     {
                         var targetType = relationshipCandidate.TargetTypeBuilder.Metadata;
@@ -111,31 +99,62 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     return Array.Empty<RelationshipCandidate>();
                 }
 
-                if (!model.IsOwned(targetClrType))
+                var candidateTargetEntityType = candidateTargetEntityTypeBuilder.Metadata;
+                if (candidateTargetEntityType.IsKeyless
+                    || (candidateTargetEntityType.IsOwned()
+                        && HasDeclaredAmbiguousNavigationsTo(entityType, targetClrType)))
                 {
-                    var targetOwnership = candidateTargetEntityType.FindOwnership();
-                    if (targetOwnership != null
-                        && (targetOwnership.PrincipalEntityType != entityType
-                            || targetOwnership.PrincipalToDependent?.Name != navigationPropertyInfo.GetSimpleMemberName())
-                        && (ownership == null
-                            || ownership.PrincipalEntityType != candidateTargetEntityType))
-                    {
-                        continue;
-                    }
+                    continue;
+                }
+
+                Check.DebugAssert(entityType.ClrType != targetClrType
+                    || !candidateTargetEntityType.IsOwned()
+                    || candidateTargetEntityType.FindOwnership()?.PrincipalToDependent?.Name == navigationPropertyInfo.GetSimpleMemberName(),
+                    "New self-referencing ownerships shouldn't be discovered");
+
+                var targetOwnership = candidateTargetEntityType.FindOwnership();
+                var shouldBeOwnership = candidateTargetEntityType.IsOwned()
+                    && (targetOwnership == null
+                        || (targetOwnership.PrincipalEntityType == entityType
+                            && targetOwnership.PrincipalToDependent?.Name == navigationPropertyInfo.GetSimpleMemberName()));
+
+                if (candidateTargetEntityType.IsOwned()
+                    && !shouldBeOwnership
+                    && (targetOwnership?.PrincipalEntityType == entityType
+                        || !candidateTargetEntityType.IsInOwnershipPath(entityType))
+                    && (ownership == null
+                        || !entityType.IsInOwnershipPath(candidateTargetEntityType)))
+                {
+                    // Only the owner or nested ownees can have navigations to an owned type
+                    // Also skip non-ownership navigations from the owner
+                    continue;
                 }
 
                 if (relationshipCandidates.TryGetValue(candidateTargetEntityType, out var existingCandidate))
                 {
-                    if (candidateTargetEntityType != entityType
-                        || !existingCandidate.InverseProperties.Contains(navigationPropertyInfo))
+                    if (!existingCandidate.IsOwnership
+                        && !shouldBeOwnership)
                     {
-                        if (!existingCandidate.NavigationProperties.Contains(navigationPropertyInfo))
+                        if (candidateTargetEntityType != entityType
+                            || !existingCandidate.InverseProperties.Contains(navigationPropertyInfo))
                         {
-                            existingCandidate.NavigationProperties.Add(navigationPropertyInfo);
+                            if (!existingCandidate.NavigationProperties.Contains(navigationPropertyInfo))
+                            {
+                                existingCandidate.NavigationProperties.Add(navigationPropertyInfo);
+                            }
                         }
+
+                        continue;
                     }
 
-                    continue;
+                    var sharedTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(
+                        targetClrType, navigationPropertyInfo.GetSimpleMemberName(), entityType);
+                    if (sharedTypeBuilder == null)
+                    {
+                        continue;
+                    }
+
+                    candidateTargetEntityType = sharedTypeBuilder.Metadata;
                 }
 
                 var navigations = new List<PropertyInfo> { navigationPropertyInfo };
@@ -147,24 +166,51 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     foreach (var inverseCandidateTuple in inverseCandidates)
                     {
                         var inversePropertyInfo = inverseCandidateTuple.Key;
-                        var inverseTargetType = inverseCandidateTuple.Value;
-
-                        if ((inverseTargetType != entityType.ClrType
-                                && (!inverseTargetType.IsAssignableFrom(entityType.ClrType)
-                                    || (!model.IsOwned(targetClrType)
-                                        && !candidateTargetEntityType.IsInOwnershipPath(entityType))))
-                            || navigationPropertyInfo.IsSameAs(inversePropertyInfo)
-                            || (ownership != null
-                                && !candidateTargetEntityType.IsInOwnershipPath(entityType)
-                                && (candidateTargetEntityType.IsOwned()
-                                    || !model.IsOwned(targetClrType))
-                                && (ownership.PrincipalEntityType != candidateTargetEntityType
-                                    || ownership.PrincipalToDependent?.Name != inversePropertyInfo.GetSimpleMemberName()))
+                        if (navigationPropertyInfo.IsSameAs(inversePropertyInfo)
                             || !IsCandidateNavigationProperty(
                                 candidateTargetEntityTypeBuilder, inversePropertyInfo.GetSimpleMemberName(), inversePropertyInfo))
                         {
                             continue;
                         }
+
+                        var inverseTargetType = inverseCandidateTuple.Value.Type;
+                        if (inverseTargetType != entityType.ClrType
+                            && (!inverseTargetType.IsAssignableFrom(entityType.ClrType)
+                                || (!shouldBeOwnership
+                                    && !candidateTargetEntityType.IsInOwnershipPath(entityType))))
+                        {
+                            // Only use inverse of a base type if the target is owned by the current entity type
+                            continue;
+                        }
+
+                        if (ownership != null
+                            && !shouldBeOwnership
+                            && !candidateTargetEntityType.IsInOwnershipPath(entityType)
+                            && (ownership.PrincipalEntityType == candidateTargetEntityType
+                                || !entityType.IsInOwnershipPath(candidateTargetEntityType))
+                            && (ownership.PrincipalEntityType != candidateTargetEntityType
+                                || ownership.PrincipalToDependent?.Name != inversePropertyInfo.GetSimpleMemberName()))
+                        {
+                            // Only the owner or nested ownees can have navigations to an owned type
+                            // Also skip non-ownership inverse candidates from the owner
+                            continue;
+                        }
+
+                        if (shouldBeOwnership
+                            && inversePropertyInfo.PropertyType.TryGetSequenceType() != null
+                            && navigations.Count == 1)
+                        {
+                            // Target type should be the principal, discover the relationship from the other side
+                            var targetType = candidateTargetEntityType;
+                            if (targetType.IsInModel
+                                && IsImplicitlyCreatedUnusedSharedType(targetType))
+                            {
+                                targetType.Builder.ModelBuilder.HasNoEntityType(targetType);
+                            }
+
+                            goto Continue;
+                        }
+
 
                         if (!inverseNavigationCandidates.Contains(inversePropertyInfo))
                         {
@@ -174,9 +220,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
 
                 relationshipCandidates[candidateTargetEntityType] =
-                    new RelationshipCandidate(candidateTargetEntityTypeBuilder, navigations, inverseNavigationCandidates);
+                    new RelationshipCandidate(candidateTargetEntityTypeBuilder, navigations, inverseNavigationCandidates, shouldBeOwnership);
+
+                Continue:;
             }
 
+            return UpdateTargetEntityTypes(entityTypeBuilder, relationshipCandidates);
+        }
+
+        private List<RelationshipCandidate> UpdateTargetEntityTypes(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            Dictionary<IConventionEntityType, RelationshipCandidate> relationshipCandidates)
+        {
             var candidates = new List<RelationshipCandidate>();
             foreach (var relationshipCandidate in relationshipCandidates.Values)
             {
@@ -191,12 +246,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     continue;
                 }
 
-                // The entity type might have been converted to a weak entity type
-                var actualTargetEntityTypeBuilder =
-                    ((InternalEntityTypeBuilder)entityTypeBuilder).GetTargetEntityTypeBuilder(
-                        relationshipCandidate.TargetTypeBuilder.Metadata.ClrType,
-                        relationshipCandidate.NavigationProperties.Single(),
-                        ConfigurationSource.Convention);
+                // The entity type might have been converted to a shared type entity type
+                var actualTargetEntityTypeBuilder = TryGetTargetEntityTypeBuilder(
+                    entityTypeBuilder,
+                    relationshipCandidate.TargetTypeBuilder.Metadata.ClrType,
+                    relationshipCandidate.NavigationProperties.Single());
 
                 if (actualTargetEntityTypeBuilder == null)
                 {
@@ -205,11 +259,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
                 candidates.Add(
                     new RelationshipCandidate(
-                        actualTargetEntityTypeBuilder, relationshipCandidate.NavigationProperties,
-                        relationshipCandidate.InverseProperties));
+                        actualTargetEntityTypeBuilder,
+                        relationshipCandidate.NavigationProperties,
+                        relationshipCandidate.InverseProperties,
+                        relationshipCandidate.IsOwnership));
             }
 
             return candidates;
+        }
+
+        /// <summary>
+        ///     Finds or tries to create an entity type target for the given navigation member.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the referencing entity type. </param>
+        /// <param name="targetClrType"> The CLR type of the target entity type. </param>
+        /// <param name="navigationMemberInfo"> The navigation member. </param>
+        /// <param name="shouldBeOwned"> Whether the target entity type should be owned. </param>
+        /// <param name="shouldCreate"> Whether an entity type should be created if one doesn't currently exist. </param>
+        /// <returns> The builder for the target entity type or <see langword="null"/> if it can't be created. </returns>
+        protected virtual IConventionEntityTypeBuilder? TryGetTargetEntityTypeBuilder(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            Type targetClrType,
+            MemberInfo navigationMemberInfo,
+            bool? shouldBeOwned = null,
+            bool shouldCreate = true)
+        {
+            if (shouldCreate)
+            {
+                var targetEntityTypeBuilder = ((InternalEntityTypeBuilder)entityTypeBuilder)
+                    .GetTargetEntityTypeBuilder(targetClrType, navigationMemberInfo, ConfigurationSource.Convention,
+                        shouldBeOwned ?? ShouldBeOwned(targetClrType, entityTypeBuilder.Metadata.Model));
+                if (targetEntityTypeBuilder != null)
+                {
+                    return targetEntityTypeBuilder;
+                }
+            }
+
+            return ((InternalEntityTypeBuilder)entityTypeBuilder)
+                .GetTargetEntityTypeBuilder(targetClrType, navigationMemberInfo, null, shouldBeOwned);
         }
 
         private static IReadOnlyList<RelationshipCandidate> RemoveIncompatibleWithExistingRelationships(
@@ -284,7 +371,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                             new RelationshipCandidate(
                                 targetEntityTypeBuilder,
                                 new List<PropertyInfo> { navigationProperty },
-                                new List<PropertyInfo>()));
+                                new List<PropertyInfo>(),
+                                relationshipCandidate.IsOwnership));
 
                         if (relationshipCandidate.TargetTypeBuilder.Metadata == entityTypeBuilder.Metadata
                             && relationshipCandidate.InverseProperties.Count > 0)
@@ -321,7 +409,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                             new RelationshipCandidate(
                                 targetEntityTypeBuilder,
                                 new List<PropertyInfo> { navigationProperty },
-                                new List<PropertyInfo> { compatibleInverse })
+                                new List<PropertyInfo> { compatibleInverse },
+                                relationshipCandidate.IsOwnership)
                         );
 
                         if (relationshipCandidate.TargetTypeBuilder.Metadata == entityTypeBuilder.Metadata
@@ -521,45 +610,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     || (targetEntityType.BaseType != null
                         && HasAmbiguousNavigationsTo(targetEntityType.BaseType, entityType.ClrType));
 
-                var ambiguousOwnership = relationshipCandidate.NavigationProperties.Count == 1
-                    && relationshipCandidate.InverseProperties.Count == 1
-                    && entityType.GetConfigurationSource() != ConfigurationSource.Explicit
-                    && targetEntityType.GetConfigurationSource() != ConfigurationSource.Explicit
-                    && targetEntityType.Model.IsOwned(entityType.ClrType)
-                    && targetEntityType.Model.IsOwned(targetEntityType.ClrType);
-
-                if (ambiguousOwnership)
-                {
-                    var existingNavigation =
-                        entityType.FindNavigation(relationshipCandidate.NavigationProperties.Single().GetSimpleMemberName());
-                    if (existingNavigation != null
-                        && existingNavigation.ForeignKey.DeclaringEntityType == targetEntityType
-                        && existingNavigation.ForeignKey.GetPrincipalEndConfigurationSource()
-                            .OverridesStrictly(ConfigurationSource.Convention))
-                    {
-                        ambiguousOwnership = false;
-                    }
-                    else
-                    {
-                        var existingInverse =
-                            targetEntityType.FindNavigation(relationshipCandidate.InverseProperties.Single().GetSimpleMemberName());
-                        if (existingInverse != null
-                            && existingInverse.ForeignKey.PrincipalEntityType == targetEntityType
-                            && existingInverse.ForeignKey.GetPrincipalEndConfigurationSource()
-                                .OverridesStrictly(ConfigurationSource.Convention))
-                        {
-                            ambiguousOwnership = false;
-                        }
-                    }
-                }
-
                 if ((relationshipCandidate.NavigationProperties.Count > 1
                         && relationshipCandidate.InverseProperties.Count > 0
-                        && (!targetEntityType.Model.IsOwned(targetEntityType.ClrType)
-                            || entityType.IsInOwnershipPath(targetEntityType)))
+                        && !relationshipCandidate.IsOwnership)
                     || relationshipCandidate.InverseProperties.Count > 1
                     || isAmbiguousOnBase
-                    || ambiguousOwnership
                     || HasDeclaredAmbiguousNavigationsTo(entityType, targetEntityType.ClrType)
                     || HasDeclaredAmbiguousNavigationsTo(targetEntityType, entityType.ClrType))
                 {
@@ -603,7 +658,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 foreach (var navigation in relationshipCandidate.NavigationProperties)
                 {
                     if (!targetEntityType.IsInModel
-                        && !targetEntityType.Model.IsOwned(targetEntityType.ClrType))
+                        && !targetEntityType.IsOwned())
                     {
                         continue;
                     }
@@ -614,17 +669,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                         continue;
                     }
 
-                    var targetOwned = !entityType.IsInOwnershipPath(targetEntityType)
-                        && (targetEntityType.Model.IsOwned(targetEntityType.ClrType)
-                            || (targetEntityType.HasSharedClrType
-                                && targetEntityType.Model.FindEntityTypes(targetEntityType.ClrType).Any(e => e.IsOwned())));
-
                     var inverse = relationshipCandidate.InverseProperties.SingleOrDefault();
                     if (inverse == null)
                     {
-                        if (targetOwned)
+                        if (relationshipCandidate.IsOwnership)
                         {
-                            entityTypeBuilder.HasOwnership(targetEntityType.ClrType, navigation);
+                            entityTypeBuilder.HasOwnership(targetEntityType, navigation);
                         }
                         else
                         {
@@ -639,25 +689,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                             continue;
                         }
 
-                        if (targetOwned
-                            && entityType.Model.IsOwned(entityType.ClrType))
+                        if (relationshipCandidate.IsOwnership)
                         {
-                            var existingInverse = targetEntityType.FindNavigation(inverse.GetSimpleMemberName());
-                            if (inverse.PropertyType.TryGetSequenceType() != null
-                                || targetEntityType.GetConfigurationSource() == ConfigurationSource.Explicit
-                                || (existingInverse != null
-                                    && existingInverse.ForeignKey.DeclaringEntityType == entityType
-                                    && existingInverse.ForeignKey.GetPrincipalEndConfigurationSource()
-                                        .OverridesStrictly(ConfigurationSource.Convention)))
-                            {
-                                // Target type is the principal, so the ownership should be configured from the other side
-                                targetOwned = false;
-                            }
-                        }
-
-                        if (targetOwned)
-                        {
-                            entityTypeBuilder.HasOwnership(targetEntityType.ClrType, navigation, inverse);
+                            entityTypeBuilder.HasOwnership(targetEntityType, navigation, inverse);
                         }
                         else if (entityTypeBuilder.HasRelationship(targetEntityType, navigation, inverse) == null)
                         {
@@ -676,7 +710,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 if (relationshipCandidate.NavigationProperties.Count == 0)
                 {
                     if (relationshipCandidate.InverseProperties.Count == 0
-                        || targetEntityType.Model.IsOwned(targetEntityType.ClrType))
+                        || targetEntityType.IsOwned())
                     {
                         unusedEntityTypes.Add(targetEntityType);
                     }
@@ -709,6 +743,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 }
             }
         }
+
+        /// <summary>
+        ///     Returns a value indicating whether the given entity type should be added as owned if it isn't currently in the model.
+        /// </summary>
+        /// <param name="targetType"> Target entity type. </param>
+        /// <param name="model"> The model. </param>
+        /// <returns> <see langword="true"/> if the given entity type should be owned. </returns>
+        protected virtual bool? ShouldBeOwned(Type targetType, IConventionModel model)
+            => null;
 
         private void RemoveNavigation(
             PropertyInfo navigationProperty,
@@ -814,7 +857,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             if ((targetEntityTypeBuilder.Metadata.IsInModel
                     || !sourceEntityTypeBuilder.ModelBuilder.IsIgnored(targetEntityTypeBuilder.Metadata.Name))
-                && IsCandidateNavigationProperty(sourceEntityTypeBuilder, navigationName, memberInfo))
+                && memberInfo != null
+                && IsCandidateNavigationProperty(sourceEntityTypeBuilder, navigationName, memberInfo)
+                && Dependencies.MemberClassifier.FindCandidateNavigationPropertyType(
+                    memberInfo, targetEntityTypeBuilder.Metadata.Model, out _) != null)
             {
                 Process(sourceEntityTypeBuilder.Metadata, navigationName, memberInfo!, context);
             }
@@ -839,16 +885,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
         }
 
-        [ContractAnnotation("memberInfo:null => false")]
         private static bool IsCandidateNavigationProperty(
             IConventionEntityTypeBuilder? sourceEntityTypeBuilder,
             string navigationName,
-            MemberInfo? memberInfo)
-            => memberInfo != null
-                && sourceEntityTypeBuilder?.IsIgnored(navigationName) == false
+            MemberInfo memberInfo)
+            => sourceEntityTypeBuilder?.IsIgnored(navigationName) == false
                 && sourceEntityTypeBuilder.Metadata.FindProperty(navigationName) == null
                 && sourceEntityTypeBuilder.Metadata.FindServiceProperty(navigationName) == null
-                && (!(memberInfo is PropertyInfo propertyInfo) || propertyInfo.GetIndexParameters().Length == 0)
+                && (memberInfo is not PropertyInfo propertyInfo || propertyInfo.GetIndexParameters().Length == 0)
                 && (!sourceEntityTypeBuilder.Metadata.IsKeyless
                     || (memberInfo as PropertyInfo)?.PropertyType.TryGetSequenceType() == null);
 
@@ -917,8 +961,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var targetClrType = ambiguousNavigation.Value.Value;
             RemoveAmbiguous(entityType, targetClrType);
 
-            var targetType = ((InternalEntityTypeBuilder)entityType.Builder)
-                .GetTargetEntityTypeBuilder(targetClrType, ambiguousNavigation.Value.Key, null)?.Metadata;
+            var targetType = TryGetTargetEntityTypeBuilder(
+                entityType.Builder, targetClrType, ambiguousNavigation.Value.Key, shouldCreate: false)?.Metadata;
             if (targetType != null)
             {
                 RemoveAmbiguous(targetType, entityType.ClrType);
@@ -1068,16 +1112,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             public RelationshipCandidate(
                 IConventionEntityTypeBuilder targetTypeBuilder,
                 List<PropertyInfo> navigations,
-                List<PropertyInfo> inverseNavigations)
+                List<PropertyInfo> inverseNavigations,
+                bool ownership)
             {
                 TargetTypeBuilder = targetTypeBuilder;
                 NavigationProperties = navigations;
                 InverseProperties = inverseNavigations;
+                IsOwnership = ownership;
             }
 
             public IConventionEntityTypeBuilder TargetTypeBuilder { [DebuggerStepThrough] get; }
             public List<PropertyInfo> NavigationProperties { [DebuggerStepThrough] get; }
             public List<PropertyInfo> InverseProperties { [DebuggerStepThrough] get; }
+            public bool IsOwnership { [DebuggerStepThrough] get; }
 
             private string DebuggerDisplay()
                 => TargetTypeBuilder.Metadata.ToDebugString(MetadataDebugStringOptions.SingleLineDefault)
@@ -1085,7 +1132,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     + string.Join(", ", NavigationProperties.Select(p => p.Name))
                     + "] - ["
                     + string.Join(", ", InverseProperties.Select(p => p.Name))
-                    + "]";
+                    + "]"
+                    + (IsOwnership ? " Ownership" : "");
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -192,7 +192,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
             else
             {
-                annotations.Remove(CoreAnnotationNames.OwnedTypes);
                 annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
             }
         }

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <summary>
         ///     <para>
-        ///         Adds a shadow state entity type to the model.
+        ///         Adds a state entity type of default type to the model.
         ///     </para>
         ///     <para>
         ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
@@ -115,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IConventionEntityType? AddEntityType(string name, Type clrType, bool fromDataAnnotation = false);
 
         /// <summary>
-        ///     Adds an entity type with a defining navigation to the model.
+        ///     Adds an owned entity type with a defining navigation to the model.
         /// </summary>
         /// <param name="name"> The name of the entity type to be added. </param>
         /// <param name="definingNavigationName"> The defining navigation. </param>
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             bool fromDataAnnotation = false);
 
         /// <summary>
-        ///     Adds an entity type with a defining navigation to the model.
+        ///     Adds an owned entity type with a defining navigation to the model.
         /// </summary>
         /// <param name="type"> The CLR class that is used to represent instances of this entity type. </param>
         /// <param name="definingNavigationName"> The defining navigation. </param>
@@ -141,6 +141,43 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             string definingNavigationName,
             IConventionEntityType definingEntityType,
             bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     <para>
+        ///         Adds an owned entity type of default type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
+        ///         Therefore, shadow state entity types will only exist in migration model snapshots, etc.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the entity to be added. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The new entity type. </returns>
+        IConventionEntityType? AddOwnedEntityType(string name, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Adds an owned entity type to the model.
+        /// </summary>
+        /// <param name="type"> The CLR class that is used to represent instances of the entity type. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The new entity type. </returns>
+        IConventionEntityType? AddOwnedEntityType(Type type, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     <para>
+        ///         Adds an owned shared type entity type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shared type entity type is an entity type which can share CLR type with other types in the model but has
+        ///         a unique name and always identified by the name.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the entity to be added. </param>
+        /// <param name="clrType"> The CLR class that is used to represent instances of the entity type. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> The new entity type. </returns>
+        IConventionEntityType? AddOwnedEntityType(string name, Type clrType, bool fromDataAnnotation = false);
 
         /// <summary>
         ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         /// <summary>
         ///     <para>
-        ///         Adds a shadow state entity type to the model.
+        ///         Adds an entity type of default type to the model.
         ///     </para>
         ///     <para>
         ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IMutableEntityType AddEntityType(string name, Type type);
 
         /// <summary>
-        ///     Adds an entity type with a defining navigation to the model.
+        ///     Adds an owned entity type with a defining navigation to the model.
         /// </summary>
         /// <param name="name"> The name of the entity type to be added. </param>
         /// <param name="definingNavigationName"> The defining navigation. </param>
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             IMutableEntityType definingEntityType);
 
         /// <summary>
-        ///     Adds an entity type with a defining navigation to the model.
+        ///     Adds an owned entity type with a defining navigation to the model.
         /// </summary>
         /// <param name="type"> The CLR class that is used to represent instances of this entity type. </param>
         /// <param name="definingNavigationName"> The defining navigation. </param>
@@ -112,6 +112,40 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Type type,
             string definingNavigationName,
             IMutableEntityType definingEntityType);
+
+        /// <summary>
+        ///     <para>
+        ///         Adds an owned entity type of default type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shadow entities are not currently supported in a model that is used at runtime with a <see cref="DbContext" />.
+        ///         Therefore, shadow state entity types will only exist in migration model snapshots, etc.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the entity to be added. </param>
+        /// <returns> The new entity type. </returns>
+        IMutableEntityType AddOwnedEntityType(string name);
+
+        /// <summary>
+        ///     Adds an owned entity type to the model.
+        /// </summary>
+        /// <param name="type"> The CLR class that is used to represent instances of the entity type. </param>
+        /// <returns> The new entity type. </returns>
+        IMutableEntityType AddOwnedEntityType(Type type);
+
+        /// <summary>
+        ///     <para>
+        ///         Adds an owned shared type entity type to the model.
+        ///     </para>
+        ///     <para>
+        ///         Shared type entity type is an entity type which can share CLR type with other types in the model but has
+        ///         a unique name and always identified by the name.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the entity to be added. </param>
+        /// <param name="type"> The CLR class that is used to represent instances of the entity type. </param>
+        /// <returns> The new entity type. </returns>
+        IMutableEntityType AddOwnedEntityType(string name, Type type);
 
         /// <summary>
         ///     Gets the entity with the given name. Returns <see langword="null" /> if no entity type with the given name is found

--- a/src/EFCore/Metadata/IReadOnlyEntityType.cs
+++ b/src/EFCore/Metadata/IReadOnlyEntityType.cs
@@ -830,6 +830,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 builder.Append(" Keyless");
             }
 
+            if (IsOwned())
+            {
+                builder.Append(" Owned");
+            }
+
             if (this is EntityType
                 && GetChangeTrackingStrategy() != ChangeTrackingStrategy.Snapshot)
             {

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -92,14 +92,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string OwnedTypes = "OwnedTypes";
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
         public const string DiscriminatorProperty = "DiscriminatorProperty";
 
         /// <summary>
@@ -306,7 +298,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ValueGeneratorFactoryType,
             PropertyAccessMode,
             NavigationAccessMode,
-            OwnedTypes,
             DiscriminatorProperty,
             DiscriminatorMappingComplete,
             DiscriminatorValue,

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -85,6 +85,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public static IConventionForeignKey? FindDeclaredOwnership(this IConventionEntityType entityType)
+            => entityType.GetDeclaredForeignKeys().FirstOrDefault(fk => fk.IsOwnership);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public static IReadOnlyEntityType? FindInOwnershipPath(this IReadOnlyEntityType entityType, Type targetType)
         {
             if (entityType.ClrType == targetType)
@@ -117,6 +126,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static bool IsInOwnershipPath(this IReadOnlyEntityType entityType, Type targetType)
             => entityType.FindInOwnershipPath(targetType) != null;
+
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static bool IsInOwnershipPath(this IReadOnlyEntityType entityType, IReadOnlyEntityType targetType)
+        {
+            if (entityType == targetType)
+            {
+                return true;
+            }
+
+            var owner = entityType;
+            while (true)
+            {
+                var ownership = owner.FindOwnership();
+                if (ownership == null)
+                {
+                    return false;
+                }
+
+                owner = ownership.PrincipalEntityType;
+                if (owner.IsAssignableFrom(targetType))
+                {
+                    return true;
+                }
+            }
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -826,10 +826,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             EnsureMutable();
 
-            if (ownership == true
-                && !DeclaringEntityType.IsOwned())
+            if (ownership == true)
             {
-                throw new InvalidOperationException(CoreStrings.ClashingNonOwnedEntityType(DeclaringEntityType.DisplayName()));
+                if (!DeclaringEntityType.IsOwned())
+                {
+                    throw new InvalidOperationException(CoreStrings.ClashingNonOwnedEntityType(DeclaringEntityType.DisplayName()));
+                }
+
+                if (PrincipalToDependent == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationlessOwnership(
+                            PrincipalEntityType.DisplayName(), DeclaringEntityType.DisplayName()));
+                }
             }
 
             var oldIsOwnership = IsOwnership;

--- a/src/EFCore/Metadata/Internal/IMemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/IMemberClassifier.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        ImmutableSortedDictionary<PropertyInfo, Type> GetNavigationCandidates(IConventionEntityType entityType);
+        ImmutableSortedDictionary<PropertyInfo, (Type Type, bool? ShouldBeOwned)> GetNavigationCandidates(IConventionEntityType entityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        Type? FindCandidateNavigationPropertyType(MemberInfo memberInfo, ModelConfiguration? configuration);
+        Type? FindCandidateNavigationPropertyType(MemberInfo memberInfo, IConventionModel model, out bool? shouldBeOwned);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         return null;
                     }
 
-                    Metadata.SetPrimaryKey(keyBuilder.Metadata.Properties, configurationSource);
+                    var newKey = Metadata.SetPrimaryKey(keyBuilder.Metadata.Properties, configurationSource);
                     foreach (var key in Metadata.GetDeclaredKeys().ToList())
                     {
                         if (key == keyBuilder.Metadata)
@@ -112,7 +112,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                         foreach (var referencingForeignKey in referencingForeignKeys)
                         {
-                            DetachRelationship(referencingForeignKey).Attach();
+                            if (referencingForeignKey.GetPropertiesConfigurationSource() != null
+                                && !ForeignKey.AreCompatible(
+                                        newKey!.Properties,
+                                        referencingForeignKey.Properties,
+                                        referencingForeignKey.PrincipalEntityType,
+                                        Metadata,
+                                        shouldThrow: false))
+                            {
+                                DetachRelationship(referencingForeignKey).Attach();
+                            }
+                            else
+                            {
+                                referencingForeignKey.Builder.HasPrincipalKey((IReadOnlyList<Property>?)null, ConfigurationSource.Convention);
+                            }
+
                         }
                     }
 
@@ -1453,7 +1467,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return HasBaseType((EntityType?)null, configurationSource);
             }
 
-            var baseType = ModelBuilder.Entity(baseEntityType, configurationSource);
+            var baseType = ModelBuilder.Entity(baseEntityType, configurationSource, shouldBeOwned: Metadata.IsOwned());
             return baseType == null
                 ? null
                 : HasBaseType(baseType.Metadata, configurationSource);
@@ -1472,7 +1486,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return HasBaseType((EntityType?)null, configurationSource);
             }
 
-            var baseType = ModelBuilder.Entity(baseEntityTypeName, configurationSource);
+            var baseType = ModelBuilder.Entity(baseEntityTypeName, configurationSource, shouldBeOwned: Metadata.IsOwned());
             return baseType == null
                 ? null
                 : HasBaseType(baseType.Metadata, configurationSource);
@@ -2586,7 +2600,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(principalClrType, nameof(principalClrType));
             Check.NotEmpty(clrMembers, nameof(clrMembers));
 
-            var principalTypeBuilder = ModelBuilder.Entity(principalClrType, configurationSource);
+            var principalTypeBuilder = ModelBuilder.Entity(
+                principalClrType, configurationSource, shouldBeOwned: Metadata.IsInOwnershipPath(principalClrType) ? null : false);
             return principalTypeBuilder == null
                 ? null
                 : HasForeignKey(
@@ -2611,7 +2626,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(principalClrType, nameof(principalClrType));
             Check.NotEmpty(clrMembers, nameof(clrMembers));
 
-            var principalTypeBuilder = ModelBuilder.Entity(principalClrType, configurationSource);
+            var principalTypeBuilder = ModelBuilder.Entity(
+                principalClrType, configurationSource, shouldBeOwned: Metadata.IsInOwnershipPath(principalClrType) ? null : false);
             return principalTypeBuilder == null
                 ? null
                 : HasForeignKey(
@@ -2731,7 +2747,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Check.NotNull(targetEntityType, nameof(targetEntityType)),
                 MemberIdentity.Create(navigationName),
                 MemberIdentity.Create(inverseNavigationName),
-                setTargetAsPrincipal ? true : (bool?)null,
+                setTargetAsPrincipal ? true : null,
                 configurationSource);
 
         /// <summary>
@@ -2750,7 +2766,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Check.NotNull(targetEntityType, nameof(targetEntityType)),
                 MemberIdentity.Create(navigation),
                 MemberIdentity.Create(inverseNavigation),
-                setTargetAsPrincipal ? true : (bool?)null,
+                setTargetAsPrincipal ? true : null,
                 configurationSource);
 
         private InternalForeignKeyBuilder? HasRelationship(
@@ -2955,9 +2971,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 else
                 {
-                    if (setTargetAsPrincipal == true
-                        || (setTargetAsPrincipal == null
-                            && !((IReadOnlyEntityType)targetEntityType).IsInOwnershipPath(Metadata)))
+                    if (!InternalForeignKeyBuilder.AreCompatible(
+                        navigationToTarget?.MemberInfo,
+                        inverseNavigation?.MemberInfo,
+                        targetEntityType,
+                        Metadata,
+                        shouldThrow: configurationSource == ConfigurationSource.Explicit,
+                        out var shouldInvert,
+                        out var shouldBeUnique))
+                    {
+                        return null;
+                    }
+
+                    if (shouldInvert == true && setTargetAsPrincipal == true)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.PrincipalEndIncompatibleNavigations(
+                                Metadata.DisplayName()
+                                + (navigationToTarget == null
+                                    ? ""
+                                    : "." + navigationToTarget.Value.Name),
+                                targetEntityType.DisplayName()
+                                + (inverseNavigation == null
+                                    ? ""
+                                    : "." + inverseNavigation.Value.Name),
+                                targetEntityType.DisplayName()));
+                    }
+
+                    shouldInvert ??= setTargetAsPrincipal != true
+                        && (setTargetAsPrincipal != null
+                            || ((IReadOnlyEntityType)targetEntityType).IsInOwnershipPath(Metadata));
+                    if (!shouldInvert.Value)
                     {
                         newRelationship = CreateForeignKey(
                             targetEntityType.Builder,
@@ -3243,13 +3287,53 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             MemberIdentity? inverse,
             ConfigurationSource configurationSource)
         {
-            InternalEntityTypeBuilder? ownedEntityTypeBuilder;
             InternalForeignKeyBuilder? relationship;
+            var existingNavigation = Metadata.FindNavigation(navigation.Name!);
+            if (existingNavigation != null
+                && !existingNavigation.IsOnDependent)
+            {
+                var existingTargetType = existingNavigation.TargetEntityType;
+                if ((targetEntityType.Type == null
+                    || existingTargetType.ClrType == targetEntityType.Type)
+                    && (!targetEntityType.IsNamed
+                        || targetEntityType.Name == existingTargetType.Name
+                        || (targetEntityType.Type == null
+                            && targetEntityType.Name == existingTargetType.ClrType.DisplayName())))
+                {
+                    relationship = existingNavigation.ForeignKey.Builder;
+                    if (existingNavigation.ForeignKey.IsOwnership)
+                    {
+                        relationship = relationship.IsOwnership(true, configurationSource)
+                            ?.HasNavigations(inverse, navigation, configurationSource);
+
+                        relationship?.Metadata.UpdateConfigurationSource(configurationSource);
+                        return relationship;
+                    }
+
+                    Check.DebugAssert(!existingTargetType.IsOwned()
+                        || existingNavigation.DeclaringEntityType.IsInOwnershipPath(existingTargetType)
+                        || (existingTargetType.IsInOwnershipPath(existingNavigation.DeclaringEntityType)
+                            && existingTargetType.FindOwnership()!.PrincipalEntityType != existingNavigation.DeclaringEntityType),
+                        $"Found '{existingNavigation.DeclaringEntityType.DisplayName()}.{existingNavigation.Name}'. " +
+                        "Owned types should only have ownership or ownee navigations point at it");
+
+                    relationship = relationship.IsOwnership(true, configurationSource)
+                        ?.HasNavigations(inverse, navigation, configurationSource);
+
+                    relationship?.Metadata.UpdateConfigurationSource(configurationSource);
+                    return relationship;
+                }
+            }
+
+            InternalEntityTypeBuilder? ownedEntityTypeBuilder;
+
             using (var batch = Metadata.Model.DelayConventions())
             {
                 var ownership = Metadata.FindOwnership();
-                ownedEntityTypeBuilder = GetTargetEntityTypeBuilder(targetEntityType, navigation, configurationSource, targetShouldBeOwned: true);
+                ownedEntityTypeBuilder = GetTargetEntityTypeBuilder(
+                    targetEntityType, navigation, configurationSource, targetShouldBeOwned: true);
 
+                // TODO: Use convention batch to get the updated builder, see #15898
                 var principalBuilder = Metadata.IsInModel
                     ? Metadata.Builder
                     : ownership?.PrincipalEntityType.FindNavigation(ownership.PrincipalToDependent!.Name)?.TargetEntityType is EntityType target
@@ -3271,8 +3355,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     inverseNavigation: navigation,
                     setTargetAsPrincipal: true,
                     configurationSource,
-                    required: true)!;
-                relationship = batch.Run(relationship.IsOwnership(true, configurationSource)!);
+                    required: true)
+                    ?.IsOwnership(true, configurationSource);
+
+                if (relationship == null)
+                {
+                    batch.Dispose();
+                }
+                else
+                {
+                    relationship = batch.Run(relationship);
+                }
             }
 
             if (relationship is null || !relationship.Metadata.IsInModel)
@@ -3289,14 +3382,213 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return relationship;
         }
 
+        private InternalForeignKeyBuilder? HasOwnership(
+            EntityType targetEntityType,
+            in MemberIdentity navigation,
+            MemberIdentity? inverse,
+            ConfigurationSource configurationSource)
+        {
+            InternalForeignKeyBuilder? relationship;
+            var existingNavigation = Metadata.FindNavigation(navigation.Name!);
+            if (existingNavigation != null
+                && !existingNavigation.IsOnDependent)
+            {
+                var existingTargetType = existingNavigation.TargetEntityType;
+                if (existingTargetType == targetEntityType)
+                {
+                    relationship = existingNavigation.ForeignKey.Builder;
+                    if (existingNavigation.ForeignKey.IsOwnership)
+                    {
+                        relationship = relationship.IsOwnership(true, configurationSource)
+                            ?.HasNavigations(inverse, navigation, configurationSource);
+
+                        relationship?.Metadata.UpdateConfigurationSource(configurationSource);
+                        return relationship;
+                    }
+
+                    Check.DebugAssert(!existingTargetType.IsOwned()
+                        || existingNavigation.DeclaringEntityType.IsInOwnershipPath(existingTargetType)
+                        || (existingTargetType.IsInOwnershipPath(existingNavigation.DeclaringEntityType)
+                            && existingTargetType.FindOwnership()!.PrincipalEntityType != existingNavigation.DeclaringEntityType),
+                        $"Found '{existingNavigation.DeclaringEntityType.DisplayName()}.{existingNavigation.Name}'. " +
+                        "Owned types should only have ownership or ownee navigations point at it");
+
+                    relationship = relationship.IsOwnership(true, configurationSource)
+                            ?.HasNavigations(inverse, navigation, configurationSource);
+
+                    relationship?.Metadata.UpdateConfigurationSource(configurationSource);
+                    return relationship;
+                }
+            }
+
+            using (var batch = Metadata.Model.DelayConventions())
+            {
+                relationship = targetEntityType.Builder.HasRelationship(
+                    targetEntityType: Metadata,
+                    navigationToTarget: inverse,
+                    inverseNavigation: navigation,
+                    setTargetAsPrincipal: true,
+                    configurationSource,
+                    required: true)
+                    ?.IsOwnership(true, configurationSource);
+
+                if (relationship == null)
+                {
+                    batch.Dispose();
+                }
+                else
+                {
+                    relationship = batch.Run(relationship);
+                }
+            }
+
+            return relationship;
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual bool RemoveNonOwnershipRelationships(ForeignKey? ownership, ConfigurationSource configurationSource)
+        public virtual InternalEntityTypeBuilder? IsOwned(
+            bool owned,
+            ConfigurationSource configurationSource,
+            ForeignKey? futureOwnership = null)
         {
+            var entityType = Metadata;
+            if (entityType.IsOwned() == owned)
+            {
+                entityType.UpdateConfigurationSource(configurationSource);
+                return this;
+            }
+
+            if (!CanSetIsOwned(owned, configurationSource))
+            {
+                return null;
+            }
+
+            entityType.UpdateConfigurationSource(configurationSource);
+            if (owned)
+            {
+                entityType.SetIsOwned(true);
+
+                HasBaseType((EntityType?)null, configurationSource);
+
+                foreach (var derivedType in entityType.GetDirectlyDerivedTypes().ToList())
+                {
+                    derivedType.Builder.HasBaseType((EntityType?)null, configurationSource);
+                }
+
+                if (!entityType.Builder.RemoveNonOwnershipRelationships(futureOwnership, configurationSource))
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                entityType.SetIsOwned(false);
+
+                var ownership = entityType.FindOwnership();
+                if (ownership != null)
+                {
+                    HasNoRelationship(ownership, configurationSource);
+                }
+
+                foreach (var derivedType in entityType.GetDerivedTypes())
+                {
+                    derivedType.SetIsOwned(false);
+                    var derivedOwnership = derivedType.FindDeclaredOwnership();
+                    if (derivedOwnership != null)
+                    {
+                        derivedType.Builder.HasNoRelationship(derivedOwnership, configurationSource);
+                    }
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual bool CanSetIsOwned(bool owned, ConfigurationSource configurationSource)
+        {
+            var entityType = Metadata;
+            if (owned)
+            {
+                if (!entityType.IsOwned())
+                {
+                    if (!configurationSource.Overrides(entityType.GetBaseTypeConfigurationSource()))
+                    {
+                        return false;
+                    }
+
+                    if (!configurationSource.OverridesStrictly(entityType.GetConfigurationSource()))
+                    {
+                        if (configurationSource == ConfigurationSource.Explicit)
+                        {
+                            throw new InvalidOperationException(CoreStrings.ClashingNonOwnedEntityType(entityType.DisplayName()));
+                        }
+
+                        return false;
+                    }
+                }
+
+                foreach (var derivedType in entityType.GetDerivedTypes())
+                {
+                    if (!derivedType.IsOwned()
+                        && !configurationSource.OverridesStrictly(derivedType.GetConfigurationSource()))
+                    {
+                        if (configurationSource == ConfigurationSource.Explicit)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.ClashingNonOwnedDerivedEntityType(entityType.DisplayName(), derivedType.DisplayName()));
+                        }
+
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                if (entityType.IsOwned()
+                    && !configurationSource.OverridesStrictly(entityType.GetConfigurationSource()))
+                {
+                    if (configurationSource == ConfigurationSource.Explicit)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.ClashingOwnedEntityType(entityType.DisplayName()));
+                    }
+
+                    return false;
+                }
+
+                foreach (var derivedType in entityType.GetDerivedTypes())
+                {
+                    if (derivedType.IsOwned()
+                        && !configurationSource.OverridesStrictly(derivedType.GetConfigurationSource()))
+                    {
+                        if (configurationSource == ConfigurationSource.Explicit)
+                        {
+                            throw new InvalidOperationException(
+                                CoreStrings.ClashingOwnedDerivedEntityType(entityType.DisplayName(), derivedType.DisplayName()));
+                        }
+
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private bool RemoveNonOwnershipRelationships(ForeignKey? futureOwnership, ConfigurationSource configurationSource)
+        {
+            var ownership = Metadata.FindOwnership() ?? futureOwnership;
             var incompatibleRelationships = Metadata.GetDerivedTypesInclusive()
                 .SelectMany(t => t.GetDeclaredForeignKeys())
                 .Where(
@@ -3318,8 +3610,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             foreach (var foreignKey in incompatibleRelationships)
             {
-                // foreignKey.Builder can be null below if calling HasNoRelationship() below
-                // affects the other foreign key(s) in incompatibleRelationships
+                // foreign keys can be removed by HasNoRelationship() for the other foreign key(s)
                 if (foreignKey.IsInModel)
                 {
                     foreignKey.DeclaringEntityType.Builder.HasNoRelationship(foreignKey, configurationSource);
@@ -3343,9 +3634,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual InternalEntityTypeBuilder? GetTargetEntityTypeBuilder(
             Type targetClrType,
             MemberInfo navigationInfo,
-            ConfigurationSource? configurationSource)
+            ConfigurationSource? configurationSource,
+            bool? targetShouldBeOwned = null)
             => GetTargetEntityTypeBuilder(
-                new TypeIdentity(targetClrType, Metadata.Model), MemberIdentity.Create(navigationInfo), configurationSource);
+                new TypeIdentity(targetClrType, Metadata.Model),
+                MemberIdentity.Create(navigationInfo),
+                configurationSource,
+                targetShouldBeOwned);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -3363,20 +3658,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (existingNavigation != null)
             {
                 var existingTargetType = existingNavigation.TargetEntityType;
-                if ((!targetEntityType.IsNamed
-                        || existingTargetType.Name == targetEntityType.Name)
-                    && (targetEntityType.Type == null
-                        || existingTargetType.ClrType == targetEntityType.Type))
+                if ((targetEntityType.Type == null
+                    || existingTargetType.ClrType == targetEntityType.Type)
+                    && (!targetEntityType.IsNamed
+                        || targetEntityType.Name == existingTargetType.Name
+                        || (targetEntityType.Type == null
+                            && targetEntityType.Name == existingTargetType.ClrType.DisplayName())))
                 {
                     Check.DebugAssert(existingNavigation.ForeignKey.IsOwnership
-                        || !((IReadOnlyNavigation)existingNavigation).TargetEntityType.IsOwned(),
-                        $"Found '{existingNavigation.DeclaringEntityType.ShortName()}.{existingNavigation.Name}'. " +
-                        "Owned types should only have ownership navigations point at it");
+                        || !((IReadOnlyNavigation)existingNavigation).TargetEntityType.IsOwned()
+                        || existingNavigation.DeclaringEntityType.IsInOwnershipPath(existingTargetType)
+                        || (existingTargetType.IsInOwnershipPath(existingNavigation.DeclaringEntityType)
+                            && existingTargetType.FindOwnership()!.PrincipalEntityType != existingNavigation.DeclaringEntityType),
+                        $"Found '{existingNavigation.DeclaringEntityType.DisplayName()}.{existingNavigation.Name}'. " +
+                        "Owned types should only have ownership and ownee navigations point at it");
 
-                    return existingTargetType.HasSharedClrType
-                        ? ModelBuilder.SharedTypeEntity(
-                            existingTargetType.Name, existingTargetType.ClrType, configurationSource!.Value, targetShouldBeOwned)
-                        : ModelBuilder.Entity(existingTargetType.ClrType, configurationSource!.Value, targetShouldBeOwned);
+                    return configurationSource == null
+                        ? existingNavigation.TargetEntityType.Builder
+                        : existingTargetType.HasSharedClrType
+                            ? ModelBuilder.SharedTypeEntity(
+                                existingTargetType.Name, existingTargetType.ClrType, configurationSource.Value, targetShouldBeOwned)
+                            : ModelBuilder.Entity(existingTargetType.ClrType, configurationSource.Value, targetShouldBeOwned);
                 }
 
                 if (configurationSource == null
@@ -3387,7 +3689,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (navigation.MemberInfo == null)
+            if (navigation.MemberInfo == null
+                && Metadata.ClrType != Model.DefaultPropertyBagType)
             {
                 if (Metadata.GetRuntimeProperties().TryGetValue(navigation.Name!, out var propertyInfo))
                 {
@@ -3435,46 +3738,77 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     return null;
             }
 
-            if (targetShouldBeOwned != true)
+            if (targetShouldBeOwned == null
+                && Metadata.Model.FindIsOwnedConfigurationSource(targetType) != null)
             {
-                var ownership = Metadata.FindOwnership();
-                if (ownership != null)
+                targetShouldBeOwned = true;
+            }
+
+            if (targetShouldBeOwned == true
+                || Metadata.IsOwned())
+            {
+                if (targetType.Equals(Metadata.ClrType)
+                    && configurationSource != ConfigurationSource.Explicit)
                 {
-                    if (targetType.Equals(Metadata.ClrType))
-                    {
-                        // Avoid infinite recursion on self reference
-                        return null;
-                    }
-
-                    if (targetType.IsAssignableFrom(ownership.PrincipalEntityType.ClrType))
-                    {
-                        if (configurationSource.HasValue)
-                        {
-                            ownership.PrincipalEntityType.UpdateConfigurationSource(configurationSource.Value);
-                        }
-
-                        return ownership.PrincipalEntityType.Builder;
-                    }
+                    // Avoid infinite recursion on self reference
+                    return null;
                 }
             }
 
-            var targetTypeName = targetEntityType.IsNamed && (targetEntityType.Type != null || targetShouldBeOwned != true)
+            if (Metadata.IsOwned()
+                && (targetShouldBeOwned != true
+                    || !configurationSource.Overrides(ConfigurationSource.Explicit)))
+            {
+                // Non-explicit relationship shouldn't create a new type if there's already
+                // a compatible one in the ownership path
+                var owner = (EntityType?)Metadata.FindInOwnershipPath(targetType);
+                if (owner != null)
+                {
+                    if (!configurationSource.Overrides(ConfigurationSource.Explicit)
+                        && (owner.ClrType != targetType
+                            || (owner.HasSharedClrType
+                                && !owner.IsOwned())))
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    var ownership = Metadata.FindOwnership();
+                    if (ownership != null
+                        && targetType.IsAssignableFrom(ownership.PrincipalEntityType.ClrType))
+                    {
+                        owner = ownership.PrincipalEntityType;
+                    }
+                }
+
+                if (owner != null)
+                {
+                    return configurationSource == null
+                        ? owner.Builder
+                        : owner.HasSharedClrType
+                            ? ModelBuilder.SharedTypeEntity(
+                                owner.Name, owner.ClrType, configurationSource.Value, targetShouldBeOwned)
+                            : ModelBuilder.Entity(owner.ClrType, configurationSource.Value, targetShouldBeOwned);
+                }
+            }
+
+            var targetTypeName = targetEntityType.IsNamed && (targetEntityType.Type != null || targetShouldBeOwned == false)
                 ? targetEntityType.Name
                 : Metadata.Model.IsShared(targetType)
                     ? Metadata.GetOwnedName(targetEntityType.IsNamed ? targetEntityType.Name : targetType.ShortDisplayName(), navigation.Name!)
                     : Metadata.Model.GetDisplayName(targetType);
 
-            var shouldBeOwned = targetShouldBeOwned ?? Metadata.Model.IsOwned(targetType);
             var targetEntityTypeBuilder = ModelBuilder.Metadata.FindEntityType(targetTypeName)?.Builder;
             if (targetEntityTypeBuilder != null
-                && shouldBeOwned)
+                && targetEntityTypeBuilder.Metadata.IsOwned()
+                && targetShouldBeOwned != false)
             {
                 var existingOwnership = targetEntityTypeBuilder.Metadata.FindDeclaredOwnership();
                 if (existingOwnership != null)
                 {
                     if (!configurationSource.Overrides(ConfigurationSource.Explicit)
-                        && navigation.MemberInfo != null
-                        && Metadata.IsInOwnershipPath(targetType))
+                        && targetShouldBeOwned != true)
                     {
                         return null;
                     }
@@ -3505,40 +3839,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (targetEntityTypeBuilder == null)
+            if (configurationSource == null)
             {
-                if (configurationSource == null)
+                if (targetEntityTypeBuilder == null
+                    || (targetShouldBeOwned.HasValue
+                        && targetEntityTypeBuilder.Metadata.IsOwned() != targetShouldBeOwned.Value))
                 {
                     return null;
                 }
-
-                if (Metadata.Model.IsShared(targetType)
+            }
+            else if (Metadata.Model.IsShared(targetType)
                     || targetEntityType.IsNamed)
-                {
-                    if (shouldBeOwned != true
-                        || (!configurationSource.Overrides(ConfigurationSource.Explicit)
-                            && navigation.MemberInfo != null
-                            && Metadata.IsInOwnershipPath(targetType)))
-                    {
-                        return null;
-                    }
-
-                    targetEntityTypeBuilder = ModelBuilder.SharedTypeEntity(
-                        targetTypeName, targetType, configurationSource.Value, shouldBeOwned);
-                }
-                else
-                {
-                    targetEntityTypeBuilder = targetEntityType.IsNamed
-                        ? targetType == null
-                            ? ModelBuilder.Entity(targetTypeName, configurationSource.Value, shouldBeOwned)
-                            : ModelBuilder.SharedTypeEntity(targetTypeName, targetType, configurationSource.Value, shouldBeOwned)
-                        : ModelBuilder.Entity(targetType, configurationSource.Value, shouldBeOwned);
-                }
-
-                if (targetEntityTypeBuilder == null)
+            {
+                if (targetShouldBeOwned != true
+                    && !configurationSource.Overrides(ConfigurationSource.Explicit))
                 {
                     return null;
                 }
+
+                targetEntityTypeBuilder = ModelBuilder.SharedTypeEntity(
+                    targetTypeName, targetType, configurationSource.Value, targetShouldBeOwned);
+            }
+            else
+            {
+                targetEntityTypeBuilder = targetEntityType.IsNamed
+                    ? targetType == null
+                        ? ModelBuilder.Entity(targetTypeName, configurationSource.Value, targetShouldBeOwned)
+                        : ModelBuilder.SharedTypeEntity(targetTypeName, targetType, configurationSource.Value, targetShouldBeOwned)
+                    : ModelBuilder.Entity(targetType, configurationSource.Value, targetShouldBeOwned);
             }
 
             return targetEntityTypeBuilder;
@@ -5092,7 +5420,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 (EntityType)targetEntityType,
                 navigationName,
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention,
-                setTargetAsPrincipal ? true : (bool?)null);
+                setTargetAsPrincipal ? true : null);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -5183,6 +5511,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName"> The name of the navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        [DebuggerStepThrough]
+        IConventionForeignKeyBuilder? IConventionEntityTypeBuilder.HasOwnership(
+            IConventionEntityType targetEntityType,
+            string navigationName,
+            bool fromDataAnnotation)
+            => HasOwnership(
+                (EntityType)targetEntityType,
+                MemberIdentity.Create(navigationName),
+                inverse: null,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
@@ -5195,6 +5541,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool fromDataAnnotation)
             => HasOwnership(
                 targetEntityType, navigation,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? IConventionEntityTypeBuilder.HasOwnership(
+            IConventionEntityType targetEntityType,
+            MemberInfo navigation,
+            bool fromDataAnnotation)
+            => HasOwnership(
+                (EntityType)targetEntityType,
+                MemberIdentity.Create(navigation),
+                inverse: null,
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -5214,6 +5580,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName"> The name of the navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="inverseNavigationName">
+        ///     The name of the navigation property on the target entity type that is part of the relationship. If <see langword="null" />
+        ///     is specified, the relationship will be configured without a navigation property on the target end.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? IConventionEntityTypeBuilder.HasOwnership(
+            IConventionEntityType targetEntityType,
+            string navigationName,
+            string? inverseNavigationName,
+            bool fromDataAnnotation)
+            => HasOwnership(
+                (EntityType)targetEntityType,
+                MemberIdentity.Create(navigationName),
+                MemberIdentity.Create(inverseNavigationName),
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
@@ -5227,6 +5618,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool fromDataAnnotation)
             => HasOwnership(
                 targetEntityType, navigation, inverseProperty,
+                fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
+
+        /// <summary>
+        ///     Configures a relationship where the target entity is owned by (or part of) this entity.
+        /// </summary>
+        /// <param name="targetEntityType"> The entity type that this relationship targets. </param>
+        /// <param name="navigation"> The navigation property on this entity type that is part of the relationship. </param>
+        /// <param name="inverseNavigation">
+        ///     The navigation property on the target entity type that is part of the relationship. If <see langword="null" />
+        ///     is specified, the relationship will be configured without a navigation property on the target end.
+        /// </param>
+        /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
+        /// <returns>
+        ///     An object that can be used to configure the relationship if it exists on the entity type,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        IConventionForeignKeyBuilder? IConventionEntityTypeBuilder.HasOwnership(
+            IConventionEntityType targetEntityType,
+            MemberInfo navigation,
+            MemberInfo? inverseNavigation,
+            bool fromDataAnnotation)
+            => HasOwnership(
+                (EntityType)targetEntityType,
+                MemberIdentity.Create(navigation),
+                MemberIdentity.Create(inverseNavigation),
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);
 
         /// <summary>
@@ -5363,7 +5779,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// <inheritdoc />
         [DebuggerStepThrough]
         IConventionEntityTypeBuilder? IConventionEntityTypeBuilder.HasNoSkipNavigation(
-            IReadOnlySkipNavigation skipNavigation,
+            IConventionSkipNavigation skipNavigation,
             bool fromDataAnnotation)
             => HasNoSkipNavigation(
                 (SkipNavigation)skipNavigation,
@@ -5371,7 +5787,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         /// <inheritdoc />
         [DebuggerStepThrough]
-        bool IConventionEntityTypeBuilder.CanRemoveSkipNavigation(IReadOnlySkipNavigation skipNavigation, bool fromDataAnnotation)
+        bool IConventionEntityTypeBuilder.CanRemoveSkipNavigation(IConventionSkipNavigation skipNavigation, bool fromDataAnnotation)
             => CanRemoveSkipNavigation(
                 (SkipNavigation)skipNavigation,
                 fromDataAnnotation ? ConfigurationSource.DataAnnotation : ConfigurationSource.Convention);

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -181,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Metadata.UpdateDependentToPrincipalConfigurationSource(configurationSource);
                     if (navigationToPrincipalName != null)
                     {
-                        principalEntityType.RemoveIgnored(navigationToPrincipalName);
+                        dependentEntityType.RemoveIgnored(navigationToPrincipalName);
                     }
                 }
 
@@ -394,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (navigationToPrincipal != null)
                 {
-                    if (navigationToDependent != null)
+                    if (navigationToPrincipal.Value.Name == Metadata.PrincipalToDependent?.Name)
                     {
                         Metadata.SetPrincipalToDependent((string?)null, configurationSource);
                     }
@@ -718,7 +718,119 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var navigationToPrincipalProperty = navigationToPrincipal?.MemberInfo;
             var navigationToDependentProperty = navigationToDependent?.MemberInfo;
 
-            // ReSharper disable once InlineOutVariableDeclaration
+            if (!AreCompatible(
+                navigationToPrincipalProperty,
+                navigationToDependentProperty,
+                principalEntityType,
+                dependentEntityType,
+                shouldThrow,
+                out shouldInvert,
+                out shouldBeUnique))
+            {
+                return false;
+            }
+
+            if (shouldBeUnique.HasValue
+                && Metadata.IsUnique != shouldBeUnique
+                && !configurationSource.Overrides(Metadata.GetIsUniqueConfigurationSource()))
+            {
+                return false;
+            }
+
+            var compatibleRelationship = FindCompatibleRelationship(
+                principalEntityType,
+                dependentEntityType,
+                navigationToPrincipal,
+                navigationToDependent,
+                null,
+                null,
+                Metadata.GetPrincipalEndConfigurationSource(),
+                configurationSource,
+                out _,
+                out var conflictingRelationshipsFound,
+                out var resolvableRelationships);
+
+            if (conflictingRelationshipsFound)
+            {
+                return false;
+            }
+
+            conflictingNavigationsFound = compatibleRelationship != null
+                || resolvableRelationships.Any(
+                    r => (r.Resolution & (Resolution.ResetToDependent | Resolution.ResetToPrincipal | Resolution.Remove)) != 0);
+
+            if (shouldBeUnique == null
+                && (Metadata.IsUnique || configurationSource.OverridesStrictly(Metadata.GetIsUniqueConfigurationSource()))
+                && ((navigationToDependentProperty != null && shouldInvert != true)
+                    || (navigationToPrincipalProperty != null && shouldInvert == true)))
+            {
+                // if new dependent can be both assume single
+                shouldBeUnique = true;
+            }
+
+            if (shouldInvert == false
+                && !conflictingNavigationsFound
+                && (principalEntityType != Metadata.PrincipalEntityType
+                    || dependentEntityType != Metadata.DeclaringEntityType))
+            {
+                if (navigationToPrincipalProperty != null
+                    && !IsCompatible(
+                        navigationToPrincipalProperty,
+                        pointsToPrincipal: true,
+                        Metadata.DeclaringEntityType,
+                        Metadata.PrincipalEntityType,
+                        shouldThrow: false,
+                        out _))
+                {
+                    changeRelatedTypes = true;
+                    return true;
+                }
+
+                if (navigationToDependentProperty != null
+                    && !IsCompatible(
+                        navigationToDependentProperty,
+                        pointsToPrincipal: false,
+                        Metadata.DeclaringEntityType,
+                        Metadata.PrincipalEntityType,
+                        shouldThrow: false,
+                        out _))
+                {
+                    changeRelatedTypes = true;
+                    return true;
+                }
+            }
+
+            return true;
+        }
+
+        private bool CanRemoveNavigation(bool pointsToPrincipal, ConfigurationSource? configurationSource, bool overrideSameSource = true)
+            => pointsToPrincipal
+                ? Metadata.DependentToPrincipal == null
+                || (configurationSource.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
+                    && (overrideSameSource || configurationSource != Metadata.GetDependentToPrincipalConfigurationSource()))
+                : Metadata.PrincipalToDependent == null
+                || (!Metadata.IsOwnership
+                    && configurationSource.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                    && (overrideSameSource || configurationSource != Metadata.GetPrincipalToDependentConfigurationSource()));
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static bool AreCompatible(
+            MemberInfo? navigationToPrincipalProperty,
+            MemberInfo? navigationToDependentProperty,
+            EntityType principalEntityType,
+            EntityType dependentEntityType,
+            bool shouldThrow,
+            out bool? shouldInvert,
+            out bool? shouldBeUnique)
+        {
+            shouldInvert = null;
+            shouldBeUnique = null;
+
             bool? invertedShouldBeUnique = null;
             if (navigationToPrincipalProperty != null
                 && !IsCompatible(
@@ -783,87 +895,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 shouldBeUnique = invertedShouldBeUnique;
             }
 
-            if (shouldBeUnique.HasValue
-                && Metadata.IsUnique != shouldBeUnique
-                && !configurationSource.Overrides(Metadata.GetIsUniqueConfigurationSource()))
-            {
-                return false;
-            }
-
-            var compatibleRelationship = FindCompatibleRelationship(
-                principalEntityType,
-                dependentEntityType,
-                navigationToPrincipal,
-                navigationToDependent,
-                null,
-                null,
-                Metadata.GetPrincipalEndConfigurationSource(),
-                configurationSource,
-                out _,
-                out var conflictingRelationshipsFound,
-                out var resolvableRelationships);
-
-            if (conflictingRelationshipsFound)
-            {
-                return false;
-            }
-
-            conflictingNavigationsFound = compatibleRelationship != null
-                || resolvableRelationships.Any(
-                    r => (r.Resolution & (Resolution.ResetToDependent | Resolution.ResetToPrincipal)) != 0);
-
-            if (shouldBeUnique == null
-                && (Metadata.IsUnique || configurationSource.OverridesStrictly(Metadata.GetIsUniqueConfigurationSource()))
-                && ((navigationToDependentProperty != null && shouldInvert != true)
-                    || (navigationToPrincipalProperty != null && shouldInvert == true)))
-            {
-                // if new dependent can be both assume single
-                shouldBeUnique = true;
-            }
-
-            if (shouldInvert == false
-                && !conflictingNavigationsFound
-                && (principalEntityType != Metadata.PrincipalEntityType
-                    || dependentEntityType != Metadata.DeclaringEntityType))
-            {
-                if (navigationToPrincipalProperty != null
-                    && !IsCompatible(
-                        navigationToPrincipalProperty,
-                        pointsToPrincipal: true,
-                        Metadata.DeclaringEntityType,
-                        Metadata.PrincipalEntityType,
-                        shouldThrow: false,
-                        out _))
-                {
-                    changeRelatedTypes = true;
-                    return true;
-                }
-
-                if (navigationToDependentProperty != null
-                    && !IsCompatible(
-                        navigationToDependentProperty,
-                        pointsToPrincipal: false,
-                        Metadata.DeclaringEntityType,
-                        Metadata.PrincipalEntityType,
-                        shouldThrow: false,
-                        out _))
-                {
-                    changeRelatedTypes = true;
-                    return true;
-                }
-            }
-
             return true;
         }
-
-        private bool CanRemoveNavigation(bool pointsToPrincipal, ConfigurationSource? configurationSource, bool overrideSameSource = true)
-            => pointsToPrincipal
-                ? Metadata.DependentToPrincipal == null
-                || (configurationSource.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
-                    && (overrideSameSource || configurationSource != Metadata.GetDependentToPrincipalConfigurationSource()))
-                : Metadata.PrincipalToDependent == null
-                || (configurationSource.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
-                    && (overrideSameSource || configurationSource != Metadata.GetPrincipalToDependentConfigurationSource()));
 
         private static bool IsCompatible(
             MemberInfo navigationMember,
@@ -1028,123 +1061,130 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            var declaringType = Metadata.DeclaringEntityType;
-            if (ownership.Value)
+            if (!ownership.Value)
             {
-                var newRelationshipBuilder = this;
-                var otherOwnership = declaringType.GetDeclaredForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
-                var invertedOwnerships = declaringType.GetDeclaredReferencingForeignKeys()
-                    .Where(fk => fk.IsOwnership && fk.DeclaringEntityType.ClrType == Metadata.PrincipalEntityType.ClrType).ToList();
+                Metadata.SetIsOwnership(ownership: false, configurationSource);
 
-                if (invertedOwnerships.Any(fk => !configurationSource.Overrides(fk.GetConfigurationSource())))
+                return this;
+            }
+
+            if (!Metadata.DeclaringEntityType.Builder.CanSetIsOwned(true, configurationSource))
+            {
+                return null;
+            }
+
+            var declaringType = Metadata.DeclaringEntityType;
+            var newRelationshipBuilder = this;
+            var otherOwnership = declaringType.GetDeclaredForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
+            var invertedOwnerships = declaringType.GetDeclaredReferencingForeignKeys()
+                .Where(fk => fk.IsOwnership && fk.DeclaringEntityType.ClrType == Metadata.PrincipalEntityType.ClrType).ToList();
+
+            if (invertedOwnerships.Any(fk => !configurationSource.Overrides(fk.GetConfigurationSource())))
+            {
+                return null;
+            }
+
+            if (declaringType.HasSharedClrType)
+            {
+                if (otherOwnership != null
+                    && !configurationSource.Overrides(otherOwnership.GetConfigurationSource()))
                 {
                     return null;
                 }
 
-                if (declaringType.HasSharedClrType)
+                Metadata.SetIsOwnership(ownership: true, configurationSource);
+                newRelationshipBuilder = newRelationshipBuilder?.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention);
+
+                if (newRelationshipBuilder == null)
                 {
-                    if (otherOwnership != null
-                        && !configurationSource.Overrides(otherOwnership.GetConfigurationSource()))
-                    {
-                        return null;
-                    }
-
-                    Metadata.SetIsOwnership(ownership: true, configurationSource);
-                    newRelationshipBuilder = newRelationshipBuilder?.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention);
-
-                    if (newRelationshipBuilder == null)
-                    {
-                        return null;
-                    }
-
-                    if (otherOwnership?.IsInModel == true)
-                    {
-                        otherOwnership.DeclaringEntityType.Builder.HasNoRelationship(otherOwnership, configurationSource);
-                    }
-
-                    foreach (var invertedOwnership in invertedOwnerships)
-                    {
-                        if (invertedOwnership.IsInModel)
-                        {
-                            invertedOwnership.DeclaringEntityType.Builder.HasNoRelationship(invertedOwnership, configurationSource);
-                        }
-                    }
-
-                    return newRelationshipBuilder;
+                    return null;
                 }
 
-                if (otherOwnership != null)
+                if (otherOwnership?.IsInModel == true)
                 {
-                    if (!Metadata.GetConfigurationSource().Overrides(ConfigurationSource.Explicit)
-                        && Metadata.PrincipalEntityType.IsInOwnershipPath(Metadata.DeclaringEntityType.ClrType))
-                    {
-                        return null;
-                    }
+                    otherOwnership.DeclaringEntityType.Builder.HasNoRelationship(otherOwnership, configurationSource);
+                }
 
-                    Metadata.SetIsOwnership(ownership: true, configurationSource);
-
-                    using var batch = ModelBuilder.Metadata.DelayConventions();
-
-                    newRelationshipBuilder = newRelationshipBuilder.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention);
-                    if (newRelationshipBuilder == null)
-                    {
-                        return null;
-                    }
-
-                    foreach (var invertedOwnership in invertedOwnerships)
+                foreach (var invertedOwnership in invertedOwnerships)
+                {
+                    if (invertedOwnership.IsInModel)
                     {
                         invertedOwnership.DeclaringEntityType.Builder.HasNoRelationship(invertedOwnership, configurationSource);
                     }
-
-                    var fk = newRelationshipBuilder.Metadata;
-                    fk.DeclaringEntityType.Builder.HasNoRelationship(fk, fk.GetConfigurationSource());
-
-                    if (otherOwnership.Builder.MakeDeclaringTypeShared(configurationSource) == null)
-                    {
-                        return null;
-                    }
-
-                    var name = Metadata.PrincipalEntityType.GetOwnedName(declaringType.ShortName(), Metadata.PrincipalToDependent!.Name);
-                    var newEntityType = ModelBuilder.SharedTypeEntity(
-                        name,
-                        declaringType.ClrType,
-                        declaringType.GetConfigurationSource(),
-                        shouldBeOwned: true)!.Metadata;
-
-                    newRelationshipBuilder = newRelationshipBuilder.Attach(newEntityType.Builder)!;
-
-                    ModelBuilder.Metadata.ConventionDispatcher.Tracker.Update(
-                        Metadata, newRelationshipBuilder.Metadata);
-
-                    return batch.Run(newRelationshipBuilder);
                 }
 
-                using (var batch = ModelBuilder.Metadata.DelayConventions())
-                {
-                    Metadata.SetIsOwnership(ownership: true, configurationSource);
-                    newRelationshipBuilder = newRelationshipBuilder.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention)
-                        ?? newRelationshipBuilder;
+                newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.IsOwned(true, configurationSource);
 
-                    foreach (var invertedOwnership in invertedOwnerships)
-                    {
-                        invertedOwnership.DeclaringEntityType.Builder.HasNoRelationship(invertedOwnership, configurationSource);
-                    }
-
-                    newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.HasBaseType((Type?)null, configurationSource);
-
-                    if (!newRelationshipBuilder.Metadata.DeclaringEntityType.Builder
-                        .RemoveNonOwnershipRelationships(newRelationshipBuilder.Metadata, configurationSource))
-                    {
-                        return null;
-                    }
-
-                    return batch.Run(newRelationshipBuilder);
-                }
+                return newRelationshipBuilder;
             }
 
-            Metadata.SetIsOwnership(ownership: false, configurationSource);
+            if (otherOwnership != null)
+            {
+                Check.DebugAssert(Metadata.DeclaringEntityType.IsOwned(),
+                    $"Expected {Metadata.DeclaringEntityType} to be owned");
 
-            return this;
+                if (!Metadata.GetConfigurationSource().Overrides(ConfigurationSource.Explicit)
+                    && Metadata.PrincipalEntityType.IsInOwnershipPath(Metadata.DeclaringEntityType.ClrType))
+                {
+                    return null;
+                }
+
+                Metadata.SetIsOwnership(ownership: true, configurationSource);
+
+                using var batch = ModelBuilder.Metadata.DelayConventions();
+
+                newRelationshipBuilder = newRelationshipBuilder.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention);
+                if (newRelationshipBuilder == null)
+                {
+                    return null;
+                }
+
+                foreach (var invertedOwnership in invertedOwnerships)
+                {
+                    invertedOwnership.DeclaringEntityType.Builder.HasNoRelationship(invertedOwnership, configurationSource);
+                }
+
+                var fk = newRelationshipBuilder.Metadata;
+                fk.DeclaringEntityType.Builder.HasNoRelationship(fk, fk.GetConfigurationSource());
+
+                if (otherOwnership.Builder.MakeDeclaringTypeShared(configurationSource) == null)
+                {
+                    return null;
+                }
+
+                var name = Metadata.PrincipalEntityType.GetOwnedName(declaringType.ShortName(), Metadata.PrincipalToDependent!.Name);
+                var newEntityType = ModelBuilder.SharedTypeEntity(
+                    name,
+                    declaringType.ClrType,
+                    declaringType.GetConfigurationSource(),
+                    shouldBeOwned: true)!.Metadata;
+
+                newRelationshipBuilder = newRelationshipBuilder.Attach(newEntityType.Builder)!;
+
+                ModelBuilder.Metadata.ConventionDispatcher.Tracker.Update(
+                    Metadata, newRelationshipBuilder.Metadata);
+
+                return batch.Run(newRelationshipBuilder);
+            }
+
+            using (var batch = ModelBuilder.Metadata.DelayConventions())
+            {
+                var declaringEntityTypeBuilder =
+                    newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.IsOwned(true, configurationSource, Metadata);
+
+                Check.DebugAssert(declaringEntityTypeBuilder != null, "Expected declared type to be owned");
+
+                Metadata.SetIsOwnership(true, configurationSource);
+                newRelationshipBuilder = newRelationshipBuilder.OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Convention)
+                    ?? newRelationshipBuilder;
+
+                foreach (var invertedOwnership in invertedOwnerships)
+                {
+                    invertedOwnership.DeclaringEntityType.Builder.HasNoRelationship(invertedOwnership, configurationSource);
+                }
+
+                return batch.Run(newRelationshipBuilder);
+            }
         }
 
         /// <summary>
@@ -1154,7 +1194,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CanSetIsOwnership(bool? ownership, ConfigurationSource? configurationSource)
-            => Metadata.IsOwnership == ownership || configurationSource.Overrides(Metadata.GetIsOwnershipConfigurationSource());
+            => (Metadata.IsOwnership == ownership || configurationSource.Overrides(Metadata.GetIsOwnershipConfigurationSource()))
+            && (ownership != true
+                || Metadata.DeclaringEntityType.IsOwned()
+                || configurationSource.OverridesStrictly(Metadata.GetConfigurationSource()));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -1325,42 +1368,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return true;
         }
 
-        // Note: These will not invert relationships, use RelatedEntityTypes for that
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? DependentEntityType(
-            InternalEntityTypeBuilder dependentEntityTypeBuilder,
-            ConfigurationSource configurationSource)
-            => DependentEntityType(dependentEntityTypeBuilder.Metadata, configurationSource);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? DependentEntityType(
-            Type dependentType,
-            ConfigurationSource configurationSource)
-            => DependentEntityType(
-                ModelBuilder.Entity(dependentType, configurationSource)!.Metadata,
-                configurationSource);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? DependentEntityType(
-            string dependentTypeName,
-            ConfigurationSource configurationSource)
-            => DependentEntityType(ModelBuilder.Entity(dependentTypeName, configurationSource)!.Metadata, configurationSource);
-
+        // Note: This will not invert relationships, use RelatedEntityTypes for that
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -1393,44 +1401,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     : null;
         }
 
-        // Note: These will not invert relationships, use RelatedEntityTypes for that
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? PrincipalEntityType(
-            InternalEntityTypeBuilder principalEntityTypeBuilder,
-            ConfigurationSource configurationSource)
-            => PrincipalEntityType(principalEntityTypeBuilder.Metadata, configurationSource);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? PrincipalEntityType(
-            Type principalType,
-            ConfigurationSource configurationSource)
-            => PrincipalEntityType(
-                ModelBuilder.Entity(principalType, configurationSource)!.Metadata,
-                configurationSource);
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual InternalForeignKeyBuilder? PrincipalEntityType(
-            string principalTypeName,
-            ConfigurationSource configurationSource)
-            => PrincipalEntityType(
-                ModelBuilder.Entity(principalTypeName, configurationSource)!.Metadata,
-                configurationSource);
-
+        // Note: This will not invert relationships, use RelatedEntityTypes for that
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -2224,23 +2195,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             isUnique ??= ((Metadata.GetIsUniqueConfigurationSource()?.Overrides(configurationSource) ?? false)
                 ? Metadata.IsUnique
-                : (bool?)null);
+                : null);
 
             isRequired ??= !oldRelationshipInverted
                 ? ((Metadata.GetIsRequiredConfigurationSource()?.Overrides(configurationSource) ?? false)
                     ? Metadata.IsRequired
-                    : (bool?)null)
+                    : null)
                 : ((Metadata.GetIsRequiredDependentConfigurationSource()?.Overrides(ConfigurationSource.Explicit) ?? false)
                     ? Metadata.IsRequiredDependent
-                    : (bool?)null);
+                    : null);
 
             isRequiredDependent ??= !oldRelationshipInverted
                 ? ((Metadata.GetIsRequiredDependentConfigurationSource()?.Overrides(configurationSource) ?? false)
                     ? Metadata.IsRequiredDependent
-                    : (bool?)null)
+                    : null)
                 : ((Metadata.GetIsRequiredConfigurationSource()?.Overrides(ConfigurationSource.Explicit) ?? false)
                     ? Metadata.IsRequired
-                    : (bool?)null);
+                    : null);
 
             isOwnership ??= !oldRelationshipInverted
                 && (Metadata.GetIsOwnershipConfigurationSource()?.Overrides(configurationSource) ?? false)
@@ -2249,7 +2220,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             deleteBehavior ??= ((Metadata.GetDeleteBehaviorConfigurationSource()?.Overrides(configurationSource) ?? false)
                 ? Metadata.DeleteBehavior
-                : (DeleteBehavior?)null);
+                : null);
 
             principalEndConfigurationSource ??= (principalEntityTypeBuilder.Metadata != dependentEntityTypeBuilder.Metadata
                 && ((principalProperties?.Count > 0)
@@ -2257,7 +2228,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     || (navigationToDependent != null && isUnique == false)
                     || isOwnership == true)
                     ? configurationSource
-                    : (ConfigurationSource?)null);
+                    : null);
             principalEndConfigurationSource = principalEndConfigurationSource.Max(Metadata.GetPrincipalEndConfigurationSource());
 
             return ReplaceForeignKey(
@@ -2527,7 +2498,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             dependentProperties?.Count == 0 ? null : dependentProperties,
                             principalKey,
                             navigationToPrincipal?.Name
-                            ?? referencingSkipNavigations?.FirstOrDefault().Navigation?.Inverse?.Name,
+                                ?? referencingSkipNavigations?.FirstOrDefault().Navigation?.Inverse?.Name,
                             isRequired,
                             configurationSource: null)!;
 
@@ -3139,7 +3110,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             resolution |= Resolution.ResetToPrincipal;
                             sameConfigurationSource = true;
                         }
-                        else
+                        else if (!configurationSource.HasValue
+                            || !matchingRelationship.Metadata.DeclaringEntityType.Builder
+                                .CanRemoveForeignKey(matchingRelationship.Metadata, configurationSource.Value))
                         {
                             resolvable = false;
                         }
@@ -3171,7 +3144,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             resolution |= Resolution.ResetToDependent;
                             sameConfigurationSource = true;
                         }
-                        else
+                        else if (!configurationSource.HasValue
+                            || !matchingRelationship.Metadata.DeclaringEntityType.Builder
+                                .CanRemoveForeignKey(matchingRelationship.Metadata, configurationSource.Value))
                         {
                             resolvable = false;
                         }
@@ -3207,7 +3182,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             resolution |= Resolution.ResetToDependent;
                             sameConfigurationSource = true;
                         }
-                        else
+                        else if (!configurationSource.HasValue
+                            || !matchingRelationship.Metadata.DeclaringEntityType.Builder
+                                .CanRemoveForeignKey(matchingRelationship.Metadata, configurationSource.Value))
                         {
                             resolvable = false;
                         }
@@ -3239,7 +3216,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             resolution |= Resolution.ResetToPrincipal;
                             sameConfigurationSource = true;
                         }
-                        else
+                        else if (!configurationSource.HasValue
+                            || !matchingRelationship.Metadata.DeclaringEntityType.Builder
+                                .CanRemoveForeignKey(matchingRelationship.Metadata, configurationSource.Value))
                         {
                             resolvable = false;
                         }
@@ -3589,15 +3568,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!Metadata.GetConfigurationSource().Overrides(ConfigurationSource.Explicit)
-                && principalEntityType.IsOwned()
-                && Metadata.DependentToPrincipal != null
-                && !Metadata.IsOwnership)
-            {
-                // An entity type can have a navigation to a principal owned type only if it's the owner
-                return null;
-            }
-
             InternalEntityTypeBuilder dependentEntityTypeBuilder;
             EntityType? dependentEntityType;
             if (Metadata.DeclaringEntityType.IsInModel)
@@ -3634,7 +3604,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                         name,
                                         Metadata.DeclaringEntityType.ClrType,
                                         Metadata.DeclaringEntityType.GetConfigurationSource(),
-                                        shouldBeOwned: null)!.Metadata;
+                                        shouldBeOwned: true)!.Metadata;
                                 }
                                 else
                                 {
@@ -3644,7 +3614,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             else
                             {
                                 dependentEntityType =
-                                    ModelBuilder.Entity(Metadata.DeclaringEntityType.ClrType, configurationSource)!.Metadata;
+                                    ModelBuilder.Entity(
+                                        Metadata.DeclaringEntityType.ClrType,
+                                        configurationSource,
+                                        shouldBeOwned: Metadata.DeclaringEntityType.IsOwned())
+                                    !.Metadata;
                             }
                         }
                     }
@@ -3653,12 +3627,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!Metadata.GetConfigurationSource().Overrides(ConfigurationSource.Explicit)
-                && dependentEntityType.IsOwned()
-                && Metadata.PrincipalToDependent != null)
+            if (!Metadata.IsOwnership
+                && !Metadata.GetConfigurationSource().Overrides(ConfigurationSource.Explicit))
             {
-                // Only the owner can have a navigation to an owned type
-                return null;
+                if (principalEntityType.IsOwned()
+                    && Metadata.DependentToPrincipal != null
+                    && !dependentEntityType.IsInOwnershipPath(principalEntityType))
+                {
+                    // An entity type can have a navigation to a principal owned type only if it's in the ownership path
+                    return null;
+                }
+
+                if (dependentEntityType.IsOwned()
+                    && Metadata.PrincipalToDependent != null
+                    && (dependentEntityType.FindOwnership()?.PrincipalEntityType == principalEntityType
+                        || !dependentEntityType.IsInOwnershipPath(principalEntityType)))
+                {
+                    // Only a type in the ownership path can have a navigation to an owned dependent
+                    return null;
+                }
             }
 
             if (dependentEntityType.GetForeignKeys().Contains(Metadata, LegacyReferenceEqualityComparer.Instance))

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -463,11 +463,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     : builder;
         }
 
-        private static MemberInfo? FindCompatibleClrMember(
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static MemberInfo? FindCompatibleClrMember(
             string navigationName,
             EntityType sourceType,
             EntityType targetType,
-            bool shouldThrow)
+            bool shouldThrow = false)
         {
             var navigationProperty = sourceType.GetNavigationMemberInfo(navigationName);
             return !Navigation.IsCompatible(navigationName, navigationProperty, sourceType, targetType, null, shouldThrow)

--- a/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
@@ -121,6 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     var originalEntityType = indexBuilder.Metadata.DeclaringEntityType;
                     var targetEntityTypeBuilder = originalEntityType.Name == entityTypeBuilder.Metadata.Name
+                        || (!originalEntityType.HasSharedClrType && originalEntityType.ClrType == entityTypeBuilder.Metadata.ClrType)
                         ? entityTypeBuilder
                         : originalEntityType.Builder;
                     indexBuilder.Attach(targetEntityTypeBuilder);

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -297,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual ConfigurationSource? FindDeclaredIgnoredConfigurationSource(string name)
             => _ignoredMembers.TryGetValue(Check.NotEmpty(name, nameof(name)), out var ignoredConfigurationSource)
-                ? (ConfigurationSource?)ignoredConfigurationSource
+                ? ignoredConfigurationSource
                 : null;
 
         /// <summary>

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> An object that can be used to configure the entity type. </returns>
         public virtual EntityTypeBuilder<TEntity> Entity<TEntity>()
             where TEntity : class
-            => new(Builder.Entity(typeof(TEntity), ConfigurationSource.Explicit)!.Metadata);
+            => new(Builder.Entity(typeof(TEntity), ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata);
 
         /// <summary>
         ///     <para>
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(type, nameof(type));
 
-            return new EntityTypeBuilder(Builder.Entity(type, ConfigurationSource.Explicit)!.Metadata);
+            return new EntityTypeBuilder(Builder.Entity(type, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotEmpty(name, nameof(name));
 
-            return new EntityTypeBuilder(Builder.Entity(name, ConfigurationSource.Explicit)!.Metadata);
+            return new EntityTypeBuilder(Builder.Entity(name, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata);
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(type, nameof(type));
 
-            return new EntityTypeBuilder(Builder.SharedTypeEntity(name, type, ConfigurationSource.Explicit)!.Metadata);
+            return new EntityTypeBuilder(Builder.SharedTypeEntity(name, type, ConfigurationSource.Explicit, shouldBeOwned: false)!.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -336,7 +336,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ownedTypeName, ownerEntityType, navigation);
 
         /// <summary>
-        ///     The type '{entityType}' cannot be marked as owned because the derived entity type '{derivedType}' has been configured as non-owned. Either don't configure '{derivedType}' as non-owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.
+        ///     The entity type '{entityType}' cannot be marked as owned because the derived entity type '{derivedType}' has been configured as non-owned. Either don't configure '{derivedType}' as non-owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.
         /// </summary>
         public static string ClashingNonOwnedDerivedEntityType(object? entityType, object? derivedType)
             => string.Format(
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, derivedType);
 
         /// <summary>
-        ///     The type '{entityType}' cannot be marked as owned because a non-owned entity type with the same name already exists.
+        ///     The entity type '{entityType}' cannot be configured as owned because it has already been configured as a non-owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'.
         /// </summary>
         public static string ClashingNonOwnedEntityType(object? entityType)
             => string.Format(
@@ -369,7 +369,15 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
-        ///     The type '{entityType}' cannot be configured as non-owned because an owned entity type with the same name already exists.
+        ///     The entity type '{entityType}' cannot be marked as non-owned because the derived entity type '{derivedType}' has been configured as owned. Either don't configure '{derivedType}' as owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.
+        /// </summary>
+        public static string ClashingOwnedDerivedEntityType(object? entityType, object? derivedType)
+            => string.Format(
+                GetString("ClashingOwnedDerivedEntityType", nameof(entityType), nameof(derivedType)),
+                entityType, derivedType);
+
+        /// <summary>
+        ///     The entity type '{entityType}' cannot be configured as non-owned because it has already been configured as a owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'.
         /// </summary>
         public static string ClashingOwnedEntityType(object? entityType)
             => string.Format(
@@ -616,6 +624,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("DerivedEntityCannotHaveKeys", nameof(entityType)),
                 entityType);
+
+        /// <summary>
+        ///     Unable to set '{baseEntityType}' as the base type for entity type '{derivedEntityType}' because '{ownedEntityType}' is configured as owned, while '{nonOwnedEntityType}' is non-owned. All entity types in a hierarchy need to have the same ownership status.
+        /// </summary>
+        public static string DerivedEntityOwnershipMismatch(object? baseEntityType, object? derivedEntityType, object? ownedEntityType, object? nonOwnedEntityType)
+            => string.Format(
+                GetString("DerivedEntityOwnershipMismatch", nameof(baseEntityType), nameof(derivedEntityType), nameof(ownedEntityType), nameof(nonOwnedEntityType)),
+                baseEntityType, derivedEntityType, ownedEntityType, nonOwnedEntityType);
 
         /// <summary>
         ///     '{derivedType}' cannot be configured as keyless because it is a derived type; the root type '{rootType}' must be configured as keyless instead. If you did not intend for '{rootType}' to be included in the model, ensure that it is not referenced by a DbSet property on your context, referenced in a configuration call to ModelBuilder in 'OnModelCreating', or referenced from a navigation on a type that is included in the model.
@@ -1665,6 +1681,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, referenceMethod, collectionMethod, propertyMethod);
 
         /// <summary>
+        ///     The relationship between '{principalEntityType}' and '{dependentEntityType}' is an ownership, but there is no associated navigation to the owned type. An ownership must always have an associated navigation.
+        /// </summary>
+        public static string NavigationlessOwnership(object? principalEntityType, object? dependentEntityType)
+            => string.Format(
+                GetString("NavigationlessOwnership", nameof(principalEntityType), nameof(dependentEntityType)),
+                principalEntityType, dependentEntityType);
+
+        /// <summary>
         ///     The navigation '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigations must be initialized before use.
         /// </summary>
         public static string NavigationNoSetter(object? navigation, object? entityType)
@@ -2027,6 +2051,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ownedType);
 
         /// <summary>
+        ///     The navigation '{navigation}' cannot be changed, because the foreign key between '{principalEntityType}' and '{dependentEntityType}' is an ownership. To change the navigation to the owned entity type remove the ownership.
+        /// </summary>
+        public static string OwnershipToDependent(object? navigation, object? principalEntityType, object? dependentEntityType)
+            => string.Format(
+                GetString("OwnershipToDependent", nameof(navigation), nameof(principalEntityType), nameof(dependentEntityType)),
+                navigation, principalEntityType, dependentEntityType);
+
+        /// <summary>
         ///     The DbContext of type '{contextType}' cannot be pooled because it does not have a public constructor accepting a single parameter of type DbContextOptions or has more than one constructor.
         /// </summary>
         public static string PoolingContextCtorError(object? contextType)
@@ -2039,6 +2071,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// </summary>
         public static string PoolingOptionsModified
             => GetString("PoolingOptionsModified");
+
+        /// <summary>
+        ///     When creating the relationship between '{navigationSpecification1}' and '{navigationSpecification2}' the entity type '{targetEntityType}' cannot be set as principal.
+        /// </summary>
+        public static string PrincipalEndIncompatibleNavigations(object? navigationSpecification1, object? navigationSpecification2, object? targetEntityType)
+            => string.Format(
+                GetString("PrincipalEndIncompatibleNavigations", nameof(navigationSpecification1), nameof(navigationSpecification2), nameof(targetEntityType)),
+                navigationSpecification1, navigationSpecification2, targetEntityType);
 
         /// <summary>
         ///     You are configuring a relationship between '{dependentEntityType}' and '{principalEntityType}', but have specified a principal key on '{entityType}'. The foreign key must target a type that is part of the relationship.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1681,7 +1681,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, referenceMethod, collectionMethod, propertyMethod);
 
         /// <summary>
-        ///     The relationship between '{principalEntityType}' and '{dependentEntityType}' is an ownership, but there is no associated navigation to the owned type. An ownership must always have an associated navigation.
+        ///     The relationship between '{principalEntityType}' and '{dependentEntityType}' cannot be configured as an ownership as there is no associated navigation to the owned type. An ownership must always have an associated navigation.
         /// </summary>
         public static string NavigationlessOwnership(object? principalEntityType, object? dependentEntityType)
             => string.Format(

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -236,10 +236,10 @@
     <value>An entity type named '{ownedTypeName}' has already been added to the model. Use a different name when configuring the ownership '{ownerEntityType}.{navigation}' in 'OnModelCreating'.</value>
   </data>
   <data name="ClashingNonOwnedDerivedEntityType" xml:space="preserve">
-    <value>The type '{entityType}' cannot be marked as owned because the derived entity type '{derivedType}' has been configured as non-owned. Either don't configure '{derivedType}' as non-owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.</value>
+    <value>The entity type '{entityType}' cannot be marked as owned because the derived entity type '{derivedType}' has been configured as non-owned. Either don't configure '{derivedType}' as non-owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.</value>
   </data>
   <data name="ClashingNonOwnedEntityType" xml:space="preserve">
-    <value>The type '{entityType}' cannot be marked as owned because a non-owned entity type with the same name already exists.</value>
+    <value>The entity type '{entityType}' cannot be configured as owned because it has already been configured as a non-owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'.</value>
   </data>
   <data name="ClashingNonSharedType" xml:space="preserve">
     <value>The shared-type entity type '{entityType}' with CLR type '{type}' cannot be added to the model because a non-shared entity type with the same CLR type already exists.</value>
@@ -248,8 +248,11 @@
     <value>The entity type '{entityType}' with a defining navigation cannot be added to the model because an entity type with the same name already exists.</value>
     <comment>Obsolete</comment>
   </data>
+  <data name="ClashingOwnedDerivedEntityType" xml:space="preserve">
+    <value>The entity type '{entityType}' cannot be marked as non-owned because the derived entity type '{derivedType}' has been configured as owned. Either don't configure '{derivedType}' as owned, or call 'HasBaseType(null)' for it in 'OnModelCreating'.</value>
+  </data>
   <data name="ClashingOwnedEntityType" xml:space="preserve">
-    <value>The type '{entityType}' cannot be configured as non-owned because an owned entity type with the same name already exists.</value>
+    <value>The entity type '{entityType}' cannot be configured as non-owned because it has already been configured as a owned. If you want to override previous configuration first remove the entity type from the model by calling 'Ignore'.</value>
   </data>
   <data name="ClashingSharedType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be added to the model because its CLR type has been configured as a shared type.</value>
@@ -346,6 +349,9 @@
   </data>
   <data name="DerivedEntityCannotHaveKeys" xml:space="preserve">
     <value>Unable to set a base type for entity type '{entityType}' because it has one or more keys defined. Only root types can have keys.</value>
+  </data>
+  <data name="DerivedEntityOwnershipMismatch" xml:space="preserve">
+    <value>Unable to set '{baseEntityType}' as the base type for entity type '{derivedEntityType}' because '{ownedEntityType}' is configured as owned, while '{nonOwnedEntityType}' is non-owned. All entity types in a hierarchy need to have the same ownership status.</value>
   </data>
   <data name="DerivedEntityTypeHasNoKey" xml:space="preserve">
     <value>'{derivedType}' cannot be configured as keyless because it is a derived type; the root type '{rootType}' must be configured as keyless instead. If you did not intend for '{rootType}' to be included in the model, ensure that it is not referenced by a DbSet property on your context, referenced in a configuration call to ModelBuilder in 'OnModelCreating', or referenced from a navigation on a type that is included in the model.</value>
@@ -1060,6 +1066,9 @@
   <data name="NavigationIsProperty" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' or '{collectionMethod}' method, but is defined in the model as a non-navigation. Use the '{propertyMethod}' method to access non-navigation properties.</value>
   </data>
+  <data name="NavigationlessOwnership" xml:space="preserve">
+    <value>The relationship between '{principalEntityType}' and '{dependentEntityType}' is an ownership, but there is no associated navigation to the owned type. An ownership must always have an associated navigation.</value>
+  </data>
   <data name="NavigationNoSetter" xml:space="preserve">
     <value>The navigation '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigations must be initialized before use.</value>
   </data>
@@ -1204,11 +1213,17 @@
   <data name="OwnerlessOwnedType" xml:space="preserve">
     <value>The entity type '{ownedType}' has been marked as owned and must be referenced from another entity type via a navigation. Add a navigation to an entity type that points at '{ownedType}' or don't configure it as owned.</value>
   </data>
+  <data name="OwnershipToDependent" xml:space="preserve">
+    <value>The navigation '{navigation}' cannot be changed, because the foreign key between '{principalEntityType}' and '{dependentEntityType}' is an ownership. To change the navigation to the owned entity type remove the ownership.</value>
+  </data>
   <data name="PoolingContextCtorError" xml:space="preserve">
     <value>The DbContext of type '{contextType}' cannot be pooled because it does not have a public constructor accepting a single parameter of type DbContextOptions or has more than one constructor.</value>
   </data>
   <data name="PoolingOptionsModified" xml:space="preserve">
     <value>'OnConfiguring' cannot be used to modify DbContextOptions when DbContext pooling is enabled.</value>
+  </data>
+  <data name="PrincipalEndIncompatibleNavigations" xml:space="preserve">
+    <value>When creating the relationship between '{navigationSpecification1}' and '{navigationSpecification2}' the entity type '{targetEntityType}' cannot be set as principal.</value>
   </data>
   <data name="PrincipalEntityTypeNotInRelationship" xml:space="preserve">
     <value>You are configuring a relationship between '{dependentEntityType}' and '{principalEntityType}', but have specified a principal key on '{entityType}'. The foreign key must target a type that is part of the relationship.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1067,7 +1067,7 @@
     <value>The property '{1_entityType}.{0_property}' is being accessed using the '{referenceMethod}' or '{collectionMethod}' method, but is defined in the model as a non-navigation. Use the '{propertyMethod}' method to access non-navigation properties.</value>
   </data>
   <data name="NavigationlessOwnership" xml:space="preserve">
-    <value>The relationship between '{principalEntityType}' and '{dependentEntityType}' is an ownership, but there is no associated navigation to the owned type. An ownership must always have an associated navigation.</value>
+    <value>The relationship between '{principalEntityType}' and '{dependentEntityType}' cannot be configured as an ownership as there is no associated navigation to the owned type. An ownership must always have an associated navigation.</value>
   </data>
   <data name="NavigationNoSetter" xml:space="preserve">
     <value>The navigation '{1_entityType}.{0_navigation}' does not have a setter and no writable backing field was found or specified. Read-only collection navigations must be initialized before use.</value>

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -341,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var collection = !foreignKey.IsUnique && !onDependent;
                 var targetType = onDependent ? foreignKey.PrincipalEntityType : foreignKey.DeclaringEntityType;
 
-                Debug.Assert(!targetType.IsOwned(), "Owned entity expanding foreign key.");
+                Check.DebugAssert(!targetType.IsOwned(), "Owned entity expanding foreign key.");
 
                 var innerQueryable = new QueryRootExpression(targetType);
                 var innerSource = (NavigationExpansionExpression)_navigationExpandingExpressionVisitor.Visit(innerQueryable);

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -50,7 +50,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.ProductVersion,
                 CoreAnnotationNames.ValueGeneratorFactory,
                 CoreAnnotationNames.ValueGeneratorFactoryType,
-                CoreAnnotationNames.OwnedTypes,
                 CoreAnnotationNames.ValueConverter,
                 CoreAnnotationNames.ValueConverterType,
                 CoreAnnotationNames.ValueComparer,
@@ -180,7 +179,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var notForProperty = new HashSet<string>
             {
                 CoreAnnotationNames.ProductVersion,
-                CoreAnnotationNames.OwnedTypes,
                 CoreAnnotationNames.NavigationAccessMode,
                 CoreAnnotationNames.EagerLoaded,
                 CoreAnnotationNames.QueryFilter,

--- a/test/EFCore.Proxies.Tests/ProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ProxyTests.cs
@@ -269,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(
                 CoreStrings.AddingProxyTypeAsEntityType("Castle.Proxies.ClassToBeProxiedProxy"),
                 Assert.Throws<ArgumentException>(
-                    () => new EntityType(proxy.GetType(), model, ConfigurationSource.Explicit)).Message);
+                    () => new EntityType(proxy.GetType(), model, owned: false, ConfigurationSource.Explicit)).Message);
         }
 
         // tests scenario in https://github.com/dotnet/efcore/issues/15958

--- a/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/Infrastructure/RelationalModelValidatorTest.cs
@@ -864,7 +864,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Animal>().Property(a => a.Id).HasMaxLength(20).HasPrecision(15, 10).IsUnicode();
             modelBuilder.Entity<Cat>().OwnsOne(a => a.FavoritePerson);
-            modelBuilder.Entity<Dog>();
+            modelBuilder.Entity<Dog>().Ignore(d => d.FavoritePerson);
 
             Validate(modelBuilder);
         }
@@ -1451,7 +1451,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.Entity<Cat>().OwnsOne(
                 a => a.FavoritePerson,
                 pb => pb.Property<byte[]>("Version").IsRowVersion().HasColumnName("Version"));
-            modelBuilder.Entity<Dog>();
+            modelBuilder.Entity<Dog>().Ignore(d => d.FavoritePerson);
 
             Validate(modelBuilder);
         }
@@ -1464,7 +1464,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             modelBuilder.Entity<Cat>().OwnsOne(
                 a => a.FavoritePerson,
                 pb => pb.Property<byte[]>("Version").IsRowVersion());
-            modelBuilder.Entity<Dog>();
+            modelBuilder.Entity<Dog>().Ignore(d => d.FavoritePerson);
 
             Validate(modelBuilder);
         }
@@ -2098,56 +2098,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             baseEntityType.SetDiscriminatorProperty(baseEntityType.AddProperty("Discriminator", typeof(string)));
             baseEntityType.SetDiscriminatorValue(baseEntityType.Name);
             entityType.SetDiscriminatorValue(entityType.Name);
-        }
-
-        protected class Animal
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-
-            public Person FavoritePerson { get; set; }
-        }
-
-        protected class Cat : Animal
-        {
-            public string Breed { get; set; }
-
-            [NotMapped]
-            public string Type { get; set; }
-
-            public int Identity { get; set; }
-        }
-
-        protected class Dog : Animal
-        {
-            public string Breed { get; set; }
-
-            [NotMapped]
-            public int Type { get; set; }
-
-            public int Identity { get; set; }
-        }
-
-        protected class Person
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-            public string FavoriteBreed { get; set; }
-        }
-
-        protected class Employee : Person
-        {
-        }
-
-        protected class Owner
-        {
-            public int Id { get; set; }
-            public OwnedEntity Owned { get; set; }
-        }
-
-        protected class OwnedEntity
-        {
-            public string Value { get; set; }
         }
 
         public class TestDecimalToLongConverter : ValueConverter<decimal, long>

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -26,7 +25,6 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
 using Index = Microsoft.EntityFrameworkCore.Metadata.Internal.Index;
 using IsolationLevel = System.Data.IsolationLevel;
@@ -41,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var constantExpression = Expression.Constant("A");
             var model = new Model();
-            var entityType = new EntityType(typeof(object), model, ConfigurationSource.Convention);
+            var entityType = new EntityType(typeof(object), model, owned: false, ConfigurationSource.Convention);
             var property = entityType.AddProperty("A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
             var key = entityType.AddKey(property, ConfigurationSource.Convention);
             var foreignKey = new ForeignKey(new List<Property> { property }, key, entityType, entityType, ConfigurationSource.Convention);

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1987,7 +1987,6 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void InversePropertyAttribute_pointing_to_same_skip_nav_on_base_causes_ambiguity()
         {
             var modelBuilder = CreateModelBuilder();
-
             modelBuilder.Entity<AmbiguousInversePropertyLeft>();
             modelBuilder.Entity<AmbiguousInversePropertyLeftDerived>();
 

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -2047,9 +2047,9 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(LogLevel.Warning, logEntry.Level);
             Assert.Equal(
                 CoreResources.LogForeignKeyAttributesOnBothProperties(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
-                    nameof(PostDetails.Post), nameof(PostDetails),
                     nameof(Post.PostDetails), nameof(Post),
-                    nameof(Post.PostDetailsId), nameof(PostDetails.PostId)),
+                    nameof(PostDetails.Post), nameof(PostDetails),
+                    nameof(PostDetails.PostId), nameof(Post.PostDetailsId)),
                 logEntry.Message);
         }
 

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -625,7 +625,7 @@ namespace Microsoft.EntityFrameworkCore
                         context.Set<EntityRoot>().CreateInstance(
                             (e, p) =>
                             {
-                                Debug.Assert(e != null, nameof(e) + " != null");
+                                Assert.True(e != null, nameof(e) + " != null");
                                 e.Id = Fixture.UseGeneratedKeys ? 0 : 7723;
                                 e.Name = "Z7723";
                             }),

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var level1 = level1Builder.Metadata;
 
             ForeignKey level2Fk;
-            var level2 = level1.Model.AddEntityType(typeof(Level2), nameof(Level1.OneToOne_Required_PK1), level1);
+            var level2 = level1.Model.AddEntityType("Level1.OneToOne_Required_PK1#Level2", typeof(Level2));
             using (var batch = ((Model)modelBuilder.Model).ConventionDispatcher.DelayConventions())
             {
                 level2Fk = (ForeignKey)level2.AddForeignKey(level2.FindProperty(nameof(Level2.Id)), level1.FindPrimaryKey(), level1);
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .IsRequired(false);
 
             ForeignKey level3Fk;
-            var level3 = level2.Model.AddEntityType(typeof(Level3), nameof(Level2.OneToOne_Required_PK2), level2);
+            var level3 = level2.Model.AddEntityType("Level1.OneToOne_Required_PK1#Level2.OneToOne_Required_PK2#Level3", typeof(Level3));
             using (var batch = ((Model)level2.Model).ConventionDispatcher.DelayConventions())
             {
                 level3Fk = (ForeignKey)level3.AddForeignKey(level3.FindProperty(nameof(Level3.Id)), level2.FindPrimaryKey(), level2);
@@ -192,7 +192,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .IsRequired(false);
 
             ForeignKey level4Fk;
-            var level4 = level3.Model.AddEntityType(typeof(Level4), nameof(Level3.OneToOne_Required_PK3), level3);
+            var level4 = level3.Model.AddEntityType(
+                "Level1.OneToOne_Required_PK1#Level2.OneToOne_Required_PK2#Level3.OneToOne_Required_PK3#Level4",
+                typeof(Level4));
             using (var batch = ((Model)level3.Model).ConventionDispatcher.DelayConventions())
             {
                 level4Fk = (ForeignKey)level4.AddForeignKey(level4.FindProperty(nameof(Level4.Id)), level3.FindPrimaryKey(), level3);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -7616,7 +7616,7 @@ FROM [Entity21807] AS [e]");
                 Assert.NotNull(query[2].Contact.Address);
 
                 AssertSql(
-                    @"SELECT [u].[Id], [u].[RowVersion], [u].[Contact_MobileNumber], [u].[SharedProperty], [u].[RowVersion], [u].[Contact_Address_City], [u].[Contact_Address_Zip], [u].[Data_Data], [u].[Data_Exists]
+                    @"SELECT [u].[Id], [u].[RowVersion], [u].[Contact_MobileNumber], [u].[SharedProperty], [u].[Contact_Address_City], [u].[Contact_Address_Zip], [u].[Data_Data], [u].[Data_Exists], [u].[RowVersion]
 FROM [User22054] AS [u]
 ORDER BY [u].[Id] DESC");
             }

--- a/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Infrastructure/SqlServerModelValidatorTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.Entity<Animal>().Property(a => a.Id).UseIdentityColumn(2, 3);
             modelBuilder.Entity<Cat>().OwnsOne(a => a.FavoritePerson);
-            modelBuilder.Entity<Dog>();
+            modelBuilder.Entity<Dog>().Ignore(d => d.FavoritePerson);
 
             Validate(modelBuilder);
         }

--- a/test/EFCore.SqlServer.Tests/SqlServerEventIdTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerEventIdTest.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Extensions.Internal;
-using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -21,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public void Every_eventId_has_a_logger_method_and_logs_when_level_enabled()
         {
-            var entityType = new EntityType(typeof(object), new Model(new ConventionSet()), ConfigurationSource.Convention);
+            var entityType = new EntityType(typeof(object), new Model(new ConventionSet()), owned: false, ConfigurationSource.Convention);
             var property = new Property(
                 "A", typeof(int), null, null, entityType, ConfigurationSource.Convention, ConfigurationSource.Convention);
             entityType.Model.FinalizeModel();

--- a/test/EFCore.Sqlite.Tests/SqliteEventIdTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteEventIdTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         [ConditionalFact]
         public void Every_eventId_has_a_logger_method_and_logs_when_level_enabled()
         {
-            var entityType = new EntityType(typeof(object), new Model(new ConventionSet()), ConfigurationSource.Convention);
+            var entityType = new EntityType(typeof(object), new Model(new ConventionSet()), owned: false, ConfigurationSource.Convention);
             entityType.Model.FinalizeModel();
 
             var fakeFactories = new Dictionary<Type, Func<object>>

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -236,9 +236,8 @@ namespace Microsoft.EntityFrameworkCore
         private static IEntityType CreateEntityType()
         {
             var model = new Model();
-            var entityType = model.AddEntityType(typeof(object), ConfigurationSource.Convention);
-            model.FinalizeModel();
-            return entityType;
+            model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention);
+            return model.FinalizeModel().FindEntityType(typeof(object));
         }
 
         private TException SerializeAndDeserialize<TException>(TException exception)

--- a/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreEventIdTest.cs
@@ -22,9 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public void Every_eventId_has_a_logger_method_and_logs_when_level_enabled()
         {
             var propertyInfo = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.Now));
-            var entityType = new Model().AddEntityType(typeof(object), ConfigurationSource.Convention);
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention);
             var property = entityType.AddProperty("A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
-            var otherEntityType = new EntityType(typeof(object), entityType.Model, ConfigurationSource.Convention);
+            var otherEntityType = new EntityType(typeof(object), entityType.Model, owned: false, ConfigurationSource.Convention);
             var otherProperty = otherEntityType.AddProperty(
                 "A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
             var otherKey = otherEntityType.AddKey(otherProperty, ConfigurationSource.Convention);

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -817,14 +817,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
             ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
 
-            var anotherEntityTypeBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
+            var baseOwnershipBuilder = entityTypeBuilder.HasOwnership(typeof(A), nameof(B.A), ConfigurationSource.Convention);
+            var anotherEntityTypeBuilder = baseOwnershipBuilder.Metadata.DeclaringEntityType.Builder;
+            anotherEntityTypeBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
             anotherEntityTypeBuilder.PrimaryKey(new[] { nameof(A.Id) }, ConfigurationSource.Convention);
             anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P0), ConfigurationSource.Explicit);
             anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P1), ConfigurationSource.Explicit);
             anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P2), ConfigurationSource.Explicit);
             anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P3), ConfigurationSource.Explicit);
 
-            ownedTypeBuilder.HasBaseType(typeof(A), ConfigurationSource.Convention);
+            Assert.NotNull(ownedTypeBuilder.HasBaseType(typeof(A), ConfigurationSource.DataAnnotation));
 
             VerifyError(CoreStrings.OwnedDerivedType(nameof(D)), builder);
         }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -688,6 +688,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.OtherSamples), ConfigurationSource.Explicit);
+            entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
             var ownershipBuilder = entityTypeBuilder.HasOwnership(
                 typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
@@ -719,14 +720,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
 
             ownedTypeBuilder.HasRelationship(
-                    entityTypeBuilder.Metadata, (string)null, null, ConfigurationSource.Convention, setTargetAsPrincipal: true)
+                    entityTypeBuilder.Metadata, null, nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Convention, setTargetAsPrincipal: true)
                 .Metadata.IsOwnership = true;
 
             ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
             ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
 
             VerifyError(
-                CoreStrings.MultipleOwnerships(nameof(ReferencedEntity), "'SampleEntity.ReferencedEntity', 'SampleEntity.'"),
+                CoreStrings.MultipleOwnerships(nameof(ReferencedEntity), "'SampleEntity.ReferencedEntity', 'SampleEntity.AnotherReferencedEntity'"),
                 builder);
         }
 
@@ -741,6 +742,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.OtherSamples), ConfigurationSource.Explicit);
+            entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
             var ownershipBuilder = entityTypeBuilder.HasOwnership(
                 typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
@@ -776,6 +778,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
             entityTypeBuilder.Ignore(nameof(SampleEntity.OtherSamples), ConfigurationSource.Explicit);
+            entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
             var ownershipBuilder = entityTypeBuilder.HasOwnership(
                 typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -121,6 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             public int Number { get; set; }
             public string Name { get; set; }
             public ReferencedEntity ReferencedEntity { get; set; }
+            [NotMapped]
+            public ReferencedEntity AnotherReferencedEntity { get; set; }
             public ICollection<SampleEntity> OtherSamples { get; set; }
         }
 

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -276,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             }
             else
             {
-                var result = builder.Metadata.AddEntityType(typeof(Order), ConfigurationSource.Convention);
+                var result = builder.Metadata.AddEntityType(typeof(Order), owned: false, ConfigurationSource.Convention);
 
                 Assert.Equal(!useScope, result == null);
             }
@@ -540,7 +540,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             else
             {
                 builder.Metadata.SetBaseType(
-                    builder.Metadata.Model.AddEntityType(typeof(Order), ConfigurationSource.Explicit), ConfigurationSource.Convention);
+                    builder.Metadata.Model.AddEntityType(typeof(Order), owned: false, ConfigurationSource.Explicit), ConfigurationSource.Convention);
             }
 
             if (useScope)
@@ -1499,7 +1499,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var builder = new InternalModelBuilder(new Model(conventions));
             var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-            var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+            var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention, shouldBeOwned: true);
             var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
                 .Metadata;
 

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -1500,7 +1500,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(conventions));
             var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention, shouldBeOwned: true);
-            var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
+            var foreignKey = dependentEntityBuilder.HasRelationship(
+                    principalEntityBuilder.Metadata, null, nameof(Order.OrderDetails), ConfigurationSource.Convention)
                 .Metadata;
 
             var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -652,7 +652,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     "NavProp",
                     "InverseReferenceNav", ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.DataAnnotation)
-                .DependentEntityType(dependentTypeWithCompositeKey, ConfigurationSource.DataAnnotation);
+                .DependentEntityType(dependentTypeWithCompositeKey.Metadata, ConfigurationSource.DataAnnotation);
 
             var newRelationshipBuilder = RunConvention(relationshipBuilder);
 

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -796,7 +796,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 PrincipalType, "SomeNav", null, ConfigurationSource.Convention);
 
             Assert.Equal(
-                nameof(PrincipalEntity) + nameof(PrincipalEntity.PeeKay),
+                "SomeNav" + nameof(PrincipalEntity.PeeKay),
                 newRelationshipBuilder.Metadata.Properties.Single().Name);
 
             newRelationshipBuilder = RunConvention(newRelationshipBuilder);

--- a/test/EFCore.Tests/Metadata/Conventions/ModelCleanupConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ModelCleanupConventionTest.cs
@@ -79,12 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
 
         private static InternalEntityTypeBuilder CreateInternalEntityBuilder<T>()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.DataAnnotation);
-
-            return entityBuilder;
-        }
+            => new InternalModelBuilder(new Model()).Entity(typeof(T), ConfigurationSource.Explicit);
 
         private class Base
         {

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         [ConditionalFact]
         public void Does_not_find_service_property_configured_as_property()
         {
-            var entityType = new Model().AddEntityType(typeof(BlogOneService), ConfigurationSource.Explicit);
+            var entityType = new Model().AddEntityType(typeof(BlogOneService), owned: false, ConfigurationSource.Explicit);
             entityType!.Builder.Property(typeof(ILazyLoader), nameof(BlogOneService.Loader), ConfigurationSource.Explicit)
                 !.HasConversion(typeof(string), ConfigurationSource.Explicit);
 
@@ -156,9 +156,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public void Does_not_find_service_property_configured_as_navigation()
         {
             var model = new Model();
-            var entityType = model.AddEntityType(typeof(BlogOneService), ConfigurationSource.Explicit);
+            var entityType = model.AddEntityType(typeof(BlogOneService), owned: false, ConfigurationSource.Explicit);
             entityType!.Builder.HasRelationship(
-                model.AddEntityType(typeof(LazyLoader), ConfigurationSource.Explicit)!,
+                model.AddEntityType(typeof(LazyLoader), owned: false, ConfigurationSource.Explicit)!,
                 nameof(BlogOneService.Loader), ConfigurationSource.Explicit);
 
             RunConvention(entityType);
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         private EntityType RunConvention<TEntity>()
-            => RunConvention(new Model().AddEntityType(typeof(TEntity), ConfigurationSource.Explicit)!);
+            => RunConvention(new Model().AddEntityType(typeof(TEntity), owned: false, ConfigurationSource.Explicit)!);
 
         private EntityType RunConvention(EntityType entityType)
         {
@@ -192,10 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         private ServicePropertyDiscoveryConvention CreateServicePropertyDiscoveryConvention()
-        {
-            var convention = new ServicePropertyDiscoveryConvention(CreateDependencies());
-            return convention;
-        }
+            => new ServicePropertyDiscoveryConvention(CreateDependencies());
 
         private ProviderConventionSetBuilderDependencies CreateDependencies()
             => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();

--- a/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -575,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [ConditionalFact]
         public void Can_change_cascade_ownership()
         {
-            var entityType = CreateModel().AddEntityType("E");
+            var entityType = CreateModel().AddOwnedEntityType("E");
             var keyProp = entityType.AddProperty("Id", typeof(int));
             var dependentProp = entityType.AddProperty("P", typeof(int));
             var principalProp = entityType.AddProperty("U", typeof(int));

--- a/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -583,12 +583,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var principalKey = entityType.AddKey(principalProp);
 
             var foreignKey = entityType.AddForeignKey(new[] { dependentProp }, principalKey, entityType);
+            foreignKey.SetPrincipalToDependent("S");
 
             Assert.False(foreignKey.IsOwnership);
 
             foreignKey.IsOwnership = true;
 
             Assert.True(foreignKey.IsOwnership);
+
+            Assert.Equal(
+                CoreStrings.OwnershipToDependent(
+                    "S",
+                    "E (Dictionary<string, object>)",
+                    "E (Dictionary<string, object>)"),
+                Assert.Throws<InvalidOperationException>(() => foreignKey.SetPrincipalToDependent((string)null)).Message);
+        }
+
+        [ConditionalFact]
+        public void IsOwnership_throws_when_no_navigation()
+        {
+            var entityType = CreateModel().AddOwnedEntityType("E");
+            var keyProp = entityType.AddProperty("Id", typeof(int));
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("U", typeof(int));
+            entityType.SetPrimaryKey(keyProp);
+            var principalKey = entityType.AddKey(principalProp);
+
+            var foreignKey = entityType.AddForeignKey(new[] { dependentProp }, principalKey, entityType);
+
+            Assert.False(foreignKey.IsOwnership);
+
+            Assert.Equal(
+                CoreStrings.NavigationlessOwnership(
+                    "E (Dictionary<string, object>)",
+                    "E (Dictionary<string, object>)"),
+                Assert.Throws<InvalidOperationException>(() => foreignKey.IsOwnership = true).Message);
         }
 
         [ConditionalFact]

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -2849,14 +2849,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit);
+            Assert.NotNull(dependentEntityBuilder.HasRelationship(
+                principalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit));
 
             var derivedPrincipalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit)
                 .HasBaseType((string)null, ConfigurationSource.Explicit);
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedDependentEntityBuilder.HasRelationship(
-                derivedPrincipalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit);
+            Assert.NotNull(derivedDependentEntityBuilder.HasRelationship(
+                derivedPrincipalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit));
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);

--- a/test/EFCore.Tests/Metadata/Internal/InternalForeignKeyBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalForeignKeyBuilderTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Null(fk.GetIsUniqueConfigurationSource());
             Assert.Null(fk.GetDeleteBehaviorConfigurationSource());
 
-            relationshipBuilder = relationshipBuilder.PrincipalEntityType(principalEntityBuilder, ConfigurationSource.Explicit)
+            relationshipBuilder = relationshipBuilder.PrincipalEntityType(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)
                 .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.Explicit).HasNavigation(
                     Order.CustomerProperty.Name,
                     pointsToPrincipal: true,
@@ -586,7 +586,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var modelBuilder = CreateInternalModelBuilder();
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit, shouldBeOwned: true);
 
             var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
             Assert.False(relationshipBuilder.Metadata.IsOwnership);

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Can_ignore_existing_entity_type_using_entity_clr_type()
         {
             var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer), ConfigurationSource.Explicit);
+            var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
             var modelBuilder = CreateModelBuilder(model);
             Assert.Same(entityType, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata);
             Assert.Null(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
@@ -137,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Can_ignore_existing_entity_type_using_entity_type_name()
         {
             var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer).FullName, ConfigurationSource.Explicit);
+            var entityType = model.AddEntityType(typeof(Customer).FullName, owned: false, ConfigurationSource.Explicit);
             var modelBuilder = CreateModelBuilder(model);
 
             Assert.Same(entityType, modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Convention).Metadata);
@@ -302,13 +302,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
 
-            Assert.NotNull(modelBuilder.Entity(typeof(Details), ConfigurationSource.Convention));
+            var ownedEntityTypeBuilder = modelBuilder.Entity(typeof(Details), ConfigurationSource.Convention);
+            Assert.NotNull(ownedEntityTypeBuilder);
 
             Assert.False(model.IsOwned(typeof(Details)));
+            Assert.False(ownedEntityTypeBuilder.Metadata.IsOwned());
 
-            Assert.NotNull(entityBuilder.HasOwnership(typeof(Details), nameof(Customer.Details), ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.HasOwnership(typeof(Details), nameof(Customer.Details), ConfigurationSource.Convention));
 
-            Assert.NotNull(modelBuilder.Ignore(typeof(Details), ConfigurationSource.Convention));
+            Assert.NotNull(entityBuilder.HasOwnership(typeof(Details), nameof(Customer.Details), ConfigurationSource.DataAnnotation));
+
+            Assert.False(model.IsOwned(typeof(Details)));
+            Assert.True(ownedEntityTypeBuilder.Metadata.IsOwned());
+
+            Assert.NotNull(modelBuilder.Ignore(typeof(Details), ConfigurationSource.DataAnnotation));
 
             Assert.Empty(model.FindEntityTypes(typeof(Details)));
 
@@ -316,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.Null(modelBuilder.Owned(typeof(Details), ConfigurationSource.Convention));
 
-            Assert.NotNull(entityBuilder.HasOwnership(typeof(Details), nameof(Customer.Details), ConfigurationSource.DataAnnotation));
+            Assert.NotNull(entityBuilder.HasOwnership(typeof(Details), nameof(Customer.Details), ConfigurationSource.Explicit));
 
             Assert.NotNull(modelBuilder.Owned(typeof(Details), ConfigurationSource.Convention));
 
@@ -352,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Null(modelBuilder.Owned(typeof(Details), ConfigurationSource.Convention));
 
             Assert.Equal(
-                CoreStrings.ClashingNonOwnedEntityType(typeof(Details).Name),
+                CoreStrings.ClashingNonOwnedEntityType("Details (Details)"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.Owned(typeof(Details), ConfigurationSource.Explicit)).Message);
         }
 
@@ -381,6 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 model.AddEntityType(
                     "JoinEntity",
                     typeof(Dictionary<string, object>),
+                    owned: false,
                     ConfigurationSource.Convention).Builder;
             var leftFK = joinEntityTypeBuilder
                 .HasRelationship(

--- a/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
@@ -237,7 +237,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var model = (Model)CreateModel();
             Assert.Null(model.RemoveEntityType(typeof(Customer).FullName));
 
-            model.AddEntityType(typeof(Customer), ConfigurationSource.Explicit);
+            model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
 
             Assert.Equal(
                 CoreStrings.CannotMarkShared(nameof(Customer)),

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -26,20 +26,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers, Action<ModelConfigurationBuilder>? configure)
                 => new NonGenericStringTestModelBuilder(testHelpers, configure);
 
-            public override void Reconfiguring_owned_type_as_non_owned_throws()
-            {
-                var modelBuilder = CreateModelBuilder();
-
-                modelBuilder.Ignore<Customer>();
-                modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details);
-
-                Assert.Equal(
-                    CoreStrings.ClashingOwnedEntityType(typeof(CustomerDetails).FullName),
-                    Assert.Throws<InvalidOperationException>(
-                        () =>
-                            modelBuilder.Entity<SpecialCustomer>().HasOne(c => c.Details)).Message);
-            }
-
             // Shadow navigations not supported #3864
             public override void Can_configure_owned_type_collection_with_one_call()
             {


### PR DESCRIPTION
- Store Owned configuration on `EntityType`
- Add methods to `IMutableModel` and `IConventionModel` for creating owned entity types
- Make sure ownerships have an associated principal to dependent navigation at all times
- Store owned types in a field instead of an annotation

Fixes #25138