### PR TITLE
Rerun relationship discovery if an ambiguity has been resolved on the inverse

### DIFF
--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -55,6 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (DiscriminatorConvention)discriminatorConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
 
+            ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+
             conventionSet.EntityTypePrimaryKeyChangedConventions.Add(storeKeyConvention);
 
             conventionSet.KeyAddedConventions.Add(storeKeyConvention);

--- a/src/EFCore.Relational/Metadata/Builders/TableBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Builders/TableBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders

--- a/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalCollectionShaperExpression.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="innerShaper"> An expression used to create individual elements of the collection. </param>
         /// <param name="navigation"> A navigation associated with this collection, if any. </param>
         /// <param name="elementType"> The clr type of individual elements in the collection. </param>
-        [Obsolete("Use ctor which takes value comaprers.")]
+        [Obsolete("Use ctor which takes value comparers.")]
         public RelationalCollectionShaperExpression(
             int collectionId,
             Expression parentIdentifier,

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 
+// ReSharper disable UnusedMember.Local
 namespace Microsoft.EntityFrameworkCore.Diagnostics
 {
     /// <summary>
@@ -686,7 +687,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         There navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
+        ///         The navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
         ///     </para>
         ///     <para>
         ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
@@ -700,7 +701,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
 
         /// <summary>
         ///     <para>
-        ///         There navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
+        ///         The navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
         ///     </para>
         ///     <para>
         ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.

--- a/src/EFCore/Internal/TypeFullNameComparer.cs
+++ b/src/EFCore/Internal/TypeFullNameComparer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 return 1;
             }
 
-            return StringComparer.Ordinal.Compare(x.Name, y.Name);
+            return StringComparer.Ordinal.Compare(x.FullName, y.FullName);
         }
 
         /// <summary>

--- a/src/EFCore/Internal/TypeFullNameComparer.cs
+++ b/src/EFCore/Internal/TypeFullNameComparer.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///         any release. You should only use it directly in your code with extreme caution and knowing that
+    ///         doing so can result in application failures when updating to a new Entity Framework Core release.
+    ///     </para>
+    /// </summary>
+    public sealed class TypeFullNameComparer : IComparer<Type>, IEqualityComparer<Type>
+    {
+        private TypeFullNameComparer()
+        {
+        }
+
+        /// <summary>
+        ///     The singleton instance of the comparer to use.
+        /// </summary>
+        public static readonly TypeFullNameComparer Instance = new();
+
+        /// <summary>
+        ///     Compares two objects and returns a value indicating whether one is less than, equal to, or greater than the other.
+        /// </summary>
+        /// <param name="x"> The first object to compare. </param>
+        /// <param name="y"> The second object to compare. </param>
+        /// <returns> A negative number if 'x' is less than 'y'; a positive number if 'x' is greater than 'y'; zero otherwise. </returns>
+        public int Compare(Type? x, Type? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
+            return StringComparer.Ordinal.Compare(x.Name, y.Name);
+        }
+
+        /// <summary>
+        ///     Determines whether the specified objects are equal.
+        /// </summary>
+        /// <param name="x"> The first object to compare. </param>
+        /// <param name="y"> The second object to compare. </param>
+        /// <returns> <see langword="true" /> if the specified objects are equal; otherwise, <see langword="false" />. </returns>
+        public bool Equals(Type? x, Type? y)
+            => Compare(x, y) == 0;
+
+        /// <summary>
+        ///     Returns a hash code for the specified object.
+        /// </summary>
+        /// <param name="obj"> The for which a hash code is to be returned. </param>
+        /// <returns> A hash code for the specified object. </returns>
+        public int GetHashCode(Type obj)
+            => obj.Name.GetHashCode();
+    }
+}

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -127,6 +127,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             = new List<IForeignKeyAnnotationChangedConvention>();
 
         /// <summary>
