### PR TITLE
Fix to #25511 - Temporal Tables: The given key 'SqlServer:TemporalHistoryTableName' was not present in the dictionary when creating migration on entity mapped to temporal table without explicitly providing history table name

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -189,7 +189,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
             if (annotations.TryGetValue(SqlServerAnnotationNames.IsTemporal, out var isTemporalAnnotation)
                 && isTemporalAnnotation.Value as bool? == true)
             {
-                var historyTableName = annotations[SqlServerAnnotationNames.TemporalHistoryTableName].Value as string;
+                var historyTableName = annotations.ContainsKey(SqlServerAnnotationNames.TemporalHistoryTableName)
+                    ? annotations[SqlServerAnnotationNames.TemporalHistoryTableName].Value as string
+                    : null;
+
                 var historyTableSchema = annotations.ContainsKey(SqlServerAnnotationNames.TemporalHistoryTableSchema)
                     ? annotations[SqlServerAnnotationNames.TemporalHistoryTableSchema].Value as string
                     : null;


### PR DESCRIPTION
Problem was that we don't store the default history table name in the annotation (like we do with default period property names), instead the getter on IReadOnlyEntityType retrieves the default value if needed.

Fix is to check if the history table annotation is present in the annotation list, just like we do with the history table schema.

Fixes #25511