### PR TITLE
Detect unknown shadow primary key values when attempting to save owned collection

### DIFF
--- a/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
+++ b/src/EFCore.Cosmos/ValueGeneration/Internal/IdValueGenerator.cs
@@ -32,6 +32,15 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.ValueGeneration.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public override bool GeneratesStableValues
+            => true;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         protected override object NextValue(EntityEntry entry)
         {
             var builder = new StringBuilder();

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1443,12 +1443,30 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 property.Name,
                                 EntityType.DisplayName()));
                     }
+
+                    CheckForUnknownKey(property);
+                }
+            }
+            else if (EntityState == EntityState.Deleted)
+            {
+                foreach (var property in entityType.GetProperties())
+                {
+                    CheckForUnknownKey(property);
                 }
             }
 
             DiscardStoreGeneratedValues();
 
             return this;
+
+            void CheckForUnknownKey(IProperty property)
+            {
+                if (property.IsKey()
+                    && _stateData.IsPropertyFlagged(property.GetIndex(), PropertyFlag.Unknown))
+                {
+                    throw new InvalidOperationException(CoreStrings.UnknownShadowKeyValue(entityType.DisplayName(), property.Name));
+                }
+            }
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -108,6 +107,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     property,
                     generatedValue,
                     temporary);
+
+                if (includePrimaryKey
+                    && property.IsPrimaryKey()
+                    && property.IsShadowProperty()
+                    && !property.IsForeignKey())
+                {
+                    entry.MarkUnknown(property);
+                }
             }
         }
 

--- a/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -102,19 +102,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 Log(entry, property, generatedValue, temporary);
 
-                SetGeneratedValue(
-                    entry,
-                    property,
-                    generatedValue,
-                    temporary);
+                SetGeneratedValue(entry, property, generatedValue, temporary);
 
-                if (includePrimaryKey
-                    && property.IsPrimaryKey()
-                    && property.IsShadowProperty()
-                    && !property.IsForeignKey())
-                {
-                    entry.MarkUnknown(property);
-                }
+                MarkKeyUnknown(entry, includePrimaryKey, property, valueGenerator);
             }
         }
 
@@ -164,6 +154,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     property,
                     generatedValue,
                     temporary);
+
+                MarkKeyUnknown(entry, includePrimaryKey, property, valueGenerator);
             }
         }
 
@@ -195,6 +187,22 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     entry[property] = generatedValue;
                 }
+            }
+        }
+
+        private static void MarkKeyUnknown(
+            InternalEntityEntry entry, 
+            bool includePrimaryKey, 
+            IProperty property, 
+            ValueGenerator valueGenerator)
+        {
+            if (includePrimaryKey
+                && property.IsKey()
+                && property.IsShadowProperty()
+                && !property.IsForeignKey()
+                && !valueGenerator.GeneratesStableValues)
+            {
+                entry.MarkUnknown(property);
             }
         }
     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2818,6 +2818,14 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType, property);
 
         /// <summary>
+        ///     The value of shadow key property '{entityType}.{property}' is unknown when attempting to save changes. This is because shadow property values cannot be preserved when the entity is not being tracked. Consider adding the property to the entity's .NET type. See https://aka.ms/efcore-docs-owned-collections for more information.
+        /// </summary>
+        public static string UnknownShadowKeyValue(object? entityType, object? property)
+            => string.Format(
+                GetString("UnknownShadowKeyValue", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
         ///     The unnamed index specified via [Index] attribute on the entity type '{entityType}' with properties {indexProperties} is invalid. The property '{propertyName}' was marked as unmapped by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. An index cannot use unmapped properties.
         /// </summary>
         public static string UnnamedIndexDefinedOnIgnoredProperty(object? entityType, object? indexProperties, object? propertyName)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1518,6 +1518,9 @@
   <data name="UnknownKeyValue" xml:space="preserve">
     <value>The value of '{entityType}.{property}' is unknown when attempting to save changes. This is because the property is also part of a foreign key for which the principal entity in the relationship is not known.</value>
   </data>
+  <data name="UnknownShadowKeyValue" xml:space="preserve">
+    <value>The value of shadow key property '{entityType}.{property}' is unknown when attempting to save changes. This is because shadow property values cannot be preserved when the entity is not being tracked. Consider adding the property to the entity's .NET type. See https://aka.ms/efcore-docs-owned-collections for more information.</value>
+  </data>
   <data name="UnnamedIndexDefinedOnIgnoredProperty" xml:space="preserve">
     <value>The unnamed index specified via [Index] attribute on the entity type '{entityType}' with properties {indexProperties} is invalid. The property '{propertyName}' was marked as unmapped by [NotMapped] attribute or 'Ignore()' in 'OnModelCreating'. An index cannot use unmapped properties.</value>
   </data>

--- a/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/Internal/DiscriminatorValueGenerator.cs
@@ -43,5 +43,14 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
         /// </summary>
         public override bool GeneratesTemporaryValues
             => false;
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public override bool GeneratesStableValues
+            => true;
     }
 }

