### PR TITLE
Cosmos FromSql

### DIFF
--- a/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
+++ b/src/EFCore.Cosmos/Extensions/CosmosQueryableExtensions.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Cosmos.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -13,7 +15,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
-    ///     Cosmos DB specific extension methods for LINQ queries.
+    ///     Cosmos-specific extension methods for LINQ queries.
     /// </summary>
     public static class CosmosQueryableExtensions
     {
@@ -45,6 +47,57 @@ namespace Microsoft.EntityFrameworkCore
                             source.Expression,
                             Expression.Constant(partitionKey)))
                     : source;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Creates a LINQ query based on a raw SQL query.
+        ///     </para>
+        ///     <para>
+        ///         You can compose on top of the raw SQL query using LINQ operators:
+        ///     </para>
+        ///     <code>context.Blogs.FromSqlRaw("SELECT * FROM root c).OrderBy(b => b.Name)</code>
+        ///     <para>
+        ///         As with any API that accepts SQL it is important to parameterize any user input to protect against a SQL injection
+        ///         attack. You can include parameter place holders in the SQL query string and then supply parameter values as additional
+        ///         arguments. Any parameter values you supply will automatically be converted to a Cosmos parameter:
+        ///     </para>
+        ///     <code>context.Blogs.FromSqlRaw(""SELECT * FROM root c WHERE c["Name"] = {0})", userSuppliedSearchTerm)</code>
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of the elements of <paramref name="source" />. </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to use as the base of the raw SQL query (typically a <see cref="DbSet{TEntity}" />).
+        /// </param>
+        /// <param name="sql"> The raw SQL query. </param>
+        /// <param name="parameters"> The values to be assigned to parameters. </param>
+        /// <returns> An <see cref="IQueryable{T}" /> representing the raw SQL query. </returns>
+        [StringFormatMethod("sql")]
+        public static IQueryable<TEntity> FromSqlRaw<TEntity>(
+            this IQueryable<TEntity> source,
+            [NotParameterized] string sql,
+            params object[] parameters)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
+
+            var queryRootExpression = (QueryRootExpression)source.Expression;
+
+            var entityType = queryRootExpression.EntityType;
+
+            Check.DebugAssert(
+                (entityType.BaseType is null && !entityType.GetDirectlyDerivedTypes().Any())
+                || entityType.FindDiscriminatorProperty() is not null,
+                "Found FromSql on a TPT entity type, but TPT isn't supported on Cosmos");
+
+            var fromSqlQueryRootExpression = new FromSqlQueryRootExpression(
+                queryRootExpression.QueryProvider!,
+                entityType,
+                sql,
+                Expression.Constant(parameters));
+
+            return source.Provider.CreateQuery<TEntity>(fromSqlQueryRootExpression);
         }
     }
 }

--- a/src/EFCore.Cosmos/Metadata/Conventions/CosmosDiscriminatorConvention.cs
+++ b/src/EFCore.Cosmos/Metadata/Conventions/CosmosDiscriminatorConvention.cs
@@ -102,14 +102,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 return;
             }
 
-            if (!entityType.IsDocumentRoot())
-            {
-                entityTypeBuilder.HasNoDiscriminator();
-            }
-            else
+            if (entityType.IsDocumentRoot())
             {
                 entityTypeBuilder.HasDiscriminator(typeof(string))
                     ?.HasValue(entityType, entityType.ShortName());
+            }
+            else
+            {
+                entityTypeBuilder.HasNoDiscriminator();
             }
         }
 

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.Designer.cs
@@ -87,6 +87,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Internal
                 derivedType, entityType);
 
         /// <summary>
+        ///     A FromSqlExpression has an invalid arguments expression type '{expressionType}' or value type '{valueType}'.
+        /// </summary>
+        public static string InvalidFromSqlArguments(object? expressionType, object? valueType)
+            => string.Format(
+                GetString("InvalidFromSqlArguments", nameof(expressionType), nameof(valueType)),
+                expressionType, valueType);
+
+        /// <summary>
         ///     Unable to generate a valid 'id' value to execute a 'ReadItem' query. This usually happens when the value provided for one of the properties is 'null' or an empty string. Please supply a value that's not 'null' or an empty string.
         /// </summary>
         public static string InvalidResourceId

