### PR TITLE
Query: Clone shaped query expression during translation

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryProjectionBindingExpressionVisitor.cs
@@ -62,9 +62,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             _indexBasedBinding = false;
 
             _projectionMembers.Push(new ProjectionMember());
-
-            var expandedExpression = _queryableMethodTranslatingExpressionVisitor.ExpandSharedTypeEntities(_queryExpression, expression);
-            var result = Visit(expandedExpression);
+            var result = Visit(expression);
 
             if (result == QueryCompilationContext.NotTranslatedExpression)
             {
@@ -73,8 +71,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                 _entityProjectionCache = new();
                 _clientProjections = new();
 
-                expandedExpression = _queryableMethodTranslatingExpressionVisitor.ExpandSharedTypeEntities(_queryExpression, expression);
-                result = Visit(expandedExpression);
+                result = Visit(expression);
 
                 _queryExpression.ReplaceProjection(_clientProjections);
                 _clientProjections = null;

--- a/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalProjectionBindingExpressionVisitor.cs
@@ -69,8 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             _projectionMembers.Push(new ProjectionMember());
 
-            var expandedExpression = _queryableMethodTranslatingExpressionVisitor.ExpandSharedTypeEntities(_selectExpression, expression);
-            var result = Visit(expandedExpression);
+            var result = Visit(expression);
 
             if (result == QueryCompilationContext.NotTranslatedExpression)
             {
@@ -79,8 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 _projectionMapping.Clear();
                 _clientProjections = new List<Expression>();
 
-                expandedExpression = _queryableMethodTranslatingExpressionVisitor.ExpandSharedTypeEntities(_selectExpression, expression);
-                result = Visit(expandedExpression);
+                result = Visit(expression);
 
                 _selectExpression.ReplaceProjection(_clientProjections);
                 _clientProjections.Clear();

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -145,13 +145,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                             queryRootExpression.EntityType, sqlQuery.Sql, Expression.Constant(Array.Empty<object>(), typeof(object[]))));
 
                 case GroupByShaperExpression groupByShaperExpression:
-                    var shapedQueryExpression = groupByShaperExpression.GroupingEnumerable;
+                    var groupShapedQueryExpression = groupByShaperExpression.GroupingEnumerable;
+                    var groupClonedSelectExpression = ((SelectExpression)groupShapedQueryExpression.QueryExpression).Clone();
+                    _groupingElementCorrelationalPredicate = groupClonedSelectExpression.Predicate;
+                    return new ShapedQueryExpression(
+                        groupClonedSelectExpression,
+                        new QueryExpressionReplacingExpressionVisitor(
+                            groupShapedQueryExpression.QueryExpression, groupClonedSelectExpression)
+                        .Visit(groupShapedQueryExpression.ShaperExpression));
+
+                case ShapedQueryExpression shapedQueryExpression:
                     var clonedSelectExpression = ((SelectExpression)shapedQueryExpression.QueryExpression).Clone();
-                    _groupingElementCorrelationalPredicate = clonedSelectExpression.Predicate;
                     return new ShapedQueryExpression(
                         clonedSelectExpression,
-                        new QueryExpressionReplacingExpressionVisitor(
-                            shapedQueryExpression.QueryExpression, clonedSelectExpression).Visit(shapedQueryExpression.ShaperExpression));
+                        new QueryExpressionReplacingExpressionVisitor(shapedQueryExpression.QueryExpression, clonedSelectExpression)
+                        .Visit(shapedQueryExpression.ShaperExpression));
 
                 default:
                     return base.VisitExtension(extensionExpression);
@@ -867,8 +875,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selectExpression.PushdownIntoSubquery();
             }
 
-            var newSelectorBody = ReplacingExpressionVisitor.Replace(
-                selector.Parameters.Single(), source.ShaperExpression, selector.Body);
+            var newSelectorBody = RemapLambdaBody(source, selector);
 
             return source.UpdateShaperExpression(_projectionBindingExpressionVisitor.Translate(selectExpression, newSelectorBody));
         }
