### PR TITLE
Query: Remove unnecessary convert to IEnumerable for OData

### DIFF
--- a/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/QueryableMethodNormalizingExpressionVisitor.cs
@@ -345,6 +345,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         if (innerQueryableElementType == null
                             || innerQueryableElementType != genericType)
                         {
+                            while (innerArgument is UnaryExpression {
+                                    NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked or ExpressionType.TypeAs } unaryExpression
+                                && unaryExpression.Type.TryGetElementType(typeof(IEnumerable<>)) != null)
+                            {
+                                innerArgument = unaryExpression.Operand;
+                            }
+
                             arguments[i] = Expression.Call(
                                 QueryableMethods.AsQueryable.MakeGenericMethod(genericType),
                                 innerArgument);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2173,6 +2173,19 @@ GROUP BY [c].[CustomerID], [o].[OrderDate]
 ORDER BY [o].[OrderDate]");
         }
 
+        public override async Task Odata_groupby_empty_key(bool async)
+        {
+            await base.Odata_groupby_empty_key(async);
+
+            AssertSql(
+                @"SELECT N'TotalAmount' AS [Name], COALESCE(SUM(CAST([t].[OrderID] AS decimal(18,2))), 0.0) AS [Value]
+FROM (
+    SELECT [o].[OrderID], 1 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
         public override async Task GroupBy_with_group_key_access_thru_navigation(bool async)
         {
             await base.GroupBy_with_group_key_access_thru_navigation(async);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -67,5 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 SqliteStrings.ApplyNotSupported,
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => base.Select_nested_collection_with_groupby(async))).Message);
+
+        public override async Task Odata_groupby_empty_key(bool async)
+            => await Assert.ThrowsAsync<NotSupportedException>(() => base.Odata_groupby_empty_key(async));
     }
 }


### PR DESCRIPTION
Resolves #24561