--- a/src/EFCore.Cosmos/Properties/CosmosStrings.resx
+++ b/src/EFCore.Cosmos/Properties/CosmosStrings.resx
@@ -144,6 +144,9 @@
   <data name="InvalidDerivedTypeInEntityProjection" xml:space="preserve">
     <value>The specified entity type '{derivedType}' is not derived from '{entityType}'.</value>
   </data>
+  <data name="InvalidFromSqlArguments" xml:space="preserve">
+    <value>A FromSqlExpression has an invalid arguments expression type '{expressionType}' or value type '{valueType}'.</value>
+  </data>
   <data name="InvalidResourceId" xml:space="preserve">
     <value>Unable to generate a valid 'id' value to execute a 'ReadItem' query. This usually happens when the value provided for one of the properties is 'null' or an empty string. Please supply a value that's not 'null' or an empty string.</value>
   </data>

--- a/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPostprocessor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosQueryTranslationPostprocessor.cs
@@ -44,8 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         {
             query = base.Process(query);
 
-            if (query is ShapedQueryExpression shapedQueryExpression
-                && shapedQueryExpression.QueryExpression is SelectExpression selectExpression)
+            if (query is ShapedQueryExpression { QueryExpression: SelectExpression selectExpression })
             {
                 // Cosmos does not have nested select expression so this should be safe.
                 selectExpression.ApplyProjection();

--- a/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosShapedQueryCompilingExpressionVisitor.cs
@@ -65,7 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             switch (shapedQueryExpression.QueryExpression)
             {
                 case SelectExpression selectExpression:
-
                     shaperBody = new CosmosProjectionBindingRemovingExpressionVisitor(
                             selectExpression, jObjectParameter,
                             QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll)
@@ -92,7 +91,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                         Expression.Constant(_threadSafetyChecksEnabled));
 
                 case ReadItemExpression readItemExpression:
-
                     shaperBody = new CosmosProjectionBindingRemovingReadItemExpressionVisitor(
                             readItemExpression, jObjectParameter,
                             QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll)

--- a/src/EFCore.Cosmos/Query/Internal/FromSqlExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlExpression.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+#nullable disable
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public class FromSqlExpression : RootReferenceExpression, IPrintableExpression
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public FromSqlExpression(IEntityType entityType, string alias, string sql, Expression arguments) : base(entityType, alias)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(arguments, nameof(arguments));
+
+            Sql = sql;
+            Arguments = arguments;
+        }
+
+        /// <inheritdoc />
+        public override string Alias => base.Alias!;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual string Sql { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual Expression Arguments { get; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual FromSqlExpression Update(Expression arguments)
+        {
+            Check.NotNull(arguments, nameof(arguments));
+
+            return arguments != Arguments
+                ? new FromSqlExpression(EntityType, Alias, Sql, arguments)
+                : this;
+        }
+
+        /// <inheritdoc />
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return this;
+        }
+
+        /// <inheritdoc />
+        public override Type Type
+            => typeof(object);
+
+        /// <inheritdoc />
+        void IPrintableExpression.Print(ExpressionPrinter expressionPrinter)
+        {
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+
+            expressionPrinter.Append(Sql);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+            => obj != null
+                && (ReferenceEquals(this, obj)
+                    || obj is FromSqlExpression fromSqlExpression
+                    && Equals(fromSqlExpression));
+
+        private bool Equals(FromSqlExpression fromSqlExpression)
+            => base.Equals(fromSqlExpression)
+                && Sql == fromSqlExpression.Sql
+                && ExpressionEqualityComparer.Instance.Equals(Arguments, fromSqlExpression.Arguments);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+            => HashCode.Combine(base.GetHashCode(), Sql);
+    }
+}

--- a/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Internal
+namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/ISqlExpressionFactory.cs
@@ -276,5 +276,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         SelectExpression Select(IEntityType entityType);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        SelectExpression Select(IEntityType entityType, string sql, Expression argument);
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/QuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/QuerySqlGeneratorFactory.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+
 namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 {
     /// <summary>
@@ -11,6 +14,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
     /// </summary>
     public class QuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
     {
+        private readonly ITypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public QuerySqlGeneratorFactory(ITypeMappingSource typeMappingSource)
+        {
+            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
+
+            _typeMappingSource = typeMappingSource;
+        }
+
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
         ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -18,6 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual QuerySqlGenerator Create()
-            => new();
+            => new(_typeMappingSource);
     }
 }

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionFactory.cs
@@ -515,6 +515,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
             return selectExpression;
         }
 
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual SelectExpression Select(IEntityType entityType, string sql, Expression argument)
+        {
+            var selectExpression = new SelectExpression(entityType, sql, argument);
+            AddDiscriminator(selectExpression, entityType);
+
+            return selectExpression;
+        }
+
         private void AddDiscriminator(SelectExpression selectExpression, IEntityType entityType)
         {
             var concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToList();

--- a/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/SqlExpressionVisitor.cs
@@ -46,6 +46,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 case ObjectArrayProjectionExpression arrayProjectionExpression:
                     return VisitObjectArrayProjection(arrayProjectionExpression);
 
+                case FromSqlExpression fromSqlExpression:
+                    return VisitFromSql(fromSqlExpression);
+
                 case RootReferenceExpression rootReferenceExpression:
                     return VisitRootReference(rootReferenceExpression);
 
@@ -82,6 +85,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
             return base.VisitExtension(extensionExpression);
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected abstract Expression VisitFromSql(FromSqlExpression fromSqlExpression);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -693,6 +693,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 derivedType, entityType);
 
         /// <summary>
