### PR TITLE
Fixes around namespaces and Fluent API calls

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -982,13 +982,21 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             if (typeQualified)
             {
-                if (instanceIdentifier is null || fragment.MethodInfo is null || fragment.ChainedCall is not null)
+                if (instanceIdentifier is null || fragment.MethodInfo is null)
                 {
                     throw new ArgumentException(DesignStrings.CannotGenerateTypeQualifiedMethodCal);
                 }
 
+                builder.Append(fragment.DeclaringType!);
+
+                if (current.ChainedCall is not null)
+                {
+                    builder
+                        .AppendLine()
+                        .IncrementIndent();
+                }
+
                 builder
-                    .Append(fragment.DeclaringType!)
                     .Append('.')
                     .Append(fragment.Method)
                     .Append('(')
@@ -1001,6 +1009,14 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 }
 
                 builder.Append(')');
+
+                if (current.ChainedCall is null)
+                {
+                    return builder.ToString();
+                }
+
+                builder.AppendLine();
+                current = current.ChainedCall;
             }
             else
             {
@@ -1015,34 +1031,34 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                             .IncrementIndent();
                     }
                 }
+            }
 
-                while (true)
+            while (true)
+            {
+                builder
+                    .Append('.')
+                    .Append(current.Method)
+                    .Append('(');
+
+                for (var i = 0; i < current.Arguments.Count; i++)
                 {
-                    builder
-                        .Append('.')
-                        .Append(current.Method)
-                        .Append('(');
-
-                    for (var i = 0; i < current.Arguments.Count; i++)
+                    if (i != 0)
                     {
-                        if (i != 0)
-                        {
-                            builder.Append(", ");
-                        }
-
-                        Arg(current.Arguments[i]);
+                        builder.Append(", ");
                     }
 
-                    builder.Append(')');
-
-                    if (current.ChainedCall is null)
-                    {
-                        break;
-                    }
-
-                    builder.AppendLine();
-                    current = current.ChainedCall;
+                    Arg(current.Arguments[i]);
                 }
+
+                builder.Append(')');
+
+                if (current.ChainedCall is null)
+                {
+                    break;
+                }
+
+                builder.AppendLine();
+                current = current.ChainedCall;
             }
 
             return builder.ToString();

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -981,21 +981,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             if (typeQualified)
             {
-                if (instanceIdentifier is null || fragment.MethodInfo is null)
+                if (instanceIdentifier is null || fragment.MethodInfo is null || fragment.ChainedCall is not null)
                 {
                     throw new ArgumentException(DesignStrings.CannotGenerateTypeQualifiedMethodCall);
                 }
 
-                builder.Append(fragment.DeclaringType!);
-
-                if (current.ChainedCall is not null)
-                {
-                    builder
-                        .AppendLine()
-                        .IncrementIndent();
-                }
-
                 builder
+                    .Append(fragment.DeclaringType!)
                     .Append('.')
                     .Append(fragment.Method)
                     .Append('(')
@@ -1009,26 +1001,20 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
                 builder.Append(')');
 
-                if (current.ChainedCall is null)
-                {
-                    return builder.ToString();
-                }
-
-                builder.AppendLine();
-                current = current.ChainedCall;
+                return builder.ToString();
             }
