### PR TITLE
Correct nullability annotation for ReferenceEntry, RC1

### DIFF
--- a/src/EFCore/ChangeTracking/EntityEntry`.cs
+++ b/src/EFCore/ChangeTracking/EntityEntry`.cs
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     given navigation property.
         /// </returns>
         public virtual ReferenceEntry<TEntity, TProperty> Reference<TProperty>(
-            Expression<Func<TEntity, TProperty>> propertyExpression)
+            Expression<Func<TEntity, TProperty?>> propertyExpression)
             where TProperty : class
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));

--- a/src/EFCore/ChangeTracking/ReferenceEntry`.cs
+++ b/src/EFCore/ChangeTracking/ReferenceEntry`.cs
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     the change tracker is aware of the change and <see cref="ChangeTracker.DetectChanges" /> is not required
         ///     for the context to detect the change.
         /// </summary>
-        public new virtual TProperty CurrentValue
+        public new virtual TProperty? CurrentValue
         {
             get => this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata);
             set => base.CurrentValue = value;


### PR DESCRIPTION
Merging to RC1 for public API changes (nullability)

Merged to 6.0 via #25591 
Fixes #24659
