### PR TITLE
Default relationships to ownership for Cosmos

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosEntityTypeExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
                 ?? GetDefaultContainer(entityType);
 
         private static string? GetDefaultContainer(IReadOnlyEntityType entityType)
-            => entityType.IsOwned()
+            => entityType.FindOwnership() != null
                 ? null
                 : entityType.Model.GetDefaultContainer()
                 ?? entityType.ShortName();

--- a/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
-using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal;

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosInversePropertyAttributeConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosInversePropertyAttributeConvention.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures the inverse navigation property based on the <see cref="InversePropertyAttribute" />
+    ///     specified on the other navigation property.
+    ///     All navigations are assumed to be targeting owned entity types for Cosmos.
+    /// </summary>
+    public class CosmosInversePropertyAttributeConvention : InversePropertyAttributeConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="InversePropertyAttributeConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public CosmosInversePropertyAttributeConvention(ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Finds or tries to create an entity type target for the given navigation member.
+        /// </summary>
+        /// <param name="entityTypeBuilder"> The builder for the referencing entity type. </param>
+        /// <param name="targetClrType"> The CLR type of the target entity type. </param>
+        /// <param name="navigationMemberInfo"> The navigation member. </param>
+        /// <param name="shouldCreate"> Whether an entity type should be created if one doesn't currently exist. </param>
+        /// <returns> The builder for the target entity type or <see langword="null"/> if it can't be created. </returns>
+        protected override IConventionEntityTypeBuilder? TryGetTargetEntityTypeBuilder(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            Type targetClrType,
+            MemberInfo navigationMemberInfo,
+            bool shouldCreate = true)
+            => ((InternalEntityTypeBuilder)entityTypeBuilder)
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                .GetTargetEntityTypeBuilder(
+                    targetClrType,
+                    navigationMemberInfo,
+                    shouldCreate ? ConfigurationSource.DataAnnotation : null,
+                    targetShouldBeOwned: true);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+    }
+}

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosRelationshipDiscoveryConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosRelationshipDiscoveryConvention.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    /// <summary>
+    ///     A convention that configures relationships between entity types based on the navigation properties
+    ///     as long as there is no ambiguity as to which is the corresponding inverse navigation.
+    ///     All navigations are assumed to be targeting owned entity types for Cosmos.
+    /// </summary>
+    public class CosmosRelationshipDiscoveryConvention : RelationshipDiscoveryConvention
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="RelationshipDiscoveryConvention" />.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this convention. </param>
+        public CosmosRelationshipDiscoveryConvention(ProviderConventionSetBuilderDependencies dependencies)
+            : base(dependencies)
+        {
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the given entity type should be added as owned if it isn't currently in the model.
+        /// </summary>
+        /// <param name="targetType"> Target entity type. </param>
+        /// <param name="model"> The model. </param>
+        /// <returns> <see langword="true"/> if the given entity type should be owned. </returns>
+        protected override bool? ShouldBeOwned(Type targetType, IConventionModel model)
+            => true;
+    }
+}

--- a/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/Internal/CosmosConventionSetBuilder.cs
@@ -44,46 +44,71 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Conventions.Internal
 
             var storeKeyConvention = new StoreKeyConvention(Dependencies);
             var discriminatorConvention = new CosmosDiscriminatorConvention(Dependencies);
-            var keyDiscoveryConvention = new CosmosKeyDiscoveryConvention(Dependencies);
+            KeyDiscoveryConvention keyDiscoveryConvention = new CosmosKeyDiscoveryConvention(Dependencies);
+            InversePropertyAttributeConvention inversePropertyAttributeConvention =
+                new CosmosInversePropertyAttributeConvention(Dependencies);
+            RelationshipDiscoveryConvention relationshipDiscoveryConvention =
+                new CosmosRelationshipDiscoveryConvention(Dependencies);
             conventionSet.EntityTypeAddedConventions.Add(storeKeyConvention);
             conventionSet.EntityTypeAddedConventions.Add(discriminatorConvention);
-            ReplaceConvention(conventionSet.EntityTypeAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeAddedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeAddedConventions, inversePropertyAttributeConvention);
+            ReplaceConvention(conventionSet.EntityTypeAddedConventions, relationshipDiscoveryConvention);
+
+            ReplaceConvention(conventionSet.EntityTypeIgnoredConventions, relationshipDiscoveryConvention);
 
             ReplaceConvention(conventionSet.EntityTypeRemovedConventions, (DiscriminatorConvention)discriminatorConvention);
+            ReplaceConvention(conventionSet.EntityTypeRemovedConventions, inversePropertyAttributeConvention);
 
             conventionSet.EntityTypeBaseTypeChangedConventions.Add(storeKeyConvention);
             ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (DiscriminatorConvention)discriminatorConvention);
-            ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, inversePropertyAttributeConvention);
+            ReplaceConvention(conventionSet.EntityTypeBaseTypeChangedConventions, relationshipDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, inversePropertyAttributeConvention);
+            ReplaceConvention(conventionSet.EntityTypeMemberIgnoredConventions, relationshipDiscoveryConvention);
 
             conventionSet.EntityTypePrimaryKeyChangedConventions.Add(storeKeyConvention);
 
             conventionSet.KeyAddedConventions.Add(storeKeyConvention);
 
             conventionSet.KeyRemovedConventions.Add(storeKeyConvention);
