### PR TITLE
Query: Remove redundant override of TranslateSubquery

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -159,21 +159,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <inheritdoc />
-        public override ShapedQueryExpression? TranslateSubquery(Expression expression)
-        {
-            Check.NotNull(expression, nameof(expression));
-
-            var subqueryVisitor = (RelationalQueryableMethodTranslatingExpressionVisitor)CreateSubqueryVisitor();
-            var translation = subqueryVisitor.Visit(expression) as ShapedQueryExpression;
-            if (translation == null && subqueryVisitor.TranslationErrorDetails != null)
-            {
-                AddTranslationErrorDetails(subqueryVisitor.TranslationErrorDetails);
-            }
-
-            return translation;
-        }
-
-        /// <inheritdoc />
         protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
             => new RelationalQueryableMethodTranslatingExpressionVisitor(this);
 


### PR DESCRIPTION
Added override to do custom task for GroupBy which ended up getting removed in final implementation but method was left behind

Part of #24743
