### PR TITLE
Fixes around scaffolding collations

### DIFF
--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -111,6 +111,11 @@ namespace Microsoft.EntityFrameworkCore.Design
                 RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema),
                 methodCallCodeFragments);
 
+            GenerateSimpleFluentApiCall(
+                annotations,
+                RelationalAnnotationNames.Collation, nameof(RelationalModelBuilderExtensions.UseCollation),
+                methodCallCodeFragments);
+
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(model, annotations, GenerateFluentApi));
             return methodCallCodeFragments;
         }

--- a/test/EFCore.Relational.Tests/Design/AnnotationCodeGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Design/AnnotationCodeGeneratorTest.cs
@@ -24,6 +24,32 @@ namespace Microsoft.EntityFrameworkCore.Design
             Assert.DoesNotContain(RelationalAnnotationNames.IsTableExcludedFromMigrations, annotations.Keys);
         }
 
+        [ConditionalFact]
+        public void GenerateFluentApi_IModel_works_with_collation()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.UseCollation("foo");
+            var annotations = modelBuilder.Model.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = CreateGenerator().GenerateFluentApiCalls((IModel)modelBuilder.Model, annotations).Single();
+
+            Assert.Equal("UseCollation", result.Method);
+            Assert.Equal("foo", Assert.Single(result.Arguments));
+        }
+
+        [ConditionalFact]
+        public void GenerateFluentApi_IProperty_works_with_collation()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity("Blog", x => x.Property<string>("Name").UseCollation("foo"));
+            var property = modelBuilder.Model.FindEntityType("Blog").FindProperty("Name");
+
+            var annotations = property.GetAnnotations().ToDictionary(a => a.Name, a => a);
+            var result = CreateGenerator().GenerateFluentApiCalls((IProperty)property, annotations).Single();
+
+            Assert.Equal("UseCollation", result.Method);
+            Assert.Equal("foo", Assert.Single(result.Arguments));
+        }
+
         private ModelBuilder CreateModelBuilder()
             => RelationalTestHelpers.Instance.CreateConventionBuilder();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -303,6 +303,17 @@ DROP TABLE [dbo].[Everest];
 DROP TABLE [dbo].[Denali];");
         }
 
+        [ConditionalFact]
+        public void Default_database_collation_is_not_scaffolded()
+        {
+            Test(
+                @"",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel => Assert.Null(dbModel.Collation),
+                @"");
+        }
+
         #endregion
 
         #region FilteringSchemaTable
@@ -2368,7 +2379,10 @@ DROP TABLE PrincipalTable;");
             Action<DatabaseModel> asserter,
             string cleanupSql)
         {
-            Fixture.TestStore.ExecuteNonQuery(createSql);
+            if (!string.IsNullOrEmpty(createSql))
+            {
+                Fixture.TestStore.ExecuteNonQuery(createSql);
+            }
 
             try
             {


### PR DESCRIPTION
* Database-level collation is scaffolded to the Fluent API call, instead of to a raw annotation.
* Don't scaffold database collation when it is identical to the server collation (i.e. is the default).

Fixes #25418
Fixes #25419

Note that we have a test the the database collation isn't scaffolded when it's the default, but no coverage for when it's different, since our DatabaseModelFactoryTest tests don't create new databases. I've manually verified this works.