### PR TITLE
API review updates

### DIFF
--- a/src/EFCore.Relational/Diagnostics/CommandCorrelatedEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandCorrelatedEventData.cs
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> A correlation ID that identifies the <see cref="DbConnection" /> instance being used. </param>
         /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
         /// <param name="startTime"> The start time of this event. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         public CommandCorrelatedEventData(
             EventDefinitionBase eventDefinition,
             Func<EventDefinitionBase, EventData, string> messageGenerator,

--- a/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEndEventData.cs
@@ -70,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
         /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
         /// <param name="startTime"> The start time of this event. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration this event. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         public CommandEndEventData(
             EventDefinitionBase eventDefinition,
             Func<EventDefinitionBase, EventData, string> messageGenerator,
@@ -84,8 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             bool logParameterValues,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             : base(
                 eventDefinition,
                 messageGenerator,

--- a/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandErrorEventData.cs
@@ -75,8 +75,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
         /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
         /// <param name="startTime"> The start time of this event. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration this event. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         public CommandErrorEventData(
             EventDefinitionBase eventDefinition,
             Func<EventDefinitionBase, EventData, string> messageGenerator,
@@ -90,8 +90,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             bool logParameterValues,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             : base(
                 eventDefinition,
                 messageGenerator,
@@ -104,8 +104,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 logParameterValues,
                 startTime,
-                commandSource,
-                duration)
+                duration,
+                commandSource)
         {
             Exception = exception;
         }

--- a/src/EFCore.Relational/Diagnostics/CommandEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandEventData.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
         /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
         /// <param name="startTime"> The start time of this event. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         public CommandEventData(
             EventDefinitionBase eventDefinition,
             Func<EventDefinitionBase, EventData, string> messageGenerator,

--- a/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/CommandExecutedEventData.cs
@@ -73,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="async"> Indicates whether or not the command was executed asynchronously. </param>
         /// <param name="logParameterValues"> Indicates whether or not the application allows logging of parameter values. </param>
         /// <param name="startTime"> The start time of this event. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration this event. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         public CommandExecutedEventData(
             EventDefinitionBase eventDefinition,
             Func<EventDefinitionBase, EventData, string> messageGenerator,
@@ -88,8 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             bool async,
             bool logParameterValues,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             : base(
                 eventDefinition,
                 messageGenerator,
@@ -102,8 +102,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 async,
                 logParameterValues,
                 startTime,
-                commandSource,
-                duration)
+                duration,
+                commandSource)
             => Result = result;
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/IRelationalCommandDiagnosticsLogger.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         InterceptionResult<DbCommand> CommandCreating(
             IRelationalConnection connection,
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
         /// <param name="duration"> The duration of the command creation. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         DbCommand CommandCreated(
             IRelationalConnection connection,
@@ -55,8 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration);
+            TimeSpan duration,
+            CommandSource commandSource);
 
         /// <summary>
         ///     Logs for the <see cref="RelationalEventId.CommandExecuting" /> event.
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         InterceptionResult<DbDataReader> CommandReaderExecuting(
             IRelationalConnection connection,
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         InterceptionResult<object> CommandScalarExecuting(
             IRelationalConnection connection,
@@ -107,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         InterceptionResult<int> CommandNonQueryExecuting(
             IRelationalConnection connection,
@@ -127,7 +127,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> An intercepted result. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> An intercepted result. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="commandId"> The correlation ID associated with the given <see cref="DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> An intercepted result. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -197,8 +197,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         DbDataReader CommandReaderExecuted(
             IRelationalConnection connection,
@@ -208,8 +208,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration);
+            TimeSpan duration,
+            CommandSource commandSource);
 
         /// <summary>
         ///     Logs for the <see cref="RelationalEventId.CommandExecuted" /> event.
@@ -221,8 +221,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         object? CommandScalarExecuted(
             IRelationalConnection connection,
@@ -232,8 +232,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration);
+            TimeSpan duration,
+            CommandSource commandSource);
 
         /// <summary>
         ///     Logs for the <see cref="RelationalEventId.CommandExecuted" /> event.
