### PR TITLE
Approach for referencing conceptual docs

### DIFF
--- a/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
+++ b/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
@@ -12,6 +12,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TElement"> The array element type. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public class ArrayStructuralComparer<TElement> : ValueComparer<TElement[]>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
+++ b/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
@@ -11,8 +11,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         A new array is constructed when snapshotting.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     /// <typeparam name="TElement"> The array element type. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public class ArrayStructuralComparer<TElement> : ValueComparer<TElement[]>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/CascadeTiming.cs
+++ b/src/EFCore/ChangeTracking/CascadeTiming.cs
@@ -7,7 +7,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Defines different strategies for when cascading actions will be performed.
     ///     See <see cref="ChangeTracker.CascadeDeleteTiming" /> and <see cref="ChangeTracker.DeleteOrphansTiming" />.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-cascading">Documentation for EF Core cascade deletes and deleting orphans.</seealso>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-cascading">EF Core cascade deletes and deleting orphans</see>.
+    /// </remarks>
     public enum CascadeTiming
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/CascadeTiming.cs
+++ b/src/EFCore/ChangeTracking/CascadeTiming.cs
@@ -7,6 +7,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Defines different strategies for when cascading actions will be performed.
     ///     See <see cref="ChangeTracker.CascadeDeleteTiming" /> and <see cref="ChangeTracker.DeleteOrphansTiming" />.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-cascading">Documentation for EF Core cascade deletes and deleting orphans.</seealso>
     public enum CascadeTiming
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -20,7 +20,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Instances of this class are typically obtained from <see cref="DbContext.ChangeTracker" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-change-tracking">EF Core change tracking</see>.
+    /// </remarks>
     public class ChangeTracker : IResettableService
     {
         private readonly IRuntimeModel _model;

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Instances of this class are typically obtained from <see cref="DbContext.ChangeTracker" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
     public class ChangeTracker : IResettableService
     {
         private readonly IRuntimeModel _model;

--- a/src/EFCore/ChangeTracking/ChangeTrackerDebugStringOptions.cs
+++ b/src/EFCore/ChangeTracking/ChangeTrackerDebugStringOptions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Debug string customization options for tracked entities.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-debug-views">Documentation for EF Core debug views.</seealso>
+    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
     [Flags]
     public enum ChangeTrackerDebugStringOptions
     {

--- a/src/EFCore/ChangeTracking/ChangeTrackerDebugStringOptions.cs
+++ b/src/EFCore/ChangeTracking/ChangeTrackerDebugStringOptions.cs
@@ -8,8 +8,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Debug string customization options for tracked entities.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-debug-views">Documentation for EF Core debug views.</seealso>
-    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-change-tracking">EF Core change tracking</see> and
+    ///     <see href="https://aka.ms/efcore-docs-debug-views">EF Core debug views</see>.
+    /// </remarks>
     [Flags]
     public enum ChangeTrackerDebugStringOptions
     {

--- a/src/EFCore/ChangeTracking/ChangeTrackerExtensions.cs
+++ b/src/EFCore/ChangeTracking/ChangeTrackerExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore
     /// <summary>
     ///     Extension methods for <see cref="ChangeTracker" />.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
     public static class ChangeTrackerExtensions
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ChangeTrackerExtensions.cs
+++ b/src/EFCore/ChangeTracking/ChangeTrackerExtensions.cs
@@ -16,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore
     /// <summary>
     ///     Extension methods for <see cref="ChangeTracker" />.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-change-tracking">EF Core change tracking</see>.
+    /// </remarks>
     public static class ChangeTrackerExtensions
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class CollectionEntry : NavigationEntry
     {
         private ICollectionLoader? _loader;

--- a/src/EFCore/ChangeTracking/CollectionEntry.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public class CollectionEntry : NavigationEntry
     {
         private ICollectionLoader? _loader;

--- a/src/EFCore/ChangeTracking/CollectionEntry`.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry`.cs
@@ -19,9 +19,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TRelatedEntity"> The type of the property. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class CollectionEntry<TEntity, TRelatedEntity> : CollectionEntry
         where TEntity : class
         where TRelatedEntity : class

--- a/src/EFCore/ChangeTracking/CollectionEntry`.cs
+++ b/src/EFCore/ChangeTracking/CollectionEntry`.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TRelatedEntity"> The type of the property. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class CollectionEntry<TEntity, TRelatedEntity> : CollectionEntry
         where TEntity : class
         where TRelatedEntity : class

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     [DebuggerDisplay("{" + nameof(InternalEntry) + ",nq}")]
     public class EntityEntry : IInfrastructure<InternalEntityEntry>
     {

--- a/src/EFCore/ChangeTracking/EntityEntry.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry.cs
@@ -28,7 +28,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     [DebuggerDisplay("{" + nameof(InternalEntry) + ",nq}")]
     public class EntityEntry : IInfrastructure<InternalEntityEntry>
     {

--- a/src/EFCore/ChangeTracking/EntityEntryEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryEventArgs.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for events relating to tracked <see cref="EntityEntry" />s.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class EntityEntryEventArgs : EventArgs
     {
         private readonly InternalEntityEntry _internalEntityEntry;

--- a/src/EFCore/ChangeTracking/EntityEntryEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryEventArgs.cs
@@ -10,7 +10,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for events relating to tracked <see cref="EntityEntry" />s.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public class EntityEntryEventArgs : EventArgs
     {
         private readonly InternalEntityEntry _internalEntityEntry;

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
@@ -19,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-track-graph">Tracking entities in EF Core</see>.
+    /// </remarks>
     public class EntityEntryGraphNode : IInfrastructure<InternalEntityEntry>
     {
         private readonly InternalEntityEntry _entry;

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         See <see cref="M:ChangeTracker.TrackGraph" /> for information on how graph nodes are used.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
     public class EntityEntryGraphNode : IInfrastructure<InternalEntityEntry>
     {
         private readonly InternalEntityEntry _entry;

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
@@ -13,6 +13,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Provides access to change tracking information and operations for a node in a
     ///     graph of entities that is being traversed.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
     public class EntityEntryGraphNode<TState> : EntityEntryGraphNode
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntryGraphNode`.cs
@@ -13,7 +13,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Provides access to change tracking information and operations for a node in a
     ///     graph of entities that is being traversed.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-track-graph">Tracking entities in EF Core</see>.
+    /// </remarks>
     public class EntityEntryGraphNode<TState> : EntityEntryGraphNode
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -22,8 +22,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="TEntity"> The type of entity being tracked by this entry. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class EntityEntry<TEntity> : EntityEntry
         where TEntity : class
     {

--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being tracked by this entry. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class EntityEntry<TEntity> : EntityEntry
         where TEntity : class
     {

--- a/src/EFCore/ChangeTracking/EntityStateChangedEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityStateChangedEventArgs.cs
@@ -9,7 +9,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for the <see cref="ChangeTracker.StateChanged" /> event.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-state-changes">Documentation for state changes of entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-state-changes">State changes of entities in EF Core</see>.
+    /// </remarks>
     public class EntityStateChangedEventArgs : EntityEntryEventArgs
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityStateChangedEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityStateChangedEventArgs.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for the <see cref="ChangeTracker.StateChanged" /> event.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-state-changes">Documentation for state changes of entities in EF Core.</seealso>
     public class EntityStateChangedEventArgs : EntityEntryEventArgs
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityTrackedEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityTrackedEventArgs.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for the <see cref="ChangeTracker.Tracked" /> event.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-state-changes">Documentation for state changes of entities in EF Core.</seealso>
     public class EntityTrackedEventArgs : EntityEntryEventArgs
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntityTrackedEventArgs.cs
+++ b/src/EFCore/ChangeTracking/EntityTrackedEventArgs.cs
@@ -9,7 +9,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Event arguments for the <see cref="ChangeTracker.Tracked" /> event.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-state-changes">Documentation for state changes of entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-state-changes">State changes of entities in EF Core</see>.
+    /// </remarks>
     public class EntityTrackedEventArgs : EntityEntryEventArgs
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/EntryCurrentValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/EntryCurrentValueComparer`.cs
@@ -18,8 +18,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not used in application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public sealed class EntryCurrentValueComparer<TProperty> : IComparer<IUpdateEntry>, IEqualityComparer<IUpdateEntry>
     {
         private readonly IPropertyBase _property;

--- a/src/EFCore/ChangeTracking/EntryCurrentValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/EntryCurrentValueComparer`.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public sealed class EntryCurrentValueComparer<TProperty> : IComparer<IUpdateEntry>, IEqualityComparer<IUpdateEntry>
     {
         private readonly IPropertyBase _property;

--- a/src/EFCore/ChangeTracking/GeometryValueComparer.cs
+++ b/src/EFCore/ChangeTracking/GeometryValueComparer.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
     ///     Value snapshotting and comparison logic for NetTopologySuite.Geometries.Geometry instances.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public class GeometryValueComparer<TGeometry> : ValueComparer<TGeometry>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/GeometryValueComparer.cs
+++ b/src/EFCore/ChangeTracking/GeometryValueComparer.cs
@@ -9,7 +9,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Value snapshotting and comparison logic for NetTopologySuite.Geometries.Geometry instances.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     public class GeometryValueComparer<TGeometry> : ValueComparer<TGeometry>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IDependentKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/IDependentKeyValueFactory.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TKey"> The generic type of the key. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-providers">Documentation for EF Core database providers.</seealso>
     public interface IDependentKeyValueFactory<TKey>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IDependentKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/IDependentKeyValueFactory.cs
@@ -18,8 +18,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not used in application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-providers">EF Core database providers</see>.
+    /// </remarks>
     /// <typeparam name="TKey"> The generic type of the key. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-providers">Documentation for EF Core database providers.</seealso>
     public interface IDependentKeyValueFactory<TKey>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
     public interface IEntityEntryGraphIterator
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
@@ -18,7 +18,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         This service cannot depend on services registered as <see cref="ServiceLifetime.Scoped" />.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-track-graph">Tracking entities in EF Core</see>.
+    /// </remarks>
     public interface IEntityEntryGraphIterator
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IPrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/IPrincipalKeyValueFactory.cs
@@ -17,8 +17,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not used in application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-providers">EF Core database providers</see>.
+    /// </remarks>
     /// <typeparam name="TKey"> The key type. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-providers">Documentation for EF Core database providers.</seealso>
     public interface IPrincipalKeyValueFactory<TKey>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/IPrincipalKeyValueFactory.cs
+++ b/src/EFCore/ChangeTracking/IPrincipalKeyValueFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TKey"> The key type. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-providers">Documentation for EF Core database providers.</seealso>
     public interface IPrincipalKeyValueFactory<TKey>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -46,8 +46,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         for WPF binding, or <see cref="ToBindingList" /> for WinForms.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-local-views">Local views of tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="TEntity">The type of the entity in the local view.</typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-local-views">Documentation for local views of tracked entities in EF Core.</seealso>
     public class LocalView<TEntity> :
         ICollection<TEntity>,
         INotifyCollectionChanged,

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -47,6 +47,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="TEntity">The type of the entity in the local view.</typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-local-views">Documentation for local views of tracked entities in EF Core.</seealso>
     public class LocalView<TEntity> :
         ICollection<TEntity>,
         INotifyCollectionChanged,

--- a/src/EFCore/ChangeTracking/MemberEntry.cs
+++ b/src/EFCore/ChangeTracking/MemberEntry.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public abstract class MemberEntry : IInfrastructure<InternalEntityEntry>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/MemberEntry.cs
+++ b/src/EFCore/ChangeTracking/MemberEntry.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public abstract class MemberEntry : IInfrastructure<InternalEntityEntry>
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -23,7 +23,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public abstract class NavigationEntry : MemberEntry
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public abstract class NavigationEntry : MemberEntry
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ObservableHashSet.cs
+++ b/src/EFCore/ChangeTracking/ObservableHashSet.cs
@@ -15,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     for a collection navigation property.
     /// </summary>
     /// <typeparam name="T"> The type of elements in the hash set. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-local-views">Documentation for local views of tracked entities in EF Core.</seealso>
     public class ObservableHashSet<T>
         : ISet<T>, IReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
     {

--- a/src/EFCore/ChangeTracking/ObservableHashSet.cs
+++ b/src/EFCore/ChangeTracking/ObservableHashSet.cs
@@ -14,8 +14,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     A hash set that implements the interfaces required for Entity Framework to use notification based change tracking
     ///     for a collection navigation property.
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-local-views">Local views of tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="T"> The type of elements in the hash set. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-local-views">Documentation for local views of tracked entities in EF Core.</seealso>
     public class ObservableHashSet<T>
         : ISet<T>, IReadOnlyCollection<T>, INotifyCollectionChanged, INotifyPropertyChanged, INotifyPropertyChanging
     {

--- a/src/EFCore/ChangeTracking/PropertyEntry.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class PropertyEntry : MemberEntry
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/PropertyEntry.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry.cs
@@ -16,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public class PropertyEntry : MemberEntry
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry`.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class PropertyEntry<TEntity, TProperty> : PropertyEntry
         where TEntity : class
     {

--- a/src/EFCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry`.cs
@@ -16,9 +16,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class PropertyEntry<TEntity, TProperty> : PropertyEntry
         where TEntity : class
     {

--- a/src/EFCore/ChangeTracking/PropertyValues.cs
+++ b/src/EFCore/ChangeTracking/PropertyValues.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         concurrency exceptions signaled by the throwing of a <see cref="DbUpdateConcurrencyException" />.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public abstract class PropertyValues
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/PropertyValues.cs
+++ b/src/EFCore/ChangeTracking/PropertyValues.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         concurrency exceptions signaled by the throwing of a <see cref="DbUpdateConcurrencyException" />.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public abstract class PropertyValues
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class ReferenceEntry : NavigationEntry
     {
         private IEntityFinder? _finder;

--- a/src/EFCore/ChangeTracking/ReferenceEntry.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     public class ReferenceEntry : NavigationEntry
     {
         private IEntityFinder? _finder;

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class ReferenceEntry<TEntity, TProperty> : ReferenceEntry
         where TEntity : class
         where TProperty : class

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -18,9 +18,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, <see href="https://aka.ms/efcore-docs-entity-entries">Accessing tracked entities in EF Core</see>.
+    /// </remarks>
     /// <typeparam name="TEntity"> The type of the entity the property belongs to. </typeparam>
     /// <typeparam name="TProperty"> The type of the property. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
     public class ReferenceEntry<TEntity, TProperty> : ReferenceEntry
         where TEntity : class
         where TProperty : class

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         reference.
     ///     </para>
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<object>
     {
         private static readonly MethodInfo _doubleEqualsMethodInfo

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         reference.
     ///     </para>
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     public abstract class ValueComparer : IEqualityComparer, IEqualityComparer<object>
     {
         private static readonly MethodInfo _doubleEqualsMethodInfo

--- a/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
@@ -6,7 +6,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Extension methods for <see cref="ValueComparer" />.
     /// </summary>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     public static class ValueComparerExtensions
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/ValueComparerExtensions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <summary>
     ///     Extension methods for <see cref="ValueComparer" />.
     /// </summary>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public static class ValueComparerExtensions
     {
         /// <summary>

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     </para>
     /// </summary>
     /// <typeparam name="T"> The type. </typeparam>
+    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
     {
         private Func<T?, T?, bool>? _equals;

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -25,8 +25,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///         reference.
     ///     </para>
     /// </summary>
+    /// <remarks>
+    ///     For more information, see <see href="https://aka.ms/efcore-docs-value-comparers">EF Core value comparers</see>.
+    /// </remarks>
     /// <typeparam name="T"> The type. </typeparam>
-    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
     public class ValueComparer<T> : ValueComparer, IEqualityComparer<T>
     {
         private Func<T?, T?, bool>? _equals;

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;


### PR DESCRIPTION
Part of #17508

This is a proof-of-concept on how to do this to get team review on before I do the whole codebase. For the change-tracking namespace I ended up with these links:

```C#
    /// <seealso href="https://aka.ms/efcore-docs-value-comparers">Documentation for EF Core value comparers.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-cascading">Documentation for EF Core cascade deletes and deleting orphans.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-change-tracking">Documentation for EF Core change tracking.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-entity-entries">Documentation for accessing tracked entities in EF Core.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-debug-views">Documentation for EF Core debug views.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-track-graph">Documentation for tracking entities in EF Core.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-providers">Documentation for EF Core database providers.</seealso>
    /// <seealso href="https://aka.ms/efcore-docs-local-views">Documentation for local views of tracked entities in EF Core.</seealso>
```

Also, I think it's okay to reference multiple of these where appropriate. In particular, for cross-cutting features like debug views.

Aka links are not actually created yet.