-            ReplaceConvention(conventionSet.KeyRemovedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.KeyRemovedConventions, keyDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.ForeignKeyAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyAddedConventions, keyDiscoveryConvention);
 
+            ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, relationshipDiscoveryConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(discriminatorConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(storeKeyConvention);
-            ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, keyDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyPropertiesChangedConventions, keyDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.ForeignKeyUniquenessChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyUniquenessChangedConventions, keyDiscoveryConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(discriminatorConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(storeKeyConvention);
-            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.ForeignKeyOwnershipChangedConventions, relationshipDiscoveryConvention);
 
+            ReplaceConvention(conventionSet.ForeignKeyNullNavigationSetConventions, relationshipDiscoveryConvention);
+
+            ReplaceConvention(conventionSet.NavigationAddedConventions, inversePropertyAttributeConvention);
+            ReplaceConvention(conventionSet.NavigationAddedConventions, relationshipDiscoveryConvention);
+
+            ReplaceConvention(conventionSet.NavigationRemovedConventions, relationshipDiscoveryConvention);
+
+            conventionSet.EntityTypeAnnotationChangedConventions.Add(discriminatorConvention);
             conventionSet.EntityTypeAnnotationChangedConventions.Add(storeKeyConvention);
-            conventionSet.EntityTypeAnnotationChangedConventions.Add(keyDiscoveryConvention);
+            conventionSet.EntityTypeAnnotationChangedConventions.Add((CosmosKeyDiscoveryConvention)keyDiscoveryConvention);
 
-            ReplaceConvention(conventionSet.PropertyAddedConventions, (KeyDiscoveryConvention)keyDiscoveryConvention);
+            ReplaceConvention(conventionSet.PropertyAddedConventions, keyDiscoveryConvention);
 
             conventionSet.PropertyAnnotationChangedConventions.Add(storeKeyConvention);
+
+            ReplaceConvention(conventionSet.ModelFinalizingConventions, inversePropertyAttributeConvention);
 
             return conventionSet;
         }

--- a/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/StoreKeyConvention.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration;
-using Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
+++ b/src/EFCore.Cosmos/Metadata/Internal/CosmosEntityTypeExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Metadata.Internal
         /// </summary>
         public static bool IsDocumentRoot(this IReadOnlyEntityType entityType)
             => entityType.BaseType?.IsDocumentRoot()
-                ?? (!entityType.IsOwned()
+                ?? (entityType.FindOwnership() == null
                     || entityType[CosmosAnnotationNames.ContainerName] != null);
     }
 }

--- a/src/EFCore.Relational/Metadata/IColumn.cs
+++ b/src/EFCore.Relational/Metadata/IColumn.cs
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 return false;
             }
 