@@ -245,8 +245,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         int CommandNonQueryExecuted(
             IRelationalConnection connection,
@@ -256,8 +256,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration);
+            TimeSpan duration,
+            CommandSource commandSource);
 
         /// <summary>
         ///     Logs for the <see cref="RelationalEventId.CommandExecuted" /> event.
@@ -269,8 +269,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -282,8 +282,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -296,8 +296,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -309,8 +309,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -323,8 +323,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="methodResult"> The return value from the underlying method execution. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The duration of the command execution, not including consuming results. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> The result of execution, which may have been modified by an interceptor. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -336,8 +336,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -351,8 +351,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="exception"> The exception that caused this failure. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The amount of time that passed until the exception was raised. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         void CommandError(
             IRelationalConnection connection,
             DbCommand command,
@@ -362,8 +362,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration);
+            TimeSpan duration,
+            CommandSource commandSource);
 
         /// <summary>
         ///     Logs for the <see cref="RelationalEventId.CommandError" /> event.
@@ -376,8 +376,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         /// <param name="connectionId"> The correlation ID associated with the <see cref="DbConnection" /> being used. </param>
         /// <param name="exception"> The exception that caused this failure. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
         /// <param name="duration"> The amount of time that passed until the exception was raised. </param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
         /// <returns> A <see cref="Task" /> representing the async operation. </returns>
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
@@ -390,8 +390,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/EFCore.Relational/Diagnostics/Internal/RelationalCommandDiagnosticsLogger.cs
+++ b/src/EFCore.Relational/Diagnostics/Internal/RelationalCommandDiagnosticsLogger.cs
@@ -96,10 +96,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     async: false,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -118,10 +118,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             bool async,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             EventDefinition<string> definition,
             bool diagnosticSourceEnabled,
-            bool simpleLogEnabled)
+            bool simpleLogEnabled,
+            CommandSource commandSource)
         {
             var eventData = new CommandCorrelatedEventData(
                 definition,
@@ -165,8 +165,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
             var definition = RelationalResources.LogCommandCreated(this);
 
@@ -191,11 +191,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     async: false,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -215,11 +215,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             bool async,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
             EventDefinition<string, int> definition,
             bool diagnosticSourceEnabled,
-            bool simpleLogEnabled)
+            bool simpleLogEnabled,
+            CommandSource commandSource)
         {
             var eventData = new CommandEndEventData(
                 definition,
@@ -233,8 +233,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                 async,
                 false,
                 startTime,
-                commandSource,
-                duration);
+                duration,
+                commandSource);
 
             DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
@@ -298,10 +298,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     false,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -358,10 +358,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     false,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -418,10 +418,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     false,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -479,10 +479,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     async: true,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -540,10 +540,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     async: true,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -601,10 +601,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     connectionId,
                     async: true,
                     startTime,
-                    commandSource,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -624,10 +624,10 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             bool async,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             EventDefinition<string, CommandType, int, string, string> definition,
             bool diagnosticSourceEnabled,
-            bool simpleLogEnabled)
+            bool simpleLogEnabled,
+            CommandSource commandSource)
         {
             var eventData = new CommandEventData(
                 definition,
@@ -678,8 +678,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
 
@@ -712,11 +712,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: false,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -741,8 +741,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
 
@@ -775,11 +775,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: false,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -804,8 +804,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
 
@@ -838,11 +838,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: false,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -867,8 +867,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
@@ -902,11 +902,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: true,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -931,8 +931,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
@@ -966,11 +966,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: true,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -995,8 +995,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
         {
             var definition = RelationalResources.LogExecutedCommand(this);
@@ -1030,11 +1030,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     methodResult,
                     async: true,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -1055,11 +1055,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             object? methodResult,
             bool async,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition,
             bool diagnosticSourceEnabled,
-            bool simpleLogEnabled)
+            bool simpleLogEnabled,
+            CommandSource commandSource)
         {
             var eventData = new CommandExecutedEventData(
                 definition,
@@ -1074,8 +1074,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                 async,
                 ShouldLogParameterValues(command),
                 startTime,
-                commandSource,
-                duration);
+                duration,
+                commandSource);
 
             DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 
@@ -1114,8 +1114,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
             var definition = RelationalResources.LogCommandFailed(this);
 
@@ -1134,11 +1134,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     exception,
                     false,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 interceptor?.CommandFailed(command, eventData);
             }