--- a/src/EFCore/ValueGeneration/ValueGenerator.cs
+++ b/src/EFCore/ValueGeneration/ValueGenerator.cs
@@ -66,5 +66,14 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration
         ///     </para>
         /// </summary>
         public abstract bool GeneratesTemporaryValues { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether the values generated are stable. That is, the value will always be the
+        ///     same for a given property in a given entity, and does not depend on what other values may have been generated
+        ///     previously. For example, discriminator values generated for a TPH hierarchy are stable. Stable values will never
+        ///     be marked as unknown.
+        /// </summary>
+        public virtual bool GeneratesStableValues
+            => false;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -158,6 +159,18 @@ namespace Microsoft.EntityFrameworkCore
             Action<DbContext> nestedTestOperation3 = null)
         {
             base.ExecuteWithStrategyInTransaction(testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);
+            Fixture.Reseed();
+        }
+
+        protected override async Task ExecuteWithStrategyInTransactionAsync(
+            Func<DbContext, Task> testOperation,
+            Func<DbContext, Task> nestedTestOperation1 = null,
+            Func<DbContext, Task> nestedTestOperation2 = null,
+            Func<DbContext, Task> nestedTestOperation3 = null)
+        {
+            await base.ExecuteWithStrategyInTransactionAsync(
+                testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);
+
             Fixture.Reseed();
         }
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -419,6 +419,36 @@ namespace Microsoft.EntityFrameworkCore
                 });
 
                 modelBuilder.Entity<SharedFkDependant>();
+
+                modelBuilder.Entity<Owner>();
+
+                modelBuilder.Entity<OwnerWithKeyedCollection>(
+                    b =>
+                    {
+                        b.Navigation(e => e.Owned).IsRequired();
+                        b.Navigation(e => e.OwnedWithKey).IsRequired();
+
+                        b.OwnsMany(
+                            e => e.OwnedCollectionPrivateKey,
+                            b => b.HasKey("OwnerWithKeyedCollectionId", "PrivateKey"));
+                    });
+
+                modelBuilder.Entity<OwnerNoKeyGeneration>(
+                    b =>
+                    {
+                        b.Property(e => e.Id).ValueGeneratedNever();
+
+                        b.OwnsOne(
+                            e => e.Owned,
+                            b => b.Property("OwnerNoKeyGenerationId").ValueGeneratedNever());
+                        b.OwnsMany(
+                            e => e.OwnedCollection,
+                            b =>
+                            {
+                                b.Property<int>("OwnedNoKeyGenerationId").ValueGeneratedNever();
+                                b.Property("OwnerNoKeyGenerationId").ValueGeneratedNever();
+                            });
+                    });
             }
 
             protected virtual object CreateFullGraph()
@@ -3089,6 +3119,185 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _parent;
                 set => SetWithNotify(value, ref _parent);
