### PR TITLE
Add FromRawSql api

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
@@ -5,6 +5,9 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -45,6 +48,69 @@ namespace Microsoft.EntityFrameworkCore
                             source.Expression,
                             Expression.Constant(partitionKey)))
                     : source;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Creates a LINQ query based on a raw SQL query.
+        ///     </para>
+        ///     <para>
+        ///         If the database provider supports composing on the supplied SQL, you can compose on top of the raw SQL query using
+        ///         LINQ operators: <c>context.Blogs.FromSqlRaw("SELECT * FROM root c WHERE c["Discriminator"] = "Blog").OrderBy(b => b.Name)</c>.
+        ///     </para>
+        ///     <para>
+        ///         As with any API that accepts SQL it is important to parameterize any user input to protect against a SQL injection
+        ///         attack. You can include parameter place holders in the SQL query string and then supply parameter values as additional
+        ///         arguments. Any parameter values you supply will automatically be converted to a DbParameter:
+        ///     </para>
+        ///     <code>context.Blogs.FromSqlRaw(""SELECT * FROM root c WHERE c["Discriminator"] = {0})", userSuppliedSearchTerm)</code>
+        ///     
+        ///     <para>
+        ///         This overload also accepts DbParameter instances as parameter values. This allows you to use named
+        ///         parameters in the SQL query string:
+        ///     </para>
+        ///     <code>context.Blogs.FromSqlRaw(""SELECT * FROM root c WHERE c["Discriminator"] = @searchTerm)", new SqlParameter("@searchTerm", userSuppliedSearchTerm))</code>
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the elements of <paramref name="source" />. </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to use as the base of the raw SQL query (typically a <see cref="DbSet{TEntity}" />).
+        /// </param>
+        /// <param name="sql"> The raw SQL query. </param>
+        /// <param name="parameters"> The values to be assigned to parameters. </param>
+        /// <returns> An <see cref="IQueryable{T}" /> representing the raw SQL query. </returns>
+        [StringFormatMethod("sql")]
+        public static IQueryable<TEntity> FromSqlRaw<TEntity>(
+            this IQueryable<TEntity> source,
+            [NotParameterized] string sql,
+            params object[] parameters)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
+
+            return source.Provider.CreateQuery<TEntity>(
+                GenerateFromSqlQueryRoot(
+                    source,
+                    sql,
+                    parameters));
+        }
+
+        private static FromSqlQueryRootExpression GenerateFromSqlQueryRoot(
+            IQueryable source,
+            string sql,
+            object?[] arguments,
+            [CallerMemberName] string memberName = null!)
+        {
+            var queryRootExpression = (QueryRootExpression)source.Expression;
+
+            var entityType = queryRootExpression.EntityType;
+            
+            return new FromSqlQueryRootExpression(
+                queryRootExpression.QueryProvider!,
+                entityType,
+                sql,
+                Expression.Constant(arguments));
         }
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryableMethodTranslatingExpressionVisitor.cs
@@ -187,6 +187,28 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             }
         }
 