+        ///     A FromSqlExpression has an invalid arguments expression type '{expressionType}' or value type '{valueType}'.
+        /// </summary>
+        public static string InvalidFromSqlArguments(object? expressionType, object? valueType)
+            => string.Format(
+                GetString("InvalidFromSqlArguments", nameof(expressionType), nameof(valueType)),
+                expressionType, valueType);
+
+        /// <summary>
         ///     The grouping key '{keySelector}' is of type '{keyType}' which is not valid key.
         /// </summary>
         public static string InvalidKeySelectorForGroupBy(object? keySelector, object? keyType)

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -378,6 +378,9 @@
   <data name="InvalidDerivedTypeInEntityProjection" xml:space="preserve">
     <value>The specified entity type '{derivedType}' is not derived from '{entityType}'.</value>
   </data>
+  <data name="InvalidFromSqlArguments" xml:space="preserve">
+    <value>A FromSqlExpression has an invalid arguments expression type '{expressionType}' or value type '{valueType}'.</value>
+  </data>
   <data name="InvalidKeySelectorForGroupBy" xml:space="preserve">
     <value>The grouping key '{keySelector}' is of type '{keyType}' which is not valid key.</value>
   </data>

--- a/src/EFCore.Relational/Query/QuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/QuerySqlGenerator.cs
@@ -363,8 +363,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             switch (fromSqlExpression.Arguments)
             {
-                case ConstantExpression constantExpression
-                    when constantExpression.Value is CompositeRelationalParameter compositeRelationalParameter:
+                case ConstantExpression { Value: CompositeRelationalParameter compositeRelationalParameter }:
                 {
                     var subParameters = compositeRelationalParameter.RelationalParameters;
                     substitutions = new string[subParameters.Count];
@@ -378,8 +377,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     break;
                 }
 
-                case ConstantExpression constantExpression
-                    when constantExpression.Value is object[] constantValues:
+                case ConstantExpression { Value: object[] constantValues }:
                 {
                     substitutions = new string[constantValues.Length];
                     for (var i = 0; i < constantValues.Length; i++)
@@ -398,14 +396,21 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     break;
                 }
+
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(fromSqlExpression),
+                        fromSqlExpression.Arguments,
+                        RelationalStrings.InvalidFromSqlArguments(
+                            fromSqlExpression.Arguments.GetType(),
+                            fromSqlExpression.Arguments is ConstantExpression constantExpression
+                                ? constantExpression.Value?.GetType()
+                                : null));
             }
 
