### PR TITLE
Register concrete DbContext type in D.I. even when registration for interface is also made

### DIFF
--- a/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -307,10 +307,15 @@ namespace Microsoft.Extensions.DependencyInjection
             AddPoolingOptions<TContextImplementation>(serviceCollection, optionsAction, poolSize);
 
             serviceCollection.TryAddSingleton<IDbContextPool<TContextImplementation>, DbContextPool<TContextImplementation>>();
-            serviceCollection.AddScoped<IScopedDbContextLease<TContextImplementation>, ScopedDbContextLease<TContextImplementation>>();
+            serviceCollection.TryAddScoped<IScopedDbContextLease<TContextImplementation>, ScopedDbContextLease<TContextImplementation>>();
 
-            serviceCollection.AddScoped<TContextService>(
+            serviceCollection.TryAddScoped<TContextService>(
                 sp => sp.GetRequiredService<IScopedDbContextLease<TContextImplementation>>().Context);
+
+            if (typeof(TContextService) != typeof(TContextImplementation))
+            {
+                serviceCollection.TryAddScoped(p => (TContextImplementation)p.GetService<TContextService>()!);
+            }
 
             return serviceCollection;
         }
@@ -526,16 +531,21 @@ namespace Microsoft.Extensions.DependencyInjection
             if (serviceCollection.Any(d => d.ServiceType == typeof(IDbContextFactorySource<TContextImplementation>)))
             {
                 // Override registration made by AddDbContextFactory
-                var serviceDescriptor = serviceCollection.FirstOrDefault(d => d.ServiceType == typeof(TContextService));
+                var serviceDescriptor = serviceCollection.FirstOrDefault(d => d.ServiceType == typeof(TContextImplementation));
                 if (serviceDescriptor != null)
                 {
                     serviceCollection.Remove(serviceDescriptor);
-                    serviceCollection.Add(new ServiceDescriptor(typeof(TContextService), typeof(TContextImplementation), contextLifetime));    
                 }
             }
-            else
+            
+            serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContextService), typeof(TContextImplementation), contextLifetime));
+
+            if (typeof(TContextService) != typeof(TContextImplementation))
             {
-                serviceCollection.TryAdd(new ServiceDescriptor(typeof(TContextService), typeof(TContextImplementation), contextLifetime));
+                serviceCollection.TryAdd(
+                    new ServiceDescriptor(typeof(TContextImplementation), 
+                        p => (TContextImplementation)p.GetService<TContextService>()!,
+                        contextLifetime));
             }
 
             return serviceCollection;

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -304,6 +304,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public void Pool_can_get_context_by_concrete_type_even_when_service_interface_is_used()
+        {
+            var serviceProvider = BuildServiceProvider<IPooledContext, PooledContext>();
+
+            using var scope = serviceProvider.CreateScope();
+
+            Assert.Same(
+                scope.ServiceProvider.GetRequiredService<IPooledContext>(),
+                scope.ServiceProvider.GetRequiredService<PooledContext>());
+        }
+
+        [ConditionalFact]
         public void Validate_pool_size_with_factory_default()
         {
             var serviceProvider = BuildServiceProviderWithFactory<PooledContext>();

--- a/test/EFCore.Tests/DbContextServicesTest.cs
+++ b/test/EFCore.Tests/DbContextServicesTest.cs
@@ -1104,6 +1104,11 @@ namespace Microsoft.EntityFrameworkCore
                     ? (ConstructorTestContextWithOC1A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC1A>()
                     : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
 
+                if (useInterface)
+                {
+                    Assert.Same(context1, serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>());
+                }
+
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStoreCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
                 Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());


### PR DESCRIPTION
Fixes #14307

This means that tooling (such as the database middleware) can still find the context, while the application can resolve using the interface.
