### PR TITLE
[release/6.0-rc1] Remove unused nullability in typeof

### DIFF
--- a/src/EFCore.Relational/Query/Internal/FromSqlParameterExpandingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlParameterExpandingExpressionVisitor.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
                     }
 
-                    return _visitedFromSqlExpressions[fromSql] = fromSql.Update(Expression.Constant(constantValues, typeof(object?[])));
+                    return _visitedFromSqlExpressions[fromSql] = fromSql.Update(Expression.Constant(constantValues, typeof(object[])));
 
                 default:
                     Check.DebugAssert(false, "FromSql.Arguments must be Constant/ParameterExpression");


### PR DESCRIPTION
**Description**

Fixes compilation errors starting with .NET SDK 6.0.100-rc.1.21417.19

**Customer Impact**

We won't be able to build the product to ship to them.

**How found**

Updating the SDK.

**Test coverage**

Compile-time issue.

**Regression?**

N/A

**Risk**

Low. Makes the compiler work.


Flagged by @sebastienros because of failures in continuous benchmark runs