-            else
-            {
-                if (instanceIdentifier is not null)
-                {
-                    builder.Append(instanceIdentifier);
 
-                    if (current.ChainedCall is not null)
-                    {
-                        builder
-                            .AppendLine()
-                            .IncrementIndent();
-                    }
+            // Non-type-qualified fragment
+
+            if (instanceIdentifier is not null)
+            {
+                builder.Append(instanceIdentifier);
+
+                if (current.ChainedCall is not null)
+                {
+                    builder
+                        .AppendLine()
+                        .IncrementIndent();
                 }
             }
 

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -976,15 +976,14 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
         private string Fragment(MethodCallCodeFragment fragment, bool typeQualified, string? instanceIdentifier, int indent)
         {
-            IndentedStringBuilder builder = new();
-
+            var builder = new IndentedStringBuilder();
             var current = fragment;
 
             if (typeQualified)
             {
                 if (instanceIdentifier is null || fragment.MethodInfo is null)
                 {
-                    throw new ArgumentException(DesignStrings.CannotGenerateTypeQualifiedMethodCal);
+                    throw new ArgumentException(DesignStrings.CannotGenerateTypeQualifiedMethodCall);
                 }
 
                 builder.Append(fragment.DeclaringType!);
@@ -1005,7 +1004,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 for (var i = 0; i < fragment.Arguments.Count; i++)
                 {
                     builder.Append(", ");
-                    Arg(fragment.Arguments[i]);
+                    Argument(fragment.Arguments[i]);
                 }
 
                 builder.Append(')');
@@ -1047,7 +1046,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                         builder.Append(", ");
                     }
 
-                    Arg(current.Arguments[i]);
+                    Argument(current.Arguments[i]);
                 }
 
                 builder.Append(')');
@@ -1063,7 +1062,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             return builder.ToString();
 
-            void Arg(object? argument)
+            void Argument(object? argument)
             {
                 if (argument is NestedClosureCodeFragment nestedFragment)
                 {

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -18,6 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
     /// </summary>
     public class CSharpSnapshotGenerator : ICSharpSnapshotGenerator
     {
+        private static readonly MethodInfo _hasAnnotationMethodInfo
+            = typeof(ModelBuilder).GetRequiredRuntimeMethod(nameof(ModelBuilder.HasAnnotation), typeof(string), typeof(string));
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="CSharpSnapshotGenerator" /> class.
         /// </summary>
@@ -40,12 +46,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for creating an <see cref="IModel" />.
         /// </summary>
-        /// <param name="builderName"> The <see cref="ModelBuilder" /> variable name. </param>
+        /// <param name="modelBuilderName"> The <see cref="ModelBuilder" /> variable name. </param>
         /// <param name="model"> The model. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
-        public virtual void Generate(string builderName, IModel model, IndentedStringBuilder stringBuilder)
+        public virtual void Generate(string modelBuilderName, IModel model, IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(modelBuilderName, nameof(modelBuilderName));
             Check.NotNull(model, nameof(model));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -53,65 +59,33 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .FilterIgnoredAnnotations(model.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            var productVersion = model.GetProductVersion();
-
-            if (annotations.Count > 0 || productVersion != null)
+            if (model.GetProductVersion() is string productVersion)
             {
-                stringBuilder.Append(builderName);
-
-                using (stringBuilder.Indent())
-                {
-                    // Temporary patch: specifically exclude some annotations which are known to produce identical Fluent API calls across different
-                    // providers, generating them as raw annotations instead.
-                    var ambiguousAnnotations = RemoveAmbiguousFluentApiAnnotations(
-                        annotations,
-                        name => name.EndsWith(":ValueGenerationStrategy", StringComparison.Ordinal)
-                            || name.EndsWith(":IdentityIncrement", StringComparison.Ordinal)
-                            || name.EndsWith(":IdentitySeed", StringComparison.Ordinal)
-                            || name.EndsWith(":HiLoSequenceName", StringComparison.Ordinal)
-                            || name.EndsWith(":HiLoSequenceSchema", StringComparison.Ordinal));
-
-                    foreach (var methodCallCodeFragment in
-                        Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(model, annotations))
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .Append(Code.Fragment(methodCallCodeFragment));
-                    }
-
-                    IEnumerable<IAnnotation> remainingAnnotations = annotations.Values;
-                    if (productVersion != null)
-                    {
-                        remainingAnnotations = remainingAnnotations.Append(
-                            new Annotation(CoreAnnotationNames.ProductVersion, productVersion));
-                    }
-
-                    GenerateAnnotations(remainingAnnotations.Concat(ambiguousAnnotations), stringBuilder);
-                }
-
-                stringBuilder.AppendLine(";");
+                annotations[CoreAnnotationNames.ProductVersion] = new Annotation(CoreAnnotationNames.ProductVersion, productVersion);
             }
+
+            GenerateRemainingAnnotations(modelBuilderName, model, stringBuilder, annotations, inChainedCall: false, leadingNewline: false);
 
             foreach (var sequence in model.GetSequences())
             {
-                GenerateSequence(builderName, sequence, stringBuilder);
+                GenerateSequence(modelBuilderName, sequence, stringBuilder);
             }
 
-            GenerateEntityTypes(builderName, model.GetEntityTypesInHierarchicalOrder(), stringBuilder);
+            GenerateEntityTypes(modelBuilderName, model.GetEntityTypesInHierarchicalOrder(), stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for <see cref="IEntityType" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="modelBuilderName"> The name of the builder variable. </param>
         /// <param name="entityTypes"> The entity types. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateEntityTypes(
-            string builderName,
+            string modelBuilderName,
             IReadOnlyList<IEntityType> entityTypes,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(modelBuilderName, nameof(modelBuilderName));
             Check.NotNull(entityTypes, nameof(entityTypes));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -120,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateEntityType(builderName, entityType, stringBuilder);
+                GenerateEntityType(modelBuilderName, entityType, stringBuilder);
             }
 
             foreach (var entityType in entityTypes.Where(
@@ -130,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateEntityTypeRelationships(builderName, entityType, stringBuilder);
+                GenerateEntityTypeRelationships(modelBuilderName, entityType, stringBuilder);
             }
 
             foreach (var entityType in entityTypes.Where(
@@ -139,22 +113,22 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateEntityTypeNavigations(builderName, entityType, stringBuilder);
+                GenerateEntityTypeNavigations(modelBuilderName, entityType, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an <see cref="IEntityType" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="modelBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateEntityType(
-            string builderName,
+            string modelBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(modelBuilderName, nameof(modelBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -169,8 +143,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 entityTypeName = entityType.ClrType.DisplayName();
             }
 
+            var entityTypeBuilderName = GenerateEntityTypeBuilderName();
+
             stringBuilder
-                .Append(builderName)
+                .Append(modelBuilderName)
                 .Append(
                     ownerNavigation != null
                         ? ownership!.IsUnique ? ".OwnsOne(" : ".OwnsMany("
@@ -184,26 +160,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     .Append(Code.Literal(ownerNavigation));
             }
 
-            if (builderName.StartsWith("b", StringComparison.Ordinal))
-            {
-                // ReSharper disable once InlineOutVariableDeclaration
-                var counter = 1;
-                if (builderName.Length > 1
-                    && int.TryParse(builderName[1..], out counter))
-                {
-                    counter++;
-                }
-
-                builderName = "b" + (counter == 0 ? "" : counter.ToString());
-            }
-            else
-            {
-                builderName = "b";
-            }
-
             stringBuilder
                 .Append(", ")
-                .Append(builderName)
+                .Append(entityTypeBuilderName)
                 .AppendLine(" =>");
 
             using (stringBuilder.Indent())
@@ -212,51 +171,70 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                 using (stringBuilder.Indent())
                 {
-                    GenerateBaseType(builderName, entityType.BaseType, stringBuilder);
+                    GenerateBaseType(entityTypeBuilderName, entityType.BaseType, stringBuilder);
 
-                    GenerateProperties(builderName, entityType.GetDeclaredProperties(), stringBuilder);
+                    GenerateProperties(entityTypeBuilderName, entityType.GetDeclaredProperties(), stringBuilder);
 
                     GenerateKeys(
-                        builderName,
+                        entityTypeBuilderName,
                         entityType.GetDeclaredKeys(),
                         entityType.BaseType == null ? entityType.FindPrimaryKey() : null,
                         stringBuilder);
 
-                    GenerateIndexes(builderName, entityType.GetDeclaredIndexes(), stringBuilder);
+                    GenerateIndexes(entityTypeBuilderName, entityType.GetDeclaredIndexes(), stringBuilder);
 
-                    GenerateEntityTypeAnnotations(builderName, entityType, stringBuilder);
+                    GenerateEntityTypeAnnotations(entityTypeBuilderName, entityType, stringBuilder);
 
-                    GenerateCheckConstraints(builderName, entityType, stringBuilder);
+                    GenerateCheckConstraints(entityTypeBuilderName, entityType, stringBuilder);
 
                     if (ownerNavigation != null)
                     {
-                        GenerateRelationships(builderName, entityType, stringBuilder);
+                        GenerateRelationships(entityTypeBuilderName, entityType, stringBuilder);
 
                         GenerateNavigations(
-                            builderName, entityType.GetDeclaredNavigations()
+                            entityTypeBuilderName, entityType.GetDeclaredNavigations()
                                 .Where(n => !n.IsOnDependent && !n.ForeignKey.IsOwnership), stringBuilder);
                     }
 
-                    GenerateData(builderName, entityType.GetProperties(), entityType.GetSeedData(providerValues: true), stringBuilder);
+                    GenerateData(
+                        entityTypeBuilderName, entityType.GetProperties(), entityType.GetSeedData(providerValues: true), stringBuilder);
                 }
 
                 stringBuilder
                     .AppendLine("});");
+            }
+
+            string GenerateEntityTypeBuilderName()
+            {
+                if (modelBuilderName.StartsWith("b", StringComparison.Ordinal))
+                {
+                    // ReSharper disable once InlineOutVariableDeclaration
+                    var counter = 1;
+                    if (modelBuilderName.Length > 1
+                        && int.TryParse(modelBuilderName[1..], out counter))
+                    {
+                        counter++;
+                    }
+
+                    return "b" + (counter == 0 ? "" : counter.ToString());
+                }
+
+                return "b";
             }
         }
 
         /// <summary>
         ///     Generates code for owned entity types.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="ownerships"> The foreign keys identifying each entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateOwnedTypes(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IForeignKey> ownerships,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(ownerships, nameof(ownerships));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -264,45 +242,45 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateOwnedType(builderName, ownership, stringBuilder);
+                GenerateOwnedType(entityTypeBuilderName, ownership, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an owned entity types.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="ownership"> The foreign key identifying the entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateOwnedType(
-            string builderName,
+            string entityTypeBuilderName,
             IForeignKey ownership,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(ownership, nameof(ownership));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
-            GenerateEntityType(builderName, ownership.DeclaringEntityType, stringBuilder);
+            GenerateEntityType(entityTypeBuilderName, ownership.DeclaringEntityType, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the relationships of an <see cref="IEntityType" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="modelBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateEntityTypeRelationships(
-            string builderName,
+            string modelBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(modelBuilderName, nameof(modelBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             stringBuilder
-                .Append(builderName)
+                .Append(modelBuilderName)
                 .Append(".Entity(")
                 .Append(Code.Literal(entityType.Name))
                 .AppendLine(", b =>");
@@ -323,46 +301,46 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for the relationships of an <see cref="IEntityType" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateRelationships(
-            string builderName,
+            string entityTypeBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
-            GenerateForeignKeys(builderName, entityType.GetDeclaredForeignKeys(), stringBuilder);
+            GenerateForeignKeys(entityTypeBuilderName, entityType.GetDeclaredForeignKeys(), stringBuilder);
 
-            GenerateOwnedTypes(builderName, entityType.GetDeclaredReferencingForeignKeys().Where(fk => fk.IsOwnership), stringBuilder);
+            GenerateOwnedTypes(entityTypeBuilderName, entityType.GetDeclaredReferencingForeignKeys().Where(fk => fk.IsOwnership), stringBuilder);
 
             GenerateNavigations(
-                builderName, entityType.GetDeclaredNavigations()
+                entityTypeBuilderName, entityType.GetDeclaredNavigations()
                     .Where(n => n.IsOnDependent || (!n.IsOnDependent && n.ForeignKey.IsOwnership)), stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the base type of an <see cref="IEntityType" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="baseType"> The base entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateBaseType(
-            string builderName,
+            string entityTypeBuilderName,
             IEntityType? baseType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             if (baseType != null)
             {
                 stringBuilder
                     .AppendLine()
-                    .Append(builderName)
+                    .Append(entityTypeBuilderName)
                     .Append(".HasBaseType(")
                     .Append(Code.Literal(baseType.Name))
                     .AppendLine(");");
@@ -372,17 +350,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for an <see cref="ISequence" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="modelBuilderName"> The name of the builder variable. </param>
         /// <param name="sequence"> The sequence. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateSequence(
-            string builderName,
+            string modelBuilderName,
             ISequence sequence,
             IndentedStringBuilder stringBuilder)
         {
             stringBuilder
                 .AppendLine()
-                .Append(builderName)
+                .Append(modelBuilderName)
                 .Append(".HasSequence");
 
             if (sequence.Type != Sequence.DefaultClrType)
@@ -459,94 +437,93 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for <see cref="IProperty" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="properties"> The properties. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateProperties(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IProperty> properties,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(properties, nameof(properties));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             foreach (var property in properties)
             {
-                GenerateProperty(builderName, property, stringBuilder);
+                GenerateProperty(entityTypeBuilderName, property, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an <see cref="IProperty" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="property"> The property. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateProperty(
-            string builderName,
+            string entityTypeBuilderName,
             IProperty property,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(property, nameof(property));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             var clrType = FindValueConverter(property)?.ProviderClrType.MakeNullable(property.IsNullable)
                 ?? property.ClrType;
 
+            var propertyBuilderName = $"{entityTypeBuilderName}.Property<{Code.Reference(clrType)}>({Code.Literal(property.Name)})";
+
             stringBuilder
                 .AppendLine()
-                .Append(builderName)
-                .Append(".Property<")
-                .Append(Code.Reference(clrType))
-                .Append(">(")
-                .Append(Code.Literal(property.Name))
-                .Append(")");
+                .Append(propertyBuilderName);
 
-            using (stringBuilder.Indent())
+            stringBuilder.IncrementIndent();
+
+            if (property.IsConcurrencyToken)
             {
-                if (property.IsConcurrencyToken)
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".IsConcurrencyToken()");
-                }
-
-                if (property.IsNullable != (clrType.IsNullableType() && !property.IsPrimaryKey()))
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".IsRequired()");
-                }
-
-                if (property.ValueGenerated != ValueGenerated.Never)
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(
-                            property.ValueGenerated == ValueGenerated.OnAdd
-                                ? ".ValueGeneratedOnAdd()"
-                                : property.ValueGenerated == ValueGenerated.OnUpdate
-                                    ? ".ValueGeneratedOnUpdate()"
-                                    : property.ValueGenerated == ValueGenerated.OnUpdateSometimes
-                                        ? ".ValueGeneratedOnUpdateSometimes()"
-                                        : ".ValueGeneratedOnAddOrUpdate()");
-                }
-
-                GeneratePropertyAnnotations(property, stringBuilder);
+                stringBuilder
+                    .AppendLine()
+                    .Append(".IsConcurrencyToken()");
             }
 
-            stringBuilder.AppendLine(";");
+            if (property.IsNullable != (clrType.IsNullableType() && !property.IsPrimaryKey()))
+            {
+                stringBuilder
+                    .AppendLine()
+                    .Append(".IsRequired()");
+            }
+
+            if (property.ValueGenerated != ValueGenerated.Never)
+            {
+                stringBuilder
+                    .AppendLine()
+                    .Append(
+                        property.ValueGenerated == ValueGenerated.OnAdd
+                            ? ".ValueGeneratedOnAdd()"
+                            : property.ValueGenerated == ValueGenerated.OnUpdate
+                                ? ".ValueGeneratedOnUpdate()"
+                                : property.ValueGenerated == ValueGenerated.OnUpdateSometimes
+                                    ? ".ValueGeneratedOnUpdateSometimes()"
+                                    : ".ValueGeneratedOnAddOrUpdate()");
+            }
+
+            GeneratePropertyAnnotations(propertyBuilderName, property, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the annotations on an <see cref="IProperty" />.
         /// </summary>
+        /// <param name="propertyBuilderName"> The name of the builder variable. </param>
         /// <param name="property"> The property. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
-        protected virtual void GeneratePropertyAnnotations(IProperty property, IndentedStringBuilder stringBuilder)
+        protected virtual void GeneratePropertyAnnotations(
+            string propertyBuilderName,
+            IProperty property,
+            IndentedStringBuilder stringBuilder)
         {
+            Check.NotNull(propertyBuilderName, nameof(propertyBuilderName));
             Check.NotNull(property, nameof(property));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -573,25 +550,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             GenerateFluentApiForDefaultValue(property, stringBuilder);
             annotations.Remove(RelationalAnnotationNames.DefaultValue);
 
-            // Temporary patch: specifically exclude some annotations which are known to produce identical Fluent API calls across different
-            // providers, generating them as raw annotations instead.
-            var ambiguousAnnotations = RemoveAmbiguousFluentApiAnnotations(
-                annotations,
-                name => name.EndsWith(":ValueGenerationStrategy", StringComparison.Ordinal)
-                    || name.EndsWith(":IdentityIncrement", StringComparison.Ordinal)
-                    || name.EndsWith(":IdentitySeed", StringComparison.Ordinal)
-                    || name.EndsWith(":HiLoSequenceName", StringComparison.Ordinal)
-                    || name.EndsWith(":HiLoSequenceSchema", StringComparison.Ordinal));
-
-            foreach (var methodCallCodeFragment in
-                Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(property, annotations))
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(Code.Fragment(methodCallCodeFragment));
-            }
-
-            GenerateAnnotations(annotations.Values.Concat(ambiguousAnnotations), stringBuilder);
+            GenerateRemainingAnnotations(propertyBuilderName, property, stringBuilder, annotations, inChainedCall: true);
         }
 
         private ValueConverter? FindValueConverter(IProperty property)
@@ -602,23 +561,23 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for <see cref="IKey" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="keys"> The keys. </param>
         /// <param name="primaryKey"> The primary key. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateKeys(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IKey> keys,
             IKey? primaryKey,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(keys, nameof(keys));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             if (primaryKey != null)
             {
-                GenerateKey(builderName, primaryKey, stringBuilder, primary: true);
+                GenerateKey(entityTypeBuilderName, primaryKey, stringBuilder, primary: true);
             }
 
             if (primaryKey?.DeclaringEntityType.IsOwned() != true)
@@ -628,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         && (!key.GetReferencingForeignKeys().Any()
                             || key.GetAnnotations().Any(a => a.Name != RelationalAnnotationNames.UniqueConstraintMappings))))
                 {
-                    GenerateKey(builderName, key, stringBuilder);
+                    GenerateKey(entityTypeBuilderName, key, stringBuilder);
                 }
             }
         }
@@ -636,173 +595,147 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for an <see cref="IKey" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="key"> The key. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         /// <param name="primary">A value indicating whether the key is primary. </param>
         protected virtual void GenerateKey(
-            string builderName,
+            string entityTypeBuilderName,
             IKey key,
             IndentedStringBuilder stringBuilder,
             bool primary = false)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(key, nameof(key));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             stringBuilder
                 .AppendLine()
-                .Append(builderName)
+                .Append(entityTypeBuilderName)
                 .Append(primary ? ".HasKey(" : ".HasAlternateKey(")
                 .Append(string.Join(", ", key.Properties.Select(p => Code.Literal(p.Name))))
                 .Append(")");
 
-            using (stringBuilder.Indent())
-            {
-                GenerateKeyAnnotations(key, stringBuilder);
-            }
+            stringBuilder.IncrementIndent();
 
-            stringBuilder.AppendLine(";");
+            GenerateKeyAnnotations(entityTypeBuilderName, key, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the annotations on a key.
         /// </summary>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="key"> The key. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
-        protected virtual void GenerateKeyAnnotations(IKey key, IndentedStringBuilder stringBuilder)
+        protected virtual void GenerateKeyAnnotations(string entityTypeBuilderName, IKey key, IndentedStringBuilder stringBuilder)
         {
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
+            Check.NotNull(key, nameof(key));
+            Check.NotNull(stringBuilder, nameof(stringBuilder));
+
             var annotations = Dependencies.AnnotationCodeGenerator
                 .FilterIgnoredAnnotations(key.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            foreach (var methodCallCodeFragment in
-                Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(key, annotations))
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(Code.Fragment(methodCallCodeFragment));
-            }
-
-            GenerateAnnotations(annotations.Values, stringBuilder);
+            GenerateRemainingAnnotations(entityTypeBuilderName, key, stringBuilder, annotations, inChainedCall: true);
         }
 
         /// <summary>
         ///     Generates code for <see cref="IIndex" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="indexes"> The indexes. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateIndexes(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IIndex> indexes,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(indexes, nameof(indexes));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             foreach (var index in indexes)
             {
-                GenerateIndex(builderName, index, stringBuilder);
+                GenerateIndex(entityTypeBuilderName, index, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code an <see cref="IIndex" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="index"> The index. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateIndex(
-            string builderName,
+            string entityTypeBuilderName,
             IIndex index,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(index, nameof(index));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             // Note - method names below are meant to be hard-coded
             // because old snapshot files will fail if they are changed
+
+            var indexProperties = string.Join(", ", index.Properties.Select(p => Code.Literal(p.Name)));
+            var indexBuilderName = $"{entityTypeBuilderName}.HasIndex("
+                + (index.Name is null
+                    ? indexProperties
+                    : $"new[] {{ {indexProperties} }}, {Code.Literal(index.Name)}")
+                + ")";
+
             stringBuilder
                 .AppendLine()
-                .Append(builderName)
-                .Append(".HasIndex(");
+                .Append(indexBuilderName);
 
-            if (index.Name == null)
+            stringBuilder.IncrementIndent();
+
+            if (index.IsUnique)
             {
                 stringBuilder
-                    .Append(string.Join(", ", index.Properties.Select(p => Code.Literal(p.Name))));
-            }
-            else
-            {
-                stringBuilder
-                    .Append("new[] { ")
-                    .Append(string.Join(", ", index.Properties.Select(p => Code.Literal(p.Name))))
-                    .Append(" }, ")
-                    .Append(Code.Literal(index.Name));
+                    .AppendLine()
+                    .Append(".IsUnique()");
             }
 
-            stringBuilder.Append(")");
-
-            using (stringBuilder.Indent())
-            {
-                if (index.IsUnique)
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".IsUnique()");
-                }
-
-                GenerateIndexAnnotations(index, stringBuilder);
-            }
-
-            stringBuilder.AppendLine(";");
+            GenerateIndexAnnotations(indexBuilderName, index, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the annotations on an index.
         /// </summary>
+        /// <param name="indexBuilderName"> The name of the builder variable. </param>
         /// <param name="index"> The index. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateIndexAnnotations(
+            string indexBuilderName,
             IIndex index,
             IndentedStringBuilder stringBuilder)
         {
+            Check.NotNull(indexBuilderName, nameof(indexBuilderName));
+            Check.NotNull(index, nameof(index));
+            Check.NotNull(stringBuilder, nameof(stringBuilder));
+
             var annotations = Dependencies.AnnotationCodeGenerator
                 .FilterIgnoredAnnotations(index.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            // Temporary patch: specifically exclude some annotations which are known to produce identical Fluent API calls across different
-            // providers, generating them as raw annotations instead.
-            var ambiguousAnnotations = RemoveAmbiguousFluentApiAnnotations(
-                annotations,
-                name => name.EndsWith(":Include", StringComparison.Ordinal));
-
-            foreach (var methodCallCodeFragment in
-                Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(index, annotations))
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(Code.Fragment(methodCallCodeFragment));
-            }
-
-            GenerateAnnotations(annotations.Values.Concat(ambiguousAnnotations), stringBuilder);
+            GenerateRemainingAnnotations(indexBuilderName, index, stringBuilder, annotations, inChainedCall: true);
         }
 
         /// <summary>
         ///     Generates code for the annotations on an entity type.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateEntityTypeAnnotations(
-            string builderName,
+            string entityTypeBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -828,7 +761,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     var schemaAnnotation = annotations.Find(RelationalAnnotationNames.Schema);
                     stringBuilder
                         .AppendLine()
-                        .Append(builderName)
+                        .Append(entityTypeBuilderName)
                         .Append(".ToTable(");
 
                     if (tableName == null
@@ -886,7 +819,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 {
                     stringBuilder
                         .AppendLine()
-                        .Append(builderName)
+                        .Append(entityTypeBuilderName)
                         .Append(".ToView(")
                         .Append(Code.UnknownLiteral(viewName));
                     if (viewNameAnnotation != null)
@@ -919,7 +852,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 {
                     stringBuilder
                         .AppendLine()
-                        .Append(builderName)
+                        .Append(entityTypeBuilderName)
                         .Append(".ToFunction(")
                         .Append(Code.UnknownLiteral(functionName))
                         .AppendLine(");");
@@ -940,7 +873,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 {
                     stringBuilder
                         .AppendLine()
-                        .Append(builderName)
+                        .Append(entityTypeBuilderName)
                         .Append(".ToSqlQuery(")
                         .Append(Code.UnknownLiteral(sqlQuery))
                         .AppendLine(");");
@@ -958,7 +891,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder
                     .AppendLine()
-                    .Append(builderName)
+                    .Append(entityTypeBuilderName)
                     .Append(".")
                     .Append("HasDiscriminator");
 
@@ -1017,42 +950,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 stringBuilder.AppendLine(";");
             }
 
-            var fluentApiCalls = Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(entityType, annotations);
-            if (fluentApiCalls.Count > 0 || annotations.Count > 0)
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(builderName);
-
-                using (stringBuilder.Indent())
-                {
-                    foreach (var methodCallCodeFragment in fluentApiCalls)
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .AppendLines(Code.Fragment(methodCallCodeFragment), skipFinalNewline: true);
-                    }
-
-                    GenerateAnnotations(annotations.Values, stringBuilder);
-
-                    stringBuilder
-                        .AppendLine(";");
-                }
-            }
+            GenerateRemainingAnnotations(entityTypeBuilderName, entityType, stringBuilder, annotations, inChainedCall: false);
         }
 
         /// <summary>
         ///     Generates code for <see cref="ICheckConstraint" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateCheckConstraints(
-            string builderName,
+            string entityTypeBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -1062,27 +974,27 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateCheckConstraint(builderName, checkConstraint, stringBuilder);
+                GenerateCheckConstraint(entityTypeBuilderName, checkConstraint, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an <see cref="ICheckConstraint" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="checkConstraint"> The check constraint. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateCheckConstraint(
-            string builderName,
+            string entityTypeBuilderName,
             ICheckConstraint checkConstraint,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(checkConstraint, nameof(checkConstraint));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             stringBuilder
-                .Append(builderName)
+                .Append(entityTypeBuilderName)
                 .Append(".HasCheckConstraint(")
                 .Append(Code.Literal(checkConstraint.ModelName))
                 .Append(", ")
@@ -1102,15 +1014,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for <see cref="IForeignKey" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="foreignKeys"> The foreign keys. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateForeignKeys(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IForeignKey> foreignKeys,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(foreignKeys, nameof(foreignKeys));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -1118,29 +1030,29 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateForeignKey(builderName, foreignKey, stringBuilder);
+                GenerateForeignKey(entityTypeBuilderName, foreignKey, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an <see cref="IForeignKey" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="foreignKey"> The foreign key. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateForeignKey(
-            string builderName,
+            string entityTypeBuilderName,
             IForeignKey foreignKey,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             if (!foreignKey.IsOwnership)
             {
                 stringBuilder
-                    .Append(builderName)
+                    .Append(entityTypeBuilderName)
                     .Append(".HasOne(")
                     .Append(Code.Literal(foreignKey.PrincipalEntityType.Name))
                     .Append(", ")
@@ -1152,7 +1064,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             else
             {
                 stringBuilder
-                    .Append(builderName)
+                    .Append(entityTypeBuilderName)
                     .Append(".WithOwner(");
 
                 if (foreignKey.DependentToPrincipal != null)
@@ -1166,13 +1078,45 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .Append(")")
                 .AppendLine();
 
-            using (stringBuilder.Indent())
+            stringBuilder.IncrementIndent();
+
+            if (foreignKey.IsUnique
+                && !foreignKey.IsOwnership)
             {
-                if (foreignKey.IsUnique
-                    && !foreignKey.IsOwnership)
+                stringBuilder
+                    .Append(".WithOne(");
+
+                if (foreignKey.PrincipalToDependent != null)
                 {
                     stringBuilder
-                        .Append(".WithOne(");
+                        .Append(Code.Literal(foreignKey.PrincipalToDependent.Name));
+                }
+
+                stringBuilder
+                    .AppendLine(")")
+                    .Append(".HasForeignKey(")
+                    .Append(Code.Literal(foreignKey.DeclaringEntityType.Name))
+                    .Append(", ")
+                    .Append(string.Join(", ", foreignKey.Properties.Select(p => Code.Literal(p.Name))))
+                    .Append(")");
+
+                if (foreignKey.PrincipalKey != foreignKey.PrincipalEntityType.FindPrimaryKey())
+                {
+                    stringBuilder
+                        .AppendLine()
+                        .Append(".HasPrincipalKey(")
+                        .Append(Code.Literal(foreignKey.PrincipalEntityType.Name))
+                        .Append(", ")
+                        .Append(string.Join(", ", foreignKey.PrincipalKey.Properties.Select(p => Code.Literal(p.Name))))
+                        .Append(")");
+                }
+            }
+            else
+            {
+                if (!foreignKey.IsOwnership)
+                {
+                    stringBuilder
+                        .Append(".WithMany(");
 
                     if (foreignKey.PrincipalToDependent != null)
                     {
@@ -1181,92 +1125,58 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     }
 
                     stringBuilder
-                        .AppendLine(")")
-                        .Append(".HasForeignKey(")
-                        .Append(Code.Literal(foreignKey.DeclaringEntityType.Name))
-                        .Append(", ")
-                        .Append(string.Join(", ", foreignKey.Properties.Select(p => Code.Literal(p.Name))))
-                        .Append(")");
-
-                    GenerateForeignKeyAnnotations(foreignKey, stringBuilder);
-
-                    if (foreignKey.PrincipalKey != foreignKey.PrincipalEntityType.FindPrimaryKey())
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .Append(".HasPrincipalKey(")
-                            .Append(Code.Literal(foreignKey.PrincipalEntityType.Name))
-                            .Append(", ")
-                            .Append(string.Join(", ", foreignKey.PrincipalKey.Properties.Select(p => Code.Literal(p.Name))))
-                            .Append(")");
-                    }
+                        .AppendLine(")");
                 }
-                else
+
+                stringBuilder
+                    .Append(".HasForeignKey(")
+                    .Append(string.Join(", ", foreignKey.Properties.Select(p => Code.Literal(p.Name))))
+                    .Append(")");
+
+                if (foreignKey.PrincipalKey != foreignKey.PrincipalEntityType.FindPrimaryKey())
                 {
-                    if (!foreignKey.IsOwnership)
-                    {
-                        stringBuilder
-                            .Append(".WithMany(");
-
-                        if (foreignKey.PrincipalToDependent != null)
-                        {
-                            stringBuilder
-                                .Append(Code.Literal(foreignKey.PrincipalToDependent.Name));
-                        }
-
-                        stringBuilder
-                            .AppendLine(")");
-                    }
-
                     stringBuilder
-                        .Append(".HasForeignKey(")
-                        .Append(string.Join(", ", foreignKey.Properties.Select(p => Code.Literal(p.Name))))
+                        .AppendLine()
+                        .Append(".HasPrincipalKey(")
+                        .Append(string.Join(", ", foreignKey.PrincipalKey.Properties.Select(p => Code.Literal(p.Name))))
                         .Append(")");
-
-                    GenerateForeignKeyAnnotations(foreignKey, stringBuilder);
-
-                    if (foreignKey.PrincipalKey != foreignKey.PrincipalEntityType.FindPrimaryKey())
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .Append(".HasPrincipalKey(")
-                            .Append(string.Join(", ", foreignKey.PrincipalKey.Properties.Select(p => Code.Literal(p.Name))))
-                            .Append(")");
-                    }
-                }
-
-                if (!foreignKey.IsOwnership)
-                {
-                    if (foreignKey.DeleteBehavior != DeleteBehavior.ClientSetNull)
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .Append(".OnDelete(")
-                            .Append(Code.Literal(foreignKey.DeleteBehavior))
-                            .Append(")");
-                    }
-
-                    if (foreignKey.IsRequired)
-                    {
-                        stringBuilder
-                            .AppendLine()
-                            .Append(".IsRequired()");
-                    }
                 }
             }
 
-            stringBuilder.AppendLine(";");
+            if (!foreignKey.IsOwnership)
+            {
+                if (foreignKey.DeleteBehavior != DeleteBehavior.ClientSetNull)
+                {
+                    stringBuilder
+                        .AppendLine()
+                        .Append(".OnDelete(")
+                        .Append(Code.Literal(foreignKey.DeleteBehavior))
+                        .Append(")");
+                }
+
+                if (foreignKey.IsRequired)
+                {
+                    stringBuilder
+                        .AppendLine()
+                        .Append(".IsRequired()");
+                }
+            }
+
+            GenerateForeignKeyAnnotations(entityTypeBuilderName, foreignKey, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the annotations on a foreign key.
         /// </summary>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="foreignKey"> The foreign key. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateForeignKeyAnnotations(
+            string entityTypeBuilderName,
             IForeignKey foreignKey,
             IndentedStringBuilder stringBuilder)
         {
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -1274,34 +1184,26 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .FilterIgnoredAnnotations(foreignKey.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            foreach (var methodCallCodeFragment in
-                Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(foreignKey, annotations))
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(Code.Fragment(methodCallCodeFragment));
-            }
-
-            GenerateAnnotations(annotations.Values, stringBuilder);
+            GenerateRemainingAnnotations(entityTypeBuilderName, foreignKey, stringBuilder, annotations, inChainedCall: true);
         }
 
         /// <summary>
         ///     Generates code for the navigations of an <see cref="IEntityType" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="modelBuilderName"> The name of the builder variable. </param>
         /// <param name="entityType"> The entity type. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateEntityTypeNavigations(
-            string builderName,
+            string modelBuilderName,
             IEntityType entityType,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotEmpty(builderName, nameof(builderName));
+            Check.NotEmpty(modelBuilderName, nameof(modelBuilderName));
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             stringBuilder
-                .Append(builderName)
+                .Append(modelBuilderName)
                 .Append(".Entity(")
                 .Append(Code.Literal(entityType.Name))
                 .AppendLine(", b =>");
@@ -1324,15 +1226,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for <see cref="INavigation" /> objects.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="navigations"> The navigations. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateNavigations(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<INavigation> navigations,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(navigations, nameof(navigations));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -1340,57 +1242,57 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 stringBuilder.AppendLine();
 
-                GenerateNavigation(builderName, navigation, stringBuilder);
+                GenerateNavigation(entityTypeBuilderName, navigation, stringBuilder);
             }
         }
 
         /// <summary>
         ///     Generates code for an <see cref="INavigation" />.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="navigation"> The navigation. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateNavigation(
-            string builderName,
+            string entityTypeBuilderName,
             INavigation navigation,
             IndentedStringBuilder stringBuilder)
         {
-            Check.NotNull(builderName, nameof(builderName));
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(navigation, nameof(navigation));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
             stringBuilder
-                .Append(builderName)
+                .Append(entityTypeBuilderName)
                 .Append(".Navigation(")
                 .Append(Code.Literal(navigation.Name))
                 .Append(")");
 
-            using (stringBuilder.Indent())
-            {
-                if (!navigation.IsOnDependent
-                    && !navigation.IsCollection
-                    && navigation.ForeignKey.IsRequiredDependent)
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".IsRequired()");
-                }
+            stringBuilder.IncrementIndent();
 
-                GenerateNavigationAnnotations(navigation, stringBuilder);
+            if (!navigation.IsOnDependent
+                && !navigation.IsCollection
+                && navigation.ForeignKey.IsRequiredDependent)
+            {
+                stringBuilder
+                    .AppendLine()
+                    .Append(".IsRequired()");
             }
 
-            stringBuilder.AppendLine(";");
+            GenerateNavigationAnnotations(entityTypeBuilderName, navigation, stringBuilder);
         }
 
         /// <summary>
         ///     Generates code for the annotations on a navigation.
         /// </summary>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="navigation"> The navigation. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateNavigationAnnotations(
+            string entityTypeBuilderName,
             INavigation navigation,
             IndentedStringBuilder stringBuilder)
         {
+            Check.NotNull(entityTypeBuilderName, nameof(entityTypeBuilderName));
             Check.NotNull(navigation, nameof(navigation));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
@@ -1398,15 +1300,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .FilterIgnoredAnnotations(navigation.GetAnnotations())
                 .ToDictionary(a => a.Name, a => a);
 
-            foreach (var methodCallCodeFragment in
-                Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(navigation, annotations))
-            {
-                stringBuilder
-                    .AppendLine()
-                    .Append(Code.Fragment(methodCallCodeFragment));
-            }
-
-            GenerateAnnotations(annotations.Values, stringBuilder);
+            GenerateRemainingAnnotations(entityTypeBuilderName, navigation, stringBuilder, annotations, inChainedCall: true);
         }
 
         /// <summary>
@@ -1421,7 +1315,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Check.NotNull(annotations, nameof(annotations));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
-            foreach (var annotation in annotations)
+            foreach (var annotation in annotations.OrderBy(a => a.Name))
             {
                 stringBuilder.AppendLine();
                 GenerateAnnotation(annotation, stringBuilder);
@@ -1451,12 +1345,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for data seeding.
         /// </summary>
-        /// <param name="builderName"> The name of the builder variable. </param>
+        /// <param name="entityTypeBuilderName"> The name of the builder variable. </param>
         /// <param name="properties"> The properties to generate. </param>
         /// <param name="data"> The data to be seeded. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateData(
-            string builderName,
+            string entityTypeBuilderName,
             IEnumerable<IProperty> properties,
             IEnumerable<IDictionary<string, object?>> data,
             IndentedStringBuilder stringBuilder)
@@ -1475,7 +1369,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             stringBuilder
                 .AppendLine()
-                .Append(builderName)
+                .Append(entityTypeBuilderName)
                 .Append(".")
                 .Append(nameof(EntityTypeBuilder.HasData))
                 .AppendLine("(");
@@ -1621,23 +1515,86 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 .Append(")");
         }
 
-        private static IReadOnlyList<IAnnotation> RemoveAmbiguousFluentApiAnnotations(
+        private void GenerateRemainingAnnotations(
+            string builderName,
+            IAnnotatable annotatable,
+            IndentedStringBuilder stringBuilder,
             Dictionary<string, IAnnotation> annotations,
-            Func<string, bool> annotationNameMatcher)
+            bool inChainedCall,
+            bool leadingNewline = true)
         {
-            List<IAnnotation>? ambiguousAnnotations = null;
+            var fluentApiCalls = Dependencies.AnnotationCodeGenerator.GenerateFluentApiCalls(annotatable, annotations);
 
-            foreach (var (name, annotation) in annotations)
+            MethodCallCodeFragment? chainedCall = null;
+            var typeQualifiedCalls = new List<MethodCallCodeFragment>();
+
+            // Chain together all Fluent API calls which we can, and leave the others to be generated as type-qualified
+            foreach (var call in fluentApiCalls)
             {
-                if (annotationNameMatcher(name))
+                if (call.MethodInfo is not null
+                    && call.MethodInfo.IsStatic
+                    && (call.MethodInfo.DeclaringType is null
+                        || call.MethodInfo.DeclaringType.Assembly != typeof(RelationalModelBuilderExtensions).Assembly))
                 {
-                    annotations.Remove(name);
-                    ambiguousAnnotations ??= new List<IAnnotation>();
-                    ambiguousAnnotations.Add(annotation);
+                    typeQualifiedCalls.Add(call);
+                }
+                else
+                {
+                    chainedCall = chainedCall is null ? call : chainedCall.Chain(call);
                 }
             }
 
-            return (IReadOnlyList<IAnnotation>?)ambiguousAnnotations ?? ImmutableList<IAnnotation>.Empty;
+            // Append remaining raw annotations which did not get generated as Fluent API calls
+            foreach (var annotation in annotations.Values.OrderBy(a => a.Name))
+            {
+                // var call = new MethodCallCodeFragment("HasAnnotation", annotation.Name, annotation.Value);
+                var call = new MethodCallCodeFragment(_hasAnnotationMethodInfo, annotation.Name, annotation.Value);
+                chainedCall = chainedCall is null ? call : chainedCall.Chain(call);
+            }
+
+            // First generate single Fluent API call chain
+            if (chainedCall is not null)
+            {
+                if (inChainedCall)
+                {
+                    stringBuilder
+                        .AppendLine()
+                        .AppendLines(Code.Fragment(chainedCall), skipFinalNewline: true);
+                }
+                else
+                {
+                    if (leadingNewline)
+                    {
+                        stringBuilder.AppendLine();
+                    }
+
+                    stringBuilder.AppendLines(Code.Fragment(chainedCall, builderName), skipFinalNewline: true);
+                    stringBuilder.AppendLine(";");
+                }
+
+                leadingNewline = true;
+            }
+
+            if (inChainedCall)
+            {
+                stringBuilder.AppendLine(";");
+                stringBuilder.DecrementIndent();
+            }
+
+            // Then generate separate fully-qualified calls
+            if (typeQualifiedCalls.Count > 0)
+            {
+                if (leadingNewline)
+                {
+                    stringBuilder.AppendLine();
+                }
+
+                foreach (var call in typeQualifiedCalls)
+                {
+                    stringBuilder.Append(Code.Fragment(call, builderName, typeQualified: true));
+                    stringBuilder.AppendLine(";");
+                }
+            }
         }
     }
 }

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 columnName, dateType);
 
         /// <summary>
-        ///     A type-qualified method call requires an instance identifier and a MethodInfo.
+        ///     A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.
         /// </summary>
         public static string CannotGenerateTypeQualifiedMethodCall
             => GetString("CannotGenerateTypeQualifiedMethodCall");

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -64,6 +64,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 columnName, dateType);
 
         /// <summary>
+        ///     A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.
+        /// </summary>
+        public static string CannotGenerateTypeQualifiedMethodCal
+            => GetString("CannotGenerateTypeQualifiedMethodCall");
+
+        /// <summary>
         ///     The entity type '{entityType}' has a custom constructor binding. This is usually caused by using proxies. Compiled model can't be generated, because dynamic proxy types are not supported. If you are not using proxies configure the custom constructor binding in '{customize}' in a partial '{className}' class instead.
         /// </summary>
         public static string CompiledModelConstructorBinding(object? entityType, object? customize, object? className)

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 columnName, dateType);
 
         /// <summary>
-        ///     A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.
+        ///     A type-qualified method call requires an instance identifier and a MethodInfo.
         /// </summary>
         public static string CannotGenerateTypeQualifiedMethodCal
             => GetString("CannotGenerateTypeQualifiedMethodCall");

--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// <summary>
         ///     A type-qualified method call requires an instance identifier and a MethodInfo.
         /// </summary>
-        public static string CannotGenerateTypeQualifiedMethodCal
+        public static string CannotGenerateTypeQualifiedMethodCall
             => GetString("CannotGenerateTypeQualifiedMethodCall");
 
         /// <summary>
@@ -777,4 +777,3 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
     }
 }
-

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -136,7 +136,7 @@
     <value>Could not find type mapping for column '{columnName}' with data type '{dateType}'. Skipping column.</value>
   </data>
   <data name="CannotGenerateTypeQualifiedMethodCall" xml:space="preserve">
-    <value>A type-qualified method call requires an instance identifier and a MethodInfo.</value>
+    <value>A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.</value>
   </data>
   <data name="CompiledModelConstructorBinding" xml:space="preserve">
     <value>The entity type '{entityType}' has a custom constructor binding. This is usually caused by using proxies. Compiled model can't be generated, because dynamic proxy types are not supported. If you are not using proxies configure the custom constructor binding in '{customize}' in a partial '{className}' class instead.</value>

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -136,7 +136,7 @@
     <value>Could not find type mapping for column '{columnName}' with data type '{dateType}'. Skipping column.</value>
   </data>
   <data name="CannotGenerateTypeQualifiedMethodCall" xml:space="preserve">
-    <value>A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.</value>
+    <value>A type-qualified method call requires an instance identifier and a MethodInfo.</value>
   </data>
   <data name="CompiledModelConstructorBinding" xml:space="preserve">
     <value>The entity type '{entityType}' has a custom constructor binding. This is usually caused by using proxies. Compiled model can't be generated, because dynamic proxy types are not supported. If you are not using proxies configure the custom constructor binding in '{customize}' in a partial '{className}' class instead.</value>

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -135,6 +135,9 @@
   <data name="CannotFindTypeMappingForColumn" xml:space="preserve">
     <value>Could not find type mapping for column '{columnName}' with data type '{dateType}'. Skipping column.</value>
   </data>
+  <data name="CannotGenerateTypeQualifiedMethodCall" xml:space="preserve">
+    <value>A type-qualified method call requires an instance identifier, a MethodInfo and no chained calls.</value>
+  </data>
   <data name="CompiledModelConstructorBinding" xml:space="preserve">
     <value>The entity type '{entityType}' has a custom constructor binding. This is usually caused by using proxies. Compiled model can't be generated, because dynamic proxy types are not supported. If you are not using proxies configure the custom constructor binding in '{customize}' in a partial '{className}' class instead.</value>
   </data>

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private readonly ICSharpHelper _code;
         private readonly IProviderConfigurationCodeGenerator _providerConfigurationCodeGenerator;
         private readonly IAnnotationCodeGenerator _annotationCodeGenerator;
-        private readonly IndentedStringBuilder _sb = new();
+        private readonly IndentedStringBuilder _builder = new();
         private readonly HashSet<string> _namespaces = new();
         private bool _entityTypeBuilderInitialized;
         private bool _useDataAnnotations;
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _useDataAnnotations = useDataAnnotations;
             _useNullableReferenceTypes = useNullableReferenceTypes;
 
-            _sb.Clear();
+            _builder.Clear();
             _namespaces.Clear();
 
             _namespaces.Add("System"); // Guid default values require new Guid() which requires this using
@@ -91,9 +91,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (!string.IsNullOrEmpty(finalContextNamespace))
             {
-                _sb.AppendLine($"namespace {finalContextNamespace}");
-                _sb.AppendLine("{");
-                _sb.IncrementIndent();
+                _builder.AppendLine($"namespace {finalContextNamespace}");
+                _builder.AppendLine("{");
+                _builder.IncrementIndent();
             }
 
             GenerateClass(
@@ -105,8 +105,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (!string.IsNullOrEmpty(finalContextNamespace))
             {
-                _sb.DecrementIndent();
-                _sb.AppendLine("}");
+                _builder.DecrementIndent();
+                _builder.AppendLine("}");
             }
 
             var namespaceStringBuilder = new StringBuilder();
@@ -115,8 +115,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     ns => ns switch
                     {
                         "System" => 1,
-                        var s when s.StartsWith("System", StringComparison.CurrentCulture) => 2,
-                        var s when s.StartsWith("Microsoft", StringComparison.CurrentCulture) => 3,
+                        var s when s.StartsWith("System", StringComparison.Ordinal) => 2,
+                        var s when s.StartsWith("Microsoft", StringComparison.Ordinal) => 3,
                         _ => 4
                     })
                 .ThenBy(ns => ns);
@@ -126,14 +126,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 namespaces = namespaces.Append(modelNamespace);
             }
 
-            foreach (var ns in namespaces)
+            foreach (var @namespace in namespaces)
             {
-                namespaceStringBuilder.Append("using ").Append(ns).AppendLine(";");
+                namespaceStringBuilder.Append("using ").Append(@namespace).AppendLine(";");
             }
 
             namespaceStringBuilder.AppendLine();
 
-            return namespaceStringBuilder.ToString() + _sb;
+            return namespaceStringBuilder.ToString() + _builder;
         }
 
         /// <summary>
@@ -153,10 +153,10 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             Check.NotNull(contextName, nameof(contextName));
             Check.NotNull(connectionString, nameof(connectionString));
 
-            _sb.AppendLine($"public partial class {contextName} : DbContext");
-            _sb.AppendLine("{");
+            _builder.AppendLine($"public partial class {contextName} : DbContext");
+            _builder.AppendLine("{");
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
                 GenerateConstructors(contextName);
                 GenerateDbSets(model);
@@ -169,24 +169,24 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 GenerateOnModelCreating(model);
             }
 
-            _sb.AppendLine();
+            _builder.AppendLine();
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
-                _sb.AppendLine("partial void OnModelCreatingPartial(ModelBuilder modelBuilder);");
+                _builder.AppendLine("partial void OnModelCreatingPartial(ModelBuilder modelBuilder);");
             }
 
-            _sb.AppendLine("}");
+            _builder.AppendLine("}");
         }
 
         private void GenerateConstructors(string contextName)
         {
-            _sb.AppendLine($"public {contextName}()")
+            _builder.AppendLine($"public {contextName}()")
                 .AppendLine("{")
                 .AppendLine("}")
                 .AppendLine();
 
-            _sb.AppendLine($"public {contextName}(DbContextOptions<{contextName}> options)")
+            _builder.AppendLine($"public {contextName}(DbContextOptions<{contextName}> options)")
                 .IncrementIndent()
                 .AppendLine(": base(options)")
                 .DecrementIndent()
@@ -199,19 +199,19 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             foreach (var entityType in model.GetEntityTypes())
             {
-                _sb.Append($"public virtual DbSet<{entityType.Name}> {entityType.GetDbSetName()} {{ get; set; }}");
+                _builder.Append($"public virtual DbSet<{entityType.Name}> {entityType.GetDbSetName()} {{ get; set; }}");
 
                 if (_useNullableReferenceTypes)
                 {
-                    _sb.Append(" = null!;");
+                    _builder.Append(" = null!;");
                 }
 
-                _sb.AppendLine();
+                _builder.AppendLine();
             }
 
             if (model.GetEntityTypes().Any())
             {
-                _sb.AppendLine();
+                _builder.AppendLine();
             }
         }
 
@@ -220,12 +220,12 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             var errors = model.GetEntityTypeErrors();
             foreach (var entityTypeError in errors)
             {
-                _sb.AppendLine($"// {entityTypeError.Value} Please see the warning messages.");
+                _builder.AppendLine($"// {entityTypeError.Value} Please see the warning messages.");
             }
 
             if (errors.Count > 0)
             {
-                _sb.AppendLine();
+                _builder.AppendLine();
             }
         }
 
@@ -241,19 +241,19 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(connectionString, nameof(connectionString));
 
-            _sb.AppendLine("protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)");
-            _sb.AppendLine("{");
+            _builder.AppendLine("protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)");
+            _builder.AppendLine("{");
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
-                _sb.AppendLine("if (!optionsBuilder.IsConfigured)");
-                _sb.AppendLine("{");
+                _builder.AppendLine("if (!optionsBuilder.IsConfigured)");
+                _builder.AppendLine("{");
 
-                using (_sb.Indent())
+                using (_builder.Indent())
                 {
                     if (!suppressConnectionStringWarning)
                     {
-                        _sb.DecrementIndent()
+                        _builder.DecrementIndent()
                             .DecrementIndent()
                             .DecrementIndent()
                             .DecrementIndent()
@@ -267,17 +267,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     var useProviderCall = _providerConfigurationCodeGenerator.GenerateUseProvider(
                         connectionString);
 
-                    _sb
+                    _builder
                         .AppendLines(_code.Fragment(useProviderCall, "optionsBuilder"), skipFinalNewline: true)
                         .AppendLine(";");
                 }
 
-                _sb.AppendLine("}");
+                _builder.AppendLine("}");
             }
 
-            _sb.AppendLine("}");
+            _builder.AppendLine("}");
 
-            _sb.AppendLine();
+            _builder.AppendLine();
         }
 
         /// <summary>
