### PR TITLE
Query: Throw better error message for grouping parameter without comp…

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos/Query/Internal/CosmosSqlTranslatingExpressionVisitor.cs
@@ -766,7 +766,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
                     var newParameterName =
                         $"{_runtimeParameterPrefix}"
-                        + $"{sqlParameterExpression.Name.Substring(QueryCompilationContext.QueryParameterPrefix.Length)}_{property.Name}";
+                        + $"{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
 
                     rewrittenSource = _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
                     break;
@@ -880,7 +880,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
 
                     var newParameterName =
                         $"{_runtimeParameterPrefix}"
-                        + $"{sqlParameterExpression.Name.Substring(QueryCompilationContext.QueryParameterPrefix.Length)}_{property.Name}";
+                        + $"{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
 
                     return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
 

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1254,7 +1254,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     var newParameterName =
                         $"{RuntimeParameterPrefix}"
-                        + $"{sqlParameterExpression.Name.Substring(QueryCompilationContext.QueryParameterPrefix.Length)}_{property.Name}";
+                        + $"{sqlParameterExpression.Name[QueryCompilationContext.QueryParameterPrefix.Length..]}_{property.Name}";
 
                     return _queryCompilationContext.RegisterRuntimeParameter(newParameterName, lambda);
 

--- a/src/EFCore/Diagnostics/LoggerCategory.cs
+++ b/src/EFCore/Diagnostics/LoggerCategory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             var index = name.IndexOf(outerClassName, StringComparison.Ordinal);
             if (index >= 0)
             {
-                name = name.Substring(0, index) + name.Substring(index + outerClassName.Length);
+                name = name.Substring(0, index) + name[(index + outerClassName.Length)..];
             }
 
             return name;

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2301,6 +2301,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 entityType);
 
         /// <summary>
+        ///     Translation of 'Select' which contains grouping parameter without composition is not supported.
+        /// </summary>
+        public static string QuerySelectContainsGrouping
+            => GetString("QuerySelectContainsGrouping");
+
+        /// <summary>
         ///     Translation of '{expression}' failed. Either the query source is not an entity type, or the specified property does not exist on the entity type.
         /// </summary>
         public static string QueryUnableToTranslateEFProperty(object? expression)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1313,6 +1313,9 @@
   <data name="QueryRootDifferentEntityType" xml:space="preserve">
     <value>The replacement entity type: {entityType} does not have same name and CLR type as entity type this query root represents.</value>
   </data>
+  <data name="QuerySelectContainsGrouping" xml:space="preserve">
+    <value>Translation of 'Select' which contains grouping parameter without composition is not supported.</value>
+  </data>
   <data name="QueryUnableToTranslateEFProperty" xml:space="preserve">
     <value>Translation of '{expression}' failed. Either the query source is not an entity type, or the specified property does not exist on the entity type.</value>
   </data>

--- a/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs
@@ -342,7 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             if (compilerPrefixIndex != -1)
             {
-                parameterName = parameterName.Substring(compilerPrefixIndex + 1);
+                parameterName = parameterName[(compilerPrefixIndex + 1)..];
             }
 
             parameterName

--- a/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CustomConvertersCosmosTest.cs
@@ -155,7 +155,7 @@ WHERE (c[""Discriminator""] IN (""Blog"", ""RssBlog"") AND NOT((c[""IndexerVisib
         public override void Value_conversion_on_enum_collection_contains()
         {
             Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(47),
+                CoreStrings.TranslationFailed("")[47..],
                 Assert.Throws<InvalidOperationException>(() => base.Value_conversion_on_enum_collection_contains()).Message);
         }
 

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/TestSqlLoggerFactory.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 var methodCallLine = Environment.StackTrace.Split(
                     new[] { _eol },
-                    StringSplitOptions.RemoveEmptyEntries)[3].Substring(6);
+                    StringSplitOptions.RemoveEmptyEntries)[3][6..];
 
                 var indexMethodEnding = methodCallLine.IndexOf(')') + 1;
                 var testName = methodCallLine.Substring(0, indexMethodEnding);

--- a/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -200,12 +200,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private void AssertTranslationFailed(Action testCode)
             => Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(21),
+                CoreStrings.TranslationFailed("")[21..],
                 Assert.Throws<InvalidOperationException>(testCode).Message);
 
         private void AssertTranslationFailedWithDetails(Action testCode, string details)
             => Assert.Contains(
-                CoreStrings.TranslationFailedWithDetails("", details).Substring(21),
+                CoreStrings.TranslationFailedWithDetails("", details)[21..],
                 Assert.Throws<InvalidOperationException>(testCode).Message);
 
         protected NorthwindContext CreateContext()

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -2160,7 +2160,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private void AssertTranslationFailed(Action testCode)
             => Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(48),
+                CoreStrings.TranslationFailed("")[48..],
                 Assert.Throws<InvalidOperationException>(testCode).Message);
     }
 }

