### PR TITLE
Drop computed columns before non-computed

### DIFF
--- a/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Migrations/MigrationsTestBase.cs
@@ -897,6 +897,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });
 
         [ConditionalFact]
+        public virtual Task Drop_column_computed_and_non_computed_with_dependency()
+            => Test(
+                builder => builder.Entity("People").Property<int>("Id"),
+                builder => builder.Entity("People", e =>
+                {
+                    e.Property<int>("X");
+                    e.Property<int>("Y").HasComputedColumnSql($"{DelimitIdentifier("X")} + 1");
+                }),
+                builder => { },
+                model =>
+                {
+                    var table = Assert.Single(model.Tables);
+                    Assert.Equal("Id", Assert.Single(table.Columns).Name);
+                });
+
+        [ConditionalFact]
         public virtual Task Rename_column()
             => Test(
                 builder => builder.Entity("People").Property<int>("Id"),

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -1041,6 +1041,28 @@ IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + ']
 ALTER TABLE [People] DROP COLUMN [Id];");
         }
 
+        public override async Task Drop_column_computed_and_non_computed_with_dependency()
+        {
+            await base.Drop_column_computed_and_non_computed_with_dependency();
+
+            AssertSql(
+                @"DECLARE @var0 sysname;
+SELECT @var0 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'Y');
+IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var0 + '];');
+ALTER TABLE [People] DROP COLUMN [Y];",
+                //
+                @"DECLARE @var1 sysname;
+SELECT @var1 = [d].[name]
+FROM [sys].[default_constraints] [d]
+INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]
+WHERE ([d].[parent_object_id] = OBJECT_ID(N'[People]') AND [c].[name] = N'X');
+IF @var1 IS NOT NULL EXEC(N'ALTER TABLE [People] DROP CONSTRAINT [' + @var1 + '];');
+ALTER TABLE [People] DROP COLUMN [X];");
+        }
+
         public override async Task Rename_column()
         {
             await base.Rename_column();
@@ -2685,7 +2707,7 @@ ALTER SCHEMA [newHistorySchema] TRANSFER [historySchema].[RenamedHistoryTable];"
                         e.Property<string>("Name");
                         e.Property<int>("Number");
                     }),
-                builder => 
+                builder =>
                     {
                     },
                 model =>


### PR DESCRIPTION
* Made DropColumnOperation inherit from ColumnOperation. This was needed to distinguish between dropping computed and non-computed, but it makes sense to expose all column facets in case they matter somehow when dropping the column.
* SQL Server and PostgreSQL don't allowing referencing a computed column from another computed column, Sqlite and MySQL do. In any case, we won't parse the computed SQL to understand dependencies.

Fixes #25237