@@ -1153,7 +1160,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return ExpandSharedTypeEntities((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
         }
 
-        internal Expression ExpandSharedTypeEntities(SelectExpression selectExpression, Expression lambdaBody)
+        private Expression ExpandSharedTypeEntities(SelectExpression selectExpression, Expression lambdaBody)
             => _sharedTypeEntityExpandingExpressionVisitor.Expand(selectExpression, lambdaBody);
 
         private sealed class SharedTypeEntityExpandingExpressionVisitor : ExpressionVisitor
@@ -1677,7 +1684,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var predicate = predicateTerms.Skip(correlationTerms.Count)
                     .Aggregate((l, r) => _sqlExpressionFactory.AndAlso(l, r));
                 selector = _sqlExpressionFactory.Case(
-                    new List<CaseWhenClause> { new (predicate, selector) },
+                    new List<CaseWhenClause> { new(predicate, selector) },
                     elseResult: null);
             }
 

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -90,5 +90,61 @@ namespace Microsoft.EntityFrameworkCore
             public bool IsDeleted { get; set; }
             public string Value { get; set; }
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task OwnsMany_correlated_projection(bool async)
+        {
+            var contextFactory = await InitializeAsync<SomeDbContext22089>();
+
+            using (var context = contextFactory.CreateContext())
+            {
+                var results = await context.Contacts.Select(contact => new ContactDto22089()
+                {
+                    Id = contact.Id,
+                    Names = contact.Names.Select(name => new NameDto22089() { }).ToArray()
+                }).ToListAsync();
+            }
+        }
+
+        protected class Contact22089
+        {
+            public Guid Id { get; set; }
+            public IReadOnlyList<Name22809> Names { get; protected set; } = new List<Name22809>();
+        }
+
+        protected class ContactDto22089
+        {
+            public Guid Id { get; set; }
+            public IReadOnlyList<NameDto22089> Names { get; set; }
+        }
+
+        protected class Name22809
+        {
+            public Guid Id { get; set; }
+            public Guid ContactId { get; set; }
+        }
+
+        protected class NameDto22089
+        {
+            public Guid Id { get; set; }
+            public Guid ContactId { get; set; }
+        }
+
+        protected class SomeDbContext22089 : DbContext
+        {
+            public SomeDbContext22089(DbContextOptions options)
+                      : base(options)
+            {
+            }
+
+            public DbSet<Contact22089> Contacts { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Contact22089>().HasKey(c => c.Id);
+                modelBuilder.Entity<Contact22089>().OwnsMany(c => c.Names, names => names.WithOwner().HasForeignKey(n => n.ContactId));
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -601,7 +601,7 @@ ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[Order
                 @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id], [o2].[Detail]
 FROM [OwnedPerson] AS [o]
 INNER JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
-LEFT JOIN [OrderDetail] AS [o2] ON (([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId])) AND (([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId]))
+LEFT JOIN [OrderDetail] AS [o2] ON ([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId])
 WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]
@@ -649,7 +649,7 @@ ORDER BY [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[Order
                 @"SELECT [o].[Id], [o0].[ClientId], [o0].[Id], [o2].[OrderClientId], [o2].[OrderId], [o2].[Id], [o2].[Detail]
 FROM [OwnedPerson] AS [o]
 INNER JOIN [Order] AS [o0] ON [o].[Id] = [o0].[ClientId]
-LEFT JOIN [OrderDetail] AS [o2] ON (([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId])) AND (([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId]))
+LEFT JOIN [OrderDetail] AS [o2] ON ([o0].[ClientId] = [o2].[OrderClientId]) AND ([o0].[Id] = [o2].[OrderId])
 WHERE (
     SELECT COUNT(*)
     FROM [OrderDetail] AS [o1]


### PR DESCRIPTION
Generally we encounter ShapedQueryExpression during translation when translating subqueries
Since ShapedQueryExpression contains QueryExpression which is mutated in-place, we lose the original expression if for any reason translation doesn't work out. Which blocks us from translating it further without recreating original tree again.
We were hitting this during client eval in projection earlier where owned entities are expanded during translation
We recreated tree by expanding owned navigation during the method to retain original expression
With issue #22089 we ran into situation where we try to translate a subquery which is not fully translatable and then we have to visit it through base.
So to avoid the whole issue with reconstruction, now we clone the shaped query during translation so we never mutate original expression

Resolves #22089