-            if (substitutions != null)
-            {
-                // ReSharper disable once CoVariantArrayConversion
-                // InvariantCulture not needed since substitutions are all strings
-                sql = string.Format(sql, substitutions);
-            }
+            // ReSharper disable once CoVariantArrayConversion
+            // InvariantCulture not needed since substitutions are all strings
+            sql = string.Format(sql, substitutions);
 
             _relationalCommandBuilder.AppendLines(sql);
         }

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2839,7 +2839,7 @@ namespace Microsoft.EntityFrameworkCore.Query.SqlExpressions
         }
 
         /// <summary>
-        ///     Checks whether this <see cref="SelectExpression" /> representes a <see cref="FromSqlExpression" /> which is not composed upon.
+        ///     Checks whether this <see cref="SelectExpression" /> represents a <see cref="FromSqlExpression" /> which is not composed upon.
         /// </summary>
         /// <returns> A bool value indicating a non-composed <see cref="FromSqlExpression" />. </returns>
         public bool IsNonComposedFromSql()

--- a/test/EFCore.Cosmos.FunctionalTests/EFCore.Cosmos.FunctionalTests.csproj
+++ b/test/EFCore.Cosmos.FunctionalTests/EFCore.Cosmos.FunctionalTests.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\src\Shared\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\EFCore.Cosmos\EFCore.Cosmos.csproj" />
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/FromSqlQueryCosmosTest.cs
@@ -1,0 +1,615 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class FromSqlQueryCosmosTest : QueryTestBase<NorthwindQueryCosmosFixture<NoopModelCustomizer>>
+    {
+        private static readonly string _eol = Environment.NewLine;
+
+        public FromSqlQueryCosmosTest(
+            NorthwindQueryCosmosFixture<NoopModelCustomizer> fixture,
+            ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            ClearLog();
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        protected NorthwindContext CreateContext()
+            => Fixture.CreateContext();
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>()
+                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""ContactName""] LIKE '%z%'");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(14, actual.Length);
+            Assert.Equal(14, context.ChangeTracker.Entries().Count());
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""ContactName""] LIKE '%z%'
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple_columns_out_of_order(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Equal(91, context.ChangeTracker.Entries().Count());
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_simple_columns_out_of_order_and_extra_columns(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                @"SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Equal(91, context.ChangeTracker.Entries().Count());
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT c[""id""], c[""Discriminator""], c[""Region""], c[""PostalCode""], c[""PostalCode""] AS Foo, c[""Phone""], c[""Fax""], c[""CustomerID""], c[""Country""], c[""ContactTitle""], c[""ContactName""], c[""CompanyName""], c[""City""], c[""Address""] FROM root c
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                @"SELECT * FROM root c").Where(c => c.ContactName.Contains("z"));
+
+            var sql = query.ToQueryString();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(14, actual.Length);
+            Assert.Equal(14, context.ChangeTracker.Entries().Count());
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""z""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_composed_after_removing_whitespaces(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    _eol + "    " + _eol + _eol + _eol + "SELECT" + _eol + "* FROM root c")
+                .Where(c => c.ContactName.Contains("z"));
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(14, actual.Length);
+
+            AssertSql(
+                @"SELECT c
+FROM (
+
+        
+
+
+    SELECT
+    * FROM root c
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""z""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_composed_compiled(bool async)
+        {
+            if (async)
+            {
+                var query = EF.CompileAsyncQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(@"SELECT * FROM root c")
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = await query(context).ToListAsync();
+
+                    Assert.Equal(14, actual.Count);
+                }
+            }
+            else
+            {
+                var query = EF.CompileQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(@"SELECT * FROM root c")
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = query(context).ToArray();
+
+                    Assert.Equal(14, actual.Length);
+                }
+            }
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""z""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_composed_compiled_with_parameter(bool async)
+        {
+            if (async)
+            {
+                var query = EF.CompileAsyncQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""CustomerID""] = {0}", "CONSH")
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = await query(context).ToListAsync();
+
+                    Assert.Single(actual);
+                }
+            }
+            else
+            {
+                var query = EF.CompileQuery(
+                    (NorthwindContext context) => context.Set<Customer>()
+                        .FromSqlRaw(@"SELECT * FROM root c WHERE c[""CustomerID""] = {0}", "CONSH")
+                        .Where(c => c.ContactName.Contains("z")));
+
+                using (var context = CreateContext())
+                {
+                    var actual = query(context).ToArray();
+
+                    Assert.Single(actual);
+                }
+            }
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""CustomerID""] = ""CONSH""
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND CONTAINS(c[""ContactName""], ""z""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_multiple_line_query(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                @"SELECT *
+FROM root c
+WHERE c[""City""] = 'London'");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(6, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT *
+    FROM root c
+    WHERE c[""City""] = 'London'
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_composed_multiple_line_query(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    @"SELECT *
+FROM root c")
+                .Where(c => c.City == "London");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(6, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT *
+    FROM root c
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters(bool async)
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    @"SELECT * FROM root c WHERE c[""City""] = {0} AND c[""ContactTitle""] = {1}", city,
+                    contactTitle);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(
+                @"@p0='London'
+@p1='Sales Representative'
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = @p0 AND c[""ContactTitle""] = @p1
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters_inline(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    @"SELECT * FROM root c WHERE c[""City""] = {0} AND c[""ContactTitle""] = {1}", "London",
+                    "Sales Representative");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(
+                @"@p0='London'
+@p1='Sales Representative'
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = @p0 AND c[""ContactTitle""] = @p1
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_null_parameter(bool async)
+        {
+            uint? reportsTo = null;
+
+            using var context = CreateContext();
+            var query = context.Set<Employee>().FromSqlRaw(
+                    @"SELECT * FROM root c WHERE c[""ReportsTo""] = {0} OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL({0}))", reportsTo);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Single(actual);
+
+            AssertSql(
+                @"@p0=null
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""ReportsTo""] = @p0 OR (IS_NULL(c[""ReportsTo""]) AND IS_NULL(@p0))
+) c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task FromSqlRaw_queryable_with_parameters_and_closure(bool async)
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(
+                    @"SELECT * FROM root c WHERE c[""City""] = {0}", city)
+                .Where(c => c.ContactTitle == contactTitle);
+            var queryString = query.ToQueryString();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            AssertSql(
+                @"@p0='London'
+@__contactTitle_1='Sales Representative'
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = @p0
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""ContactTitle""] = @__contactTitle_1))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_simple_cache_key_includes_query_string(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>()
+                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""City""] = 'London'");
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(6, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+
+            query = context.Set<Customer>()
+                .FromSqlRaw(@"SELECT * FROM root c WHERE c[""City""] = 'Seattle'");
+
+            actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Single(actual);
+            Assert.True(actual.All(c => c.City == "Seattle"));
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = 'London'
+) c
+WHERE (c[""Discriminator""] = ""Customer"")",
+                //
+                @"SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = 'Seattle'
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_with_parameters_cache_key_includes_parameters(bool async)
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+            var sql = @"SELECT * FROM root c WHERE c[""City""] = {0} AND c[""ContactTitle""] = {1}";
+
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(3, actual.Length);
+            Assert.True(actual.All(c => c.City == "London"));
+            Assert.True(actual.All(c => c.ContactTitle == "Sales Representative"));
+
+            city = "Madrid";
+            contactTitle = "Accounting Manager";
+
+            query = context.Set<Customer>().FromSqlRaw(sql, city, contactTitle);
+
+            actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(2, actual.Length);
+            Assert.True(actual.All(c => c.City == "Madrid"));
+            Assert.True(actual.All(c => c.ContactTitle == "Accounting Manager"));
+
+            AssertSql(
+                @"@p0='London'
+@p1='Sales Representative'
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = @p0 AND c[""ContactTitle""] = @p1
+) c
+WHERE (c[""Discriminator""] = ""Customer"")",
+                //
+                @"@p0='Madrid'
+@p1='Accounting Manager'
+
+SELECT c
+FROM (
+    SELECT * FROM root c WHERE c[""City""] = @p0 AND c[""ContactTitle""] = @p1
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_simple_as_no_tracking_not_composed(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c")
+                .AsNoTracking();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Empty(context.ChangeTracker.Entries());
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_simple_projection_composed(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Product>().FromSqlRaw(
+                    @"SELECT *
+FROM root c
+WHERE NOT c[""Discontinued""] AND ((c[""UnitsInStock""] + c[""UnitsOnOrder""]) < c[""ReorderLevel""])")
+                .Select(p => p.ProductName);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(2, actual.Length);
+
+            AssertSql(
+                @"SELECT c[""ProductName""]
+FROM (
+    SELECT *
+    FROM root c
+    WHERE NOT c[""Discontinued""] AND ((c[""UnitsInStock""] + c[""UnitsOnOrder""]) < c[""ReorderLevel""])
+) c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_composed_with_nullable_predicate(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c")
+                .Where(c => c.ContactName == c.CompanyName);
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Empty(actual);
+
+            AssertSql(
+                @"SELECT c
+FROM (
+    SELECT * FROM root c
+) c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""ContactName""] = c[""CompanyName""]))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_does_not_parameterize_interpolated_string(bool async)
+        {
+            using var context = CreateContext();
+            var propertyName = "OrderID";
+            var max = 10250;
+            var query = context.Orders.FromSqlRaw($@"SELECT * FROM root c WHERE c[""{propertyName}""] < {{0}}", max);
+
+            var actual = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Equal(2, actual.Count);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task FromSqlRaw_queryable_simple_projection_not_composed(bool async)
+        {
+            using var context = CreateContext();
+            var query = context.Set<Customer>().FromSqlRaw(@"SELECT * FROM root c")
+                .Select(
+                    c => new { c.CustomerID, c.City })
+                .AsNoTracking();
+
+            var actual = async
+                ? await query.ToArrayAsync()
+                : query.ToArray();
+
+            Assert.Equal(91, actual.Length);
+            Assert.Empty(context.ChangeTracker.Entries());
+
+            AssertSql(
+                @"SELECT c[""CustomerID""], c[""City""]
+FROM (
+    SELECT * FROM root c
+) c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        protected void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
+    }
+}


### PR DESCRIPTION
Notes:

* Did not implement FromSqlInterpolated for now as we're not sure we want to. Current naming is FromSqlRaw (as opposed to FromSql).
* Cosmos has no DbParameter - parameters are added via [QueryDefinition.WithParameter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.querydefinition.withparameter?view=azure-dotnet) where the name/value are given directly. The main use of accepting DbParameter in relational is to allow configuring parameter facets (size, precision, scale), but as these concepts don't exist in Cosmos we simply don't support it. So Cosmos FromSql supports only direct values.
* The current implementation always integrates the raw SQL as a subquery, even when it isn't composed over. This is because we currently always send `SELECT c FROM root c` for entity projection, which adds an additional level of nesting (with c as key), compared to `SELECT *` (see #25527); this means we don't know how to materialize results from `SELECT *`, or projections such as `SELECT c.Region, c.PostalCode` (even when all the entity's properties are properly projected). Always wrapping in a subquery allows us to produce the correct nested structure; we should probably plan for producing `SELECT *` at some point.
    * Note also that since by default we map all DbSets to the same container with a discriminator, and we compose to filter by the discriminator, we'll (almost?) always be composing anyway (compared to relational where we only compose for discriminator for TPH sub-types).

### Subqueries in Cosmos

Docs say only correlated subqueries are supported (https://docs.microsoft.com/en-us/azure/cosmos-db/sql/sql-query-subquery). However, this seems to (implicitly) refer to subqueries within JOIN:
* Works (correlated subquery in join): `SELECT Count(1) FROM c JOIN (SELECT VALUE t FROM t IN c.Tags)`
* Does not work (non-correlated): `SELECT Count(1) FROM c JOIN (SELECT * FROM root)`
* In other words, JOIN subqueries (like JOIN in general) are just a mechanism for projecting out from the same document (which means they must be correlated)
* So it will never be possible to use FromSql in a JOIN (unlike in relational) - only in FROM.

Composition over subquery in FROM:

Operator       | Sample Northwind SQL
-------------- | ---------------------------------------------------------------------------------------------------------------------------------------------
WHERE          | `SELECT * FROM (SELECT * FROM root c WHERE c.Discriminator = 'Customer') c WHERE c.City = 'Berlin'`
ORDER BY       | `SELECT * FROM (SELECT * FROM root c WHERE c.Discriminator = 'Customer') c ORDER BY c.PostalCode`
LIMIT / OFFSET | `SELECT * FROM (SELECT * FROM root c WHERE c.Discriminator = 'Customer') c OFFSET 1 LIMIT 3`



Closes #17311

Thanks to @RaymondHuy for previous work in #25457