+            }
+        }
+
+        protected class Owner : NotifyingEntity
+        {
+            private int _id;
+            private Owned _owned;
+            private ICollection<Owned> _ownedCollection = new ObservableHashSet<Owned>();
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public Owned Owned
+            {
+                get => _owned;
+                set => SetWithNotify(value, ref _owned);
+            }
+
+            public ICollection<Owned> OwnedCollection
+            {
+                get => _ownedCollection;
+                set => SetWithNotify(value, ref _ownedCollection);
+            }
+        }
+
+        [Owned]
+        protected class Owned : NotifyingEntity
+        {
+            private int _foo;
+            private string _bar;
+
+            public int Foo
+            {
+                get => _foo;
+                set => SetWithNotify(value, ref _foo);
+            }
+
+            public string Bar
+            {
+                get => _bar;
+                set => SetWithNotify(value, ref _bar);
+            }
+        }
+
+        protected class OwnerWithKeyedCollection : NotifyingEntity
+        {
+            private int _id;
+            private Owned _owned;
+            private OwnedWithKey _ownedWithKey;
+            private ICollection<OwnedWithKey> _ownedCollection = new ObservableHashSet<OwnedWithKey>();
+            private ICollection<OwnedWithPrivateKey> _ownedCollectionPrivateKey = new ObservableHashSet<OwnedWithPrivateKey>();
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public Owned Owned
+            {
+                get => _owned;
+                set => SetWithNotify(value, ref _owned);
+            }
+
+            public OwnedWithKey OwnedWithKey
+            {
+                get => _ownedWithKey;
+                set => SetWithNotify(value, ref _ownedWithKey);
+            }
+
+            public ICollection<OwnedWithKey> OwnedCollection
+            {
+                get => _ownedCollection;
+                set => SetWithNotify(value, ref _ownedCollection);
+            }
+
+            public ICollection<OwnedWithPrivateKey> OwnedCollectionPrivateKey
+            {
+                get => _ownedCollectionPrivateKey;
+                set => SetWithNotify(value, ref _ownedCollectionPrivateKey);
+            }
+        }
+
+        [Owned]
+        protected class OwnedWithKey : NotifyingEntity
+        {
+            private int _foo;
+            private string _bar;
+            private int _ownedWithKeyId;
+
+            public int OwnedWithKeyId
+            {
+                get => _ownedWithKeyId;
+                set => SetWithNotify(value, ref _ownedWithKeyId);
+            }
+
+            public int Foo
+            {
+                get => _foo;
+                set => SetWithNotify(value, ref _foo);
+            }
+
+            public string Bar
+            {
+                get => _bar;
+                set => SetWithNotify(value, ref _bar);
+            }
+        }
+
+        [Owned]
+        protected class OwnedWithPrivateKey : NotifyingEntity
+        {
+            private int _foo;
+            private string _bar;
+            private int _privateKey;
+
+            private int PrivateKey
+            {
+                get => _privateKey;
+                set => SetWithNotify(value, ref _privateKey);
+            }
+
+            public int Foo
+            {
+                get => _foo;
+                set => SetWithNotify(value, ref _foo);
+            }
+
+            public string Bar
+            {
+                get => _bar;
+                set => SetWithNotify(value, ref _bar);
+            }
+        }
+
+        protected class OwnerNoKeyGeneration : NotifyingEntity
+        {
+            private int _id;
+            private OwnedNoKeyGeneration _owned;
+            private ICollection<OwnedNoKeyGeneration> _ownedCollection = new ObservableHashSet<OwnedNoKeyGeneration>();
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public OwnedNoKeyGeneration Owned
+            {
+                get => _owned;
+                set => SetWithNotify(value, ref _owned);
+            }
+
+            public ICollection<OwnedNoKeyGeneration> OwnedCollection
+            {
+                get => _ownedCollection;
+                set => SetWithNotify(value, ref _ownedCollection);
+            }
+        }
+
+        [Owned]
+        protected class OwnedNoKeyGeneration : NotifyingEntity
+        {
+            private int _foo;
+            private string _bar;
+
+            public int Foo
+            {
+                get => _foo;
+                set => SetWithNotify(value, ref _foo);
+            }
+
+            public string Bar
+            {
+                get => _bar;
+                set => SetWithNotify(value, ref _bar);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -626,6 +626,36 @@ namespace Microsoft.EntityFrameworkCore
                     });
 
                     modelBuilder.Entity<SharedFkDependant>();
