### PR TITLE
Query: Allow using STET overload for Set in query filter/defining query

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Cosmos/Query/Internal/FromSqlQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -80,6 +81,18 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new FromSqlQueryRootExpression(EntityType, Sql, Argument);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new FromSqlQueryRootExpression(entityType, Sql, Argument);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -79,6 +80,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new FromSqlQueryRootExpression(EntityType, Sql, Argument);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new FromSqlQueryRootExpression(entityType, Sql, Argument);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
+++ b/src/EFCore.Relational/Query/Internal/TableValuedFunctionQueryRootExpression.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -75,6 +76,18 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 ? new TableValuedFunctionQueryRootExpression(EntityType, Function, arguments)
                 : this;
         }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TableValuedFunctionQueryRootExpression(entityType, Function, Arguments);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/TemporalAllQueryRootExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/TemporalAllQueryRootExpression.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -45,6 +47,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new TemporalAllQueryRootExpression(EntityType);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TemporalAllQueryRootExpression(entityType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/TemporalAsOfQueryRootExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/TemporalAsOfQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -57,6 +58,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new TemporalAsOfQueryRootExpression(EntityType, PointInTime);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TemporalAsOfQueryRootExpression(entityType, PointInTime);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/TemporalBetweenQueryRootExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/TemporalBetweenQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -53,6 +54,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new TemporalBetweenQueryRootExpression(EntityType, From, To);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TemporalBetweenQueryRootExpression(entityType, From, To);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/TemporalContainedInQueryRootExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/TemporalContainedInQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -53,6 +54,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new TemporalContainedInQueryRootExpression(EntityType, From, To);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TemporalContainedInQueryRootExpression(entityType, From, To);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.SqlServer/Query/Internal/TemporalFromToQueryRootExpression.cs
+++ b/src/EFCore.SqlServer/Query/Internal/TemporalFromToQueryRootExpression.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -53,6 +54,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         /// </summary>
         public override Expression DetachQueryProvider()
             => new TemporalFromToQueryRootExpression(EntityType, From, To);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new TemporalFromToQueryRootExpression(entityType, From, To);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Conventions/QueryFilterRewritingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/QueryFilterRewritingConvention.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -93,7 +96,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     && memberExpression.Type.GetGenericTypeDefinition() == typeof(DbSet<>)
                     && _model != null)
                 {
-                    return new QueryRootExpression(FindEntityType(memberExpression.Type)!);
+                    var entityClrType = memberExpression.Type.GetGenericArguments()[0];
+                    return new QueryRootExpression(FindEntityType(entityClrType)!);
                 }
 
                 return base.VisitMember(memberExpression);
@@ -111,14 +115,62 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     && methodCallExpression.Type.GetGenericTypeDefinition() == typeof(DbSet<>)
                     && _model != null)
                 {
-                    return new QueryRootExpression(FindEntityType(methodCallExpression.Type)!);
+                    IEntityType? entityType;
+                    var entityClrType = methodCallExpression.Type.GetGenericArguments()[0];
+                    if (methodCallExpression.Arguments.Count == 1)
+                    {
+                        // STET Set method
+                        var entityTypeName = methodCallExpression.Arguments[0].GetConstantValue<string>();
+                        entityType = (IEntityType?)_model.FindEntityType(entityTypeName);
+                    }
+                    else
+                    {
+                        entityType = FindEntityType(entityClrType);
+                    }
+
+                    if (entityType == null)
+                    {
+                        if (_model.IsShared(entityClrType))
+                        {
+                            throw new InvalidOperationException(CoreStrings.InvalidSetSharedType(entityClrType.ShortDisplayName()));
+                        }
+
+                        var findSameTypeName = ((IModel)_model).FindSameTypeNameWithDifferentNamespace(entityClrType);
+                        //if the same name exists in your entity types we will show you the full namespace of the type
+                        if (!string.IsNullOrEmpty(findSameTypeName))
+                        {
+                            throw new InvalidOperationException(CoreStrings.InvalidSetSameTypeWithDifferentNamespace(entityClrType.DisplayName(), findSameTypeName));
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException(CoreStrings.InvalidSetType(entityClrType.ShortDisplayName()));
+                        }
+                    }
+
+                    if (entityType.IsOwned())
+                    {
+                        var message = CoreStrings.InvalidSetTypeOwned(
+                            entityType.DisplayName(), entityType.FindOwnership()!.PrincipalEntityType.DisplayName());
+
+                        throw new InvalidOperationException(message);
+                    }
+
+                    if (entityType.ClrType != entityClrType)
+                    {
+                        var message = CoreStrings.DbSetIncorrectGenericType(
+                            entityType.ShortName(), entityType.ClrType.ShortDisplayName(), entityClrType.ShortDisplayName());
+
+                        throw new InvalidOperationException(message);
+                    }
+
+                    return new QueryRootExpression(entityType);
                 }
 
                 return base.VisitMethodCall(methodCallExpression);
             }
 
