### PR TITLE
Make the non-thread-safety of DbContext more visible

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -24,8 +24,16 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     A DbContext instance represents a session with the database and can be used to query and save
-    ///     instances of your entities. DbContext is a combination of the Unit Of Work and Repository patterns.
+    ///     <para>
+    ///         A DbContext instance represents a session with the database and can be used to query and save
+    ///         instances of your entities. DbContext is a combination of the Unit Of Work and Repository patterns.
+    ///     </para>
+    ///     <para>
+    ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+    ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+    ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+    ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+    ///     </para>
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -284,7 +292,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Creates a <see cref="DbSet{TEntity}" /> that can be used to query and save instances of <typeparamref name="TEntity" />.
+        ///     <para>
+        ///         Creates a <see cref="DbSet{TEntity}" /> that can be used to query and save instances of <typeparamref name="TEntity" />.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+        ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
         /// </summary>
         /// <typeparam name="TEntity"> The type of entity for which a set should be returned. </typeparam>
         /// <returns> A set for the given entity type. </returns>
@@ -478,6 +494,12 @@ namespace Microsoft.EntityFrameworkCore
         ///         changes to entity instances before saving to the underlying database. This can be disabled via
         ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
         ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+        ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
         /// </summary>
         /// <returns>
         ///     The number of state entries written to the database.
@@ -501,6 +523,12 @@ namespace Microsoft.EntityFrameworkCore
         ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any
         ///         changes to entity instances before saving to the underlying database. This can be disabled via
         ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+        ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         /// </summary>
         /// <param name="acceptAllChangesOnSuccess">
@@ -586,8 +614,10 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
         ///     </para>
         ///     <para>
-        ///         Multiple active operations on the same context instance are not supported.  Use <see langword="await" /> to ensure
-        ///         that any asynchronous operations have completed before calling another method on this context.
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+        ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         /// </summary>
         /// <param name="cancellationToken"> A <see cref="CancellationToken" /> to observe while waiting for the task to complete. </param>
@@ -617,8 +647,10 @@ namespace Microsoft.EntityFrameworkCore
         ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
         ///     </para>
         ///     <para>
-        ///         Multiple active operations on the same context instance are not supported.  Use <see langword="await" /> to ensure
-        ///         that any asynchronous operations have completed before calling another method on this context.
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same DbContext instance. This
+        ///         includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         /// </summary>
         /// <param name="acceptAllChangesOnSuccess">

--- a/src/EFCore/DbSet.cs
+++ b/src/EFCore/DbSet.cs
@@ -36,6 +36,12 @@ namespace Microsoft.EntityFrameworkCore
     ///         property on a derived <see cref="DbContext" /> or from the <see cref="DbContext.Set{TEntity}()" />
     ///         method.
     ///     </para>
+    ///     <para>
+    ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+    ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+    ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+    ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+    ///     </para>
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being operated on by this set. </typeparam>
     public abstract class DbSet<TEntity> : IQueryable<TEntity>, IInfrastructure<IServiceProvider>, IListSource

--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -73,6 +79,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -132,6 +144,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -171,6 +189,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -220,6 +244,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -267,6 +297,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -353,6 +389,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -378,6 +420,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -411,6 +459,18 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -464,6 +524,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -563,6 +629,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         instance to be resolved from a dependency injection scope directly or created by the factory, as appropriate.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -621,6 +693,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     <para>
         ///         This overload allows a specific implementation of <see cref="IDbContextFactory{TContext}" /> to be registered
         ///         instead of using the default factory shipped with EF Core.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -694,6 +772,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal Entity Framework services.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -760,6 +844,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         By default, we recommend using
         ///         <see cref="AddDbContextFactory{TContext}(IServiceCollection,Action{DbContextOptionsBuilder},ServiceLifetime)" /> which allows
         ///         Entity Framework to create and maintain its own <see cref="IServiceProvider" /> for internal Entity Framework services.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
@@ -838,6 +928,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         overridden to configure a connection string and other options.
         ///     </para>
         ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
+        ///     </para>
+        ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.
         ///         For more information on using dependency injection, see https://go.microsoft.com/fwlink/?LinkId=526890.
         ///     </para>
@@ -880,6 +976,12 @@ namespace Microsoft.Extensions.DependencyInjection
         ///         For applications that don't use dependency injection, consider creating <see cref="DbContext" />
         ///         instances directly with its constructor. The <see cref="DbContext.OnConfiguring" /> method can then be
         ///         overridden to configure a connection string and other options.
+        ///     </para>
+        ///     <para>
+        ///         Entity Framework Core does not support multiple parallel operations being run on the same <see cref="DbContext" />
+        ///         instance. This includes both parallel execution of async queries and any explicit concurrent use from multiple threads.
+        ///         Therefore, always await async calls immediately, or use separate DbContext instances for operations that execute
+        ///         in parallel. See https://aka.ms/efcore-docs-threading for more information.
         ///     </para>
         ///     <para>
         ///         For more information on how to use this method, see the Entity Framework Core documentation at https://aka.ms/efdocs.


### PR DESCRIPTION
Fixes #23319