@@ -290,8 +290,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(model, nameof(model));
 
-            _sb.AppendLine("protected override void OnModelCreating(ModelBuilder modelBuilder)");
-            _sb.Append("{");
+            _builder.AppendLine("protected override void OnModelCreating(ModelBuilder modelBuilder)");
+            _builder.Append("{");
 
             var annotations = _annotationCodeGenerator
                 .FilterIgnoredAnnotations(model.GetAnnotations())
@@ -310,25 +310,25 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (lines.Count > 0)
             {
-                using (_sb.Indent())
+                using (_builder.Indent())
                 {
-                    _sb.AppendLine();
-                    _sb.Append("modelBuilder" + lines[0]);
+                    _builder.AppendLine();
+                    _builder.Append("modelBuilder" + lines[0]);
 
-                    using (_sb.Indent())
+                    using (_builder.Indent())
                     {
                         foreach (var line in lines.Skip(1))
                         {
-                            _sb.AppendLine();
-                            _sb.Append(line);
+                            _builder.AppendLine();
+                            _builder.Append(line);
                         }
                     }
 
-                    _sb.AppendLine(";");
+                    _builder.AppendLine(";");
                 }
             }
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
                 foreach (var entityType in model.GetEntityTypes())
                 {
@@ -338,7 +338,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                     if (_entityTypeBuilderInitialized)
                     {
-                        _sb.AppendLine("});");
+                        _builder.AppendLine("});");
                     }
                 }
 