@@ -1177,8 +1177,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
         {
             var definition = RelationalResources.LogCommandFailed(this);
@@ -1198,11 +1198,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                     exception,
                     true,
                     startTime,
-                    commandSource,
                     duration,
                     definition,
                     diagnosticSourceEnabled,
-                    simpleLogEnabled);
+                    simpleLogEnabled,
+                    commandSource);
 
                 if (interceptor != null)
                 {
@@ -1223,11 +1223,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
             Exception exception,
             bool async,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
             EventDefinition<string, string, CommandType, int, string, string> definition,
             bool diagnosticSourceEnabled,
-            bool simpleLogEnabled)
+            bool simpleLogEnabled,
+            CommandSource commandSource)
         {
             var eventData = new CommandErrorEventData(
                 definition,
@@ -1242,8 +1242,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
                 async,
                 ShouldLogParameterValues(command),
                 startTime,
-                commandSource,
-                duration);
+                duration,
+                commandSource);
 
             DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
 

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -117,8 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             nonQueryResult,
                             startTime,
-                            parameterObject.CommandSource,
-                            _stopwatch.Elapsed)
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource)
                         ?? nonQueryResult;
                 }
                 else
@@ -137,8 +137,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    parameterObject.CommandSource,
-                    _stopwatch.Elapsed);
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
 
                 throw;
             }
@@ -208,8 +208,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                                 connection.ConnectionId,
                                 result,
                                 startTime,
-                                parameterObject.CommandSource,
                                 _stopwatch.Elapsed,
+                                parameterObject.CommandSource,
                                 cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -234,8 +234,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            parameterObject.CommandSource,
                             _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -297,8 +297,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             result,
                             startTime,
-                            parameterObject.CommandSource,
-                            _stopwatch.Elapsed)
+                            _stopwatch.Elapsed,
+                            parameterObject.CommandSource)
                         ?? result;
                 }
                 else
@@ -317,8 +317,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    parameterObject.CommandSource,
-                    _stopwatch.Elapsed);
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
 
                 throw;
             }
@@ -388,8 +388,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             result,
                             startTime,
-                            parameterObject.CommandSource,
                             _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
                             cancellationToken).ConfigureAwait(false);
                     }
 
@@ -413,8 +413,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            parameterObject.CommandSource,
                             _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -482,8 +482,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                         connection.ConnectionId,
                         reader,
                         startTime,
-                        parameterObject.CommandSource,
-                        _stopwatch.Elapsed);
+                        _stopwatch.Elapsed,
+                        parameterObject.CommandSource);
                 }
                 else
                 {
@@ -501,8 +501,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     connection.ConnectionId,
                     exception,
                     startTime,
-                    parameterObject.CommandSource,
-                    _stopwatch.Elapsed);
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
 
                 CleanupCommand(command, connection);
 
@@ -599,8 +599,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             reader,
                             startTime,
-                            parameterObject.CommandSource,
                             _stopwatch.Elapsed,
+                            parameterObject.CommandSource,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -622,8 +622,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             connection.ConnectionId,
                             exception,
                             startTime,
-                            parameterObject.CommandSource,
                             DateTimeOffset.UtcNow - startTime,