+        ///     Conventions to run when a navigation is set to <see langword="null"/> on a foreign key.
+        /// </summary>
+        public virtual IList<IForeignKeyNullNavigationSetConvention> ForeignKeyNullNavigationSetConventions { get; }
+            = new List<IForeignKeyNullNavigationSetConvention>();
+
+        /// <summary>
         ///     Conventions to run when a navigation property is added.
         /// </summary>
         public virtual IList<INavigationAddedConvention> NavigationAddedConventions { get; } = new List<INavigationAddedConvention>();

--- a/src/EFCore/Metadata/Conventions/IForeignKeyNullNavigationSetConvention.cs
+++ b/src/EFCore/Metadata/Conventions/IForeignKeyNullNavigationSetConvention.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     Represents an operation that should be performed when a navigation is set to <see langword="null"/> on a foreign key.
+    /// </summary>
+    public interface IForeignKeyNullNavigationSetConvention : IConvention
+    {
+        /// <summary>
+        ///     Called after a navigation is set to <see langword="null"/> on a foreign key.
+        /// </summary>
+        /// <param name="relationshipBuilder"> The builder for the foreign key. </param>
+        /// <param name="pointsToPrincipal">
+        ///     A value indicating whether the <see langword="null"/> navigation would be pointing to the principal entity type.
+        /// </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        void ProcessForeignKeyNullNavigationSet(
+            IConventionForeignKeyBuilder relationshipBuilder,
+            bool pointsToPrincipal,
+            IConventionContext<IConventionNavigation> context);
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -98,6 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
 
             conventionSet.EntityTypeMemberIgnoredConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