@@ -348,23 +348,23 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 }
             }
 
-            _sb.AppendLine();
+            _builder.AppendLine();
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
-                _sb.AppendLine("OnModelCreatingPartial(modelBuilder);");
+                _builder.AppendLine("OnModelCreatingPartial(modelBuilder);");
             }
 
-            _sb.AppendLine("}");
+            _builder.AppendLine("}");
         }
 
         private void InitializeEntityTypeBuilder(IEntityType entityType)
         {
             if (!_entityTypeBuilderInitialized)
             {
-                _sb.AppendLine();
-                _sb.AppendLine($"modelBuilder.Entity<{entityType.Name}>({EntityLambdaIdentifier} =>");
-                _sb.Append("{");
+                _builder.AppendLine();
+                _builder.AppendLine($"modelBuilder.Entity<{entityType.Name}>({EntityLambdaIdentifier} =>");
+                _builder.Append("{");
             }
 
             _entityTypeBuilderInitialized = true;
@@ -439,22 +439,22 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             InitializeEntityTypeBuilder(entityType);
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
-                _sb.AppendLine();
+                _builder.AppendLine();
 
-                _sb.Append(EntityLambdaIdentifier + lines[0]);
+                _builder.Append(EntityLambdaIdentifier + lines[0]);
 
-                using (_sb.Indent())
+                using (_builder.Indent())
                 {
                     foreach (var line in lines.Skip(1))
                     {
-                        _sb.AppendLine();
-                        _sb.Append(line);
+                        _builder.AppendLine();
+                        _builder.Append(line);
                     }
                 }
 
-                _sb.AppendLine(";");
+                _builder.AppendLine(";");
             }
         }
 