+                            parameterObject.CommandSource,
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -701,7 +701,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
                     : connection.DbConnection.CreateCommand();
 
                 command = logger.CommandCreated(
-                    connection, command, commandMethod, context, commandId, connectionId, startTime, parameterObject.CommandSource, _stopwatch.Elapsed);
+                    connection, 
+                    command, 
+                    commandMethod, 
+                    context, 
+                    commandId, 
+                    connectionId, 
+                    startTime, 
+                    _stopwatch.Elapsed,
+                    parameterObject.CommandSource);
             }
             else
             {

--- a/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommandParameterObject.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="readerColumns"> The expected columns if the reader needs to be buffered, or null otherwise. </param>
         /// <param name="context"> The current <see cref="DbContext" /> instance, or null if it is not known. </param>
         /// <param name="logger"> A logger, or null if no logger is available. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         public RelationalCommandParameterObject(
             IRelationalConnection connection,
             IReadOnlyDictionary<string, object?>? parameterValues,
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="context"> The current <see cref="DbContext" /> instance, or null if it is not known. </param>
         /// <param name="logger"> A logger, or null if no logger is available. </param>
         /// <param name="detailedErrorsEnabled"> A value indicating if detailed errors are enabled. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         public RelationalCommandParameterObject(
             IRelationalConnection connection,
             IReadOnlyDictionary<string, object?>? parameterValues,

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -608,13 +608,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> <see langword="true" /> if the underlying connection was actually opened; <see langword="false" /> otherwise. </returns>
         public virtual bool Open(bool errorsExpected = false)
         {
-            if (DbConnectionState == ConnectionState.Broken)
+            if (DbConnection.State == ConnectionState.Broken)
             {
                 CloseDbConnection();
             }
 
             var wasOpened = false;
-            if (DbConnectionState != ConnectionState.Open)
+            if (DbConnection.State != ConnectionState.Open)
             {
                 CurrentTransaction?.Dispose();
                 ClearTransactions(clearAmbient: false);
@@ -641,13 +641,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <exception cref="OperationCanceledException"> If the <see cref="CancellationToken"/> is canceled. </exception>
         public virtual async Task<bool> OpenAsync(CancellationToken cancellationToken, bool errorsExpected = false)
         {
-            if (DbConnectionState == ConnectionState.Broken)
+            if (DbConnection.State == ConnectionState.Broken)
             {
                 await CloseDbConnectionAsync().ConfigureAwait(false);
             }
 
             var wasOpened = false;
-            if (DbConnectionState != ConnectionState.Open)
+            if (DbConnection.State != ConnectionState.Open)
             {
                 if (CurrentTransaction != null)
                 {
@@ -857,7 +857,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 CurrentTransaction?.Dispose();
                 ClearTransactions(clearAmbient: false);
 
-                if (DbConnectionState != ConnectionState.Closed)
+                if (DbConnection.State != ConnectionState.Closed)
                 {
                     var logger = Dependencies.ConnectionLogger;
                     var startTime = DateTimeOffset.UtcNow;
@@ -925,7 +925,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
                 ClearTransactions(clearAmbient: false);
 
-                if (DbConnectionState != ConnectionState.Closed)
+                if (DbConnection.State != ConnectionState.Closed)
                 {
                     var logger = Dependencies.ConnectionLogger;
                     var startTime = DateTimeOffset.UtcNow;
@@ -980,12 +980,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual Task CloseDbConnectionAsync()
             => DbConnection.CloseAsync();
-
-        /// <summary>
-        ///     Template method that by default calls <see cref="M:System.Data.Common.DbConnection.State" /> but can be overridden
-        ///     by providers to make a different call instead.
-        /// </summary>
-        protected virtual ConnectionState DbConnectionState => DbConnection.State;
 
         private bool ShouldClose()
             => (_openedCount == 0

--- a/src/EFCore/Metadata/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/ContextParameterBinding.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
         public ContextParameterBinding(
             Type contextType,
-            IPropertyBase[]? serviceProperties = null)
+            params IPropertyBase[]? serviceProperties)
             : base(contextType, contextType, serviceProperties)
         {
         }

--- a/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionMethodParameterBinding.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             Type parameterType,
             Type serviceType,
             MethodInfo method,
-            IPropertyBase[]? serviceProperties = null)
+            params IPropertyBase[]? serviceProperties)
             : base(parameterType, serviceType, serviceProperties)
         {
             Check.NotNull(method, nameof(method));

--- a/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
+++ b/src/EFCore/Metadata/DependencyInjectionParameterBinding.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public DependencyInjectionParameterBinding(
             Type parameterType,
             Type serviceType,
-            IPropertyBase[]? serviceProperties = null)
+            params IPropertyBase[]? serviceProperties)
             : base(parameterType, serviceType, serviceProperties)
         {
         }

--- a/src/EFCore/Metadata/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/EntityTypeParameterBinding.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Creates a new <see cref="EntityTypeParameterBinding" /> instance for the given service type.
         /// </summary>
         /// <param name="serviceProperties"> The associated <see cref="IServiceProperty" /> objects, or <see langword="null" />. </param>
-        public EntityTypeParameterBinding(IPropertyBase[]? serviceProperties = null)
+        public EntityTypeParameterBinding(params IPropertyBase[]? serviceProperties)
             : base(typeof(IEntityType), typeof(IEntityType), serviceProperties)
         {
         }

--- a/src/EFCore/Metadata/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/ServiceParameterBinding.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         protected ServiceParameterBinding(
             Type parameterType,
             Type serviceType,
-            IPropertyBase[]? serviceProperties = null)
+            params IPropertyBase[]? serviceProperties)
             : base(parameterType, serviceProperties)
         {
             Check.NotNull(serviceType, nameof(serviceType));

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeRelationalCommandDiagnosticsLogger.cs
@@ -33,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid commandId,
             Guid connectionId,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             => command;
 
         public InterceptionResult<DbDataReader> CommandReaderExecuting(
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         /// <param name="commandId"> The correlation ID associated with the given <see cref="System.Data.Common.DbCommand" />. </param>
         /// <param name="connectionId"> The correlation ID associated with the <see cref="System.Data.Common.DbConnection" /> being used. </param>
         /// <param name="startTime"> The time that execution began. </param>
-        /// <param name="commandSource">Source of the command.</param>
+        /// <param name="commandSource"> Source of the command. </param>
         /// <returns> An intercepted result. </returns>
         public InterceptionResult<int> CommandNonQueryExecuting(
             IRelationalConnection connection,
@@ -119,8 +119,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             => methodResult;
 
         public object? CommandScalarExecuted(
@@ -131,8 +131,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             => methodResult;
 
         public int CommandNonQueryExecuted(
@@ -143,8 +143,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
             => methodResult;
 
         public ValueTask<DbDataReader> CommandReaderExecutedAsync(
@@ -155,8 +155,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             DbDataReader methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
             => new(methodResult);
 
@@ -168,8 +168,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             object? methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
             => new(methodResult);
 
@@ -181,8 +181,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             int methodResult,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
             => new(methodResult);
 
@@ -195,8 +195,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
-            TimeSpan duration)
+            TimeSpan duration,
+            CommandSource commandSource)
         {
         }
 
@@ -209,8 +209,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Guid connectionId,
             Exception exception,
             DateTimeOffset startTime,
-            CommandSource commandSource,
             TimeSpan duration,
+            CommandSource commandSource,
             CancellationToken cancellationToken = default)
             => Task.CompletedTask;
 


### PR DESCRIPTION
Part of #24743

- Add params to ContextParameterBinding and related
- Remove RelationalConnection.DbConnectionState
- Move commandSource constructor parameters to the end in *EventData classes and IRelationalCommandDiagnosticsLogger
