### PR TITLE
Change the default subfolder/subnamespace for compiled models to CompiledModels

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpRuntimeModelCodeGenerator.cs
@@ -141,11 +141,13 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             bool nullable)
         {
             var mainBuilder = new IndentedStringBuilder();
-            var namespaces = new SortedSet<string>(new NamespaceComparer()) {
-                contextType.Namespace!,
+            var namespaces = new SortedSet<string>(new NamespaceComparer())
+            {
                 typeof(RuntimeModel).Namespace!,
                 typeof(DbContextAttribute).Namespace!
             };
+
+            AddNamespace(contextType, namespaces);
 
             if (!string.IsNullOrEmpty(@namespace))
             {
@@ -1371,14 +1373,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
         private static void AddNamespace(Type type, ISet<string> namespaces)
         {
-            if (type.Namespace != null)
+            if (!string.IsNullOrEmpty(type.Namespace))
             {
                 namespaces.Add(type.Namespace);
             }
 
             if (type.IsGenericType)
             {
-                foreach(var argument in type.GenericTypeArguments)
+                foreach (var argument in type.GenericTypeArguments)
                 {
                     AddNamespace(argument, namespaces);
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpRuntimeModelCodeGeneratorTest.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal;
 using Microsoft.EntityFrameworkCore.Design;
@@ -27,6 +28,20 @@ using NetTopologySuite;
 using NetTopologySuite.Geometries;
 using Newtonsoft.Json.Linq;
 using Xunit;
+
+public class GlobalNamespaceContext : Microsoft.EntityFrameworkCore.Scaffolding.Internal.CSharpRuntimeModelCodeGeneratorTest.ContextBase
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity("1", e =>
+        {
+            e.Property<int>("Id");
+            e.HasKey("Id");
+        });
+    }
+}
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
@@ -120,20 +135,6 @@ namespace TestNamespace
                 {
                     Assert.NotNull(model.FindEntityType("1"));
                 });
-        }
-
-        public class GlobalNamespaceContext : ContextBase
-        {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                base.OnModelCreating(modelBuilder);
-
-                modelBuilder.Entity("1", e =>
-                {
-                    e.Property<int>("Id");
-                    e.HasKey("Id");
-                });
-            }
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Handle context types in the global namespace

Fixes #25058
Fixes #25059