### PR TITLE
Add IServiceCollection.Use[DbProviderName]<DbContext> extension methods

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -30,6 +31,81 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class SqlServerServiceCollectionExtensions
     {
+        /// <summary>
+        ///     <para>
+        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
+        ///         and configures it to connect to a SQL Server database.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure the SQL Server provider and connection string.
+        ///     </para>
+        ///     <para>
+        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
+        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
+        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="sqlServerOptionsAction"> An optional action to allow additional SQL Server specific configuration. </param>
+        /// <returns> The same service collection so that multiple calls can be chained. </returns>
+        public static IServiceCollection AddSqlServer<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+            Check.NotEmpty(connectionString, nameof(connectionString));
+
+            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlServer(connectionString, sqlServerOptionsAction));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
+        ///         and configures it to connect to a SQL Server database.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure the SQL Server provider and connection string.
+        ///     </para>
+        ///     <para>
+        ///         The connection or connection string must be set before the <see cref="DbContext" /> is used to connect
+        ///         to a database. Set a connection using <see cref="RelationalDatabaseFacadeExtensions.SetDbConnection" />.
+        ///         Set a connection string using <see cref="RelationalDatabaseFacadeExtensions.SetConnectionString" />.
+        ///     </para>
+        ///     <para>
+        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
+        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
+        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="sqlServerOptionsAction"> An optional action to allow additional SQL Server specific configuration. </param>
+        /// <returns> The same service collection so that multiple calls can be chained. </returns>
+        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+
+            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlServer(sqlServerOptionsAction));
+        }
+
         /// <summary>
         ///     <para>
         ///         Adds the services required by the Microsoft SQL Server database provider for Entity Framework

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -44,9 +44,8 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
-        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
-        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or supply 
+        ///         an optional action to configure the <see cref="DbContextOptions" /> for the context. 
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -59,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="sqlServerOptionsAction"> An optional action to allow additional SQL Server specific configuration. </param>
         /// <param name="optionsAction"> An optional action to configure the <see cref="DbContextOptions" /> for the context. </param>
         /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlServer<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
+        public static IServiceCollection AddSqlServer<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null, Action<DbContextOptionsBuilder>? optionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));
@@ -67,7 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return serviceCollection.AddDbContext<TContext>((serviceProvider, options) =>
             {
-                optionsAction?.Invoke(serviceProvider, options);
+                optionsAction?.Invoke(options);
                 options.UseSqlServer(connectionString, sqlServerOptionsAction);
             });
         }

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -57,14 +57,19 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
         /// <param name="connectionString"> The connection string of the database to connect to. </param>
         /// <param name="sqlServerOptionsAction"> An optional action to allow additional SQL Server specific configuration. </param>
+        /// <param name="optionsAction"> An optional action to configure the <see cref="DbContextOptions" /> for the context. </param>
         /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlServer<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+        public static IServiceCollection AddSqlServer<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));
             Check.NotEmpty(connectionString, nameof(connectionString));
 
