### PR TITLE
minor cleanup for temporal table feature

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerDbSetExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerDbSetExtensions.cs
@@ -12,9 +12,9 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     Sql Server database specific extension methods for LINQ queries.
+    ///     Sql Server database specific extension methods for LINQ queries rooted in DbSet.
     /// </summary>
-    public static class SqlServerQueryableExtensions
+    public static class SqlServerDbSetExtensions
     {
         /// <summary>
         ///     <para>
@@ -97,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="to">Point in time representing the end of the period for which results should be returned.</param>
         /// <returns> An <see cref="IQueryable{T}" /> representing the entities present in a given time range.</returns>
         public static IQueryable<TEntity> TemporalBetween<TEntity>(
-            this IQueryable<TEntity> source,
+            this DbSet<TEntity> source,
             DateTime from,
             DateTime to)
             where TEntity : class

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerTemporalConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerTemporalConvention.cs
@@ -36,6 +36,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     {
                         entityTypeBuilder.HasPeriodEnd(PeriodEndDefaultName);
                     }
+
+                    foreach (var skipLevelNavigation in entityTypeBuilder.Metadata.GetSkipNavigations())
+                    {
+                        if (skipLevelNavigation.DeclaringEntityType.IsTemporal()
+                            && skipLevelNavigation.Inverse is IConventionSkipNavigation inverse
+                            && inverse.DeclaringEntityType.IsTemporal()
+                            && skipLevelNavigation.JoinEntityType is IConventionEntityType joinEntityType
+                            && joinEntityType.HasSharedClrType
+                            && !joinEntityType.IsTemporal()
+                            && joinEntityType.GetConfigurationSource() == ConfigurationSource.Convention)
+                        {
+                            joinEntityType.SetIsTemporal(true);
+                        }
+                    }
                 }
                 else
                 {

--- a/src/EFCore.SqlServer/Query/SqlExpressions/TemporalTableExpression.cs
+++ b/src/EFCore.SqlServer/Query/SqlExpressions/TemporalTableExpression.cs
@@ -10,13 +10,20 @@ using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.SqlExpressions
 {
     /// <summary>
-    ///     Fill in later
+    ///     <para>
+    ///         An expression that represents a temporal table source in a SQL tree.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
     /// </summary>
     public class TemporalTableExpression : TableExpressionBase, ICloneable
     {
         /// <summary>
-        ///     Fill in later
+        ///     Creates a new instance of the <see cref="TemporalTableExpression" /> class representing temporal 'All' operation.
         /// </summary>
+        /// <param name="table"> A table source. </param>
         public TemporalTableExpression(ITableBase table)
             : base(table.Name.Substring(0, 1).ToLowerInvariant())
         {
@@ -26,8 +33,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.SqlExpressions
         }
 
         /// <summary>
-        ///     Fill in later
+        ///     Creates a new instance of the <see cref="TemporalTableExpression" /> class representing temporal 'AsOf' operation.
         /// </summary>
+        /// <param name="table"> A table source. </param>
+        /// <param name="pointInTime">Point in time. </param>
         public TemporalTableExpression(ITableBase table, DateTime pointInTime)
             : base(table.Name.Substring(0, 1).ToLowerInvariant())
         {
@@ -38,8 +47,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.SqlExpressions
         }
 
         /// <summary>
-        ///     Fill in later
+        ///     Creates a new instance of the <see cref="TemporalTableExpression" /> class representing temporal range operation.
         /// </summary>
+        /// <param name="table"> A table source. </param>
+        /// <param name="from">Start of the time range.</param>
+        /// <param name="to">End of the time range.</param>
+        /// <param name="temporalOperationType">Temporal operation type.</param>
         public TemporalTableExpression(ITableBase table, DateTime from, DateTime to, TemporalOperationType temporalOperationType)
             : base(table.Name.Substring(0, 1).ToLowerInvariant())
         {
@@ -69,32 +82,32 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.SqlExpressions
         }
 
         /// <summary>
-        ///     Fill in later
+        ///     Table schema.
         /// </summary>
         public virtual string? Schema { get; }
 
         /// <summary>
-        ///     Fill in later
+        ///     Table name.
         /// </summary>
         public virtual string Name { get; }
 
         /// <summary>
-        ///     Fill in later
+        ///     Point in time for the temporal 'AsOf' operation.
         /// </summary>
         public virtual DateTime? PointInTime { get; }
 
         /// <summary>
-        ///     Fill in later
+        ///     Start date for the temporal range operation.
         /// </summary>
         public virtual DateTime? From { get; }
 
         /// <summary>
-        ///     Fill in later
+        ///     End date for the temporal range operation.
         /// </summary>
         public virtual DateTime? To { get; }
 
         /// <summary>
-        ///     Fill in later
+        ///     Temporal operation type.
         /// </summary>
         public virtual TemporalOperationType TemporalOperationType { get; }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalPointInTimeQueryRewriter.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalPointInTimeQueryRewriter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             = typeof(ISetSource).GetMethod(nameof(ISetSource.Set));
 
         private static readonly MethodInfo _asOfMethodInfo
-            = typeof(SqlServerQueryableExtensions).GetMethod(nameof(SqlServerQueryableExtensions.TemporalAsOf));
+            = typeof(SqlServerDbSetExtensions).GetMethod(nameof(SqlServerDbSetExtensions.TemporalAsOf));
 
         private readonly DateTime _pointInTime;
 

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -1097,6 +1097,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(3, entity.GetProperties().Count());
             }
 
+            [ConditionalFact]
+            public virtual void Implicit_many_to_many_converted_from_non_temporal_to_temporal()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<ImplicitManyToManyA>();
+                modelBuilder.Entity<ImplicitManyToManyB>();
+
+                modelBuilder.Entity<ImplicitManyToManyA>().ToTable(tb => tb.IsTemporal());
+                modelBuilder.Entity<ImplicitManyToManyB>().ToTable(tb => tb.IsTemporal());
+
+                modelBuilder.FinalizeModel();
+
+                var entity = model.FindEntityType(typeof(ImplicitManyToManyA));
+                var joinEntity = entity.GetSkipNavigations().Single().JoinEntityType;
+
+                Assert.True(joinEntity.IsTemporal());
+            }
+
             protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder> configure = null)
                 => CreateTestModelBuilder(SqlServerTestHelpers.Instance, configure);
         }


### PR DESCRIPTION
- added some comments,
- moved temporal query methods from queryable extensions to dbset extensions
- added convention logic for case when initially non-temporal implicit many to many gets converted to temporal