+
+                    modelBuilder.Entity<Owner>();
+
+                    modelBuilder.Entity<OwnerWithKeyedCollection>(
+                        b =>
+                        {
+                            b.Navigation(e => e.Owned).IsRequired();
+                            b.Navigation(e => e.OwnedWithKey).IsRequired();
+
+                            b.OwnsMany(
+                                e => e.OwnedCollectionPrivateKey,
+                                b => b.HasKey("OwnerWithKeyedCollectionId", "PrivateKey"));
+                        });
+
+                    modelBuilder.Entity<OwnerNoKeyGeneration>(
+                        b =>
+                        {
+                            b.Property(e => e.Id).ValueGeneratedNever();
+
+                            b.OwnsOne(
+                                e => e.Owned,
+                                b => b.Property("OwnerNoKeyGenerationId").ValueGeneratedNever());
+                            b.OwnsMany(
+                                e => e.OwnedCollection,
+                                b =>
+                                {
+                                    b.Property<int>("OwnedNoKeyGenerationId").ValueGeneratedNever();
+                                    b.Property("OwnerNoKeyGenerationId").ValueGeneratedNever();
+                                });
+                        });
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdates/GraphUpdatesSqlServerTest.cs
@@ -656,6 +656,26 @@ namespace Microsoft.EntityFrameworkCore
                                     b.Property("OwnerNoKeyGenerationId").ValueGeneratedNever();
                                 });
                         });
