### PR TITLE
Fix to #25013 - Outstanding work for temporal tables

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerCSharpRuntimeAnnotationCodeGenerator.cs
@@ -90,5 +90,22 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
 
             base.Generate(key, parameters);
         }
+
+        /// <inheritdoc />
+        public override void Generate(IEntityType entityType, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
+        {
+            if (!parameters.IsRuntime)
+            {
+                var annotations = parameters.Annotations;
+                annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableSchema);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndPropertyName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartPropertyName);
+            }
+
+            base.Generate(entityType, parameters);
+        }
     }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
@@ -102,7 +103,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Name of the period start property. </returns>
         public static string? GetPeriodStartPropertyName(this IReadOnlyEntityType entityType)
-            => entityType[SqlServerAnnotationNames.TemporalPeriodStartPropertyName] as string;
+            => entityType is RuntimeEntityType
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[SqlServerAnnotationNames.TemporalPeriodStartPropertyName] as string;
 
         /// <summary>
         ///     Sets a value representing the name of the period start property of the entity mapped to a temporal table.
@@ -146,7 +149,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Name of the period start property. </returns>
         public static string? GetPeriodEndPropertyName(this IReadOnlyEntityType entityType)
-            => entityType[SqlServerAnnotationNames.TemporalPeriodEndPropertyName] as string;
+            => entityType is RuntimeEntityType
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[SqlServerAnnotationNames.TemporalPeriodEndPropertyName] as string;
 
         /// <summary>
         ///     Sets a value representing the name of the period end property of the entity mapped to a temporal table.
@@ -190,11 +195,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Name of the history table. </returns>
         public static string? GetHistoryTableName(this IReadOnlyEntityType entityType)
-            => entityType[SqlServerAnnotationNames.TemporalHistoryTableName] is string historyTableName
-                ? historyTableName
-                : entityType[SqlServerAnnotationNames.IsTemporal] as bool? == true
-                    ? entityType.ShortName() + DefaultHistoryTableNameSuffix
-                    : null;
+            => entityType is RuntimeEntityType
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[SqlServerAnnotationNames.TemporalHistoryTableName] is string historyTableName
+                    ? historyTableName
+                    : entityType[SqlServerAnnotationNames.IsTemporal] as bool? == true
+                        ? entityType.ShortName() + DefaultHistoryTableNameSuffix
+                        : null;
 
         /// <summary>
         ///     Sets a value representing the name of the history table associated with the entity mapped to a temporal table.
@@ -238,8 +245,10 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entityType"> The entity type. </param>
         /// <returns> Name of the history table. </returns>
         public static string? GetHistoryTableSchema(this IReadOnlyEntityType entityType)
-            => entityType[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
-                ?? entityType[RelationalAnnotationNames.Schema] as string;
+            => entityType is RuntimeEntityType
+                ? throw new InvalidOperationException(CoreStrings.RuntimeModelMissingData)
+                : entityType[SqlServerAnnotationNames.TemporalHistoryTableSchema] as string
+                    ?? entityType[RelationalAnnotationNames.Schema] as string;
 
         /// <summary>
         ///     Sets a value representing the schema of the history table associated with the entity mapped to a temporal table.

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerRuntimeModelConvention.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
@@ -115,6 +114,32 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             if (!runtime)
             {
                 annotations.Remove(SqlServerAnnotationNames.Clustered);
+            }
+        }
+
+        /// <summary>
+        ///     Updates the entity type annotations that will be set on the read-only object.
+        /// </summary>
+        /// <param name="annotations"> The annotations to be processed. </param>
+        /// <param name="entityType"> The source entity type. </param>
+        /// <param name="runtimeEntityType"> The target entity type that will contain the annotations. </param>
+        /// <param name="runtime"> Indicates whether the given annotations are runtime annotations. </param>
+        protected override void ProcessEntityTypeAnnotations(
+            IDictionary<string, object?> annotations,
+            IEntityType entityType,
+            RuntimeEntityType runtimeEntityType,
+            bool runtime)
+        {
+            base.ProcessEntityTypeAnnotations(annotations, entityType, runtimeEntityType, runtime);
+
+            if (!runtime)
+            {
+                annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalHistoryTableSchema);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndColumnName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodEndPropertyName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartColumnName);
+                annotations.Remove(SqlServerAnnotationNames.TemporalPeriodStartPropertyName);
             }
         }
     }


### PR DESCRIPTION
Removing unnecessary temporal annotations on runtime entity types, also avoiding adding EnsureSchemaOperation if the schema that is to be created has already been added in the migration batch.