+        /// <inheritdoc />
+        protected override Expression VisitExtension(Expression extensionExpression)
+        {
+            switch (extensionExpression)
+            {
+                case FromSqlQueryRootExpression fromSqlQueryRootExpression:
+                    var queryExpression = new SelectExpression(
+                        fromSqlQueryRootExpression.EntityType,
+                        fromSqlQueryRootExpression.Sql,
+                        fromSqlQueryRootExpression.Argument);
+
+                    return new ShapedQueryExpression(
+                        queryExpression,
+                        new FromSqlCosmosEntityShaperExpression(
+                            fromSqlQueryRootExpression.EntityType,
+                            new ProjectionBindingExpression(queryExpression, new ProjectionMember(), typeof(ValueBuffer)),
+                            false));
+                default:
+                    return base.VisitExtension(extensionExpression);
+            }
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in

--- a/src/EFCore.Cosmos/Query/Internal/FromSqlCosmosEntityShaperExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlCosmosEntityShaperExpression.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         An expression that represents creation of an entity instance for Cosmos provider in
+    ///         <see cref="ShapedQueryExpression.ShaperExpression" />.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class FromSqlCosmosEntityShaperExpression : EntityShaperExpression
+    {
+        /// <summary>
+        ///     Creates a new instance of the <see cref="FromSqlCosmosEntityShaperExpression" /> class.
+        /// </summary>
+        /// <param name="entityType"> The entity type to shape. </param>
+        /// <param name="valueBufferExpression"> An expression of ValueBuffer to get values for properties of the entity. </param>
+        /// <param name="nullable"> A bool value indicating whether this entity instance can be null. </param>
+        public FromSqlCosmosEntityShaperExpression(IEntityType entityType, Expression valueBufferExpression, bool nullable)
+            : base(entityType, valueBufferExpression, nullable, null)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override LambdaExpression GenerateMaterializationCondition(IEntityType entityType, bool nullable)
+        {
+            Check.NotNull(entityType, nameof(EntityType));
+
+            var valueBufferParameter = Parameter(typeof(ValueBuffer));
+            Expression body;
+            var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToArray();
+            
+            body = Constant(concreteEntityTypes.Length == 1 ? concreteEntityTypes[0] : entityType, typeof(IEntityType));
+
+            return Lambda(body, valueBufferParameter);
+        }
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/FromSqlExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlExpression.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class FromSqlExpression : RootReferenceExpression, ICloneable, IPrintableExpression
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlExpression(IEntityType entityType, string alias, string sql, Expression arguments) : base(entityType, alias)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(arguments, nameof(arguments));
+
+            Sql = sql;
+            Arguments = arguments;
+        }
+
+        /// <summary>
+        ///     The alias assigned to this table source.
+        /// </summary>
+        [NotNull]
+        public override string? Alias => base.Alias!;
+
+        /// <summary>
+        ///     The user-provided custom SQL for the table source.
+        /// </summary>
+        public virtual string Sql { get; }
+
+        /// <summary>
+        ///     The user-provided parameters passed to the custom SQL.
+        /// </summary>
+        public virtual Expression Arguments { get; }
+
+        /// <summary>
+        ///     Creates a new expression that is like this one, but using the supplied children. If all of the children are the same, it will
+        ///     return this expression.
+        /// </summary>
+        /// <param name="arguments"> The <see cref="Arguments" /> property of the result. </param>
+        /// <returns> This expression if no children changed, or an expression with the updated children. </returns>
+        public virtual FromSqlExpression Update(Expression arguments)
+        {
+            Check.NotNull(arguments, nameof(arguments));
+
+            return arguments != Arguments
+                ? new FromSqlExpression(EntityType, Alias, Sql, arguments)
+                : this;
+        }
+
+        /// <inheritdoc />
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public override Type Type
+            => typeof(object);
+
+        /// <inheritdoc />
+        public virtual object Clone() => new FromSqlExpression(EntityType, Alias, Sql, Arguments);
+
+        /// <inheritdoc />
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
+        {
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+
+            expressionPrinter.Append(Sql);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+            => obj != null
+                && (ReferenceEquals(this, obj)
+                    || obj is FromSqlExpression fromSqlExpression
+                    && Equals(fromSqlExpression));
+
+        private bool Equals(FromSqlExpression fromSqlExpression)
+            => base.Equals(fromSqlExpression)
+                && Sql == fromSqlExpression.Sql
+                && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), Sql);
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class FromSqlQueryRootExpression : QueryRootExpression
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlQueryRootExpression(
+            IAsyncQueryProvider queryProvider,
+            IEntityType entityType,
+            string sql,
+            Expression argument)
+            : base(queryProvider, entityType)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(argument, nameof(argument));
+
+            Sql = sql;
+            Argument = argument;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlQueryRootExpression(
+            IEntityType entityType,
+            string sql,
+            Expression argument)
+            : base(entityType)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(argument, nameof(argument));
+
+            Sql = sql;
+            Argument = argument;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string Sql { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Expression Argument { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override Expression DetachQueryProvider()
+            => new FromSqlQueryRootExpression(EntityType, Sql, Argument);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var argument = visitor.Visit(Argument);
+
+            return argument != Argument
+                ? new FromSqlQueryRootExpression(EntityType, Sql, argument)
+                : this;
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override void Print(ExpressionPrinter expressionPrinter)
+        {
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+
+            base.Print(expressionPrinter);
+            expressionPrinter.Append($".FromSql({Sql}, ");
+            expressionPrinter.Visit(Argument);
+            expressionPrinter.AppendLine(")");
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override bool Equals(object? obj)
+            => obj != null
+                && (ReferenceEquals(this, obj)
+                    || obj is FromSqlQueryRootExpression queryRootExpression
+                    && Equals(queryRootExpression));
+
+        private bool Equals(FromSqlQueryRootExpression queryRootExpression)
+            => base.Equals(queryRootExpression)
+                && string.Equals(Sql, queryRootExpression.Sql, StringComparison.OrdinalIgnoreCase)
+                && ExpressionEqualityComparer.Instance.Equals(Argument, queryRootExpression.Argument);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), Sql, ExpressionEqualityComparer.Instance.GetHashCode(Argument));
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SelectExpression.cs
@@ -51,6 +51,19 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public SelectExpression(IEntityType entityType, string sql, Expression argument)
+        {
+            Container = entityType.GetContainer();
+            FromExpression = new FromSqlExpression(entityType, RootAlias, sql, argument);
+            _projectionMapping[new ProjectionMember()] = new EntityProjectionExpression(entityType, new RootReferenceExpression(entityType, RootAlias));
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public SelectExpression(
             List<ProjectionExpression> projections,
             RootReferenceExpression fromExpression,

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -46,6 +46,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 case ObjectArrayProjectionExpression arrayProjectionExpression:
                     return VisitObjectArrayProjection(arrayProjectionExpression);
 
+                case FromSqlExpression fromSqlExpression:
+                    return VisitFromSql(fromSqlExpression);
+
                 case RootReferenceExpression rootReferenceExpression:
                     return VisitRootReference(rootReferenceExpression);
 
@@ -82,6 +85,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             return base.VisitExtension(extensionExpression);
         }
+
+        /// <summary>
+        ///     Visits the children of the from sql expression.
+        /// </summary>
+        /// <param name="fromSqlExpression"> The expression to visit. </param>
+        /// <returns> The modified expression, if it or any subexpression was modified; otherwise, returns the original expression. </returns>
+        protected abstract Expression VisitFromSql(FromSqlExpression fromSqlExpression);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Storage/Internal/ParameterNameGenerator.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/ParameterNameGenerator.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
+{
+    /// <summary>
+    ///     <para>
+    ///         Generates unique names for parameters.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public class ParameterNameGenerator
+    {
+        private int _count;
+
+        /// <summary>
+        ///     Generates the next unique parameter name.
+        /// </summary>
+        /// <returns> The generated name. </returns>
+        public virtual string GenerateNext()
+            => "@p" + _count++;
+
+        /// <summary>
+        ///     Resets the generator, meaning it can reuse previously generated names.
+        /// </summary>
+        public virtual void Reset()
+            => _count = 0;
+    }
+}

--- a/test/EFCore.Cosmos.FunctionalTests/EFCore.Cosmos.FunctionalTests.csproj
+++ b/test/EFCore.Cosmos.FunctionalTests/EFCore.Cosmos.FunctionalTests.csproj
@@ -14,6 +14,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\..\src\Shared\*.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EFCore.Cosmos\EFCore.Cosmos.csproj" />
@@ -21,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonVersion)" />
   </ItemGroup>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -1,0 +1,389 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class FromSqlQueryCosmosTest : QueryTestBase<NorthwindQueryCosmosFixture<NoopModelCustomizer>>
+    {
+        public FromSqlQueryCosmosTest(
+            NorthwindQueryCosmosFixture<NoopModelCustomizer> fixture,
+            ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            ClearLog();
+        }
+
+        protected NorthwindContext CreateContext()
+            => Fixture.CreateContext();
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>()
+                .FromSqlRaw(@"SELECT *
+                    FROM root c
+                    WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%'");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(14, actual.Length);
+            Assert.Equal(14, context.ChangeTracker.Entries().Count());
+
+            AssertSql(@"SELECT c
+FROM (
+SELECT *
+                    FROM root c
+                    WHERE c[""Discriminator""] = ""Customer"" AND c[""ContactName""] LIKE '%z%') c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple_columns_out_of_order(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(
+                        @"SELECT c[id], c[Region], c[PostalCode], c[Phone], c[Fax], c[CustomerID], c[Country], c[ContactTitle], c[ContactName], c[CompanyName], c[City], c[Address]
+                        FROM root c
+                        WHERE c[Discriminator] = ""Customer"""));
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Equal(91, context.ChangeTracker.Entries().Count());
+            AssertSql(@"SELECT c
+FROM (
+SELECT c[""id""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""]
+                        FROM root c
+                        WHERE c[""Discriminator""] = ""Customer"") c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple_columns_out_of_order_and_extra_columns(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(
+                        @"SELECT c[id], c[Region], c[PostalCode], c[PostalCode] AS Foo, c[Phone], c[Fax], c[CustomerID], c[Country], c[ContactTitle], c[ContactName], c[CompanyName], c[City], c[Address]
+                        FROM root c
+                        WHERE c[Discriminator] = ""Customer"""));
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Equal(91, context.ChangeTracker.Entries().Count());
+
+            AssertSql(@"SELECT c
+FROM (
+SELECT c[""id""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""]
+                        FROM root c
+                        WHERE c[""Discriminator""] = ""Customer"") c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"""))
+                .Where(c => c.ContactName.Contains("z"));
+
+            var sql = query.ToQueryString();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(14, actual.Length);
+            Assert.Equal(14, context.ChangeTracker.Entries().Count());
+
+            AssertSql(@"SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"") c
+WHERE CONTAINS(c[""ContactName""], ""z"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed_compiled(bool async)
+        {
+            if (async)
+            {
+                var query = EF.CompileAsyncQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"""))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = await query(context).ToListAsync();
+
+                    Assert.Equal(14, actual.Count);
+                }
+            }
+            else
+            {
+                var query = EF.CompileQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"""))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = query(context).ToArray();
+
+                    Assert.Equal(14, actual.Length);
+                }
+            }
+
+            AssertSql(@"SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"") c
+WHERE CONTAINS(c[""ContactName""], ""z"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed_compiled_with_DbParameter(bool async)
+        {
+            if (async)
+            {
+                var query = EF.CompileAsyncQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(
+                            NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[CustomerID] = @customer"),
+                            CreateDbParameter("@customer", "CONSH"))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = await query(context).ToListAsync();
+
+                    Assert.Single(actual);
+                }
+            }
+            else
+            {
+                var query = EF.CompileQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(
+                            NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[CustomerID] = @customer"),
+                            CreateDbParameter("@customer", "CONSH"))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = query(context).ToArray();
+
+                    Assert.Single(actual);
+                }
+            }
+
+            AssertSql(@"@customer='CONSH'
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = @customer) c
+WHERE CONTAINS(c[""ContactName""], ""z"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed_compiled_with_nameless_DbParameter(bool async)
+        {
+            if (async)
+            {
+                var query = EF.CompileAsyncQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(
+                            NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[CustomerID] = {0}"),
+                            CreateDbParameter(null, "CONSH"))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = await query(context).ToListAsync();
+
+                    Assert.Single(actual);
+                }
+            }
+            else
+            {
+                var query = EF.CompileQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(
+                            NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[CustomerID] = {0}"),
+                            CreateDbParameter(null, "CONSH"))
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = query(context).ToArray();
+
+                    Assert.Single(actual);
+                }
+            }
+
+            AssertSql(@"@p0='CONSH'
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""CustomerID""] = @p0) c
+WHERE CONTAINS(c[""ContactName""], ""z"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters(bool async)
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[City] = {0} AND c[ContactTitle] = {1}"), city,
+                    contactTitle);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(@"@p0='London'
+@p1='Sales Representative'
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = @p0 AND c[""ContactTitle""] = @p1) c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters_inline(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[City] = {0} AND c[ContactTitle] = {1}"), "London",
+                    "Sales Representative");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(@"@p0='London'
+@p1='Sales Representative'
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = @p0 AND c[""ContactTitle""] = @p1) c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_null_parameter(bool async)
+        {
+            uint? reportsTo = null;
+
+            using var context = CreateContext();
+            var query = context.Set<Employee>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(
+                        @"SELECT * FROM root c WHERE c[Discriminator] = ""Employee"" AND c[ReportsTo] = {0} OR (IS_NULL(c[ReportsTo]) AND IS_NULL({0}))"), reportsTo);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Single(actual);
+
+            AssertSql(@"@p0=null
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Employee"" AND c[""ReportsTo""] = @p0 OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL(@p0))) c
+");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters_and_closure(bool async)
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    NormalizeDelimitersInRawString(@"SELECT * FROM root c WHERE c[Discriminator] = ""Customer"" AND c[City] = {0}"), city)
+                .Where(c => c.ContactTitle == contactTitle);
+            var queryString = query.ToQueryString();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(@"@p0='London'
+@__contactTitle_1='Sales Representative'
+
+SELECT c
+FROM (
+SELECT * FROM root c WHERE c[""Discriminator""] = ""Customer"" AND c[""City""] = @p0) c
+WHERE (c[""ContactTitle""] = @__contactTitle_1)");
+        }
+
+        protected DbParameter CreateDbParameter(string name, object value)
+            => new SqlParameter { ParameterName = name, Value = value };
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        protected void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
+
+        public virtual string NormalizeDelimitersInRawString(string sql)
+            => sql.Replace("[", OpenDelimiter).Replace("]", CloseDelimiter);
+
+        protected virtual string OpenDelimiter
+            => "[\"";
+
+        protected virtual string CloseDelimiter
+            => "\"]";
+    }
+}


### PR DESCRIPTION
- Fix https://github.com/dotnet/efcore/issues/17311
- All added test cases are chosen from a subset in 
https://github.com/dotnet/efcore/blob/main/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
- There is one considerable constraint is that: user has to include "id" column when listing all column names (in case of not using (Select *)) because of internal keys in cosmos. Not sure if this constraint can be accepted.