@@ -805,19 +805,19 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 lines = new List<string> { lines[0] + lines[1] };
             }
 
-            _sb.AppendLine();
-            _sb.Append(lines[0]);
+            _builder.AppendLine();
+            _builder.Append(lines[0]);
 
-            using (_sb.Indent())
+            using (_builder.Indent())
             {
                 foreach (var line in lines.Skip(1))
                 {
-                    _sb.AppendLine();
-                    _sb.Append(line);
+                    _builder.AppendLine();
+                    _builder.Append(line);
                 }
             }
 
-            _sb.AppendLine(";");
+            _builder.AppendLine(";");
         }
 
         private void GenerateAnnotations(IAnnotatable annotatable, Dictionary<string, IAnnotation> annotations, List<string> lines)
@@ -831,14 +831,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 {
                     var methodParameters = methodInfo.GetParameters();
 
-                    for (int i = fluentApiCall.Arguments.Count - 1, j = methodInfo.IsStatic ? i + 1 : i; i >= 0; i--, j--)
+                    var paramOffset = methodInfo.IsStatic ? 1 : 0;
+
+                    for (int i = fluentApiCall.Arguments.Count - 1; i >= 0; i--)
                     {
-                        if (!methodParameters[j].HasDefaultValue)
+                        if (!methodParameters[i + paramOffset].HasDefaultValue)
                         {
                             break;
                         }
 
-                        var defaultValue = methodParameters[j].DefaultValue;
+                        var defaultValue = methodParameters[i + paramOffset].DefaultValue;
                         var argument = fluentApiCall.Arguments[i];
 
                         if (argument is null && defaultValue is null || argument is not null && argument.Equals(defaultValue))

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using NotNullWhenAttribute = System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
@@ -34,6 +36,78 @@ namespace Microsoft.EntityFrameworkCore.Design
             RelationalAnnotationNames.DbFunctions,
             RelationalAnnotationNames.RelationalOverrides
         };
+
+        #region MethodInfos
+
+        private static readonly MethodInfo _modelHasDefaultSchemaMethodInfo
+            = typeof(RelationalModelBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalModelBuilderExtensions.HasDefaultSchema), typeof(ModelBuilder), typeof(string));
+
+        private static readonly MethodInfo _modelUseCollationMethodInfo
+            = typeof(RelationalModelBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalModelBuilderExtensions.UseCollation), typeof(ModelBuilder), typeof(string));
+
+        private static readonly MethodInfo _entityTypeHasCommentMethodInfo
+            = typeof(RelationalEntityTypeBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalEntityTypeBuilderExtensions.HasComment), typeof(EntityTypeBuilder), typeof(string));
+
+        private static readonly MethodInfo _propertyHasColumnNameMethodInfo
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasColumnName), typeof(PropertyBuilder), typeof(string));
+
+        private static readonly MethodInfo _propertyHasDefaultValueSqlMethodInfo1
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql), typeof(PropertyBuilder));
+
+        private static readonly MethodInfo _propertyHasDefaultValueSqlMethodInfo2
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql), typeof(PropertyBuilder), typeof(string));
+
+        private static readonly MethodInfo _propertyHasComputedColumnSqlMethodInfo1
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), typeof(PropertyBuilder));
+
+        private static readonly MethodInfo _propertyHasComputedColumnSqlMethodInfo2
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), typeof(PropertyBuilder), typeof(string));
+
+        private static readonly MethodInfo _hasComputedColumnSqlMethodInfo3
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), typeof(PropertyBuilder), typeof(string), typeof(bool));
+
+        private static readonly MethodInfo _propertySsFixedLengthMethodInfo
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.IsFixedLength), typeof(PropertyBuilder), typeof(bool));
+
+        private static readonly MethodInfo _propertyHasCommentMethodInfo
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.HasComment), typeof(PropertyBuilder), typeof(string));
+
+        private static readonly MethodInfo _propertyUseCollationMethodInfo
+            = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalPropertyBuilderExtensions.UseCollation), typeof(PropertyBuilder), typeof(string));
+
+        private static readonly MethodInfo _keyHasNameMethodInfo
+            = typeof(RelationalKeyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalKeyBuilderExtensions.HasName), typeof(KeyBuilder), typeof(string));
+
+        private static readonly MethodInfo _referenceReferenceHasConstraintNameMethodInfo
+            = typeof(RelationalForeignKeyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalForeignKeyBuilderExtensions.HasConstraintName), typeof(ReferenceReferenceBuilder), typeof(string));
+
+        private static readonly MethodInfo _referenceCollectionHasConstraintNameMethodInfo
+            = typeof(RelationalForeignKeyBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalForeignKeyBuilderExtensions.HasConstraintName), typeof(ReferenceCollectionBuilder), typeof(string));
+
+        private static readonly MethodInfo _indexHasDatabaseNameMethodInfo
+            = typeof(RelationalIndexBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalIndexBuilderExtensions.HasDatabaseName), typeof(IndexBuilder), typeof(string));
+
+        private static readonly MethodInfo _indexHasFilterNameMethodInfo
+            = typeof(RelationalIndexBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(RelationalIndexBuilderExtensions.HasFilter), typeof(IndexBuilder), typeof(string));
+
+        #endregion MethodInfos
 
         /// <summary>
         ///     Initializes a new instance of this class.
@@ -108,12 +182,12 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema),
+                RelationalAnnotationNames.DefaultSchema, _modelHasDefaultSchemaMethodInfo,
                 methodCallCodeFragments);
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.Collation, nameof(RelationalModelBuilderExtensions.UseCollation),
+                RelationalAnnotationNames.Collation, _modelUseCollationMethodInfo,
                 methodCallCodeFragments);
 
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(model, annotations, GenerateFluentApi));
@@ -129,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.Comment, nameof(RelationalEntityTypeBuilderExtensions.HasComment), methodCallCodeFragments);
+                RelationalAnnotationNames.Comment, _entityTypeHasCommentMethodInfo, methodCallCodeFragments);
 
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(entityType, annotations, GenerateFluentApi));
 
@@ -145,50 +219,41 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), methodCallCodeFragments);
+                RelationalAnnotationNames.ColumnName, _propertyHasColumnNameMethodInfo, methodCallCodeFragments);
 
             if (TryGetAndRemove(annotations, RelationalAnnotationNames.DefaultValueSql, out string? defaultValueSql))
             {
                 methodCallCodeFragments.Add(
                     defaultValueSql.Length == 0
-                        ? new MethodCallCodeFragment(
-                            nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql))
-                        : new MethodCallCodeFragment(
-                            nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
-                            defaultValueSql));
+                        ? new MethodCallCodeFragment(_propertyHasDefaultValueSqlMethodInfo1)
+                        : new MethodCallCodeFragment(_propertyHasDefaultValueSqlMethodInfo2, defaultValueSql));
             }
 
             if (TryGetAndRemove(annotations, RelationalAnnotationNames.ComputedColumnSql, out string? computedColumnSql))
             {
                 methodCallCodeFragments.Add(
                     computedColumnSql.Length == 0
-                        ? new MethodCallCodeFragment(
-                            nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql))
+                        ? new MethodCallCodeFragment(_propertyHasComputedColumnSqlMethodInfo1)
                         : TryGetAndRemove(annotations, RelationalAnnotationNames.IsStored, out bool isStored)
-                            ? new MethodCallCodeFragment(
-                                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
-                                computedColumnSql,
-                                isStored)
-                            : new MethodCallCodeFragment(
-                                nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
-                                computedColumnSql));
+                            ? new MethodCallCodeFragment(_hasComputedColumnSqlMethodInfo3, computedColumnSql, isStored)
+                            : new MethodCallCodeFragment(_propertyHasComputedColumnSqlMethodInfo2, computedColumnSql));
             }
 
             if (TryGetAndRemove(annotations, RelationalAnnotationNames.IsFixedLength, out bool isFixedLength))
             {
                 methodCallCodeFragments.Add(
                         isFixedLength
-                        ? new MethodCallCodeFragment(nameof(RelationalAnnotationNames.IsFixedLength))
-                        : new MethodCallCodeFragment(nameof(RelationalAnnotationNames.IsFixedLength), isFixedLength));
+                        ? new MethodCallCodeFragment(_propertySsFixedLengthMethodInfo)
+                        : new MethodCallCodeFragment(_propertySsFixedLengthMethodInfo, isFixedLength));
             }
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.Comment, nameof(RelationalPropertyBuilderExtensions.HasComment), methodCallCodeFragments);
+                RelationalAnnotationNames.Comment, _propertyHasCommentMethodInfo, methodCallCodeFragments);
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.Collation, nameof(RelationalPropertyBuilderExtensions.UseCollation), methodCallCodeFragments);
+                RelationalAnnotationNames.Collation, _propertyUseCollationMethodInfo, methodCallCodeFragments);
 
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(property, annotations, GenerateFluentApi));
 
@@ -202,9 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         {
             var methodCallCodeFragments = new List<MethodCallCodeFragment>();
 
-            GenerateSimpleFluentApiCall(
-                annotations,
-                RelationalAnnotationNames.Name, nameof(RelationalKeyBuilderExtensions.HasName), methodCallCodeFragments);
+            GenerateSimpleFluentApiCall(annotations, RelationalAnnotationNames.Name, _keyHasNameMethodInfo, methodCallCodeFragments);
 
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(key, annotations, GenerateFluentApi));
 
@@ -213,16 +276,18 @@ namespace Microsoft.EntityFrameworkCore.Design
 
         /// <inheritdoc />
         public virtual IReadOnlyList<MethodCallCodeFragment> GenerateFluentApiCalls(
-            IForeignKey navigation,
+            IForeignKey foreignKey,
             IDictionary<string, IAnnotation> annotations)
         {
             var methodCallCodeFragments = new List<MethodCallCodeFragment>();
 
             GenerateSimpleFluentApiCall(
                 annotations,
-                RelationalAnnotationNames.Name, nameof(RelationalForeignKeyBuilderExtensions.HasConstraintName), methodCallCodeFragments);
+                RelationalAnnotationNames.Name,
+                foreignKey.IsUnique ? _referenceReferenceHasConstraintNameMethodInfo : _referenceCollectionHasConstraintNameMethodInfo,
+                methodCallCodeFragments);
 
-            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(navigation, annotations, GenerateFluentApi));
+            methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(foreignKey, annotations, GenerateFluentApi));
 
             return methodCallCodeFragments;
         }
@@ -259,12 +324,9 @@ namespace Microsoft.EntityFrameworkCore.Design
             var methodCallCodeFragments = new List<MethodCallCodeFragment>();
 
             GenerateSimpleFluentApiCall(
-                annotations,
-                RelationalAnnotationNames.Name, nameof(RelationalIndexBuilderExtensions.HasDatabaseName), methodCallCodeFragments);
-
+                annotations, RelationalAnnotationNames.Name, _indexHasDatabaseNameMethodInfo, methodCallCodeFragments);
             GenerateSimpleFluentApiCall(
-                annotations,
-                RelationalAnnotationNames.Filter, nameof(RelationalIndexBuilderExtensions.HasFilter), methodCallCodeFragments);
+                annotations, RelationalAnnotationNames.Filter, _indexHasFilterNameMethodInfo, methodCallCodeFragments);
 
             methodCallCodeFragments.AddRange(GenerateFluentApiCallsHelper(index, annotations, GenerateFluentApi));
 
@@ -659,7 +721,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             }
         }
 
-        private static bool TryGetAndRemove<T>(IDictionary<string, IAnnotation> annotations, string annotationName, [NotNullWhen(true)] out T? annotationValue)
+        private static bool TryGetAndRemove<T>(
+            IDictionary<string, IAnnotation> annotations, string annotationName, [NotNullWhen(true)] out T? annotationValue)
         {
             if (annotations.TryGetValue(annotationName, out var annotation)
                 && annotation.Value != null)
@@ -676,7 +739,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         private static void GenerateSimpleFluentApiCall(
             IDictionary<string, IAnnotation> annotations,
             string annotationName,
-            string methodName,
+            MethodInfo methodInfo,
             List<MethodCallCodeFragment> methodCallCodeFragments)
         {
             if (annotations.TryGetValue(annotationName, out var annotation))
@@ -685,15 +748,13 @@ namespace Microsoft.EntityFrameworkCore.Design
                 if (annotation.Value is object annotationValue)
                 {
                     methodCallCodeFragments.Add(
-                        new MethodCallCodeFragment(methodName, annotationValue));
+                        new MethodCallCodeFragment(methodInfo, annotationValue));
                 }
             }
         }
 
         // Dictionary is safe for removal during enumeration
         private static IEnumerable<KeyValuePair<string, IAnnotation>> EnumerateForRemoval(IDictionary<string, IAnnotation> annotations)
-            => annotations is Dictionary<string, IAnnotation>
-                ? (IEnumerable<KeyValuePair<string, IAnnotation>>)annotations
-                : annotations.ToList();
+            => annotations is Dictionary<string, IAnnotation> ? annotations : annotations.ToList();
     }
 }

--- a/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
+++ b/src/EFCore.Relational/Design/AnnotationCodeGenerator.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), typeof(PropertyBuilder), typeof(string), typeof(bool));
 
-        private static readonly MethodInfo _propertySsFixedLengthMethodInfo
+        private static readonly MethodInfo _propertyIsFixedLengthMethodInfo
             = typeof(RelationalPropertyBuilderExtensions).GetRequiredRuntimeMethod(
                 nameof(RelationalPropertyBuilderExtensions.IsFixedLength), typeof(PropertyBuilder), typeof(bool));
 
@@ -243,8 +243,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             {
                 methodCallCodeFragments.Add(
                         isFixedLength
-                        ? new MethodCallCodeFragment(_propertySsFixedLengthMethodInfo)
-                        : new MethodCallCodeFragment(_propertySsFixedLengthMethodInfo, isFixedLength));
+                        ? new MethodCallCodeFragment(_propertyIsFixedLengthMethodInfo)
+                        : new MethodCallCodeFragment(_propertyIsFixedLengthMethodInfo, isFixedLength));
             }
 
             GenerateSimpleFluentApiCall(

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -1097,6 +1097,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 memberType, member, entityType);
 
         /// <summary>
+        ///     Unhandled annotatable type '{annotatableType}'.
+        /// </summary>
+        public static string UnhandledAnnotatableType(object? expressionType)
+            => string.Format(
+                GetString("UnhandledAnnotatableType", nameof(expressionType)),
+                expressionType);
+
+        /// <summary>
         ///     Unhandled expression '{expression}' of type '{expressionType}' encountered in '{visitor}'.
         /// </summary>
         public static string UnhandledExpressionInVisitor(object? expression, object? expressionType, object? visitor)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -771,6 +771,9 @@
   <data name="UnableToBindMemberToEntityProjection" xml:space="preserve">
     <value>Unable to bind '{memberType}.{member}' to an entity projection of '{entityType}'.</value>
   </data>