-            var converter = property.GetValueConverter() ?? PropertyMappings.First().TypeMapping?.Converter;
+            var converter = property.GetValueConverter() ?? PropertyMappings.First().TypeMapping.Converter;
 
             if (converter != null)
             {

--- a/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/OwnedNavigationBuilder`.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigation,
                 DependentEntityType.Builder.HasRelationship(
                     relatedEntityType, navigation, ConfigurationSource.Explicit,
-                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : (bool?)null)!.Metadata);
+                    targetIsPrincipal: DependentEntityType == relatedEntityType ? true : null)!.Metadata);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Infrastructure/ProviderConventionSetBuilder.cs
@@ -149,6 +149,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ForeignKeyAddedConventions.Add(cascadeDeleteConvention);
             conventionSet.ForeignKeyAddedConventions.Add(foreignKeyIndexConvention);
 
+            conventionSet.ForeignKeyRemovedConventions.Add(baseTypeDiscoveryConvention);
+            conventionSet.ForeignKeyRemovedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(valueGeneratorConvention);
             conventionSet.ForeignKeyRemovedConventions.Add(foreignKeyIndexConvention);
@@ -166,8 +168,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure
             conventionSet.ForeignKeyRequirednessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention(Dependencies));
-            conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(valueGeneratorConvention);
 
             conventionSet.ForeignKeyNullNavigationSetConventions.Add(relationshipDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
+++ b/src/EFCore/Metadata/Conventions/NavigationAttributeConventionBase.cs
@@ -120,8 +120,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             IConventionEntityType entityType,
             IConventionContext<IConventionEntityType> context)
         {
-            var type = entityType.ClrType;
-
             var navigations = GetNavigationsWithAttribute(entityType);
             if (navigations == null)
             {

--- a/src/EFCore/Metadata/IConventionModel.cs
+++ b/src/EFCore/Metadata/IConventionModel.cs
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IConventionEntityType> FindLeastDerivedEntityTypes(
             Type type,
             Func<IReadOnlyEntityType, bool>? condition = null)
-            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition == null ? null : t => condition(t))
+            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition)
                 .Cast<IConventionEntityType>();
 
         /// <summary>
@@ -303,6 +303,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="type"> The type of the entity type that should be shared. </param>
         /// <param name="fromDataAnnotation"> Indicates whether the configuration was specified using a data annotation. </param>
         void AddShared(Type type, bool fromDataAnnotation = false);
+
+        /// <summary>
+        ///     Marks the given type as not shared, indicating that when discovered matching entity types
+        ///     should not be configured as shared type entity types.
+        /// </summary>
+        /// <param name="type"> The type of the entity type that should be shared. </param>
+        /// <returns> The removed type. </returns>
+        Type? RemoveShared(Type type);
+
+        /// <summary>
+        ///     Returns the configuration source if the given type is marked as shared.
+        /// </summary>
+        /// <param name="type"> The type that could be shared. </param>
+        /// <returns>
+        ///     The configuration source if the given type is marked as shared,
+        ///     <see langword="null" /> otherwise.
+        /// </returns>
+        ConfigurationSource? FindIsSharedConfigurationSource(Type type);
 
         /// <summary>
         ///     Marks the given entity type as owned, indicating that when discovered entity types using the given type
@@ -326,18 +344,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="type"> The type of the entity type that could be owned. </param>
         /// <returns>
-        ///     <see langword="true" /> if the given type name is marked as owned,
+        ///     <see langword="true" /> if the given type is marked as owned,
         ///     <see langword="null" /> otherwise.
         /// </returns>
         bool IsOwned(Type type) => FindIsOwnedConfigurationSource(type) != null;
 
         /// <summary>
-        ///     Returns a value indicating whether the entity types using the given type should be configured
-        ///     as owned types when discovered.
+        ///     Returns the configuration source if the given type is marked as owned.
         /// </summary>
         /// <param name="type"> The type of the entity type that could be owned. </param>
         /// <returns>
-        ///     The configuration source if the given type name is marked as owned,
+        ///     The configuration source if the given type is marked as owned,
         ///     <see langword="null" /> otherwise.
         /// </returns>
         ConfigurationSource? FindIsOwnedConfigurationSource(Type type);

--- a/src/EFCore/Metadata/IModel.cs
+++ b/src/EFCore/Metadata/IModel.cs
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IEntityType> FindLeastDerivedEntityTypes(
             Type type,
             Func<IReadOnlyEntityType, bool>? condition = null)
-            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition == null ? null : t => condition(t))
+            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition)
                 .Cast<IEntityType>();
 
         /// <summary>

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new IEnumerable<IMutableEntityType> FindLeastDerivedEntityTypes(
             Type type,
             Func<IReadOnlyEntityType, bool>? condition = null)
-            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition == null ? null : t => condition(t))
+            => ((IReadOnlyModel)this).FindLeastDerivedEntityTypes(type, condition)
                 .Cast<IMutableEntityType>();
 
         /// <summary>
@@ -272,6 +272,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <param name="type"> The type of the entity type that should be shared. </param>
         void AddShared(Type type);
+
+        /// <summary>
+        ///     Marks the given type as not shared, indicating that when discovered matching entity types
+        ///     should not be configured as shared type entity types.
+        /// </summary>
+        /// <param name="type"> The type of the entity type that should be shared. </param>
+        /// <returns> The removed type. </returns>
+        Type? RemoveShared(Type type);
 
         /// <summary>
         ///     Marks the given entity type as owned, indicating that when discovered matching entity types

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -224,6 +224,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public virtual EntityType? Owner
+            => FindOwnership()?.PrincipalEntityType;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         private string DisplayName()
             => ((IReadOnlyEntityType)this).DisplayName();
 

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -89,7 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         && configurationSource.Value.Overrides(Metadata.GetIsNullableConfigurationSource()))
                     || (Metadata.IsNullable == !required))
                 && (required != false
-                    || Metadata.ClrType.IsNullableType());
+                    || (Metadata.ClrType.IsNullableType()
+                        && Metadata.GetContainingKeys().All(k => configurationSource.Overrides(k.GetConfigurationSource()))));
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -783,7 +783,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             EnsureMutable();
 
             if (_sharedTypes.TryGetValue(type, out var existingTypes)
-                && existingTypes.Types.Any())
+                && existingTypes.Types.Count != 0)
             {
                 throw new InvalidOperationException(CoreStrings.CannotMarkNonShared(type.ShortDisplayName()));
             }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -272,6 +272,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 navigation, entityType);
 
         /// <summary>
+        ///     The type '{type}' cannot be marked as a non-shared type since a shared type entity type with this CLR type exists in the model.
+        /// </summary>
+        public static string CannotMarkNonShared(object? type)
+            => string.Format(
+                GetString("CannotMarkNonShared", nameof(type)),
+                type);
+
+        /// <summary>
         ///     The type '{type}' cannot be marked as a shared type since an entity type with the same CLR type already exists in the model.
         /// </summary>
         public static string CannotMarkShared(object? type)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -211,6 +211,9 @@
   <data name="CannotLoadDetached" xml:space="preserve">
     <value>The navigation '{1_entityType}.{0_navigation}' cannot be loaded because the entity is not being tracked. Navigations can only be loaded for tracked entities.</value>
   </data>
+  <data name="CannotMarkNonShared" xml:space="preserve">
+    <value>The type '{type}' cannot be marked as a non-shared type since a shared type entity type with this CLR type exists in the model.</value>
+  </data>
   <data name="CannotMarkShared" xml:space="preserve">
     <value>The type '{type}' cannot be marked as a shared type since an entity type with the same CLR type already exists in the model.</value>
   </data>

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -560,12 +560,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
+                //modelBuilder.Ignore<Operator>();
                 modelBuilder.Entity<Vehicle>(
                     eb =>
                     {
                         eb.HasKey(e => e.Name);
                         eb.OwnsOne(v => v.Operator).OwnsOne(v => v.Details);
                     });
+                modelBuilder.Entity<PoweredVehicle>();
 
                 modelBuilder.Entity<Engine>(
                     eb =>

--- a/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/EmbeddedDocumentsTest.cs
@@ -560,7 +560,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                //modelBuilder.Ignore<Operator>();
                 modelBuilder.Entity<Vehicle>(
                     eb =>
                     {

--- a/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
+++ b/test/EFCore.Cosmos.Tests/Infrastructure/CosmosModelValidatorTest.cs
@@ -137,6 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual void Detects_missing_partition_key_property()
         {
             var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>();
             modelBuilder.Entity<Order>().HasPartitionKey("PartitionKey");
 
             VerifyError(CosmosStrings.PartitionKeyMissingProperty(typeof(Order).Name, "PartitionKey"), modelBuilder);
@@ -193,6 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual void Detects_properties_mapped_to_same_property()
         {
             var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>();
             modelBuilder.Entity<Order>(
                 ob =>
                 {
@@ -209,6 +211,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual void Detects_property_and_embedded_type_mapped_to_same_property()
         {
             var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Customer>();
             modelBuilder.Entity<Order>(
                 ob =>
                 {

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.NotNull(
                 modelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit)
-                    .HasOwnership(typeof(Details), nameof(Product.Details), ConfigurationSource.Convention));
+                    .HasOwnership(typeof(Details), nameof(Product.Details), ConfigurationSource.Explicit));
 
             Assert.Null(modelBuilder.Ignore(typeof(Details), ConfigurationSource.Convention));
 

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -213,6 +213,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<Product>();
 
                 var principalEntityBuilder = modelBuilder.Entity<Customer>();
                 principalEntityBuilder.Ignore(nameof(Customer.Orders));
@@ -278,6 +279,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<Product>();
 
                 var principalEntityBuilder = modelBuilder.Entity<Customer>();
                 principalEntityBuilder.Ignore(nameof(Customer.Orders));
@@ -312,6 +314,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Can_match_navigation_to_derived_type_with_inverse_on_base()
             {
                 var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<OrderDetails>();
 
@@ -526,6 +529,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<BackOrder>();
                 modelBuilder.Ignore<SpecialCustomer>();
+                modelBuilder.Ignore<Product>();
 
                 var principalEntityBuilder = modelBuilder.Entity<Customer>();
                 var derivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
@@ -609,6 +613,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<BackOrder>();
                 modelBuilder.Ignore<SpecialCustomer>();
+                modelBuilder.Ignore<Product>();
 
                 modelBuilder.Entity<Customer>();
                 var derivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
@@ -698,10 +703,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public virtual void Removing_derived_type_make_sure_that_entity_type_is_removed_from_directly_derived_type()
+            public virtual void Removing_derived_removes_it_from_directly_derived_type()
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<Book>();
+                modelBuilder.Entity<BookLabel>();
                 modelBuilder.Ignore<SpecialBookLabel>();
                 modelBuilder.Ignore<AnotherBookLabel>();
 
@@ -760,9 +766,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var extraSpecialBookLabelEntityBuilder = modelBuilder.Entity<ExtraSpecialBookLabel>();
                 modelBuilder.Entity<SpecialBookLabel>()
                     .HasOne(e => (ExtraSpecialBookLabel)e.SpecialBookLabel)
-                    .WithOne(e => (SpecialBookLabel)e.BookLabel);
+                    .WithOne(e => (SpecialBookLabel)e.BookLabel)
+                    .HasForeignKey<ExtraSpecialBookLabel>();
 
                 var fk = bookLabelEntityBuilder.Metadata.FindNavigation(nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                Assert.Equal(new[] { fk }, extraSpecialBookLabelEntityBuilder.Metadata.GetForeignKeys());
                 Assert.Equal(nameof(SpecialBookLabel.BookLabel), fk.DependentToPrincipal.Name);
                 Assert.Equal(new[] { fk }, extraSpecialBookLabelEntityBuilder.Metadata.GetForeignKeys());
             }
@@ -853,7 +861,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact] // #7049
-            public void Base_type_can_be_discovered_after_creating_foreign_keys_on_derived()
+            public virtual void Base_type_can_be_discovered_after_creating_foreign_keys_on_derived()
             {
                 var mb = CreateModelBuilder();
                 mb.Entity<AL>();
@@ -863,7 +871,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
-            public void Can_get_set_discriminator_mapping_is_complete()
+            public virtual void Can_get_set_discriminator_mapping_is_complete()
             {
                 var mb = CreateModelBuilder();
                 var baseTypeBuilder = mb.Entity<PBase>();

--- a/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToManyTestBase.cs
@@ -220,7 +220,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         .Where(et => ((EntityType)et).IsImplicitlyCreatedJoinEntityType));
 
                 Assert.Empty(hob.GetSkipNavigations());
-                Assert.Empty(nob.GetSkipNavigations());
+                if (nob != null)
+                {
+                    Assert.Empty(nob.GetSkipNavigations());
+                }
             }
 
             [ConditionalFact]
@@ -441,6 +444,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .Navigation(e => e.Dependents)
                     .UsePropertyAccessMode(PropertyAccessMode.Field);
 
+                modelBuilder.Entity<OneToManyNavPrincipal>();
                 modelBuilder.Entity<NavDependent>()
                     .Navigation(e => e.ManyToManyPrincipals)
                     .UsePropertyAccessMode(PropertyAccessMode.Property);

--- a/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ManyToOneTestBase.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     .HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .HasForeignKey(e => e.CustomerId);
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -120,6 +121,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder
                     .Entity<Order>().HasOne(o => o.Customer).WithMany()
                     .HasForeignKey(c => c.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -153,6 +155,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Order>()
                     .HasOne<Customer>().WithMany(e => e.Orders)
                     .HasForeignKey(e => e.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -187,6 +190,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>().HasOne<Customer>().WithMany().HasForeignKey(e => e.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -221,6 +225,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -259,6 +264,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -360,6 +366,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -807,6 +814,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -847,6 +855,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -900,6 +909,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -941,6 +951,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -982,6 +993,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -1030,6 +1042,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -1894,8 +1907,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Creates_shadow_property_for_foreign_key_according_to_navigation_to_principal_name_when_present()
             {
                 var modelBuilder = CreateModelBuilder();
-                var beta = modelBuilder.Entity<Beta>().Metadata;
+                modelBuilder.Entity<Alpha>();
+                modelBuilder.Entity<Beta>();
+                modelBuilder.Ignore<Theta>();
 
+                var model = modelBuilder.FinalizeModel();
+
+                var beta = model.FindEntityType(typeof(Beta));
                 Assert.Equal("FirstNavId", beta.FindNavigation("FirstNav").ForeignKey.Properties.First().Name);
                 Assert.Equal("SecondNavId", beta.FindNavigation("SecondNav").ForeignKey.Properties.First().Name);
             }
@@ -1917,6 +1935,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 // For NonGenericStringTest
                 modelBuilder.Entity<Beta>();
+                modelBuilder.Ignore<Theta>();
 
                 modelBuilder.Entity<Alpha>(
                     b =>
@@ -1940,6 +1959,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 // For NonGenericStringTest
                 modelBuilder.Entity<Beta>();
+                modelBuilder.Ignore<Theta>();
 
                 var entityA = modelBuilder.Entity<Alpha>();
                 entityA.Property<int>("ShadowPK");
@@ -1972,8 +1992,10 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void One_to_many_relationship_has_no_ambiguity_explicit()
             {
                 var modelBuilder = CreateModelBuilder();
-                modelBuilder.Entity<Kappa>().Ignore(e => e.Omegas);
-                modelBuilder.Entity<Kappa>().HasMany<Omega>().WithOne(e => e.Kappa);
+                modelBuilder.Entity<Alpha>();
+                modelBuilder.Entity<Kappa>()
+                    .Ignore(e => e.Omegas)
+                    .HasMany<Omega>().WithOne(e => e.Kappa);
 
                 modelBuilder.FinalizeModel();
 

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -79,6 +79,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<Order>().Property<int>("Id");
+                modelBuilder.Entity<Customer>();
+                modelBuilder.Ignore<Product>();
 
                 var entity = modelBuilder.Model.FindEntityType(typeof(Order));
 
@@ -313,6 +315,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder
                     .Entity<Customer>()
                     .Property(c => c.Name).HasAnnotation("foo", "bar");
@@ -327,6 +330,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder
                     .Entity<Customer>()
                     .Property<string>(Customer.NameProperty.Name).HasAnnotation("foo", "bar");
@@ -341,6 +345,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder(c => c.Properties<string>().HaveAnnotation("foo", "bar"));
 
+                modelBuilder.Ignore<Product>();
                 var propertyBuilder = modelBuilder
                     .Entity<Customer>()
                     .Property(c => c.Name).HasAnnotation("foo", "bar");
@@ -404,6 +409,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder(c => c.IgnoreAny<Guid>());
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>();
 
                 var entityType = modelBuilder.FinalizeModel().FindEntityType(typeof(Customer));
@@ -446,6 +452,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>(
                     b =>
                     {
@@ -1521,6 +1528,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder
                     .Entity<Customer>()
                     .HasIndex(ix => ix.Name);
@@ -1537,6 +1545,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder
                     .Entity<Customer>(
                         b =>
@@ -1557,6 +1566,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 var entityBuilder = modelBuilder.Entity<Customer>();
                 entityBuilder.HasIndex(ix => ix.Id).IsUnique();
                 entityBuilder.HasIndex(ix => ix.Name).HasAnnotation("A1", "V1");
@@ -1583,6 +1593,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 var entityBuilder = modelBuilder.Entity<Customer>();
                 var firstIndexBuilder = entityBuilder.HasIndex(
                     ix => new { ix.Id, ix.AlternateKey }).IsUnique();
@@ -1798,6 +1809,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
+                modelBuilder.Ignore<Theta>();
                 modelBuilder.Entity<Beta>(
                     c =>
                     {
@@ -1822,6 +1834,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Can_add_seed_data_anonymous_objects()
             {
                 var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<Theta>();
                 modelBuilder.Entity<Beta>(
                     c =>
                     {

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Order>()
                     .HasOne(o => o.Customer).WithMany(c => c.Orders)
                     .HasForeignKey(c => c.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -124,6 +125,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder
                     .Entity<Order>().HasOne(c => c.Customer).WithMany()
                     .HasForeignKey(c => c.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -156,6 +158,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne()
                     .HasForeignKey(e => e.CustomerId);
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -191,6 +194,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder
                     .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .HasForeignKey(c => c.CustomerId);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -226,6 +230,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -365,6 +370,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -823,6 +829,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -866,6 +873,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -949,6 +957,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Ignore<Order>();
                 modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<Product>();
 
                 modelBuilder.Entity<KeylessEntity>().HasNoKey();
                 modelBuilder.Entity<Customer>();
@@ -970,6 +979,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -1013,6 +1023,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Ignore<BackOrder>();
@@ -1056,6 +1067,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -1104,6 +1116,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -1152,6 +1165,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>();
 
@@ -1199,6 +1213,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
                 modelBuilder.Entity<Customer>();
@@ -1895,6 +1910,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>(
                     eb =>
                     {
@@ -2234,8 +2250,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Creates_shadow_property_for_foreign_key_according_to_navigation_to_principal_name_when_present()
             {
                 var modelBuilder = CreateModelBuilder();
-                var entityB = modelBuilder.Entity<Beta>().Metadata;
+                modelBuilder.Entity<Beta>();
+                modelBuilder.Entity<Alpha>();
+                modelBuilder.Ignore<Theta>();
 
+                var model = modelBuilder.FinalizeModel();
+
+                var entityB = model.FindEntityType(typeof(Beta));
                 Assert.Equal("FirstNavId", entityB.FindNavigation("FirstNav").ForeignKey.Properties.First().Name);
                 Assert.Equal("SecondNavId", entityB.FindNavigation("SecondNav").ForeignKey.Properties.First().Name);
             }
@@ -2310,6 +2331,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Throws_when_foreign_key_references_shadow_key()
             {
                 var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders).HasForeignKey(e => e.AnotherCustomerId);
 
                 Assert.Equal(
@@ -2551,6 +2573,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<Kappa>().Ignore(e => e.Omegas);
                 modelBuilder.Entity<Omega>().HasOne(e => e.Kappa).WithMany();
+                modelBuilder.Entity<Alpha>();
 
                 modelBuilder.FinalizeModel();
 
@@ -2595,12 +2618,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Entity<Parent>();
                 modelBuilder.Entity<CompositeChild>().HasKey(e => new { e.Id, e.Value });
 
-                var fk = modelBuilder.Model.FindEntityType(typeof(CompositeChild)).GetForeignKeys().Single();
-                Assert.Equal("ParentId", fk.Properties[0].Name);
+                var model = modelBuilder.FinalizeModel();
 
-                modelBuilder.FinalizeModel();
+                var child = model.FindEntityType(typeof(CompositeChild));
+                var fk = child.GetForeignKeys().Single();
+                Assert.Equal("ParentId", fk.Properties[0].Name);
             }
 
             [ConditionalFact]

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -320,6 +320,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<OrderDetails>().Ignore(d => d.Id);
                 modelBuilder.Entity<Order>().Ignore(o => o.Details);
 
@@ -1164,6 +1165,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = (Model)modelBuilder.Model;
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<Customer>();
 
                 var dependentType = model.FindEntityType(typeof(OrderDetails));
@@ -1209,6 +1211,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = (Model)modelBuilder.Model;
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<Customer>();
 
                 var dependentType = model.FindEntityType(typeof(OrderDetails));
@@ -1643,6 +1646,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<OrderDetails>()
                     .HasOne(e => e.Order).WithOne(e => e.Details)
                     .HasPrincipalKey<OrderDetails>(e => e.Id);
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -1739,6 +1743,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Entity<OrderDetails>();
                 modelBuilder.Entity<Order>().Property<int>("OrderDetailsId");
 
                 Assert.Equal(

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>()
                     .OwnsOne(
                         c => c.Details, db =>
@@ -52,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(
                     c => c.Details,
                     r => r.HasAnnotation("foo", "bar")
@@ -72,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Owned<OneToOneOwnedWithField>();
                 modelBuilder.Entity<OneToOneOwnerWithField>(
                     e =>
@@ -165,6 +168,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
                 IReadOnlyModel model = modelBuilder.Model;
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
 
                 var owner = model.FindEntityType(typeof(Customer));
@@ -189,6 +193,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
                     .UsePropertyAccessMode(PropertyAccessMode.FieldDuringConstruction)
                     .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications)
@@ -210,6 +215,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
                     .HasKey(c => c.Id);
 
@@ -225,6 +231,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>()
                     .OwnsOne(c => c.Details)
                     .WithOwner(d => d.Customer)
@@ -243,6 +250,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(
                     c => c.Details,
                     r =>
@@ -298,6 +306,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<Customer>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<OtherCustomer>().OwnsOne(c => c.Details);
                 modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details);
 
@@ -319,13 +328,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<Customer>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<SpecialCustomer>();
                 modelBuilder.Entity<OtherCustomer>().OwnsOne(c => c.Details)
                     .HasOne<SpecialCustomer>()
                     .WithOne()
                     .HasPrincipalKey<SpecialCustomer>();
-
-                Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(CustomerDetails)));
 
                 modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details);
 
@@ -338,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                             && fk.PrincipalToDependent == null);
                 Assert.Same(ownership.DeclaringEntityType, foreignKey.DeclaringEntityType);
                 Assert.NotEqual(ownership.Properties.Single().Name, foreignKey.Properties.Single().Name);
-                Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
+                Assert.Equal(2, model.FindEntityTypes(typeof(CustomerDetails)).Count());
                 Assert.Equal(2, ownership.DeclaringEntityType.GetForeignKeys().Count());
             }
 
@@ -349,6 +357,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 IReadOnlyModel model = modelBuilder.Model;
 
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<Product>();
                 var entityBuilder = modelBuilder.Entity<CustomerDetails>().OwnsOne(o => o.Customer)
                     .OwnsMany(c => c.Orders);
 
@@ -387,6 +396,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 var entityBuilder = modelBuilder.Entity<Customer>().OwnsMany(c => c.Orders)
                     .UsePropertyAccessMode(PropertyAccessMode.FieldDuringConstruction)
                     .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications)
@@ -428,6 +438,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsMany(
                     c => c.Orders,
                     r =>
@@ -467,6 +478,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<OtherCustomer>().OwnsMany(
                     c => c.Orders, ob =>
                     {
@@ -475,8 +487,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                             .WithOne()
                             .HasPrincipalKey<SpecialCustomer>();
                     });
-
-                Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Order)));
 
                 modelBuilder.Entity<SpecialCustomer>().OwnsMany(c => c.Orders)
                     .HasKey(o => o.OrderId);
@@ -501,7 +511,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Same(ownership1.DeclaringEntityType, foreignKey.DeclaringEntityType);
                 Assert.Null(foreignKey.PrincipalToDependent);
                 Assert.NotEqual(ownership1.Properties.Single().Name, foreignKey.Properties.Single().Name);
-                Assert.Equal(5, model.GetEntityTypes().Count());
                 Assert.Equal(2, model.FindEntityTypes(typeof(Order)).Count());
                 Assert.Equal(2, ownership1.DeclaringEntityType.GetForeignKeys().Count());
 
@@ -543,6 +552,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsMany(
                     c => c.Orders, ob =>
                     {
@@ -754,7 +764,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Owned<Order>();
+                modelBuilder.Entity<OrderDetails>();
                 modelBuilder.Entity<Customer>()
                     .OwnsMany(c => c.Orders)
                     .HasKey(o => o.OrderId);
@@ -779,7 +791,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
                 Assert.Same(ownership.DeclaringEntityType,
                     model.FindEntityType(typeof(Order), nameof(Customer.Orders), customer));
-                Assert.Equal(2, model.FindEntityTypes(typeof(Order)).Count());
                 Assert.True(model.IsShared(typeof(Order)));
 
                 var specialOwnership = specialCustomer.FindNavigation(nameof(SpecialCustomer.SpecialOrders)).ForeignKey;
@@ -793,7 +804,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(9, modelBuilder.Model.GetEntityTypes().Count());
                 Assert.Equal(2, modelBuilder.Model.FindEntityTypes(typeof(Order)).Count());
                 Assert.Equal(7, modelBuilder.Model.GetEntityTypes().Count(e => !e.HasSharedClrType));
-                Assert.Equal(5, modelBuilder.Model.GetEntityTypes().Count(e => e.IsOwned()));
 
                 var conventionModel = (IConventionModel)modelBuilder.Model;
                 Assert.Null(conventionModel.FindIgnoredConfigurationSource(typeof(Order)));
@@ -807,6 +817,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
+                modelBuilder.Entity<OrderDetails>();
                 modelBuilder.Owned<SpecialOrder>();
 
                 modelBuilder.Entity<SpecialCustomer>();
@@ -838,11 +850,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(
                     nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
 
-                Assert.Equal(9, modelBuilder.Model.GetEntityTypes().Count());
                 Assert.Equal(2, modelBuilder.Model.FindEntityTypes(typeof(Order)).Count());
                 // SpecialOrder and Address are only used once, but once they are made shared they don't revert to non-shared
-                Assert.Equal(5, modelBuilder.Model.GetEntityTypes().Count(e => !e.HasSharedClrType));
-                Assert.Equal(5, modelBuilder.Model.GetEntityTypes().Count(e => e.IsOwned()));
+                Assert.Equal(7, modelBuilder.Model.GetEntityTypes().Count(e => !e.HasSharedClrType));
 
                 var conventionModel = (IConventionModel)modelBuilder.Model;
                 Assert.Null(conventionModel.FindIgnoredConfigurationSource(typeof(Order)));
@@ -856,7 +866,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<OrderCombination>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<SpecialOrder>();
+                modelBuilder.Entity<Customer>();
+                modelBuilder.Entity<SpecialCustomer>();
 
                 var model = modelBuilder.FinalizeModel();
 
@@ -911,7 +925,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<BookLabel>();
+                modelBuilder.Ignore<Product>();
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
+                modelBuilder.Entity<BookDetails>();
                 modelBuilder.Entity<BookDetailsBase>();
                 modelBuilder.Ignore<SpecialBookLabel>();
 
@@ -932,6 +948,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<BookLabel>();
+                modelBuilder.Ignore<Product>();
+                modelBuilder.Entity<BookDetails>();
                 modelBuilder.Entity<BookDetailsBase>();
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
                 modelBuilder.Ignore<SpecialBookLabel>();
@@ -953,6 +971,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<Customer>();
+                modelBuilder.Ignore<Product>();
+                modelBuilder.Ignore<SpecialOrder>();
                 modelBuilder.Entity<OrderCombination>().OwnsOne(c => c.Details);
                 modelBuilder.Entity<Customer>();
 
@@ -983,9 +1003,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<Product>();
+                modelBuilder.Ignore<SpecialOrder>();
                 modelBuilder.Entity<OrderCombination>().OwnsOne(c => c.Details);
 
                 IReadOnlyModel model = modelBuilder.Model;
+
+                modelBuilder.Entity<CustomerDetails>();
 
                 var owner = model.FindEntityType(typeof(OrderCombination));
                 var owned = owner.FindNavigation(nameof(OrderCombination.Details)).ForeignKey.DeclaringEntityType;
@@ -998,7 +1022,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                             return targetType != typeof(DetailsBase) && typeof(DetailsBase).IsAssignableFrom(targetType);
                         }));
                 Assert.Single(owned.GetForeignKeys());
-                Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(DetailsBase)));
+                Assert.Single(model.FindEntityTypes(typeof(DetailsBase)));
                 Assert.Null(model.FindEntityType(typeof(CustomerDetails)).BaseType);
 
                 modelBuilder.Entity<Customer>().Ignore(c => c.Details);
@@ -1012,8 +1036,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
+                modelBuilder.Ignore<BookDetails>();
                 modelBuilder.Ignore<SpecialBookLabel>();
+                modelBuilder.Ignore<AnotherBookLabel>();
                 modelBuilder.Entity<Book>();
+                modelBuilder.Entity<BookLabel>();
 
                 Assert.Equal(
                     CoreStrings.AmbiguousForeignKeyPropertyCandidates(
@@ -1066,6 +1093,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                                 ab.OwnsOne(l => l.SpecialBookLabel).Ignore(l => l.Book).Ignore(s => s.BookLabel);
                             });
                     });
+
+                modelBuilder.Entity<BookDetails>();
 
                 var model = modelBuilder.FinalizeModel();
 
@@ -1123,6 +1152,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                             });
                     });
 
+                modelBuilder.Entity<BookDetails>();
+
                 var model = modelBuilder.FinalizeModel();
 
                 VerifyOwnedBookLabelModel(model);
@@ -1171,6 +1202,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                                 .Ignore(l => l.Book);
                         });
 
+                modelBuilder.Entity<BookDetails>();
+
                 var model = modelBuilder.FinalizeModel();
 
                 VerifyOwnedBookLabelModel(model);
@@ -1217,6 +1250,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                                 .OwnsOne(b => b.AnotherBookLabel)
                                 .Ignore(l => l.Book);
                         });
+
+                modelBuilder.Entity<BookDetails>();
 
                 var model = modelBuilder.FinalizeModel();
 
@@ -1278,6 +1313,60 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [ConditionalFact]
+            public virtual void Removing_ambiguous_inverse_allows_navigations_to_be_discovered()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Owned<BookLabel>();
+                modelBuilder.Entity<Book>();
+
+                modelBuilder.Entity<Book>()
+                    .OwnsOne(
+                        b => b.AlternateLabel, al =>
+                        {
+                            al.OwnsOne(b => b.AnotherBookLabel)
+                                .OwnsOne(b => b.SpecialBookLabel)
+                                .Ignore(l => l.BookLabel);
+
+                            al.OwnsOne(b => b.SpecialBookLabel)
+                                .OwnsOne(b => b.AnotherBookLabel);
+                        });
+
+                modelBuilder.Entity<Book>().Ignore(b => b.Label);
+
+                modelBuilder.Entity<BookDetails>();
+
+                var model = modelBuilder.FinalizeModel();
+
+                var bookOwnership = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).ForeignKey;
+                Assert.Equal(nameof(BookLabel.Book), bookOwnership.DependentToPrincipal.Name);
+
+                var bookLabelOwnership1 = bookOwnership.DeclaringEntityType.FindNavigation(
+                    nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                var bookLabelOwnership2 = bookOwnership.DeclaringEntityType.FindNavigation(
+                    nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+
+                Assert.Null(bookLabelOwnership1.DependentToPrincipal);
+                Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabelOwnership2.DependentToPrincipal.Name);
+
+                var bookLabel2Ownership1Subownership = bookLabelOwnership1.DeclaringEntityType.FindNavigation(
+                    nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                var bookLabel2Ownership2Subownership = bookLabelOwnership2.DeclaringEntityType.FindNavigation(
+                    nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+
+                Assert.NotNull(bookLabelOwnership1.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
+                Assert.NotNull(bookLabelOwnership2.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
+                Assert.NotNull(bookLabel2Ownership1Subownership.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
+                Assert.NotNull(bookLabel2Ownership2Subownership.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
+                Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel2Ownership1Subownership.DependentToPrincipal.Name);
+                Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel2Ownership2Subownership.DependentToPrincipal.Name);
+
+                Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(BookLabel)));
+                Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(AnotherBookLabel)));
+                Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(SpecialBookLabel)));
+            }
+
+            [ConditionalFact]
             public virtual void Can_configure_self_ownership()
             {
                 var modelBuilder = CreateModelBuilder();
@@ -1309,8 +1398,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(
                     CoreStrings.ClashingNonOwnedEntityType(nameof(CustomerDetails)),
                     Assert.Throws<InvalidOperationException>(
-                        () =>
-                            modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details)).Message);
+                        () => modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details)).Message);
             }
 
             [ConditionalFact]
@@ -1319,7 +1407,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 modelBuilder.Ignore<Customer>();
-                var entityType = modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details).OwnedEntityType;
+                modelBuilder.Entity<SpecialCustomer>().OwnsOne(c => c.Details);
 
                 Assert.Equal(
                     CoreStrings.ClashingOwnedEntityType(nameof(CustomerDetails)),


### PR DESCRIPTION
Allow to reconfigure STETs as regular entity types
Rerun `CosmosDiscriminatorConvention` and `BaseTypeDiscoveryConvention` when ownership changes
Keep `OwnedNavigationBuilder.DependentEntityType` up-to-day

Fixes #24803