### PR TITLE
Query: Don't expand include on entity reference which will be convert…

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -259,6 +259,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 test = Expression.Equal(test, Expression.Constant(true, typeof(bool?)));
             }
 
+            ifTrue = MatchTypes(ifTrue, conditionalExpression.IfTrue.Type);
+            ifFalse = MatchTypes(ifFalse, conditionalExpression.IfFalse.Type);
+
             return conditionalExpression.Update(test, ifTrue, ifFalse);
         }
 

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -514,6 +514,26 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _ignoreAutoIncludes = navigationExpandingExpressionVisitor._queryCompilationContext.IgnoreAutoIncludes;
             }
 
+            protected override Expression VisitBinary(BinaryExpression binaryExpression)
+            {
+                if (binaryExpression.NodeType == ExpressionType.Equal
+                    || binaryExpression.NodeType == ExpressionType.NotEqual)
+                {
+                    // This could be entity equality. We don't want to expand include nodes over them
+                    // as either they translate or throw.
+                    var leftEntityReference = IsEntityReference(binaryExpression.Left);
+                    var rightEntityReference = IsEntityReference(binaryExpression.Right);
+                    if (leftEntityReference || rightEntityReference)
+                    {
+                        return binaryExpression;
+                    }
+                }
+
+                return base.VisitBinary(binaryExpression);
+
+                bool IsEntityReference(Expression expression) => TryGetEntityType(expression) != null;
+            }
+
             protected override Expression VisitExtension(Expression extensionExpression)
             {
                 Check.NotNull(extensionExpression, nameof(extensionExpression));
@@ -553,26 +573,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (memberExpression.Expression != null)
                 {
-                    var innerExpression = memberExpression.Expression.UnwrapTypeConversion(out var convertedType);
-                    if (UnwrapEntityReference(innerExpression) is EntityReference entityReference)
+                    // If it is mapped property then, it would get converted to a column so we don't need to expand includes.
+                    var entityType = TryGetEntityType(memberExpression.Expression);
+                    var property = entityType?.FindProperty(memberExpression.Member);
+                    if (property != null)
                     {
-                        // If it is mapped property then, it would get converted to a column so we don't need to expand includes.
-                        var entityType = entityReference.EntityType;
-                        if (convertedType != null)
-                        {
-                            entityType = entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
-                                .FirstOrDefault(et => et.ClrType == convertedType);
-                            if (entityType == null)
-                            {
-                                return base.VisitMember(memberExpression);
-                            }
-                        }
-
-                        var property = entityType.FindProperty(memberExpression.Member);
-                        if (property != null)
-                        {
-                            return memberExpression;
-                        }
+                        return memberExpression;
                     }
                 }
 
@@ -592,14 +598,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (methodCallExpression.TryGetIndexerArguments(Model, out var source, out var propertyName))
                 {
-                    if (UnwrapEntityReference(source) is EntityReference entityReferece)
+                    // If it is mapped property then, it would get converted to a column so we don't need to expand includes.
+                    var entityType = TryGetEntityType(source);
+                    var property = entityType?.FindProperty(propertyName);
+                    if (property != null)
                     {
-                        // If it is mapped property then, it would get converted to a column so we don't need to expand includes.
-                        var property = entityReferece.EntityType.FindProperty(propertyName);
-                        if (property != null)
-                        {
-                            return methodCallExpression;
-                        }
+                        return methodCallExpression;
                     }
                 }
 
@@ -624,6 +628,28 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression)
                 => typeBinaryExpression;
+
+            private IEntityType? TryGetEntityType(Expression expression)
+            {
+                var innerExpression = expression.UnwrapTypeConversion(out var convertedType);
+                if (UnwrapEntityReference(innerExpression) is EntityReference entityReference)
+                {
+                    var entityType = entityReference.EntityType;
+                    if (convertedType != null)
+                    {
+                        entityType = entityType.GetAllBaseTypes().Concat(entityType.GetDerivedTypesInclusive())
+                            .FirstOrDefault(et => et.ClrType == convertedType);
+                        if (entityType == null)
+                        {
+                            return null;
+                        }
+                    }
+
+                    return entityType;
+                }
+
+                return null;
+            }
 
             private bool ReconstructAnonymousType(
                 Expression currentRoot,

--- a/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
@@ -987,5 +987,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }),
                 asserter: (e, a) => AssertCollection(e.Orders, a.Orders, ordered: true));
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Condition_on_entity_with_include(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
+                      join o in ss.Set<Order>().Include(o => o.OrderDetails)
+                        on c.CustomerID equals o.CustomerID into g
+                      from o in g.DefaultIfEmpty()
+                      select new
+                      {
+                          a = o != null ? o.OrderID : -1
+                      });
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindJoinQuerySqlServerTest.cs
@@ -748,6 +748,20 @@ OUTER APPLY (
 ORDER BY [t].[CustomerID], [t0].[OrderDate], [t0].[OrderID]");
         }
 
+        public override async Task Condition_on_entity_with_include(bool async)
+        {
+            await base.Condition_on_entity_with_include(async);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [o].[OrderID] IS NOT NULL THEN [o].[OrderID]
+    ELSE -1
+END AS [a]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] LIKE N'F%'");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
…ed to entity equality

Also fix a bug in argument type mismatch in conditional expression during client eval for InMemory provider

Resolves #22758