+  <data name="UnhandledAnnotatableType" xml:space="preserve">
+    <value>Unhandled annotatable type '{annotatableType}'.</value>
+  </data>
   <data name="UnhandledExpressionInVisitor" xml:space="preserve">
     <value>Unhandled expression '{expression}' of type '{expressionType}' encountered in '{visitor}'.</value>
   </data>

--- a/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
@@ -14,6 +17,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
     /// </summary>
     public class SqlServerNetTopologySuiteCodeGeneratorPlugin : ProviderCodeGeneratorPlugin
     {
+        private static readonly MethodInfo _useNetTopologySuiteMethodInfo
+            = typeof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite),
+                typeof(Action<SqlServerDbContextOptionsBuilder>));
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -21,6 +29,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override MethodCallCodeFragment GenerateProviderOptions()
-            => new(nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite));
+            => new(_useNetTopologySuiteMethodInfo);
     }
 }

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerCodeGenerator.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
@@ -14,6 +17,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
     /// </summary>
     public class SqlServerCodeGenerator : ProviderCodeGenerator
     {
+        private static readonly MethodInfo _useSqlServerMethodInfo
+            = typeof(SqlServerDbContextOptionsExtensions).GetRequiredRuntimeMethod(
+                nameof(SqlServerDbContextOptionsExtensions.UseSqlServer),
+                typeof(DbContextOptionsBuilder),
+                typeof(string),
+                typeof(Action<SqlServerDbContextOptionsBuilder>));
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="SqlServerCodeGenerator" /> class.
         /// </summary>
@@ -33,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
             string connectionString,
             MethodCallCodeFragment? providerOptions)
             => new(
-                nameof(SqlServerDbContextOptionsExtensions.UseSqlServer),
+                _useSqlServerMethodInfo,
                 providerOptions == null
                     ? new object[] { connectionString }
                     : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
@@ -14,6 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
     /// </summary>
     public class SqliteCodeGenerator : ProviderCodeGenerator
     {
+        private static readonly MethodInfo _useSqliteMethodInfo
+            = typeof(SqliteDbContextOptionsBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(SqliteDbContextOptionsBuilderExtensions.UseSqlite),
+                typeof(DbContextOptionsBuilder),
+                typeof(string),
+                typeof(Action<SqliteDbContextOptionsBuilder>));
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="SqliteCodeGenerator" /> class.
         /// </summary>
@@ -33,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
             string connectionString,
             MethodCallCodeFragment? providerOptions)
             => new(
-                nameof(SqliteDbContextOptionsBuilderExtensions.UseSqlite),
+                _useSqliteMethodInfo,
                 providerOptions == null
                     ? new object[] { connectionString }
                     : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });

--- a/src/EFCore.Sqlite.NTS/Scaffolding/Internal/SqliteNetTopologySuiteCodeGeneratorPlugin.cs
+++ b/src/EFCore.Sqlite.NTS/Scaffolding/Internal/SqliteNetTopologySuiteCodeGeneratorPlugin.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
@@ -14,6 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
     /// </summary>
     public class SqliteNetTopologySuiteCodeGeneratorPlugin : ProviderCodeGeneratorPlugin
     {
+        private static readonly MethodInfo _useNetTopologySuiteMethodInfo
+            = typeof(SqliteNetTopologySuiteDbContextOptionsBuilderExtensions).GetRequiredRuntimeMethod(
+                nameof(SqliteNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite),
+                typeof(SqliteDbContextOptionsBuilder));
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -21,7 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override MethodCallCodeFragment GenerateProviderOptions()
-            => new(
-                nameof(SqliteNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite));
+            => new(_useNetTopologySuiteMethodInfo);
     }
 }

--- a/src/EFCore/Design/AttributeCodeFragment.cs
+++ b/src/EFCore/Design/AttributeCodeFragment.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Design

--- a/src/EFCore/Design/ICSharpHelper.cs
+++ b/src/EFCore/Design/ICSharpHelper.cs
@@ -17,8 +17,12 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     Generates a method call code fragment.
         /// </summary>
         /// <param name="fragment"> The method call. </param>
+        /// <param name="instanceIdentifier"> An identifier on which the method call will be generated. </param>
+        /// <param name="typeQualified">
+        ///     <see langword="true" /> if the method call should be type-qualified, <see langword="false" /> for instance/extension syntax.
+        /// </param>
         /// <returns> The fragment. </returns>
-        string Fragment(MethodCallCodeFragment fragment);
+        string Fragment(MethodCallCodeFragment fragment, string? instanceIdentifier = null, bool typeQualified = false);
 
         /// <summary>
         ///     Generates a valid C# identifier from the specified string unique to the scope.

--- a/src/EFCore/Design/MethodCallCodeFragment.cs
+++ b/src/EFCore/Design/MethodCallCodeFragment.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Design
@@ -14,17 +17,65 @@ namespace Microsoft.EntityFrameworkCore.Design
         private readonly List<object?> _arguments;
 
         /// <summary>
+        ///     Only used when <see cref="MethodInfo" /> is null
+        /// </summary>
+        private readonly string? _method;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MethodCallCodeFragment" /> class.
+        /// </summary>
+        /// <param name="methodInfo"> The method's <see cref="MethodInfo" />. </param>
+        /// <param name="arguments"> The method call's arguments. Can be <see cref="NestedClosureCodeFragment" />. </param>
+        public MethodCallCodeFragment(MethodInfo methodInfo, params object?[] arguments)
+        {
+            Check.NotNull(methodInfo, nameof(methodInfo));
+            Check.NotNull(arguments, nameof(arguments));
+
+            var parameterLength = methodInfo.GetParameters().Length;
+            if (methodInfo.IsStatic)
+            {
+                parameterLength--;
+            }
+
+            if (arguments.Length > parameterLength)
+            {
+                throw new ArgumentException(CoreStrings.TooManyArguments, nameof(arguments));
+            }
+
+            MethodInfo = methodInfo;
+            _arguments = new List<object?>(arguments);
+        }
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="MethodCallCodeFragment" /> class.
         /// </summary>
         /// <param name="method"> The method's name. </param>
         /// <param name="arguments"> The method call's arguments. Can be <see cref="NestedClosureCodeFragment" />. </param>
+        [Obsolete("Use the overload accepting a MethodInfo")]
         public MethodCallCodeFragment(string method, params object?[] arguments)
         {
             Check.NotEmpty(method, nameof(method));
             Check.NotNull(arguments, nameof(arguments));
 
-            Method = method;
+            _method = method;
             _arguments = new List<object?>(arguments);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MethodCallCodeFragment" /> class.
+        /// </summary>
+        /// <param name="methodInfo"> The method's <see cref="MethodInfo" />. </param>
+        /// <param name="arguments"> The method call's arguments.  Can be <see cref="NestedClosureCodeFragment" />. </param>
+        /// <param name="chainedCall"> The next method call to chain after this. </param>
+        public MethodCallCodeFragment(
+            MethodInfo methodInfo,
+            object?[] arguments,
+            MethodCallCodeFragment chainedCall)
+            : this(methodInfo, arguments)
+        {
+            Check.NotNull(chainedCall, nameof(chainedCall));
+
+            ChainedCall = chainedCall;
         }
 
         /// <summary>
@@ -33,6 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="method"> The method's name. </param>
         /// <param name="arguments"> The method call's arguments.  Can be <see cref="NestedClosureCodeFragment" />. </param>
         /// <param name="chainedCall"> The next method call to chain after this. </param>
+        [Obsolete("Use the overload accepting a MethodInfo")]
         public MethodCallCodeFragment(
             string method,
             object?[] arguments,
@@ -45,10 +97,31 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         /// <summary>
-        ///     Gets or sets the method's name.
+        ///     Gets the <see cref="MethodInfo" /> for this method call.
+        /// </summary>
+        /// <value> The <see cref="MethodInfo" />. </value>
+        public virtual MethodInfo? MethodInfo { get; }
+
+        /// <summary>
+        ///     Gets the namespace of the method's declaring type.
+        /// </summary>
+        /// <value> The declaring type's name. </value>
+        public virtual string? Namespace
+            => MethodInfo?.DeclaringType?.Namespace;
+
+        /// <summary>
+        ///     Gets the name of the method's declaring type.
+        /// </summary>
+        /// <value> The declaring type's name. </value>
+        public virtual string? DeclaringType
+            => MethodInfo?.DeclaringType?.Name;
+
+        /// <summary>
+        ///     Gets the method's name.
         /// </summary>
         /// <value> The method's name. </value>
-        public virtual string Method { get; }
+        public virtual string Method
+            => MethodInfo is null ? _method! : MethodInfo.Name;
 
         /// <summary>
         ///     Gets the method call's arguments.
@@ -66,9 +139,19 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <summary>
         ///     Creates a method chain from this method to another.
         /// </summary>
+        /// <param name="methodInfo"> The method's <see cref="MethodInfo" />. </param>
+        /// <param name="arguments"> The next method call's arguments. </param>
+        /// <returns> A new fragment representing the method chain. </returns>
+        public virtual MethodCallCodeFragment Chain(MethodInfo methodInfo, params object[] arguments)
+            => Chain(new MethodCallCodeFragment(methodInfo, arguments));
+
+        /// <summary>
+        ///     Creates a method chain from this method to another.
+        /// </summary>
         /// <param name="method"> The next method's name. </param>
         /// <param name="arguments"> The next method call's arguments. </param>
         /// <returns> A new fragment representing the method chain. </returns>
+        [Obsolete("Use the overload accepting a MethodInfo")]
         public virtual MethodCallCodeFragment Chain(string method, params object[] arguments)
             => Chain(new MethodCallCodeFragment(method, arguments));
 
@@ -78,6 +161,10 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="call"> The next method. </param>
         /// <returns> A new fragment representing the method chain. </returns>
         public virtual MethodCallCodeFragment Chain(MethodCallCodeFragment call)
-            => new(Method, _arguments.ToArray(), ChainedCall?.Chain(call) ?? call);
+            => MethodInfo is null
+#pragma warning disable 618
+                ? new(_method!, _arguments.ToArray(), ChainedCall?.Chain(call) ?? call)
+#pragma warning restore 618
+                : new(MethodInfo, _arguments.ToArray(), ChainedCall?.Chain(call) ?? call);
     }
 }

--- a/src/EFCore/Design/MethodCallCodeFragment.cs
+++ b/src/EFCore/Design/MethodCallCodeFragment.cs
@@ -39,7 +39,9 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             if (arguments.Length > parameterLength)
             {
-                throw new ArgumentException(CoreStrings.TooManyArguments, nameof(arguments));
+                throw new ArgumentException(
+                    CoreStrings.IncorrectNumberOfArguments(methodInfo.Name, arguments.Length, parameterLength),
+                    nameof(arguments));
             }
 
             MethodInfo = methodInfo;

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1167,6 +1167,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 ownedEntityType, nonOwnedEntityType);
 
         /// <summary>
+        ///     '{method}' was invoked with {argumentCount} arguments, but has {parameterCount} parameters.
+        /// </summary>
+        public static string IncorrectNumberOfArguments(object? method, object? argumentCount, object? parameterCount)
+            => string.Format(
+                GetString("IncorrectNumberOfArguments", nameof(method), nameof(argumentCount), nameof(parameterCount)),
+                method, argumentCount, parameterCount);
+
+        /// <summary>
         ///     The specified index properties {indexProperties} are not declared on the entity type '{entityType}'. Ensure that index properties are declared on the target entity type.
         /// </summary>
         public static string IndexPropertiesWrongEntity(object? indexProperties, object? entityType)
@@ -2689,12 +2697,6 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("TempValuePersists", "0_property", "1_entityType", nameof(state)),
                 property, entityType, state);
-
-        /// <summary>
-        ///     Too many arguments.
-        /// </summary>
-        public static string TooManyArguments
-            => GetString("TooManyArguments");
 
         /// <summary>
         ///     The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2691,6 +2691,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, state);
 
         /// <summary>
+        ///     Too many arguments.
+        /// </summary>
+        public static string TooManyArguments
+            => GetString("TooManyArguments");
+
+        /// <summary>
         ///     The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.
         /// </summary>
         public static string TrackingTypeMismatch(object? runtimeEntityType, object? entityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -561,6 +561,9 @@
     <value>The entity type '{ownedEntityType}' is configured as owned, but the entity type '{nonOwnedEntityType}' is not. Configure all entity types with defining navigations sharing a CLR type as owned in 'OnModelCreating'.</value>
     <comment>Obsolete</comment>
   </data>
+  <data name="IncorrectNumberOfArguments" xml:space="preserve">
+    <value>'{method}' was invoked with {argumentCount} arguments, but has {parameterCount} parameters.</value>
+  </data>
   <data name="IndexPropertiesWrongEntity" xml:space="preserve">
     <value>The specified index properties {indexProperties} are not declared on the entity type '{entityType}'. Ensure that index properties are declared on the target entity type.</value>
   </data>
@@ -1465,9 +1468,6 @@
   </data>
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly, or ensure that the database is configured to generate values for this property.</value>
-  </data>
-  <data name="TooManyArguments" xml:space="preserve">
-    <value>Too many arguments.</value>
   </data>
   <data name="TrackingTypeMismatch" xml:space="preserve">
     <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.</value>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1466,6 +1466,9 @@
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{1_entityType}.{0_property}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly, or ensure that the database is configured to generate values for this property.</value>
   </data>
+  <data name="TooManyArguments" xml:space="preserve">
+    <value>Too many arguments.</value>
+  </data>
   <data name="TrackingTypeMismatch" xml:space="preserve">
     <value>The instance of entity type '{runtimeEntityType}' cannot be tracked as the entity type '{entityType}' because the two types are not in the same hierarchy.</value>
   </data>

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -163,77 +163,31 @@ namespace System
         }
 
         public static PropertyInfo GetRequiredProperty(this Type type, string name)
