### PR TITLE
Disable SSL certificate validation in Cosmos tests

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosDbContextOptionsBuilderExtensions.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosDbContextOptionsBuilderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net.Http;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
@@ -10,8 +12,16 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
     {
         public static CosmosDbContextOptionsBuilder ApplyConfiguration(this CosmosDbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.ExecutionStrategy(d => new TestCosmosExecutionStrategy(d));
-            optionsBuilder.RequestTimeout(TimeSpan.FromMinutes(1));
+            optionsBuilder
+                .ExecutionStrategy(d => new TestCosmosExecutionStrategy(d))
+                .RequestTimeout(TimeSpan.FromMinutes(20))
+                .HttpClientFactory(
+                    () => new HttpClient(
+                        new HttpClientHandler
+                        {
+                            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                        }))
+                .ConnectionMode(ConnectionMode.Gateway);
 
             return optionsBuilder;
         }

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -55,12 +55,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             AuthToken = TestEnvironment.AuthToken;
             ConnectionString = TestEnvironment.ConnectionString;
             _configureCosmos = extensionConfiguration == null
-                ? (Action<CosmosDbContextOptionsBuilder>)(b => b.ApplyConfiguration())
-                : (b =>
+                ? b => b.ApplyConfiguration()
+                : b =>
                 {
                     b.ApplyConfiguration();
                     extensionConfiguration(b);
-                });
+                };
 
             _storeContext = new TestStoreContext(this);
 


### PR DESCRIPTION
This can make it easier to run the Cosmos tests (instead of messing around with installing the self-signed certificate etc.)