-            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlServer(connectionString, sqlServerOptionsAction));
+            return serviceCollection.AddDbContext<TContext>((serviceProvider, options) =>
+            {
+                optionsAction?.Invoke(serviceProvider, options);
+                options.UseSqlServer(connectionString, sqlServerOptionsAction);
+            });
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -69,45 +69,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
-        ///         and configures it to connect to a SQL Server database.
-        ///     </para>
-        ///     <para>
-        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
-        ///         overridden to configure the SQL Server provider and connection string.
-        ///     </para>
-        ///     <para>
-        ///         The connection or connection string must be set before the <see cref="DbContext" /> is used to connect
-        ///         to a database. Set a connection using <see cref="RelationalDatabaseFacadeExtensions.SetDbConnection" />.
-        ///         Set a connection string using <see cref="RelationalDatabaseFacadeExtensions.SetConnectionString" />.
-        ///     </para>
-        ///     <para>
-        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
-        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
-        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
-        ///     </para>
-        ///     <para>
-        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
-        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
-        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
-        /// <param name="sqlServerOptionsAction"> An optional action to allow additional SQL Server specific configuration. </param>
-        /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
-            where TContext : DbContext
-        {
-            Check.NotNull(serviceCollection, nameof(serviceCollection));
-
-            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlServer(sqlServerOptionsAction));
-        }
-
-        /// <summary>
-        ///     <para>
         ///         Adds the services required by the Microsoft SQL Server database provider for Entity Framework
         ///         to an <see cref="IServiceCollection" />.
         ///     </para>

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -29,6 +30,81 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class SqliteServiceCollectionExtensions
     {
+        /// <summary>
+        ///     <para>
+        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
+        ///         and configures it to connect to a SQLite database.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure the SQLite provider and connection string.
+        ///     </para>
+        ///     <para>
+        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
+        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
+        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="connectionString"> The connection string of the database to connect to. </param>
+        /// <param name="sqliteOptionsAction"> An optional action to allow additional SQLite specific configuration. </param>
+        /// <returns> The same service collection so that multiple calls can be chained. </returns>
+        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+            Check.NotEmpty(connectionString, nameof(connectionString));
+
+            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlite(connectionString, sqliteOptionsAction));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
+        ///         and configures it to connect to a SQLite database.
+        ///     </para>
+        ///     <para>
+        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
+        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
+        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
+        ///         overridden to configure the SQLite provider and connection string.
+        ///     </para>
+        ///     <para>
+        ///         The connection or connection string must be set before the <see cref="DbContext" /> is used to connect
+        ///         to a database. Set a connection using <see cref="RelationalDatabaseFacadeExtensions.SetDbConnection" />.
+        ///         Set a connection string using <see cref="RelationalDatabaseFacadeExtensions.SetConnectionString" />.
+        ///     </para>
+        ///     <para>
+        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
+        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
+        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+        ///     </para>
+        ///     <para>
+        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
+        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="sqliteOptionsAction"> An optional action to allow additional SQLite specific configuration. </param>
+        /// <returns> The same service collection so that multiple calls can be chained. </returns>
+        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+            where TContext : DbContext
+        {
+            Check.NotNull(serviceCollection, nameof(serviceCollection));
+
+            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlite(sqliteOptionsAction));
+        }
+
         /// <summary>
         ///     <para>
         ///         Adds the services required by the SQLite database provider for Entity Framework

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
-
         ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or supply 
         ///         an optional action to configure the <see cref="DbContextOptions" /> for the context. 
         ///     </para>

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Sqlite.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
-using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
@@ -56,14 +55,19 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
         /// <param name="connectionString"> The connection string of the database to connect to. </param>
         /// <param name="sqliteOptionsAction"> An optional action to allow additional SQLite specific configuration. </param>
+        /// <param name="optionsAction"> An optional action to configure the <see cref="DbContextOptions" /> for the context. </param>
         /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
+        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));
             Check.NotEmpty(connectionString, nameof(connectionString));
 
-            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlite(connectionString, sqliteOptionsAction));
+            return serviceCollection.AddDbContext<TContext>((serviceProvider, options) =>
+            {
+                optionsAction?.Invoke(serviceProvider, options);
+                options.UseSqlite(connectionString, sqliteOptionsAction);
+            });
         }
 
         /// <summary>

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
-        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
-        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
+
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or supply 
+        ///         an optional action to configure the <see cref="DbContextOptions" /> for the context. 
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="sqliteOptionsAction"> An optional action to allow additional SQLite specific configuration. </param>
         /// <param name="optionsAction"> An optional action to configure the <see cref="DbContextOptions" /> for the context. </param>
         /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = null)
+        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, string connectionString, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null, Action< DbContextOptionsBuilder>? optionsAction = null)
             where TContext : DbContext
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return serviceCollection.AddDbContext<TContext>((serviceProvider, options) =>
             {
-                optionsAction?.Invoke(serviceProvider, options);
+                optionsAction?.Invoke(options);
                 options.UseSqlite(connectionString, sqliteOptionsAction);
             });
         }

--- a/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Extensions/SqliteServiceCollectionExtensions.cs
@@ -68,45 +68,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         ///     <para>
-        ///         Registers the given Entity Framework context as a service in the <see cref="IServiceCollection" />
-        ///         and configures it to connect to a SQLite database.
-        ///     </para>
-        ///     <para>
-        ///         Use this method when using dependency injection in your application, such as with ASP.NET Core.
-        ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
-        ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
-        ///         overridden to configure the SQLite provider and connection string.
-        ///     </para>
-        ///     <para>
-        ///         The connection or connection string must be set before the <see cref="DbContext" /> is used to connect
-        ///         to a database. Set a connection using <see cref="RelationalDatabaseFacadeExtensions.SetDbConnection" />.
-        ///         Set a connection string using <see cref="RelationalDatabaseFacadeExtensions.SetConnectionString" />.
-        ///     </para>
-        ///     <para>
-        ///         To configure the <see cref="DbContextOptions{TContext}" /> for the context, either override the
-        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context, or use the appropriate
-        ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder}?, ServiceLifetime, ServiceLifetime)"/>
-        ///         method and supply an optional action to configure the <see cref="DbContextOptions" /> for the context. 
-        ///     </para>
-        ///     <para>
-        ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
-        ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
-        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
-        /// <param name="sqliteOptionsAction"> An optional action to allow additional SQLite specific configuration. </param>
-        /// <returns> The same service collection so that multiple calls can be chained. </returns>
-        public static IServiceCollection AddSqlite<TContext>(this IServiceCollection serviceCollection, Action<SqliteDbContextOptionsBuilder>? sqliteOptionsAction = null)
-            where TContext : DbContext
-        {
-            Check.NotNull(serviceCollection, nameof(serviceCollection));
-
-            return serviceCollection.AddDbContext<TContext>(options => options.UseSqlite(sqliteOptionsAction));
-        }
-
-        /// <summary>
-        ///     <para>
         ///         Adds the services required by the SQLite database provider for Entity Framework
         ///         to an <see cref="IServiceCollection" />.
         ///     </para>