-        {
-            var property = type.GetTypeInfo().GetProperty(name);
-            if (property == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return property;
-        }
+            => type.GetTypeInfo().GetProperty(name)
+                ?? throw new InvalidOperationException($"Could not find property '{name}' on type '{type}'");
 
         public static FieldInfo GetRequiredDeclaredField(this Type type, string name)
-        {
-            var field = type.GetTypeInfo().GetDeclaredField(name);
-            if (field == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return field;
-        }
+            => type.GetTypeInfo().GetDeclaredField(name)
+                ?? throw new InvalidOperationException($"Could not find field '{name}' on type '{type}'");
 
         public static MethodInfo GetRequiredDeclaredMethod(this Type type, string name)
-        {
-            var method = type.GetTypeInfo().GetDeclaredMethod(name);
-            if (method == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return method;
-        }
+            => type.GetTypeInfo().GetDeclaredMethod(name) 
+                ?? throw new InvalidOperationException($"Could not find method '{name}' on type '{type}'");
 
         public static MethodInfo GetRequiredDeclaredMethod(this Type type, string name, Func<MethodInfo, bool> methodSelector)
-        {
-            var method = type.GetTypeInfo().GetDeclaredMethods(name).Single(methodSelector);
-
-            return method;
-        }
+            => type.GetTypeInfo().GetDeclaredMethods(name).Single(methodSelector);
 
         public static PropertyInfo GetRequiredDeclaredProperty(this Type type, string name)
-        {
-            var property = type.GetTypeInfo().GetDeclaredProperty(name);
-            if (property == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return property;
-        }
+            => type.GetTypeInfo().GetDeclaredProperty(name)
+                ?? throw new InvalidOperationException($"Could not find property '{name}' on type '{type}'");
 
         public static MethodInfo GetRequiredRuntimeMethod(this Type type, string name, params Type[] parameters)
-        {
-            var method = type.GetTypeInfo().GetRuntimeMethod(name, parameters);
-            if (method == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return method;
-        }
+            => type.GetTypeInfo().GetRuntimeMethod(name, parameters)
+                ?? throw new InvalidOperationException($"Could not find method '{name}' on type '{type}'");
 
         public static PropertyInfo GetRequiredRuntimeProperty(this Type type, string name)
-        {
-            var property = type.GetTypeInfo().GetRuntimeProperty(name);
-            if (property == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            return property;
-        }
+            => type.GetTypeInfo().GetRuntimeProperty(name)
+                ?? throw new InvalidOperationException($"Could not find property '{name}' on type '{type}'");
 
         public static bool IsInstantiable(this Type type)
             => !type.IsAbstract

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
     public class CSharpMigrationsGeneratorTest
     {
         private static readonly string _nl = Environment.NewLine;
-        private static readonly string _toTable = _nl + @"modelBuilder.ToTable(""WithAnnotations"");" + _nl;
+        private static readonly string _toTable = _nl + @"entityTypeBuilder.ToTable(""WithAnnotations"")";
 
         [ConditionalFact]
         public void Test_new_annotations_handled_for_entity_types()
@@ -108,42 +108,36 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             {
                 {
                     RelationalAnnotationNames.TableName,
-                    ("MyTable", _nl + "modelBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToTable) + @"(""MyTable"");" + _nl)
+                    ("MyTable", _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToTable) + @"(""MyTable"")")
                 },
                 {
                     RelationalAnnotationNames.Schema, ("MySchema",
                         _nl
-                        + "modelBuilder."
+                        + "entityTypeBuilder."
                         + nameof(RelationalEntityTypeBuilderExtensions.ToTable)
-                        + @"(""WithAnnotations"", ""MySchema"");"
-                        + _nl)
+                        + @"(""WithAnnotations"", ""MySchema"")")
                 },
                 {
                     CoreAnnotationNames.DiscriminatorProperty, ("Id",
-                        _toTable
+                        _toTable + ";" + _nl
                         + _nl
-                        + "modelBuilder.HasDiscriminator"
-                        + @"<int>(""Id"");"
-                        + _nl)
+                        + "entityTypeBuilder.HasDiscriminator"
+                        + @"<int>(""Id"")")
                 },
                 {
                     CoreAnnotationNames.DiscriminatorValue, ("MyDiscriminatorValue",
-                        _toTable
+                        _toTable + ";" + _nl
                         + _nl
-                        + "modelBuilder.HasDiscriminator"
+                        + "entityTypeBuilder.HasDiscriminator"
                         + "()."
                         + nameof(DiscriminatorBuilder.HasValue)
-                        + @"(""MyDiscriminatorValue"");"
-                        + _nl)
+                        + @"(""MyDiscriminatorValue"")")
                 },
                 {
                     RelationalAnnotationNames.Comment, ("My Comment",
-                        _toTable
+                        _toTable + ";" + _nl
                         + _nl
-                        + "modelBuilder"
-                        + _nl
-                        + @"    .HasComment(""My Comment"");"
-                        + _nl)
+                        + @"entityTypeBuilder.HasComment(""My Comment"")")
                 },
                 {
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -153,15 +147,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 },
                 {
                     RelationalAnnotationNames.ViewName,
-                    ("MyView", _nl + "modelBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToView) + @"(""MyView"");" + _nl)
+                    ("MyView", _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToView) + @"(""MyView"")")
                 },
                 {
                     RelationalAnnotationNames.FunctionName,
-                    (null, _nl + "modelBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToFunction) + @"(null);" + _nl)
+                    (null, _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToFunction) + @"(null)")
                 },
                 {
                     RelationalAnnotationNames.SqlQuery,
-                    (null, _nl + "modelBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToSqlQuery) + @"(null);" + _nl)
+                    (null, _nl + "entityTypeBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToSqlQuery) + @"(null)")
                 }
             };
 
@@ -169,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 b => b.Entity<WithAnnotations>().Metadata,
                 notForEntityType, forEntityType,
                 a => _toTable,
-                (g, m, b) => g.TestGenerateEntityTypeAnnotations("modelBuilder", (IEntityType)m, b));
+                (g, m, b) => g.TestGenerateEntityTypeAnnotations("entityTypeBuilder", (IEntityType)m, b));
         }
 
         [ConditionalFact]
@@ -229,8 +223,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.ModelDependencies
             };
 
-            var columnMapping =
-                $@"{_nl}.{nameof(RelationalPropertyBuilderExtensions.HasColumnType)}(""default_int_mapping"")";
+            var columnMapping = $@"{_nl}.{nameof(RelationalPropertyBuilderExtensions.HasColumnType)}(""default_int_mapping"")";
 
             // Add a line here if the code generator is supposed to handle this annotation
             // Note that other tests should be added to check code is generated correctly
@@ -291,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 b => b.Entity<WithAnnotations>().Property(e => e.Id).Metadata,
                 notForProperty, forProperty,
                 a => $"{columnMapping}",
-                (g, m, b) => g.TestGeneratePropertyAnnotations((IProperty)m, b));
+                (g, m, b) => g.TestGeneratePropertyAnnotations("propertyBuilder", (IProperty)m, b));
         }
 
         private static void MissingAnnotationCheck(
@@ -353,11 +346,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                     try
                     {
-                        Assert.Equal(
-                        validAnnotations.ContainsKey(annotationName)
+                        var expected = validAnnotations.ContainsKey(annotationName)
                             ? validAnnotations[annotationName].Expected
-                            : generationDefault(annotationName),
-                        sb.ToString());
+                            : generationDefault(annotationName);
+
+                        Assert.Equal(
+                            string.IsNullOrEmpty(expected) ? expected : $"{expected};{_nl}",
+                            sb.ToString());
                     }
                     catch (Exception e)
                     {
@@ -381,8 +376,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 IndentedStringBuilder stringBuilder)
                 => GenerateEntityTypeAnnotations(builderName, entityType, stringBuilder);
 
-            public virtual void TestGeneratePropertyAnnotations(IProperty property, IndentedStringBuilder stringBuilder)
-                => GeneratePropertyAnnotations(property, stringBuilder);
+            public virtual void TestGeneratePropertyAnnotations(
+                string builderName,
+                IProperty property,
+                IndentedStringBuilder stringBuilder)
+                => GeneratePropertyAnnotations(builderName, property, stringBuilder);
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local
@@ -470,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             var sb = new IndentedStringBuilder();
 
-            generator.TestGeneratePropertyAnnotations((IProperty)property, sb);
+            generator.TestGeneratePropertyAnnotations("propertyBuilder", (IProperty)property, sb);
 
             Assert.Equal(expected + _nl + ".HasMaxLength(1000)", sb.ToString());
         }
@@ -589,8 +587,7 @@ namespace MyNamespace
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
+            modelBuilder.HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
 
             modelBuilder.Entity(""T1"", b =>
                 {
@@ -719,8 +716,7 @@ namespace MyNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
+            modelBuilder.HasAnnotation(""Some:EnumValue"", RegexOptions.Multiline);
 
             modelBuilder.Entity(""Cheese"", b =>
                 {

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -26,6 +25,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Xunit;
+using Xunit.Sdk;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -296,14 +296,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     @"
             modelBuilder
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:DatabaseMaxSize"", ""100 MB"")
-                .HasAnnotation(""SqlServer:PerformanceLevelSql"", ""'S0'"")
-                .HasAnnotation(""SqlServer:ServiceTierSql"", ""'basic'"")
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+            SqlServerModelBuilderExtensions.HasDatabaseMaxSize(modelBuilder, ""100 MB"");
+            SqlServerModelBuilderExtensions.HasServiceTierSql(modelBuilder, ""'basic'"");
+            SqlServerModelBuilderExtensions.HasPerformanceLevelSql(modelBuilder, ""'S0'"");"),
                 o =>
                 {
-                    Assert.Equal(6, o.GetAnnotations().Count());
+                    Assert.Equal(8, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                 });
         }
@@ -322,11 +323,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             modelBuilder
                 .HasDefaultSchema(""DefaultSchema"")
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);"),
                 o =>
                 {
-                    Assert.Equal(4, o.GetAnnotations().Count());
+                    Assert.Equal(6, o.GetAnnotations().Count());
                     Assert.Equal("AnnotationValue", o["AnnotationName"]);
                     Assert.Equal("DefaultSchema", o[RelationalAnnotationNames.DefaultSchema]);
                 });
@@ -348,8 +350,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -360,8 +363,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -399,8 +403,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .HasColumnType(""nvarchar(max)"");
@@ -430,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(2, o.GetAnnotations().Count());
+                    Assert.Equal(4, o.GetAnnotations().Count());
 
                     Assert.Equal(
                         "DerivedEntity",
@@ -456,8 +461,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .HasColumnType(""nvarchar(max)"");
@@ -487,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 });"),
                 o =>
                 {
-                    Assert.Equal(2, o.GetAnnotations().Count());
+                    Assert.Equal(4, o.GetAnnotations().Count());
 
                     Assert.Equal(
                         "DerivedEntity",
@@ -507,8 +513,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
                 {
                     b.Property<int>(""Id"")
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -622,7 +629,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .IsCyclic();"),
                 o =>
                 {
-                    Assert.Equal(3, o.GetAnnotations().Count());
+                    Assert.Equal(5, o.GetAnnotations().Count());
                 });
         }
 
@@ -643,8 +650,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -679,8 +687,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -730,11 +739,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder => builder.UseIdentityColumns(),
                 AddBoilerPlate(
                     @"
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:IdentityIncrement"", 1)
-                .HasAnnotation(""SqlServer:IdentitySeed"", 1L)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);"),
                 o =>
                 {
                     Assert.Equal(4, o.GetAnnotations().Count());
@@ -751,11 +758,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder => builder.UseIdentityColumns(5),
                 AddBoilerPlate(
                     @"
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:IdentityIncrement"", 1)
-                .HasAnnotation(""SqlServer:IdentitySeed"", 5L)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 5L, 1);"),
                 o =>
                 {
                     Assert.Equal(4, o.GetAnnotations().Count());
@@ -772,11 +777,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder => builder.UseIdentityColumns(increment: 5),
                 AddBoilerPlate(
                     @"
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:IdentityIncrement"", 5)
-                .HasAnnotation(""SqlServer:IdentitySeed"", 1L)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 5);"),
             o =>
                 {
                     Assert.Equal(4, o.GetAnnotations().Count());
@@ -804,18 +807,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 },
                 AddBoilerPlate(
                     @"
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:IdentityIncrement"", 5)
-                .HasAnnotation(""SqlServer:IdentitySeed"", 9223372036854775807L)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 9223372036854775807L, 5);
 
             modelBuilder.Entity(""Building"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 9223372036854775807L, 5);
 
                     b.HasKey(""Id"");
 
@@ -855,15 +857,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
                     b.ToTable(""EntityWithOneProperty"");
 
-                    b
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
                 });"),
                 o =>
                 {
@@ -888,8 +890,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -956,8 +959,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -1016,8 +1020,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1114,8 +1119,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1152,8 +1158,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1188,8 +1195,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1229,8 +1237,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -1241,8 +1250,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -1312,8 +1322,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
@@ -1327,8 +1338,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Description"")
                         .HasColumnType(""nvarchar(max)"");
@@ -1453,8 +1465,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
@@ -1468,8 +1481,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Description"")
                         .HasColumnType(""nvarchar(max)"");
@@ -1622,8 +1636,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnUpdateSometimes()
@@ -1730,8 +1745,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -1767,8 +1783,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -1799,8 +1816,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -1837,8 +1855,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<DateTime>(""End"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -1857,14 +1876,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
                     b.ToTable(""EntityWithStringProperty"");
 
-                    b
-                        .ToTable(tb => tb.IsTemporal(ttb =>
-                            {
-                                ttb.UseHistoryTable(""HistoryTable"");
-                                ttb.HasPeriodStart(""Start"").HasColumnName(""PeriodStart"");
-                                ttb.HasPeriodEnd(""End"").HasColumnName(""PeriodEnd"");
-                            }
-                        ));
+                    b.ToTable(tb => tb.IsTemporal(ttb =>
+                        {
+                            ttb.UseHistoryTable(""HistoryTable"");
+                            ttb
+                                .HasPeriodStart(""Start"")
+                                .HasColumnName(""PeriodStart"");
+                            ttb
+                                .HasPeriodEnd(""End"")
+                                .HasColumnName(""PeriodEnd"");
+                        }
+                    ));
                 });", usingSystem: true),
                 o =>
                 {
@@ -1929,8 +1951,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
@@ -1974,8 +1997,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                                 .IsUnique()
                                 .HasFilter(""[EntityWithTwoProperties_EntityWithStringKeyId] IS NOT NULL"");
 
-                            b1.HasIndex(""Id"")
-                                .HasAnnotation(""SqlServer:Include"", new[] { ""AlternateId"" });
+                            b1.HasIndex(""Id"");
+
+                            SqlServerIndexBuilderExtensions.IncludeProperties(b1.HasIndex(""Id""), new[] { ""AlternateId"" });
 
                             b1.ToTable(""EntityWithOneProperty"");
 
@@ -2008,8 +2032,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         {
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .HasColumnType(""int"");
+
+                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>(""Id""), 1L, 1);
 
                             b1.Property<int?>(""EntityWithOnePropertyId"")
                                 .HasColumnType(""int"");
@@ -2155,8 +2180,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"")
                         .HasName(""PK_Custom"");
