### PR TITLE
Query: Add regression test for #21490

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindSelectQueryCosmosTest.cs
@@ -1308,6 +1308,12 @@ ORDER BY c[""OrderID""]");
             return base.Client_projection_via_ctor_arguments(async);
         }
 
+        [ConditionalTheory(Skip = "Cross collection join Issue#17246")]
+        public override Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
+        {
+            return base.Client_projection_with_string_initialization_with_scalar_subquery(async);
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSelectQuerySqlServerTest.cs
@@ -1842,6 +1842,19 @@ LEFT JOIN [Orders] AS [o0] ON [t].[CustomerID] = [o0].[CustomerID]
 ORDER BY [t].[CustomerID]");
         }
 
+        public override async Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
+        {
+            await base.Client_projection_with_string_initialization_with_scalar_subquery(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], (
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE ([c].[CustomerID] = [o].[CustomerID]) AND ([o].[OrderID] < 11000)), [c].[City], N'test' + COALESCE([c].[City], N'')
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'F%'");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #21490

By 5.0 we expanded navigation correctly but failed in translation
in 6.0 we translate correctly too