-            private IEntityType? FindEntityType(Type dbSetType)
-                => ((IModel)_model!).FindRuntimeEntityType(dbSetType.GetGenericArguments()[0]);
+            private IEntityType? FindEntityType(Type entityClrType)
+                => ((IModel)_model!).FindRuntimeEntityType(entityClrType);
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -613,7 +613,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             /// <inheritdoc />
             protected override Expression VisitExtension(Expression extensionExpression)
                 => extensionExpression is QueryRootExpression queryRootExpression
-                    ? new QueryRootExpression(_model.FindEntityType(queryRootExpression.EntityType.Name)!)
+                    ? queryRootExpression.UpdateEntityType(_model.FindEntityType(queryRootExpression.EntityType.Name)!)
                     : base.VisitExtension(extensionExpression);
         }
     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2291,6 +2291,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 projection, queryableType);
 
         /// <summary>
+        ///     The replacement entity type: {entityType} does not have same name and CLR type as entity type this query root represents.
+        /// </summary>
+        public static string QueryRootDifferentEntityType(object? entityType)
+            => string.Format(
+                GetString("QueryRootDifferentEntityType", nameof(entityType)),
+                entityType);
+
+        /// <summary>
         ///     Translation of '{expression}' failed. Either the query source is not an entity type, or the specified property does not exist on the entity type.
         /// </summary>
         public static string QueryUnableToTranslateEFProperty(object? expression)
@@ -2848,7 +2856,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             => string.Format(
                 GetString("ValueGenWithConversion", nameof(entityType), nameof(property), nameof(converter)),
                 entityType, property, converter);
-        
+
         /// <summary>
         ///     Calling '{visitMethodName}' is not allowed. Visit the expression manually for the relevant part in the visitor.
         /// </summary>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -972,7 +972,7 @@
   </data>
   <data name="LogShadowForeignKeyPropertyCreated" xml:space="preserve">
     <value>The foreign key property '{entityType}.{property}' was created in shadow state because a conflicting property with the simple name '{baseName}' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.</value>
-    <comment>Warning CoreEventId.ShadowForeignKeyPropertyCreated string string</comment>
+    <comment>Warning CoreEventId.ShadowForeignKeyPropertyCreated string string string</comment>
   </data>
   <data name="LogShadowPropertyCreated" xml:space="preserve">
     <value>The property '{entityType}.{property}' was created in shadow state because there are no eligible CLR members with a matching name.</value>
@@ -1309,6 +1309,9 @@
   </data>
   <data name="QueryInvalidMaterializationType" xml:space="preserve">
     <value>The query contains a projection '{projection}' of type '{queryableType}'. Collections in the final projection must be an 'IEnumerable&lt;T&gt;' type such as 'List&lt;T&gt;'. Consider using 'ToList' or some other mechanism to convert the 'IQueryable&lt;T&gt;' or 'IOrderedEnumerable&lt;T&gt;' into an 'IEnumerable&lt;T&gt;'.</value>
