### PR TITLE
[release/3.1] Update SQLite dependencies to 2.0.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,9 +24,9 @@
     <NetTopologySuitePackageVersion>2.0.0</NetTopologySuitePackageVersion>
     <NetTopologySuiteIOSpatiaLitePackageVersion>2.0.0</NetTopologySuiteIOSpatiaLitePackageVersion>
     <NetTopologySuiteIOSqlServerBytesPackageVersion>2.0.0</NetTopologySuiteIOSqlServerBytesPackageVersion>
-    <SQLitePCLRawBundleESqlite3PackageVersion>2.0.2</SQLitePCLRawBundleESqlite3PackageVersion>
-    <SQLitePCLRawBundleESqlcipherPackageVersion>2.0.2</SQLitePCLRawBundleESqlcipherPackageVersion>
-    <SQLitePCLRawCorePackageVersion>2.0.2</SQLitePCLRawCorePackageVersion>
+    <SQLitePCLRawBundleESqlite3PackageVersion>2.0.4</SQLitePCLRawBundleESqlite3PackageVersion>
+    <SQLitePCLRawBundleESqlcipherPackageVersion>2.0.4</SQLitePCLRawBundleESqlcipherPackageVersion>
+    <SQLitePCLRawCorePackageVersion>2.0.4</SQLitePCLRawCorePackageVersion>
     <StyleCopAnalyzersPackageVersion>1.1.118</StyleCopAnalyzersPackageVersion>
     <BenchmarkDotNetPackageVersion>0.11.3</BenchmarkDotNetPackageVersion>
     <MicrosoftDataSqlClientPackageVersion>1.1.3</MicrosoftDataSqlClientPackageVersion>


### PR DESCRIPTION
Fixes #25497

**Description**

Update dependency on external SQLite packages from 2.0.2 to 2.0.4. This version fixes an important bug [System.AccessViolationException at System.Text.UTF8Encoding.GetCharCount(Byte*, Int32, System.Text.DecoderNLS)](https://github.com/ericsink/SQLitePCL.raw/issues/321) which has been hit by many customers. Our 5.0 packages have already depended on this newer version for about a year. We now want to update the 3.1 packages because they are LTS and are the last version of EF Core that runs on .NET Framework.

**Customer Impact**

Fixes an AccessViolationException hit my many customers, and avoids every customer having to manually reference the updated package.

**How found**

Reported by customers.

**Test coverage**

Sufficient test coverage already exists since this is only an external dependency update.

**Regression?**

The external bug is a regression from previous versions.

**Risk**

Low. The new version has been out for a year already with lots of usage, and we already depend on it in 5.0.
