### PR TITLE
Don't fallback to default foreign key properties for many-to-many if no attribute was specified.

### DIFF
--- a/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ForeignKeyAttributeConvention.cs
@@ -433,8 +433,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 && foreignKey.IsInModel)
             {
                 var fkPropertiesToSet = FindCandidateDependentPropertiesThroughNavigation(skipNavigationBuilder.Metadata);
-
-                foreignKey.Builder.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
+                if (fkPropertiesToSet != null)
+                {
+                    foreignKey.Builder.HasForeignKey(fkPropertiesToSet, fromDataAnnotation: true);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes the conflict between https://github.com/dotnet/efcore/pull/25444 and https://github.com/dotnet/efcore/pull/25443