### PR TITLE
Query: Better pattern match to add code to join fetch entity when inc…

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.ExpressionVisitors.cs
@@ -783,10 +783,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         var filterExpression = entityReference.IncludePaths[navigationBase].FilterExpression;
                         if (_queryStateManager
-                            && navigationBase is ISkipNavigation
+                            && navigationBase is ISkipNavigation skipNavigation
                             && subquery is MethodCallExpression joinMethodCallExpression
                             && joinMethodCallExpression.Method.IsGenericMethod
-                            && joinMethodCallExpression.Method.GetGenericMethodDefinition() == QueryableMethods.Join
+                            && joinMethodCallExpression.Method.GetGenericMethodDefinition()
+                                == (skipNavigation.Inverse.ForeignKey.IsRequired ? QueryableMethods.Join : QueryableExtensions.LeftJoinMethodInfo)
                             && joinMethodCallExpression.Arguments[4] is UnaryExpression unaryExpression
                             && unaryExpression.NodeType == ExpressionType.Quote
                             && unaryExpression.Operand is LambdaExpression resultSelectorLambda

--- a/test/EFCore.InMemory.FunctionalTests/Query/ManyToManyHeterogeneousQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ManyToManyHeterogeneousQueryInMemoryTest.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class ManyToManyHeterogeneousQueryInMemoryTest : ManyToManyHeterogeneousQueryTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+    }
+}

