### PR TITLE
Query: Add a test for group by constant composed

### DIFF
--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -1803,6 +1803,18 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task GroupBy_count_filter(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Order>().Select(e => new { e.OrderID, Name = "Order" })
+                    .GroupBy(o => o.Name)
+                    .Select(g => new { Name = g.Key, Count = g.Count() })
+                    .Where(o => o.Count > 0));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task GroupBy_filter_count_OrderBy_count_Select_sum(bool async)
         {
             return AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -1378,6 +1378,20 @@ GROUP BY [o].[CustomerID]
 HAVING COUNT(*) > 4");
         }
 
+        public override async Task GroupBy_count_filter(bool async)
+        {
+            await base.GroupBy_count_filter(async);
+
+            AssertSql(
+                @"SELECT [t].[Key] AS [Name], COUNT(*) AS [Count]
+FROM (
+    SELECT N'Order' AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]
+HAVING COUNT(*) > 0");
+        }
+
         public override async Task GroupBy_filter_count_OrderBy_count_Select_sum(bool async)
         {
             await base.GroupBy_filter_count_OrderBy_count_Select_sum(async);


### PR DESCRIPTION
Don't remember which bug I was testing when I wrote this.