--- a/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/test/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 var methodCallLine = Environment.StackTrace.Split(
                     new[] { _eol },
-                    StringSplitOptions.RemoveEmptyEntries)[3].Substring(6);
+                    StringSplitOptions.RemoveEmptyEntries)[3][6..];
 
                 var indexMethodEnding = methodCallLine.IndexOf(')') + 1;
                 var testName = methodCallLine.Substring(0, indexMethodEnding);

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -716,7 +716,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Contains(
                 CoreStrings.TranslationFailedWithDetails(
                     "",
-                    CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer))).Substring(21),
+                    CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)))[21..],
                 (await Assert.ThrowsAsync<InvalidOperationException>(
                     () => AssertQuery(
                         async,

--- a/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -1131,13 +1131,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected static async Task AssertTranslationFailed(Func<Task> query)
             => Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(48),
+                CoreStrings.TranslationFailed("")[48..],
                 (await Assert.ThrowsAsync<InvalidOperationException>(query))
                 .Message);
 
         protected static async Task AssertTranslationFailedWithDetails(Func<Task> query, string details)
             => Assert.Contains(
-                CoreStrings.TranslationFailedWithDetails("", details).Substring(21),
+                CoreStrings.TranslationFailedWithDetails("", details)[21..],
                 (await Assert.ThrowsAsync<InvalidOperationException>(query))
                 .Message);
 

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -295,7 +295,7 @@ WHERE [b].[Id] = 1");
         public override void Value_conversion_on_enum_collection_contains()
         {
             Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(47),
+                CoreStrings.TranslationFailed("")[47..],
                 Assert.Throws<InvalidOperationException>(() => base.Value_conversion_on_enum_collection_contains()).Message);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -1471,11 +1471,11 @@ WHERE 0 = 1");
             {
                 var methodCallLine = Environment.StackTrace.Split(
                     new[] { Environment.NewLine },
-                    StringSplitOptions.RemoveEmptyEntries)[2].Substring(6);
+                    StringSplitOptions.RemoveEmptyEntries)[2][6..];
 
                 var testName = methodCallLine.Substring(0, methodCallLine.IndexOf(')') + 1);
                 var lineIndex = methodCallLine.LastIndexOf("line", StringComparison.Ordinal);
-                var lineNumber = lineIndex > 0 ? methodCallLine.Substring(lineIndex) : "";
+                var lineNumber = lineIndex > 0 ? methodCallLine[lineIndex..] : "";
 
                 var currentDirectory = Directory.GetCurrentDirectory();
                 var logFile = currentDirectory.Substring(

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyFieldsLoadSqlServerTest.cs
@@ -236,7 +236,7 @@ ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t
             {
                 var methodCallLine = Environment.StackTrace.Split(
                     new[] { Environment.NewLine },
-                    StringSplitOptions.RemoveEmptyEntries)[2].Substring(6);
+                    StringSplitOptions.RemoveEmptyEntries)[2][6..];
 
                 var indexMethodEnding = methodCallLine.IndexOf(')') + 1;
                 var testName = methodCallLine.Substring(0, indexMethodEnding);

--- a/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ManyToManyLoadSqlServerTest.cs
@@ -235,7 +235,7 @@ ORDER BY [e].[Id], [t].[EntityOneId], [t].[EntityTwoId], [t].[Id], [t0].[Id], [t
             {
                 var methodCallLine = Environment.StackTrace.Split(
                     new[] { Environment.NewLine },
-                    StringSplitOptions.RemoveEmptyEntries)[2].Substring(6);
+                    StringSplitOptions.RemoveEmptyEntries)[2][6..];
 
                 var indexMethodEnding = methodCallLine.IndexOf(')') + 1;
                 var testName = methodCallLine.Substring(0, indexMethodEnding);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2442,6 +2442,21 @@ FROM (
 GROUP BY [t].[CustomerID]");
         }
 
+        public override async Task GroupBy_aggregate_without_selectMany_selecting_first(bool async)
+        {
+            await base.GroupBy_aggregate_without_selectMany_selecting_first(async);
+
+            AssertSql(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM (
+    SELECT MIN([o].[OrderID]) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [t]
+CROSS JOIN [Orders] AS [o0]
+WHERE [o0].[OrderID] = [t].[c]");
+        }
+
         public override async Task GroupBy_with_grouping_key_using_Like(bool async)
         {
             await base.GroupBy_with_grouping_key_using_Like(async);

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1644,7 +1644,7 @@ ORDER BY ""b"".""Id"", ""b0"".""Id""");
 
         private void AssertTranslationFailed(Action testCode)
             => Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(21),
+                CoreStrings.TranslationFailed("")[21..],
                 Assert.Throws<InvalidOperationException>(testCode).Message);
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -119,7 +119,7 @@ WHERE ""b"".""IndexerVisible"" = 'Nay'");
         public override void Value_conversion_on_enum_collection_contains()
         {
             Assert.Contains(
-                CoreStrings.TranslationFailed("").Substring(47),
+                CoreStrings.TranslationFailed("")[47..],
                 Assert.Throws<InvalidOperationException>(() => base.Value_conversion_on_enum_collection_contains()).Message);
         }
 


### PR DESCRIPTION
…osition in Select

Resolves #21446