--- a/test/EFCore.Relational.Specification.Tests/Query/ManyToManyHeterogeneousQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/ManyToManyHeterogeneousQueryRelationalTestBase.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class ManyToManyHeterogeneousQueryRelationalTestBase : ManyToManyHeterogeneousQueryTestBase
+    {
+        protected TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override void ClearLog() => TestSqlLoggerFactory.Clear();
+
+        protected void AssertSql(params string[] expected) => TestSqlLoggerFactory.AssertBaseline(expected);
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/ManyToManyHeterogeneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyHeterogeneousQueryTestBase.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class ManyToManyHeterogeneousQueryTestBase : NonSharedModelTestBase
+    {
+        public static IEnumerable<object[]> IsAsyncData = new[] { new object[] { false }, new object[] { true } };
+
+        protected override string StoreName => "ManyToManyHeterogeneousQueryTests";
+
+        protected virtual void ClearLog() => ListLoggerFactory.Clear();
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Many_to_many_load_works_when_join_entity_has_custom_key(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context20277>();
+
+            int id;
+            using (var context = contextFactory.CreateContext())
+            {
+                var m = new ManyM_DB();
+                var n = new ManyN_DB();
+                context.AddRange(m, n);
+                m.ManyN_DB = new List<ManyN_DB> { n };
+
+                context.SaveChanges();
+
+                id = m.Id;
+            }
+
+            ClearLog();
+
+            using (var context = contextFactory.CreateContext())
+            {
+                var m = context.Find<ManyM_DB>(id);
+
+                if (async)
+                {
+                    await context.Entry(m).Collection(x => x.ManyN_DB).LoadAsync();
+                }
+                else
+                {
+                    context.Entry(m).Collection(x => x.ManyN_DB).Load();
+                }
+
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                Assert.Equal(1, m.ManyN_DB.Count);
+                Assert.Equal(1, m.ManyN_DB.Single().ManyM_DB.Count);
+                Assert.Equal(1, m.ManyNM_DB.Count);
+                Assert.Equal(1, m.ManyN_DB.Single().ManyNM_DB.Count);
+
+                id = m.ManyN_DB.Single().Id;
+            }
+
+            using (var context = contextFactory.CreateContext())
+            {
+                var n = context.Find<ManyN_DB>(id);
+
+                if (async)
+                {
+                    await context.Entry(n).Collection(x => x.ManyM_DB).LoadAsync();
+                }
+                else
+                {
+                    context.Entry(n).Collection(x => x.ManyM_DB).Load();
+                }
+
+                Assert.Equal(3, context.ChangeTracker.Entries().Count());
+                Assert.Equal(1, n.ManyM_DB.Count);
+                Assert.Equal(1, n.ManyM_DB.Single().ManyN_DB.Count);
+                Assert.Equal(1, n.ManyNM_DB.Count);
+                Assert.Equal(1, n.ManyM_DB.Single().ManyNM_DB.Count);
+            }
+        }
+
+        protected class Context20277 : DbContext
+        {
+            public Context20277(DbContextOptions options)
+                   : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<ManyM_DB>()
+                    .HasMany(e => e.ManyN_DB)
+                    .WithMany(e => e.ManyM_DB)
+                    .UsingEntity<ManyMN_DB>(
+                        r => r.HasOne(e => e.ManyN_DB).WithMany(e => e.ManyNM_DB).HasForeignKey(e => e.ManyN_Id),
+                        l => l.HasOne(e => e.ManyM_DB).WithMany(e => e.ManyNM_DB).HasForeignKey(e => e.ManyM_Id),
+                        b => b.HasKey(e => e.Id));
+            }
+        }
+
+        public class ManyM_DB
+        {
+            public int Id { get; set; }
+            public ICollection<ManyN_DB> ManyN_DB { get; set; }
+            public ICollection<ManyMN_DB> ManyNM_DB { get; set; }
+        }
+
+        public class ManyN_DB
+        {
+            public int Id { get; set; }
+            public ICollection<ManyM_DB> ManyM_DB { get; set; }
+            public ICollection<ManyMN_DB> ManyNM_DB { get; set; }
+        }
+
+        public sealed class ManyMN_DB
+        {
+            public int Id { get; set; }
+
+            public int ManyM_Id { get; set; }
+            public ManyM_DB ManyM_DB { get; set; }
+
+            public int? ManyN_Id { get; set; }
+            public ManyN_DB ManyN_DB { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = contextFactory.CreateContext())
             {
-                await context.Entities.AsNoTracking().Select(e => new
+                var query = context.Entities.AsNoTracking().Select(e => new
                 {
                     Id = e.Id,
                     FirstChild = e.Children
@@ -38,7 +38,11 @@ namespace Microsoft.EntityFrameworkCore
                     .AsQueryable()
                     .Select(_project)
                     .FirstOrDefault(),
-                }).ToListAsync();
+                });
+
+                var result = async
+                    ? await query.ToListAsync()
+                    : query.ToList();
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyHeterogeneousQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ManyToManyHeterogeneousQuerySqlServerTest.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class ManyToManyHeterogeneousQuerySqlServerTest : ManyToManyHeterogeneousQueryRelationalTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+
+        public override async Task Many_to_many_load_works_when_join_entity_has_custom_key(bool async)
+        {
+            await base.Many_to_many_load_works_when_join_entity_has_custom_key(async);
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT TOP(1) [m].[Id]
+FROM [ManyM_DB] AS [m]
+WHERE [m].[Id] = @__p_0",
+                //
+                @"@__p_0='1'
+
+SELECT [t].[Id], [m].[Id], [t].[Id0], [t0].[Id], [t0].[ManyM_Id], [t0].[ManyN_Id], [t0].[Id0]
+FROM [ManyM_DB] AS [m]
+INNER JOIN (
+    SELECT [m1].[Id], [m0].[Id] AS [Id0], [m0].[ManyM_Id]
+    FROM [ManyMN_DB] AS [m0]
+    LEFT JOIN [ManyN_DB] AS [m1] ON [m0].[ManyN_Id] = [m1].[Id]
+) AS [t] ON [m].[Id] = [t].[ManyM_Id]
+LEFT JOIN (
+    SELECT [m2].[Id], [m2].[ManyM_Id], [m2].[ManyN_Id], [m3].[Id] AS [Id0]
+    FROM [ManyMN_DB] AS [m2]
+    INNER JOIN [ManyM_DB] AS [m3] ON [m2].[ManyM_Id] = [m3].[Id]
+    WHERE [m3].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[ManyN_Id]
+WHERE [m].[Id] = @__p_0
+ORDER BY [m].[Id], [t].[Id0], [t].[Id], [t0].[Id]",
+                //
+                @"@__p_0='1'
+
+SELECT TOP(1) [m].[Id]
+FROM [ManyN_DB] AS [m]
+WHERE [m].[Id] = @__p_0",
+                //
+                @"@__p_0='1'
+
+SELECT [t].[Id], [m].[Id], [t].[Id0], [t0].[Id], [t0].[ManyM_Id], [t0].[ManyN_Id], [t0].[Id0]
+FROM [ManyN_DB] AS [m]
+INNER JOIN (
+    SELECT [m1].[Id], [m0].[Id] AS [Id0], [m0].[ManyN_Id]
+    FROM [ManyMN_DB] AS [m0]
+    INNER JOIN [ManyM_DB] AS [m1] ON [m0].[ManyM_Id] = [m1].[Id]
+) AS [t] ON [m].[Id] = [t].[ManyN_Id]
+LEFT JOIN (
+    SELECT [m2].[Id], [m2].[ManyM_Id], [m2].[ManyN_Id], [m3].[Id] AS [Id0]
+    FROM [ManyMN_DB] AS [m2]
+    INNER JOIN [ManyN_DB] AS [m3] ON [m2].[ManyN_Id] = [m3].[Id]
+    WHERE [m3].[Id] = @__p_0
+) AS [t0] ON [t].[Id] = [t0].[ManyM_Id]
+WHERE [m].[Id] = @__p_0
+ORDER BY [m].[Id], [t].[Id0], [t].[Id], [t0].[Id]");
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyHeterogeneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ManyToManyHeterogeneousQuerySqliteTest.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class ManyToManyHeterogeneousQuerySqliteTest : ManyToManyHeterogeneousQueryRelationalTestBase
+    {
+        protected override ITestStoreFactory TestStoreFactory
+            => SqliteTestStoreFactory.Instance;
+    }
+}


### PR DESCRIPTION
…luding SkipNavigation

Earlier we only matched Join. Now we detect based on FK if we need to look for Join or LeftJoin

Resolves #24329