+            conventionSet.EntityTypeMemberIgnoredConventions.Add(keyDiscoveryConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             var keyAttributeConvention = new KeyAttributeConvention(Dependencies);
@@ -168,6 +169,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(valueGeneratorConvention);
+
+            conventionSet.ForeignKeyNullNavigationSetConventions.Add(relationshipDiscoveryConvention);
 
             var requiredNavigationAttributeConvention = new RequiredNavigationAttributeConvention(Dependencies);
             var nonNullableNavigationConvention = new NonNullableNavigationConvention(Dependencies);

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.ConventionScope.cs
@@ -115,6 +115,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public abstract bool? OnForeignKeyUniquenessChanged(
                 IConventionForeignKeyBuilder relationshipBuilder);
 
+            public abstract IConventionNavigation? OnForeignKeyNullNavigationSet(
+                IConventionForeignKeyBuilder relationshipBuilder,
+                bool pointsToPrincipal);
+
             public abstract IConventionIndexBuilder? OnIndexAdded(IConventionIndexBuilder indexBuilder);
 
             public abstract IConventionAnnotation? OnIndexAnnotationChanged(

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.DelayedConventionScope.cs
@@ -121,6 +121,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return foreignKey;
             }
 
+            public override IConventionNavigation? OnForeignKeyNullNavigationSet(
+                IConventionForeignKeyBuilder relationshipBuilder,
+                bool pointsToPrincipal)
+            {
+                Add(new OnForeignKeyNullNavigationSetNode(relationshipBuilder, pointsToPrincipal));
+                return null;
+            }
+
             public override IConventionAnnotation? OnForeignKeyAnnotationChanged(
                 IConventionForeignKeyBuilder relationshipBuilder,
                 string name,
@@ -600,6 +608,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             public override void Run(ConventionDispatcher dispatcher)
                 => dispatcher._immediateConventionScope.OnForeignKeyOwnershipChanged(RelationshipBuilder);
+        }
+
+        private sealed class OnForeignKeyNullNavigationSetNode : ConventionNode
+        {
+            public OnForeignKeyNullNavigationSetNode(IConventionForeignKeyBuilder relationshipBuilder, bool pointsToPrincipal)
+            {
+                RelationshipBuilder = relationshipBuilder;
+                PointsToPrincipal = pointsToPrincipal;
+            }
+
+            public IConventionForeignKeyBuilder RelationshipBuilder { get; }
+            public bool PointsToPrincipal { get; }
+
+            public override void Run(ConventionDispatcher dispatcher)
+                => dispatcher._immediateConventionScope.OnForeignKeyNullNavigationSet(RelationshipBuilder, PointsToPrincipal);
         }
 
         private sealed class OnForeignKeyPrincipalEndChangedNode : ConventionNode

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -281,6 +281,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual IConventionNavigation? OnForeignKeyNullNavigationSet(
+            IConventionForeignKeyBuilder relationshipBuilder,
+            bool pointsToPrincipal)
+            => _scope.OnForeignKeyNullNavigationSet(relationshipBuilder, pointsToPrincipal);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public virtual IConventionNavigationBuilder? OnNavigationAdded(IConventionNavigationBuilder navigationBuilder)
             => _scope.OnNavigationAdded(navigationBuilder);
 

--- a/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/KeyDiscoveryConvention.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         IPropertyAddedConvention,
         IKeyRemovedConvention,
         IEntityTypeBaseTypeChangedConvention,
+        IEntityTypeMemberIgnoredConvention,
         IForeignKeyAddedConvention,
         IForeignKeyRemovedConvention,
         IForeignKeyPropertiesChangedConvention,
@@ -186,6 +187,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             return keyProperties;
             // ReSharper restore PossibleMultipleEnumeration
+        }
+
+        /// <summary>
+        ///     Called after an entity type member is ignored.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the entity type. </param>
+        /// <param name="name"> The name of the ignored member. </param>
+        /// <param name="context"> Additional information associated with convention execution. </param>
+        public virtual void ProcessEntityTypeMemberIgnored(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            string name,
+            IConventionContext<string> context)
+        {
+            var entityTypeName = entityTypeBuilder.Metadata.ShortName();
+            if (string.Equals(name, KeySuffix, StringComparison.OrdinalIgnoreCase)
+                || (name.Length == entityTypeName.Length + KeySuffix.Length
+                    && name.StartsWith(entityTypeName, StringComparison.OrdinalIgnoreCase)
+                    && name.EndsWith(KeySuffix, StringComparison.OrdinalIgnoreCase)))
+            {
+                TryConfigurePrimaryKey(entityTypeBuilder);
+            }
         }
 
         /// <inheritdoc />

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2861,7 +2861,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     if (navigationToTarget.Value.Name == existingRelationship.Metadata.DependentToPrincipal?.Name)
                     {
-                        existingRelationship.Metadata.UpdateDependentToPrincipalConfigurationSource(configurationSource);
+                        existingRelationship.Metadata.SetDependentToPrincipal(navigationToTarget.Value.Name, configurationSource);
                     }
                     else if (setTargetAsPrincipal == true)
                     {
@@ -2869,7 +2869,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                     else
                     {
-                        existingRelationship.Metadata.UpdatePrincipalToDependentConfigurationSource(configurationSource);
+                        existingRelationship.Metadata.SetPrincipalToDependent(navigationToTarget.Value.Name, configurationSource);
                     }
 
                     if (navigationToTarget.Value.Name != null)
@@ -2882,7 +2882,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     if (inverseNavigation.Value.Name == existingRelationship.Metadata.PrincipalToDependent?.Name)
                     {
-                        existingRelationship.Metadata.UpdatePrincipalToDependentConfigurationSource(configurationSource);
+                        existingRelationship.Metadata.SetPrincipalToDependent(inverseNavigation.Value.Name, configurationSource);
                     }
                     else if (setTargetAsPrincipal == true)
                     {
@@ -2890,7 +2890,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                     else
                     {
-                        existingRelationship.Metadata.UpdateDependentToPrincipalConfigurationSource(configurationSource);
+                        existingRelationship.Metadata.SetDependentToPrincipal(inverseNavigation.Value.Name, configurationSource);
                     }
 
                     if (inverseNavigation.Value.Name != null)
@@ -4304,6 +4304,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 var removed = skipNavigation.Inverse.Builder.HasInverse(null, configurationSource);
                 Check.DebugAssert(removed != null, "Expected inverse to be removed");
+            }
+
+            if (skipNavigation.ForeignKey != null)
+            {
+                skipNavigation.Builder.HasForeignKey(null, configurationSource);
             }
 
             Metadata.RemoveSkipNavigation(skipNavigation);

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Metadata.UpdateConfigurationSource(configurationSource);
                 if (navigationToPrincipal != null)
                 {
-                    Metadata.UpdateDependentToPrincipalConfigurationSource(configurationSource);
+                    Metadata.SetDependentToPrincipal(navigationToPrincipal?.Name, configurationSource);
                     if (navigationToPrincipalName != null)
                     {
                         dependentEntityType.RemoveIgnored(navigationToPrincipalName);
@@ -187,7 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                 if (navigationToDependent != null)
                 {
-                    Metadata.UpdatePrincipalToDependentConfigurationSource(configurationSource);
+                    Metadata.SetPrincipalToDependent(navigationToDependent?.Name, configurationSource);
                     if (navigationToDependentName != null)
                     {
                         principalEntityType.RemoveIgnored(navigationToDependentName);

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -449,7 +449,7 @@ namespace Microsoft.EntityFrameworkCore
                         && e.GetParameters().SingleOrDefault()?.ParameterType.GetGenericTypeDefinition()
                         == typeof(IEntityTypeConfiguration<>));
 
-            foreach (var type in assembly.GetConstructibleTypes())
+            foreach (var type in assembly.GetConstructibleTypes().OrderBy(t => t.FullName))
             {
                 // Only accept types that contain a parameterless constructor, are not abstract and satisfy a predicate if it was used.
                 if (type.GetConstructor(Type.EmptyTypes) == null

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -1700,6 +1700,87 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         [InlineData(false, true)]
         [InlineData(true, true)]
         [ConditionalTheory]
+        public void OnForeignKeyNullNavigationSet_calls_conventions_in_order(bool useBuilder, bool useScope)
+        {
+            var conventions = new ConventionSet();
+
+            var convention1 = new ForeignKeyNullNavigationSetConvention(terminate: false);
+            var convention2 = new ForeignKeyNullNavigationSetConvention(terminate: true);
+            var convention3 = new ForeignKeyNullNavigationSetConvention(terminate: false);
+            conventions.ForeignKeyNullNavigationSetConventions.Add(convention1);
+            conventions.ForeignKeyNullNavigationSetConventions.Add(convention2);
+            conventions.ForeignKeyNullNavigationSetConventions.Add(convention3);
+
+            var builder = new InternalModelBuilder(new Model(conventions));
+            var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+            var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+
+            var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
+
+            if (useBuilder)
+            {
+                var result = dependentEntityBuilder.HasRelationship(
+                    principalEntityBuilder.Metadata, (MemberInfo)null, null, ConfigurationSource.Convention);
+
+                Assert.NotNull(result);
+            }
+            else
+            {
+                var fk = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
+                    .IsUnique(true, ConfigurationSource.Convention)
+                    .Metadata;
+                var result = fk.SetDependentToPrincipal((MemberInfo)null, ConfigurationSource.Explicit);
+
+                Assert.Null(result);
+
+                result = fk.SetPrincipalToDependent((MemberInfo)null, ConfigurationSource.Explicit);
+
+                Assert.Null(result);
+            }
+
+            if (useScope)
+            {
+                Assert.Empty(convention1.Calls);
+                Assert.Empty(convention2.Calls);
+                scope.Dispose();
+            }
+
+            Assert.Equal(new[] { true, false }, convention1.Calls);
+            Assert.Equal(new[] { true, false }, convention2.Calls);
+            Assert.Empty(convention3.Calls);
+        }
+
+        private class ForeignKeyNullNavigationSetConvention : IForeignKeyNullNavigationSetConvention
+        {
+            private readonly bool _terminate;
+            public readonly List<bool> Calls = new();
+
+            public ForeignKeyNullNavigationSetConvention(bool terminate)
+            {
+                _terminate = terminate;
+            }
+
+            public void ProcessForeignKeyNullNavigationSet(
+                IConventionForeignKeyBuilder relationshipBuilder,
+                bool pointsToPrincipal,
+                IConventionContext<IConventionNavigation> context)
+            {
+                Assert.NotNull(relationshipBuilder.Metadata.Builder);
+
+                Calls.Add(pointsToPrincipal);
+
+                if (_terminate)
+                {
+                    context.StopProcessing();
+                }
+            }
+        }
+
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        [ConditionalTheory]
         public void OnNavigationAdded_calls_conventions_in_order(bool useBuilder, bool useScope)
         {
             var conventions = new ConventionSet();

--- a/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -133,6 +132,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             Assert.Equal(
                 CoreResources.LogMultiplePrimaryKeyCandidates(new TestLogger<TestLoggingDefinitions>()).GenerateMessage(
                     nameof(EntityWithMultipleIds.ID), nameof(EntityWithMultipleIds.Id), nameof(EntityWithMultipleIds)), logEntry.Message);
+
+            var context = new ConventionContext<string>(
+                entityBuilder.Metadata.Model.ConventionDispatcher);
+
+            entityBuilder.Ignore("ID", ConfigurationSource.DataAnnotation);
+
+            CreateKeyDiscoveryConvention().ProcessEntityTypeMemberIgnored(entityBuilder, "ID", context);
+
+            Assert.Equal("Id", entityBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
         }
 
         public ListLoggerFactory ListLoggerFactory { get; }

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -185,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             entityType.AddProperty(nameof(Blog.Id), typeof(int), ConfigurationSource.Explicit, ConfigurationSource.Explicit);
 
-            var context = new ConventionContext<IConventionEntityTypeBuilder>(entityType.Model.ConventionDispatcher);
+            var context = new ConventionContext<IConventionEntityTypeBuilder?>(entityType.Model.ConventionDispatcher);
             CreateServicePropertyDiscoveryConvention().ProcessEntityTypeAdded(entityType.Builder, context);
 
             return context.ShouldStopProcessing() ? (EntityType)context.Result!.Metadata : entityType;

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -454,7 +454,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);
             }
 
-            [ConditionalFact(Skip = "Issue #18388")]
+            [ConditionalFact]
             public virtual void Can_promote_shadow_fk_to_the_base_type()
             {
                 var modelBuilder = CreateModelBuilder();

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -1688,6 +1688,27 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Relationships_discovered_when_ambiguity_on_the_inverse_is_resolved()
+            {
+                var modelBuilder = HobNobBuilder();
+                modelBuilder.Entity<Nob>()
+                    .Ignore(e => e.Hobs)
+                    .HasOne(e => e.Hob).WithOne()
+                    .HasForeignKey<Nob>(
+                        e => new { e.HobId1, e.HobId2 });
+
+                var model = modelBuilder.FinalizeModel();
+
+                var hobType = model.FindEntityType(typeof(Hob));
+                var nobType = model.FindEntityType(typeof(Nob));
+
+                Assert.Null(hobType.GetNavigations().Single(n => n.Name == nameof(Hob.Nob)).Inverse);
+                Assert.Null(hobType.GetNavigations().Single(n => n.Name == nameof(Hob.Nobs)).Inverse);
+                Assert.Null(nobType.GetNavigations().Single(n => n.Name == nameof(Nob.Hob)).Inverse);
+                Assert.DoesNotContain(nobType.GetNavigations(), n => n.Name == nameof(Nob.Hobs));
+            }
+
+            [ConditionalFact]
             public virtual void Can_add_annotations()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Rerun KeyDiscoveryConvention when a property is ignored
Remove the associated FK when a skip navigation is removed
Add IForeignKeyNullNavigationSetConvention
Sort IEntityTypeConfiguration applied from assembly

Fixes #18388
Fixes #24521
