### PR TITLE
Translate Math.PI

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMathPIMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMathPIMemberTranslator.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class SqlServerMathPIMemberTranslator : IMemberTranslator
+    {
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public SqlServerMathPIMemberTranslator(ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual SqlExpression? Translate(
+            SqlExpression? instance,
+            MemberInfo member,
+            Type returnType,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            Check.NotNull(member, nameof(member));
+            Check.NotNull(returnType, nameof(returnType));
+            Check.NotNull(logger, nameof(logger));
+
+            if (member.Name == nameof(Math.PI)
+                && instance?.Type == typeof(double))
+            {
+                return _sqlExpressionFactory.Convert(
+                    _sqlExpressionFactory.Function(
+                        "PI",
+                        new[] { instance },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(double)),
+                    returnType);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerMemberTranslatorProvider.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerMemberTranslatorProvider.cs
@@ -35,7 +35,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
                 {
                     new SqlServerDateTimeMemberTranslator(sqlExpressionFactory, typeMappingSource),
                     new SqlServerStringMemberTranslator(sqlExpressionFactory),
-                    new SqlServerTimeSpanMemberTranslator(sqlExpressionFactory)
+                    new SqlServerTimeSpanMemberTranslator(sqlExpressionFactory),
+                    new SqlServerMathPIMemberTranslator(sqlExpressionFactory)
                 });
         }
     }


### PR DESCRIPTION
Issue #25049

I've added a new member translator. I expected that it will run after this test
```
[ConditionalTheory]
[MemberData(nameof(IsAsyncData))]
public virtual Task Where_math_pi(bool async)
{
            return AssertQuery(
                async,
                ss => ss.Set<Product>()
                    .Where(od => Math.Abs(od.ProductID) > Math.PI),
                entryCount: 0);
}
```
Could you please suggest what I am doing wrong?
It just translates `Math.PI` to constant without calling my translator. It seems I missed something  🤔