+  </data>
+  <data name="QueryRootDifferentEntityType" xml:space="preserve">
+    <value>The replacement entity type: {entityType} does not have same name and CLR type as entity type this query root represents.</value>
   </data>
   <data name="QueryUnableToTranslateEFProperty" xml:space="preserve">
     <value>Translation of '{expression}' failed. Either the query source is not an entity type, or the specified property does not exist on the entity type.</value>

--- a/src/EFCore/Query/QueryRootExpression.cs
+++ b/src/EFCore/Query/QueryRootExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -65,6 +66,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <returns> A new query root expression without query provider. </returns>
         public virtual Expression DetachQueryProvider()
             => new QueryRootExpression(EntityType);
+
+        /// <summary>
+        ///     Updates entity type associated with this query root with equivalent optimized version.
+        /// </summary>
+        /// <param name="entityType"> The entity type to replace with. </param>
+        /// <returns> New query root containing given entity type. </returns>
+        public virtual QueryRootExpression UpdateEntityType(IEntityType entityType)
+            => entityType.ClrType != EntityType.ClrType
+                || entityType.Name != EntityType.Name
+                ? throw new InvalidOperationException(CoreStrings.QueryRootDifferentEntityType(entityType.DisplayName()))
+                : new QueryRootExpression(entityType);
 
         /// <inheritdoc />
         public override ExpressionType NodeType