+
+                    modelBuilder.Entity<Provider>().HasData(
+                        new Provider { Id = "prov1" },
+                        new Provider { Id = "prov2" });
+
+                    modelBuilder.Entity<Partner>().HasData(
+                        new Partner { Id = "partner1" });
+
+                    modelBuilder.Entity<ProviderContract>(
+                        b =>
+                        {
+                            b.HasOne(p => p.Partner).WithMany().IsRequired().HasForeignKey("PartnerId");
+                            b.HasOne<Provider>().WithMany().IsRequired().HasForeignKey("ProviderId");
+
+                            b.HasDiscriminator<string>("ProviderId")
+                                .HasValue<ProviderContract1>("prov1")
+                                .HasValue<ProviderContract2>("prov2");
+
+                            b.HasKey("PartnerId", "ProviderId");
+                        });
                 }
             }
         }

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTest.cs
@@ -5,13 +5,14 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class GraphUpdatesSqliteTest
     {
         public class ChangedChangingNotifications
-            : GraphUpdatesTestBase<ChangedChangingNotifications.SqliteFixture>
+            : GraphUpdatesSqliteTestBase<ChangedChangingNotifications.SqliteFixture>
         {
             public ChangedChangingNotifications(SqliteFixture fixture)
                 : base(fixture)
@@ -21,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
-            public class SqliteFixture : GraphUpdatesSqliteTestBase<SqliteFixture>.GraphUpdatesSqliteFixtureBase
+            public class SqliteFixture : GraphUpdatesSqliteFixtureBase
             {
                 protected override string StoreName { get; } = "GraphUpdatesChangedChangingTest";
 
@@ -35,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public class ChangedNotifications
-            : GraphUpdatesTestBase<ChangedNotifications.SqliteFixture>
+            : GraphUpdatesSqliteTestBase<ChangedNotifications.SqliteFixture>
         {
             public ChangedNotifications(SqliteFixture fixture)
                 : base(fixture)
@@ -45,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
-            public class SqliteFixture : GraphUpdatesSqliteTestBase<SqliteFixture>.GraphUpdatesSqliteFixtureBase
+            public class SqliteFixture : GraphUpdatesSqliteFixtureBase
             {
                 protected override string StoreName { get; } = "GraphUpdatesChangedTest";
 
@@ -59,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public class FullWithOriginalsNotifications
-            : GraphUpdatesTestBase<FullWithOriginalsNotifications.SqliteFixture>
+            : GraphUpdatesSqliteTestBase<FullWithOriginalsNotifications.SqliteFixture>
         {
             public FullWithOriginalsNotifications(SqliteFixture fixture)
                 : base(fixture)
@@ -69,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
-            public class SqliteFixture : GraphUpdatesSqliteTestBase<SqliteFixture>.GraphUpdatesSqliteFixtureBase
+            public class SqliteFixture : GraphUpdatesSqliteFixtureBase
             {
                 protected override string StoreName { get; } = "GraphUpdatesFullWithOriginalsTest";
 
@@ -83,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         public class SnapshotNotifications
-            : GraphUpdatesTestBase<SnapshotNotifications.SqliteFixture>
+            : GraphUpdatesSqliteTestBase<SnapshotNotifications.SqliteFixture>
         {
             public SnapshotNotifications(SqliteFixture fixture)
                 : base(fixture)
@@ -93,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore
             protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
                 => facade.UseTransaction(transaction.GetDbTransaction());
 
-            public class SqliteFixture : GraphUpdatesSqliteTestBase<SqliteFixture>.GraphUpdatesSqliteFixtureBase
+            public class SqliteFixture : GraphUpdatesSqliteFixtureBase
             {
                 protected override string StoreName { get; } = "GraphUpdatesSnapshotTest";
 
@@ -114,6 +115,36 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected GraphUpdatesSqliteTestBase(TFixture fixture)
                 : base(fixture)
+            {
+            }
+
+            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Update_principal_with_shadow_key_owned_collection_throws()
+            {
+            }
+
+            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Delete_principal_with_shadow_key_owned_collection_throws()
+            {
+            }
+
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Clearing_shadow_key_owned_collection_throws(bool useUpdate, bool addNew)
+            {
+            }
+
+            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Update_principal_with_CLR_key_owned_collection()
+            {
+            }
+
+            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Delete_principal_with_CLR_key_owned_collection()
+            {
+            }
+
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override void Clearing_CLR_key_owned_collection(bool useUpdate, bool addNew)
             {
             }
 

--- a/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/GraphUpdates/GraphUpdatesSqliteTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -118,35 +119,29 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Update_principal_with_shadow_key_owned_collection_throws()
-            {
-            }
-
-            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Delete_principal_with_shadow_key_owned_collection_throws()
-            {
-            }
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override Task Update_principal_with_shadow_key_owned_collection_throws(bool async)
+                => Task.CompletedTask;
 
             [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Clearing_shadow_key_owned_collection_throws(bool useUpdate, bool addNew)
-            {
-            }
-
-            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Update_principal_with_CLR_key_owned_collection()
-            {
-            }
-
-            [ConditionalFact(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Delete_principal_with_CLR_key_owned_collection()
-            {
-            }
+            public override Task Delete_principal_with_shadow_key_owned_collection_throws(bool async)
+                => Task.CompletedTask;
 
             [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
-            public override void Clearing_CLR_key_owned_collection(bool useUpdate, bool addNew)
-            {
-            }
+            public override Task Clearing_shadow_key_owned_collection_throws(bool async, bool useUpdate, bool addNew)
+                => Task.CompletedTask;
+
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override Task Update_principal_with_CLR_key_owned_collection(bool async)
+                => Task.CompletedTask;
+
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override Task Delete_principal_with_CLR_key_owned_collection(bool async)
+                => Task.CompletedTask;
+
+            [ConditionalTheory(Skip = "Default owned collection pattern does not work with SQLite due to composite key.")]
+            public override Task Clearing_CLR_key_owned_collection(bool async, bool useUpdate, bool addNew)
+                => Task.CompletedTask;
 
             protected override IQueryable<Root> ModifyQueryRoot(IQueryable<Root> query)
                 => query.AsSplitQuery();

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -4853,6 +4853,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private class Role : IEquatable<Role>
         {
+            private Guid RoleAssignmentId { get; set; }
             public string Value { get; set; }
 
             public bool Equals(Role other)


### PR DESCRIPTION
Fixes #19856

The fundamental issue here is that the key for owned collections is, by default, formed from shadow properties. This means the values of these properties are lost when the entities in the collection are no longer tracked by a DbContext. When the entities are then later attached there is no way to get these values back. (Contrast this with owned non-collection entities, where the shadow key value can be synthesized from the owner key.) This in turn means that there is no way to identify these entities in the database, and there is therefore no way to update or delete them.

This PR detects this situation and throws an exception with a (hopefully) helpful error message.

The best way to deal with this is to add a CLR property for the key (which can be private) to the owned entity type. The key values are then preserved while the entities are not being tracked, and re-attaching the entities works correctly. We should document this.

Fixes #21206.

Let value generators indicate that they return stable values, and don't mark these values as unknown. This stops values generated for discriminator properties from being marked as unknown. Also, use the correct derived entity type when generating a discriminator value.