### PR TITLE
Correct nullability annotation for ReferenceEntry

### DIFF
--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     given navigation property.
         /// </returns>
         public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>(
-            Expression<Func<TEntity, TProperty>> propertyExpression)
+            Expression<Func<TEntity, TProperty?>> propertyExpression)
             where TProperty : class
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
         ///     for the context to detect the change.
         /// </summary>
-        public new virtual TProperty CurrentValue
+        public new virtual TProperty? CurrentValue
         {
             get => this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata);
             set => base.CurrentValue = value;


### PR DESCRIPTION
Unfortunately, the situation here is complicated, since ReferenceEntry APIs sometimes returns nullable for TProperty, sometimes not:

* ReferenceEntry.CurrentValue can return nulls if the reference navigation property was nullable.
* ReferenceEntry.TargetEntry returns a nullable EntityEntry, so the TProperty it wraps is never null. Query also return `IQueryable<TProperty>` where TProperty should never be null.

I don't think there's a perfect solution, here are some options with what they mean for the return values of ReferenceEntry.TargetEntry and CurrentValue:

|                                                                                                  | TargetEntry for nullable property  | TargetEntry for non-nullable property  | CurrentValue for nullable property  | CurrentValue for non-nullable property
| ------------------------------------------------------------------------------------------------ | ---------------------------------- | -------------------------------------- | ----------------------------------- | --------------------------------------
| 1. Only change EntityEntry.Reference to accept nullable property (no change to ReferenceEntry)   | `EntityEntry<BlogDetails>?`, good  | `EntityEntry<BlogDetails>?`, good      | `BlogDetails`, really bad           | `BlogDetails`, good
| 2. (1) + change ReferenceEntry.CurrentValue to return `TProperty?`                               | `EntityEntry<BlogDetails>?`, good  | `EntityEntry<BlogDetails>?`, good      | `BlogDetails?`, good                | `BlogDetails?`, bad
| 3. (1) + change ReferenceEntry to accept `class?` constraint                                     | `EntityEntry<BlogDetails?>?`, bad  | `EntityEntry<BlogDetails>?`, good      | `BlogDetails?`, good                | `BlogDetails`, good

* It's always better to return non-nullable as nullable (only forcing an extra check) rather than to return nullable as non-nullable (causing unexpected NRE) - so option (1) is the worst.
* Option (3) also requires changing EntityEntry's constraint to `class?`, since ReferenceEntry.TargetEntry returns that; this means EntityEntry.Entry would return nullable when reached through a nullable reference navigation - not ideal. It would also make ReferenceEntry.Query return `IQueryable<TProperty?>`, which isn't good.
* So option (2) seems the least bad - the only downside is that users need an extra annoying null check when accessing ReferenceEntry.CurrentValue. This is what this PR implements.

Fixes #24659