--- a/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
                     sqlServerOption.MaxBatchSize(123);
                     sqlServerOption.CommandTimeout(30);
                 },
-                (serviceProvider, dbContextOption) =>
+                dbContextOption =>
                 {
                     dbContextOption.EnableDetailedErrors(true);
                 });

--- a/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -3,7 +3,9 @@
 
 using System.Linq;
 using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -83,6 +85,46 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Same(connection, extension.Connection);
             Assert.Null(extension.ConnectionString);
+        }
+
+        [ConditionalFact]
+        public void Service_collection_extension_method_can_configure_sqlserver_options()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSqlServer<ApplicationDbContext>(
+                "Database=Crunchie",
+                sqlServerOption =>
+                {
+                    sqlServerOption.MaxBatchSize(123);
+                    sqlServerOption.CommandTimeout(30);
+                },
+                (serviceProvider, dbContextOption) =>
+                {
+                    dbContextOption.EnableDetailedErrors(true);
+                });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            using (var serviceScope = services
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var coreOptions = serviceScope.ServiceProvider.GetRequiredService<DbContextOptions<ApplicationDbContext>>().GetExtension<CoreOptionsExtension>();
+                Assert.True(coreOptions.DetailedErrorsEnabled);
+
+                var sqlServerOptions = serviceScope.ServiceProvider.GetRequiredService<DbContextOptions<ApplicationDbContext>>().GetExtension<SqlServerOptionsExtension>();
+                Assert.Equal(123, sqlServerOptions.MaxBatchSize);
+                Assert.Equal(30, sqlServerOptions.CommandTimeout);
+                Assert.Equal("Database=Crunchie", sqlServerOptions.ConnectionString);
+            }
+        }
+
+        private class ApplicationDbContext : DbContext
+        {
+            public ApplicationDbContext(DbContextOptions options)
+                   : base(options)
+            {
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -3,7 +3,9 @@
 
 using System.Linq;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -95,6 +97,46 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Same(connection, extension.Connection);
             Assert.Null(extension.ConnectionString);
+        }
+
+        [ConditionalFact]
+        public void Service_collection_extension_method_can_configure_sqlite_options()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSqlite<ApplicationDbContext>(
+                "Database=Crunchie",
+                sqlServerOption =>
+                {
+                    sqlServerOption.MaxBatchSize(123);
+                    sqlServerOption.CommandTimeout(30);
+                },
+                (serviceProvider, dbContextOption) =>
+                {
+                    dbContextOption.EnableDetailedErrors(true);
+                });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            using (var serviceScope = services
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var coreOptions = serviceScope.ServiceProvider.GetRequiredService<DbContextOptions<ApplicationDbContext>>().GetExtension<CoreOptionsExtension>();
+                Assert.True(coreOptions.DetailedErrorsEnabled);
+
+                var sqlServerOptions = serviceScope.ServiceProvider.GetRequiredService<DbContextOptions<ApplicationDbContext>>().GetExtension<SqliteOptionsExtension>();
+                Assert.Equal(123, sqlServerOptions.MaxBatchSize);
+                Assert.Equal(30, sqlServerOptions.CommandTimeout);
+                Assert.Equal("Database=Crunchie", sqlServerOptions.ConnectionString);
+            }
+        }
+
+        private class ApplicationDbContext : DbContext
+        {
+            public ApplicationDbContext(DbContextOptions options)
+                   : base(options)
+            {
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
                     sqlServerOption.MaxBatchSize(123);
                     sqlServerOption.CommandTimeout(30);
                 },
-                (serviceProvider, dbContextOption) =>
+                dbContextOption =>
                 {
                     dbContextOption.EnableDetailedErrors(true);
                 });


### PR DESCRIPTION
Adds extension methods to enable simpler adding and configuration of contexts for a specific EF Core provider, e.g.:

``` csharp
var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
builder.Services.AddSqlite<ApplicationDbContext>(connectionString);
```

Contributes to #25192

Todo:
- [x] Add Sqlite methods
- [x] Add SQL Server methods
- [x] Add tests