--- a/test/EFCore.InMemory.FunctionalTests/Query/SharedTypeQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/SharedTypeQueryInMemoryTest.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class SharedTypeQueryInMemoryTest : SharedTypeQueryTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Can_use_shared_type_entity_type_in_ToInMemoryQuery(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContextInMemory24601>(
+                   seed: c => c.Seed());
+
+            using var context = contextFactory.CreateContext();
+
+            var data = context.Set<ViewQuery24601>();
+
+            Assert.Equal("Maumar", Assert.Single(data).Value);
+        }
+
+        private class MyContextInMemory24601 : MyContext24601
+        {
+            public MyContextInMemory24601(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.SharedTypeEntity<Dictionary<string, object>>("STET",
+                    b =>
+                    {
+                        b.IndexerProperty<int>("Id");
+                        b.IndexerProperty<string>("Value");
+                    });
+
+                modelBuilder.Entity<ViewQuery24601>().HasNoKey()
+                    .ToInMemoryQuery(() => Set<Dictionary<string, object>>("STET").Select(e => new ViewQuery24601 { Value = (string)e["Value"] }));
+            }
+        }
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/SharedTypeQueryRelationalTestBase.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class SharedTypeQueryRelationalTestBase : SharedTypeQueryTestBase
+    {
+        protected TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected void ClearLog() => TestSqlLoggerFactory.Clear();
+
+        protected void AssertSql(params string[] expected) => TestSqlLoggerFactory.AssertBaseline(expected);
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Can_use_shared_type_entity_type_in_query_filter_with_from_sql(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContextRelational24601>(
+                seed: c => c.Seed());
+
+            using var context = contextFactory.CreateContext();
+            var query = context.Set<ViewQuery24601>();
+            var result = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Empty(result);
+        }
+
+        protected class MyContextRelational24601 : MyContext24601
+        {
+            public MyContextRelational24601(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+                modelBuilder.Entity<ViewQuery24601>()
+                    .HasQueryFilter(e => Set<Dictionary<string, object>>("STET")
+                        .FromSqlRaw("Select * from STET").Select(i => (string)i["Value"]).Contains(e.Value));
+            }
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class SharedTypeQueryTestBase : NonSharedModelTestBase
+    {
+        public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+
+        protected override string StoreName => "SharedTypeQueryTests";
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Can_use_shared_type_entity_type_in_query_filter(bool async)
+        {
+            var contextFactory = await InitializeAsync<MyContext24601>(
+                seed: c => c.Seed());
+
+            using var context = contextFactory.CreateContext();
+            var query = context.Set<ViewQuery24601>();
+            var result = async
+                ? await query.ToListAsync()
+                : query.ToList();
+
+            Assert.Empty(result);
+        }
+
+        protected class MyContext24601 : DbContext
+        {
+            public MyContext24601(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public void Seed()
+            {
+                Set<Dictionary<string, object>>("STET").Add(new Dictionary<string, object>
+                {
+                    ["Value"] = "Maumar"
+                });
+
+                SaveChanges();
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.SharedTypeEntity<Dictionary<string, object>>("STET",
+                    b =>
+                    {
+                        b.IndexerProperty<int>("Id");
+                        b.IndexerProperty<string>("Value");
+                    });
+
+                modelBuilder.Entity<ViewQuery24601>().HasNoKey()
+                    .HasQueryFilter(e => Set<Dictionary<string, object>>("STET").Select(i => (string)i["Value"]).Contains(e.Value));
+            }
+        }
+
+        protected class ViewQuery24601
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -10159,7 +10159,7 @@ CROSS APPLY OPENJSON([c].[Json], N'$.items') AS [o]" });
 
         #endregion
 
-        #region Issue24569
+        #region Issue25400
 
         [ConditionalTheory]
         [InlineData(true)]
@@ -10171,14 +10171,14 @@ CROSS APPLY OPENJSON([c].[Json], N'$.items') AS [o]" });
 
             using (var context = contextFactory.CreateContext())
             {
-                Test24569.ConstructorCallCount = 0;
+                Test25400.ConstructorCallCount = 0;
 
-                var query = context.Set<Test24569>().AsNoTracking().OrderBy(e => e.Id);
+                var query = context.Set<Test25400>().AsNoTracking().OrderBy(e => e.Id);
                 var test = async
                     ? await query.FirstOrDefaultAsync()
                     : query.FirstOrDefault();
 
-                Assert.Equal(1, Test24569.ConstructorCallCount);
+                Assert.Equal(1, Test25400.ConstructorCallCount);
 
             AssertSql(
                 @"SELECT TOP(1) [t].[Id], [t].[Value]
@@ -10189,7 +10189,7 @@ ORDER BY [t].[Id]");
 
         protected class MyContext25400 : DbContext
         {
-            public DbSet<Test24569> Tests { get; set; }
+            public DbSet<Test25400> Tests { get; set; }
 
             public MyContext25400(DbContextOptions options)
                 : base(options)
@@ -10198,27 +10198,27 @@ ORDER BY [t].[Id]");
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Test24569>().HasKey(e => e.Id);
+                modelBuilder.Entity<Test25400>().HasKey(e => e.Id);
             }
 
             public void Seed()
             {
-                Tests.Add(new Test24569(15));
+                Tests.Add(new Test25400(15));
 
                 SaveChanges();
             }
         }
 
-        protected class Test24569
+        protected class Test25400
         {
             public static int ConstructorCallCount = 0;
 
-            public Test24569()
+            public Test25400()
             {
                 ++ConstructorCallCount;
             }
 
-            public Test24569(int value)
+            public Test25400(int value)
             {
                 Value = value;
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SharedTypeQuerySqlServerTest.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class SharedTypeQuerySqlServerTest : SharedTypeQueryRelationalTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+
+        public override async Task Can_use_shared_type_entity_type_in_query_filter(bool async)
+        {
+            await base.Can_use_shared_type_entity_type_in_query_filter(async);
+
+            AssertSql(
+                @"SELECT [v].[Value]
+FROM [ViewQuery24601] AS [v]
+WHERE EXISTS (
+    SELECT 1
+    FROM [STET] AS [s]
+    WHERE ([s].[Value] = [v].[Value]) OR ([s].[Value] IS NULL AND [v].[Value] IS NULL))");
+        }
+
+        public override async Task Can_use_shared_type_entity_type_in_query_filter_with_from_sql(bool async)
+        {
+            await base.Can_use_shared_type_entity_type_in_query_filter_with_from_sql(async);
+
+            AssertSql(
+                @"SELECT [v].[Value]
+FROM [ViewQuery24601] AS [v]
+WHERE EXISTS (
+    SELECT 1
+    FROM (
+        Select * from STET
+    ) AS [s]
+    WHERE ([s].[Value] = [v].[Value]) OR ([s].[Value] IS NULL AND [v].[Value] IS NULL))");
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SharedTypeQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SharedTypeQuerySqliteTest.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class SharedTypeQuerySqliteTest : SharedTypeQueryRelationalTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+    }
+}

--- a/test/EFCore.Tests/Metadata/Conventions/QueryFilterRewritingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/QueryFilterRewritingConventionTest.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Local
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
+{
+    public class QueryFilterRewritingConventionTest
+    {
+        [ConditionalFact]
+        public virtual void QueryFilter_containing_db_set_with_not_included_type()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            Expression<Func<Blog, bool>> lambda = (Blog e) => new MyContext().Set<Post>().Single().Id == e.Id;
+            modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+                .HasQueryFilter(lambda, ConfigurationSource.Explicit);
+
+            Assert.Equal(
+                CoreStrings.InvalidSetType(typeof(Post).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => RunConvention(modelBuilder)).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void QueryFilter_containing_db_set_with_shared_type_without_name()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            modelBuilder.SharedTypeEntity("Post1", typeof(Post), ConfigurationSource.Explicit);
+            Expression<Func<Blog, bool>> lambda = (Blog e) => new MyContext().Set<Post>().Single().Id == e.Id;
+            modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+                .HasQueryFilter(lambda, ConfigurationSource.Explicit);
+
+            Assert.Equal(
+                CoreStrings.InvalidSetSharedType(typeof(Post).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => RunConvention(modelBuilder)).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void QueryFilter_containing_db_set_of_incorrect_type()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            modelBuilder.SharedTypeEntity("Post1", typeof(Post), ConfigurationSource.Explicit);
+            Expression<Func<Blog, bool>> lambda = (Blog e) => new MyContext().Set<Blog>("Post1").Single().Id == e.Id;
+            modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+                .HasQueryFilter(lambda, ConfigurationSource.Explicit);
+
+            Assert.Equal(
+                CoreStrings.DbSetIncorrectGenericType("Post1", typeof(Post).ShortDisplayName(), typeof(Blog).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => RunConvention(modelBuilder)).Message);
+        }
+
+        [ConditionalFact]
+        public virtual void QueryFilter_containing_db_set_of_owned()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)
+                .HasOwnership(typeof(Blog), "Blog", ConfigurationSource.Explicit);
+
+            Expression<Func<Owner, bool>> lambda = (Owner e) => new MyContext().Set<Blog>().Single().Id == e.Id;
+            modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)
+                .HasQueryFilter(lambda, ConfigurationSource.Explicit);
+
+            Assert.Equal(
+                CoreStrings.InvalidSetTypeOwned(typeof(Blog).ShortDisplayName(), typeof(Owner).ShortDisplayName()),
+                Assert.Throws<InvalidOperationException>(() => RunConvention(modelBuilder)).Message);
+        }
+
+        private void RunConvention(InternalModelBuilder modelBuilder)
+        {
+            var context = new ConventionContext<IConventionModelBuilder>(modelBuilder.Metadata.ConventionDispatcher);
+
+            new QueryFilterRewritingConvention(CreateDependencies())
+                .ProcessModelFinalizing(modelBuilder, context);
+
+            Assert.False(context.ShouldStopProcessing());
+        }
+
+        private ProviderConventionSetBuilderDependencies CreateDependencies()
+            => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
+
+        protected class Blog
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Post
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Owner
+        {
+            public int Id { get; set; }
+            public Blog Blog { get; set; }
+        }
+
+        protected class MyContext : DbContext
+        {
+            public MyContext()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #24601