@@ -2233,8 +2259,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         {
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .HasColumnType(""int"");
+
+                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>(""Id""), 1L, 1);
 
                             b1.Property<int?>(""EntityWithOnePropertyId"")
                                 .HasColumnType(""int"");
@@ -2343,8 +2370,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -2506,16 +2534,17 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -2530,8 +2559,9 @@ namespace RootNamespace
                                 .HasColumnType(""int"");
 
                             b1.Property<int>(""Id"")
-                                .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .HasColumnType(""int"");
+
+                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>(""Id""), 1L, 1);
 
                             b1.Property<int>(""TestEnum"")
                                 .HasColumnType(""int"");
@@ -2587,16 +2617,17 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+TestOwner"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -2612,8 +2643,9 @@ namespace RootNamespace
 
                             b1.Property<int>(""Id"")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType(""int"")
-                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                                .HasColumnType(""int"");
+
+                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>(""Id""), 1L, 1);
 
                             b1.Property<int>(""TestEnum"")
                                 .HasColumnType(""int"");
@@ -2693,8 +2725,9 @@ namespace RootNamespace
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
                         .HasColumnType(""int"")
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -2720,8 +2753,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -2743,8 +2777,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -2773,8 +2808,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -2841,8 +2877,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasMaxLength(100)
@@ -2867,8 +2904,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .IsUnicode(false)
@@ -2893,8 +2931,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasMaxLength(100)
@@ -2927,8 +2966,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasMaxLength(100)
@@ -2965,8 +3005,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .IsConcurrencyToken()
@@ -2995,8 +3036,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"")
@@ -3025,8 +3067,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""CType"");
@@ -3054,8 +3097,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -3085,8 +3129,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -3117,8 +3162,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -3148,8 +3194,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAdd()
@@ -3179,8 +3226,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -3210,8 +3258,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -3245,8 +3294,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .ValueGeneratedOnAddOrUpdate()
@@ -3272,8 +3322,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<long>(""Day"")
                         .ValueGeneratedOnAdd()
@@ -3306,8 +3357,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Day"")
                         .IsRequired()
@@ -3347,8 +3399,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<long?>(""Day"")
                         .HasColumnType(""bigint"");
@@ -3373,8 +3426,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<long>(""Day"")
                         .HasColumnType(""bigint"");
@@ -3398,8 +3452,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Day"")
                         .HasColumnType(""nvarchar(max)"");
@@ -3428,8 +3483,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"")
@@ -3476,8 +3532,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -3511,10 +3568,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:IdentityIncrement"", 1)
-                        .HasAnnotation(""SqlServer:IdentitySeed"", 1L)
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -3551,10 +3607,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:IdentityIncrement"", 1)
-                        .HasAnnotation(""SqlServer:IdentitySeed"", 5L)
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 5L, 1);
 
                     b.HasKey(""Id"");
 
@@ -3591,10 +3646,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:IdentityIncrement"", 5)
-                        .HasAnnotation(""SqlServer:IdentitySeed"", 1L)
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 5);
 
                     b.HasKey(""Id"");
 
@@ -3630,10 +3684,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:IdentityIncrement"", 5)
-                        .HasAnnotation(""SqlServer:IdentitySeed"", 5L)
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 5L, 5);
 
                     b.HasKey(""Id"");
 
@@ -3669,8 +3722,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3702,8 +3756,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3736,8 +3791,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3780,8 +3836,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3812,8 +3869,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3846,8 +3904,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3884,8 +3943,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3919,8 +3979,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -3961,8 +4022,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
@@ -3991,8 +4053,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -4034,8 +4097,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -4081,8 +4145,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""FirstName"")
                         .HasColumnType(""nvarchar(450)"");
@@ -4134,16 +4199,18 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(max)"");
 
                     b.HasKey(""Id"");
 
-                    b.HasIndex(""Id"")
-                        .HasAnnotation(""SqlServer:Include"", new[] { ""Name"" });
+                    b.HasIndex(""Id"");
+
+                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex(""Id""), new[] { ""Name"" });
 
                     b.ToTable(""EntityWithStringProperty"");
                 });", usingSystem: true),
@@ -4176,8 +4243,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4188,8 +4256,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4207,9 +4276,9 @@ namespace RootNamespace
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .IsRequired()
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.Navigation(""EntityWithOneProperty"");
                 });
@@ -4252,8 +4321,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .IsRequired()
@@ -4306,8 +4376,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Name"")
                         .HasColumnType(""nvarchar(450)"");
@@ -4362,8 +4433,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4415,8 +4487,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4476,8 +4549,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<Guid>(""Property"")
                         .HasColumnType(""uniqueidentifier"");
@@ -4544,8 +4618,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4556,8 +4631,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4575,9 +4651,9 @@ namespace RootNamespace
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .HasConstraintName(""Constraint"")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .IsRequired()
+                        .HasConstraintName(""Constraint"");
 
                     b.Navigation(""EntityWithOneProperty"");
                 });
@@ -4610,8 +4686,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4622,8 +4699,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4641,10 +4719,10 @@ namespace RootNamespace
                     b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
                         .WithOne(""EntityWithTwoProperties"")
                         .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                        .HasConstraintName(""Constraint"")
-                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .IsRequired()
+                        .HasConstraintName(""Constraint"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
                     b.Navigation(""EntityWithOneProperty"");
                 });
@@ -4679,8 +4757,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<string>(""Discriminator"")
                         .IsRequired()
@@ -4702,8 +4781,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4757,8 +4837,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4822,8 +4903,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4886,8 +4968,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4898,8 +4981,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -4953,8 +5037,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.HasKey(""Id"");
 
@@ -4965,8 +5050,9 @@ namespace RootNamespace
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<int>(""AlternateId"")
                         .HasColumnType(""int"");
@@ -5158,16 +5244,17 @@ namespace RootNamespace
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
             modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithManyProperties"", b =>
                 {
                     b.Property<int>(""Id"")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType(""int"")
-                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType(""int"");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>(""Id""), 1L, 1);
 
                     b.Property<bool>(""Boolean"")
                         .HasColumnType(""bit"");
@@ -5504,9 +5591,9 @@ namespace RootNamespace
 
         protected virtual string GetHeading(bool empty = false)
             => @"
-            modelBuilder
-                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"
+            modelBuilder.HasAnnotation(""Relational:MaxIdentifierLength"", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);"
                 + (empty
                     ? null
                     : @"
@@ -5564,7 +5651,15 @@ namespace RootNamespace
         {
             var generator = CreateMigrationsGenerator();
             var code = generator.GenerateSnapshot("RootNamespace", typeof(DbContext), "Snapshot", model);
-            Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);
+
+            try
+            {
+                Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);
+            }
+            catch (EqualException e)
+            {
+                throw new Exception(e.Message + Environment.NewLine + Environment.NewLine + "-- Actual code:" + Environment.NewLine + code);
+            }
 
             var modelFromSnapshot = BuildModelFromSnapshotSource(code);
             assert(modelFromSnapshot, model);

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -298,10 +298,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
-            SqlServerModelBuilderExtensions.HasDatabaseMaxSize(modelBuilder, ""100 MB"");
-            SqlServerModelBuilderExtensions.HasServiceTierSql(modelBuilder, ""'basic'"");
-            SqlServerModelBuilderExtensions.HasPerformanceLevelSql(modelBuilder, ""'S0'"");"),
+            SqlServerModelBuilderExtensions
+                .UseIdentityColumns(modelBuilder, 1L, 1)
+                .HasDatabaseMaxSize(""100 MB"")
+                .HasServiceTierSql(""'basic'"")
+                .HasPerformanceLevelSql(""'S0'"");"),
                 o =>
                 {
                     Assert.Equal(8, o.GetAnnotations().Count());

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -298,11 +298,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
                 .HasAnnotation(""Relational:MaxIdentifierLength"", 128);
 
-            SqlServerModelBuilderExtensions
-                .UseIdentityColumns(modelBuilder, 1L, 1)
-                .HasDatabaseMaxSize(""100 MB"")
-                .HasServiceTierSql(""'basic'"")
-                .HasPerformanceLevelSql(""'S0'"");"),
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+            SqlServerModelBuilderExtensions.HasDatabaseMaxSize(modelBuilder, ""100 MB"");
+            SqlServerModelBuilderExtensions.HasServiceTierSql(modelBuilder, ""'basic'"");
+            SqlServerModelBuilderExtensions.HasPerformanceLevelSql(modelBuilder, ""'S0'"");"),
                 o =>
                 {
                     Assert.Equal(8, o.GetAnnotations().Count());

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -2023,22 +2023,21 @@ namespace TestNamespace
 
         protected override void AddModelServices(IServiceCollection services)
         {
-            services.Replace(ServiceDescriptor.Singleton<IRelationalAnnotationProvider, ModelAnnotationProvider>());
+            services.Replace(ServiceDescriptor.Singleton<IRelationalAnnotationProvider, TestModelAnnotationProvider>());
         }
 
         protected override void AddScaffoldingServices(IServiceCollection services)
         {
-            services.Replace(ServiceDescriptor.Singleton<IAnnotationCodeGenerator, ModelAnnotationCodeGenerator>());
+            services.Replace(ServiceDescriptor.Singleton<IAnnotationCodeGenerator, TestModelAnnotationCodeGenerator>());
         }
 
-        public class ModelAnnotationProvider : SqlServerAnnotationProvider
+        private class TestModelAnnotationProvider : SqlServerAnnotationProvider
         {
-            public ModelAnnotationProvider(RelationalAnnotationProviderDependencies dependencies)
+            public TestModelAnnotationProvider(RelationalAnnotationProviderDependencies dependencies)
                 : base(dependencies)
             {
             }
 
-            /// <inheritdoc />
             public override IEnumerable<IAnnotation> For(ITable table, bool designTime)
             {
                 foreach (var annotation in base.For(table, designTime))
@@ -2054,7 +2053,6 @@ namespace TestNamespace
                 }
             }
 
-            /// <inheritdoc />
             public override IEnumerable<IAnnotation> For(IColumn column, bool designTime)
             {
                 foreach (var annotation in base.For(column, designTime))
@@ -2072,9 +2070,9 @@ namespace TestNamespace
             }
         }
 
-        public class ModelAnnotationCodeGenerator : SqlServerAnnotationCodeGenerator
+        private class TestModelAnnotationCodeGenerator : SqlServerAnnotationCodeGenerator
         {
-            public ModelAnnotationCodeGenerator(AnnotationCodeGeneratorDependencies dependencies)
+            public TestModelAnnotationCodeGenerator(AnnotationCodeGeneratorDependencies dependencies)
                 : base(dependencies)
             {
             }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestProviderCodeGenerator.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestProviderCodeGenerator.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
@@ -17,9 +19,19 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             string connectionString,
             MethodCallCodeFragment providerOptions)
             => new(
-                "UseTestProvider",
+                _useTestProviderMethodInfo,
                 providerOptions == null
                     ? new object[] { connectionString }
                     : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
+
+        private static readonly MethodInfo _useTestProviderMethodInfo
+            = typeof(TestProviderCodeGenerator).GetRequiredRuntimeMethod(
+                nameof(UseTestProvider), typeof(DbContextOptionsBuilder), typeof(string), typeof(Action<object>));
+
+        public static void UseTestProvider(
+            DbContextOptionsBuilder optionsBuilder,
+            string connectionString,
+            Action<object> optionsAction = null)
+            => throw new NotSupportedException();
     }
 }

--- a/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Xunit;
 
@@ -34,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                 new ProviderCodeGeneratorDependencies(
                     Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
 
-            var providerOptions = new MethodCallCodeFragment("SetProviderOption");
+            var providerOptions = new MethodCallCodeFragment(_setProviderOptionMethodInfo);
 
             var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions);
 
@@ -51,5 +54,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                 });
             Assert.Null(result.ChainedCall);
         }
+
+        private static readonly MethodInfo _setProviderOptionMethodInfo
+            = typeof(SqlServerCodeGeneratorTest).GetRuntimeMethod(nameof(SetProviderOption), new[] { typeof(DbContextOptionsBuilder) });
+
+        public static SqlServerDbContextOptionsBuilder SetProviderOption(DbContextOptionsBuilder optionsBuilder)
+            => throw new NotSupportedException();
     }
 }

--- a/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
 using Xunit;
 
@@ -33,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                 new ProviderCodeGeneratorDependencies(
                     Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
 
-            var providerOptions = new MethodCallCodeFragment("SetProviderOption");
+            var providerOptions = new MethodCallCodeFragment(_setProviderOptionMethodInfo);
 
             var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions);
 
@@ -50,5 +53,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
                 });
             Assert.Null(result.ChainedCall);
         }
+
+        private static readonly MethodInfo _setProviderOptionMethodInfo
+            = typeof(SqliteCodeGeneratorTest).GetRuntimeMethod(nameof(SetProviderOption), new[] { typeof(DbContextOptionsBuilder) });
+
+        public static SqliteDbContextOptionsBuilder SetProviderOption(DbContextOptionsBuilder optionsBuilder)
+            => throw new NotSupportedException();
     }
 }

--- a/test/EFCore.Tests/Design/MethodCallCodeFragmentTest.cs
+++ b/test/EFCore.Tests/Design/MethodCallCodeFragmentTest.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public class MethodCallCodeFragmentTest
+    {
+        [ConditionalFact]
+        public virtual void Ctor_throw_when_too_many_parameters_extension()
+        {
+            _ = new MethodCallCodeFragment(_extensionFuncMethodInfo, 1);
+            Assert.Throws<ArgumentException>(() => new MethodCallCodeFragment(_extensionFuncMethodInfo, 1, 2));
+        }
+
+        [ConditionalFact]
+        public virtual void Ctor_throw_when_too_many_parameters_instance()
+        {
+            _ = new MethodCallCodeFragment(_instanceFuncMethodInfo, 1);
+            Assert.Throws<ArgumentException>(() => new MethodCallCodeFragment(_instanceFuncMethodInfo, 1, 2));
+        }
+
+        private static readonly MethodInfo _extensionFuncMethodInfo
+            = typeof(MethodCallCodeFragmentTest).GetRequiredRuntimeMethod(nameof(ExtensionFunc), typeof(object), typeof(int));
+
+        private static readonly MethodInfo _instanceFuncMethodInfo
+            = typeof(MethodCallCodeFragmentTest).GetRequiredRuntimeMethod(nameof(InstanceFunc), typeof(int));
+
+        public static void ExtensionFunc(object thisParameter, int p)
+            => throw new NotSupportedException();
+
+        public void InstanceFunc(int p)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
@bricelam this is a draft for getting your general OK before going further... #25046 (custom namespaces in scaffolding) is fully implemented, while #23848 (type-qualified Fluent APIs in the model snapshot) is a bit more tricky/ugly.

Closes #25046
Closes #23848
Closes #25434