### PR TITLE
[release/6.0-preview7] Update dependencies from latest p7 runtime

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.7.21372.16">
+    <Dependency Name="Microsoft.Extensions.Caching.Memory" Version="6.0.0-preview.7.21373.17">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d17b813d431e63dac3db60b03c2afc17881168b8</Sha>
+      <Sha>46b249d7a1b2708ea62319d021fc8e61cb6e02ef</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0-preview.7.21373.17">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -33,9 +33,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>46b249d7a1b2708ea62319d021fc8e61cb6e02ef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="6.0.0-preview.7.21372.16">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="6.0.0-preview.7.21373.17">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d17b813d431e63dac3db60b03c2afc17881168b8</Sha>
+      <Sha>46b249d7a1b2708ea62319d021fc8e61cb6e02ef</Sha>
     </Dependency>
     <Dependency Name="System.Collections.Immutable" Version="6.0.0-preview.7.21373.17">
       <Uri>https://github.com/dotnet/runtime</Uri>


### PR DESCRIPTION
Unpinned dependencies in https://github.com/dotnet/efcore/pull/25324#issuecomment-886525732 need an update to the latest runtime.