### PR TITLE
[release/6.0-rc1] Fix #25225 by forcing usage of renting and populating commands when using relational command cache

### DIFF
--- a/src/EFCore.Relational/Extensions/Internal/RelationCommandCacheExtensions.cs
+++ b/src/EFCore.Relational/Extensions/Internal/RelationCommandCacheExtensions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static class RelationCommandCacheExtensions
+    {
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public static IRelationalCommand RentAndPopulateRelationalCommand(this RelationalCommandCache relationalCommandCache, RelationalQueryContext queryContext)
+        {
+            var relationalCommandTemplate = relationalCommandCache.GetRelationalCommandTemplate(queryContext.ParameterValues);
+            var relationalCommand = queryContext.Connection.RentCommand();
+            relationalCommand.PopulateFrom(relationalCommandTemplate);
+            return relationalCommand;
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalCommandCache.cs
@@ -62,13 +62,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual IRelationalCommand GetRelationalCommand(IReadOnlyDictionary<string, object?> parameters)
+        public virtual IRelationalCommandTemplate GetRelationalCommandTemplate(IReadOnlyDictionary<string, object?> parameters)
         {
             var cacheKey = new CommandCacheKey(_selectExpression, parameters);
 
-            if (_memoryCache.TryGetValue(cacheKey, out IRelationalCommand relationalCommand))
+            if (_memoryCache.TryGetValue(cacheKey, out IRelationalCommandTemplate relationalCommandTemplate))
             {
-                return relationalCommand;
+                return relationalCommandTemplate;
             }
 
             // When multiple threads attempt to start processing the same query (program startup / thundering
@@ -80,19 +80,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 lock (compilationLock)
                 {
-                    if (!_memoryCache.TryGetValue(cacheKey, out relationalCommand))
+                    if (!_memoryCache.TryGetValue(cacheKey, out relationalCommandTemplate))
                     {
                         var selectExpression = _relationalParameterBasedSqlProcessor.Optimize(
                             _selectExpression, parameters, out var canCache);
-                        relationalCommand = _querySqlGeneratorFactory.Create().GetCommand(selectExpression);
+                        relationalCommandTemplate = _querySqlGeneratorFactory.Create().GetCommand(selectExpression);
 
                         if (canCache)
                         {
-                            _memoryCache.Set(cacheKey, relationalCommand, new MemoryCacheEntryOptions { Size = 10 });
+                            _memoryCache.Set(cacheKey, relationalCommandTemplate, new MemoryCacheEntryOptions { Size = 10 });
                         }
                     }
 
-                    return relationalCommand;
+                    return relationalCommandTemplate;
                 }
             }
             finally

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
@@ -94,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual DbCommand CreateDbCommand()
             => _relationalCommandCache
-                .GetRelationalCommand(_relationalQueryContext.ParameterValues)
+                .GetRelationalCommandTemplate(_relationalQueryContext.ParameterValues)
                 .CreateDbCommand(
                     new RelationalCommandParameterObject(
                         _relationalQueryContext.Connection,
@@ -221,11 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
-                    enumerator._relationalQueryContext.ParameterValues);
-
-                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
-                relationalCommand.PopulateFrom(relationalCommandTemplate);
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalCommandCache.RentAndPopulateRelationalCommand(enumerator._relationalQueryContext);
 
                 var dataReader = enumerator._dataReader = relationalCommand.ExecuteReader(
                     new RelationalCommandParameterObject(
@@ -369,11 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
-                    enumerator._relationalQueryContext.ParameterValues);
-
-                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
-                relationalCommand.PopulateFrom(relationalCommandTemplate);
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalCommandCache.RentAndPopulateRelationalCommand(enumerator._relationalQueryContext);
 
                 var dataReader = enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
@@ -100,7 +101,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual DbCommand CreateDbCommand()
             => _relationalCommandCache
-                .GetRelationalCommand(_relationalQueryContext.ParameterValues)
+                .GetRelationalCommandTemplate(_relationalQueryContext.ParameterValues)
                 .CreateDbCommand(
                     new RelationalCommandParameterObject(
                         _relationalQueryContext.Connection,
@@ -220,11 +221,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
-                    enumerator._relationalQueryContext.ParameterValues);
-
-                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
-                relationalCommand.PopulateFrom(relationalCommandTemplate);
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalCommandCache.RentAndPopulateRelationalCommand(enumerator._relationalQueryContext);
 
                 var dataReader = enumerator._dataReader = relationalCommand.ExecuteReader(
                     new RelationalCommandParameterObject(
@@ -371,11 +368,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                var relationalCommandTemplate = enumerator._relationalCommandCache.GetRelationalCommand(
-                    enumerator._relationalQueryContext.ParameterValues);
-
-                var relationalCommand = enumerator._relationalCommand = enumerator._relationalQueryContext.Connection.RentCommand();
-                relationalCommand.PopulateFrom(relationalCommandTemplate);
+                var relationalCommand = enumerator._relationalCommand = enumerator._relationalCommandCache.RentAndPopulateRelationalCommand(enumerator._relationalQueryContext);
 
                 var dataReader = enumerator._dataReader = await relationalCommand.ExecuteReaderAsync(
                     new RelationalCommandParameterObject(

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -1403,9 +1404,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         RelationalCommandCache relationalCommandCache,
                         bool detailedErrorsEnabled)
                     {
-                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
-                        var relationalCommand = queryContext.Connection.RentCommand();
-                        relationalCommand.PopulateFrom(relationalCommandTemplate);
+                        var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
 
                         return relationalCommand.ExecuteReader(
                             new RelationalCommandParameterObject(
@@ -1492,9 +1491,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         bool detailedErrorsEnabled,
                         CancellationToken cancellationToken)
                     {
-                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
-                        var relationalCommand = queryContext.Connection.RentCommand();
-                        relationalCommand.PopulateFrom(relationalCommandTemplate);
+                        var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
 
                         return await relationalCommand.ExecuteReaderAsync(
                                 new RelationalCommandParameterObject(
@@ -1734,9 +1731,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         RelationalCommandCache relationalCommandCache,
                         bool detailedErrorsEnabled)
                     {
-                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
-                        var relationalCommand = queryContext.Connection.RentCommand();
-                        relationalCommand.PopulateFrom(relationalCommandTemplate);
+                        var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
 
                         return relationalCommand.ExecuteReader(
                             new RelationalCommandParameterObject(
@@ -1815,9 +1810,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         bool detailedErrorsEnabled,
                         CancellationToken cancellationToken)
                     {
-                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
-                        var relationalCommand = queryContext.Connection.RentCommand();
-                        relationalCommand.PopulateFrom(relationalCommandTemplate);
+                        var relationalCommand = relationalCommandCache.RentAndPopulateRelationalCommand(queryContext);
 
                         return await relationalCommand.ExecuteReaderAsync(
                             new RelationalCommandParameterObject(

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.cs
@@ -1734,7 +1734,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                         RelationalCommandCache relationalCommandCache,
                         bool detailedErrorsEnabled)
                     {
-                        var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommand = queryContext.Connection.RentCommand();
+                        relationalCommand.PopulateFrom(relationalCommandTemplate);
 
                         return relationalCommand.ExecuteReader(
                             new RelationalCommandParameterObject(
@@ -1813,7 +1815,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                         bool detailedErrorsEnabled,
                         CancellationToken cancellationToken)
                     {
-                        var relationalCommand = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommandTemplate = relationalCommandCache.GetRelationalCommand(queryContext.ParameterValues);
+                        var relationalCommand = queryContext.Connection.RentCommand();
+                        relationalCommand.PopulateFrom(relationalCommandTemplate);
 
                         return await relationalCommand.ExecuteReaderAsync(
                             new RelationalCommandParameterObject(

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
@@ -19,18 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    public interface IRelationalCommand
+    public interface IRelationalCommand : IRelationalCommandTemplate
     {
-        /// <summary>
-        ///     Gets the command text to be executed.
-        /// </summary>
-        string CommandText { get; }
-
-        /// <summary>
-        ///     Gets the parameters for the command.
-        /// </summary>
-        IReadOnlyList<IRelationalParameter> Parameters { get; }
-
         /// <summary>
         ///     Executes the command with no results.
         /// </summary>
@@ -92,28 +79,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        ///     <para>
-        ///         Called by the execute methods to create a <see cref="DbCommand" /> for the given <see cref="DbConnection" />
-        ///         and configure timeouts and transactions.
-        ///     </para>
-        ///     <para>
-        ///         This method is typically used by database providers (and other extensions). It is generally
-        ///         not used in application code.
-        ///     </para>
+        ///     Populates this command from the provided <paramref name="commandTemplate"/>.
         /// </summary>
-        /// <param name="parameterObject"> Parameters for this method. </param>
-        /// <param name="commandId"> The command correlation ID. </param>
-        /// <param name="commandMethod"> The method that will be called on the created command. </param>
-        /// <returns> The created command. </returns>
-        DbCommand CreateDbCommand(
-            RelationalCommandParameterObject parameterObject,
-            Guid commandId,
-            DbCommandMethod commandMethod);
-
-        /// <summary>
-        ///     Populates this command from the provided <paramref name="command"/>.
-        /// </summary>
-        /// <param name="command"> A template command from which the command text and parameters will be copied. </param>
-        void PopulateFrom(IRelationalCommand command);
+        /// <param name="commandTemplate"> A template command from which the command text and parameters will be copied. </param>
+        void PopulateFrom(IRelationalCommandTemplate commandTemplate);
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        ///     Populates this command from the provided <paramref name="commandTemplate"/>.
+        ///     Populates this command from the provided <paramref name="commandTemplate" />.
         /// </summary>
         /// <param name="commandTemplate"> A template command from which the command text and parameters will be copied. </param>
         void PopulateFrom(IRelationalCommandTemplate commandTemplate);

--- a/src/EFCore.Relational/Storage/IRelationalCommandTemplate.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommandTemplate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
     ///     <para>
-    ///         A command template to populate a <see cref="IRelationalCommand"/> or create a <see cref="DbCommand"/>
+    ///         A command template to populate an <see cref="IRelationalCommand" /> or create a <see cref="DbCommand" />
     ///     </para>
     ///     <para>
     ///         This type is typically used by database providers (and other extensions). It is generally

--- a/src/EFCore.Relational/Storage/IRelationalCommandTemplate.cs
+++ b/src/EFCore.Relational/Storage/IRelationalCommandTemplate.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         A command template to populate a <see cref="IRelationalCommand"/> or create a <see cref="DbCommand"/>
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public interface IRelationalCommandTemplate
+    {
+        /// <summary>
+        ///     Gets the command text to be copied to the destination command.
+        /// </summary>
+        string CommandText { get; }
+
+        /// <summary>
+        ///     Gets the parameters to be copied to the destination command.
+        /// </summary>
+        IReadOnlyList<IRelationalParameter> Parameters { get; }
+        
+        /// <summary>
+        ///     <para>
+        ///         Called by the execute methods to create a <see cref="DbCommand" /> for the given <see cref="DbConnection" />
+        ///         and configure timeouts and transactions.
+        ///     </para>
+        ///     <para>
+        ///         This method is typically used by database providers (and other extensions). It is generally
+        ///         not used in application code.
+        ///     </para>
+        /// </summary>
+        /// <param name="parameterObject"> Parameters for this method. </param>
+        /// <param name="commandId"> The command correlation ID. </param>
+        /// <param name="commandMethod"> The method that will be called on the created command. </param>
+        /// <returns> The created command. </returns>
+        DbCommand CreateDbCommand(
+            RelationalCommandParameterObject parameterObject,
+            Guid commandId,
+            DbCommandMethod commandMethod);
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/RelationalCommand.cs
@@ -781,13 +781,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
              => new();
 
         /// <summary>
-        ///     Populates this command from the provided <paramref name="command"/>.
+        ///     Populates this command from the provided <paramref name="commandTemplate"/>.
         /// </summary>
-        /// <param name="command"> A template command from which the command text and parameters will be copied. </param>
-        public virtual void PopulateFrom(IRelationalCommand command)
+        /// <param name="commandTemplate"> A template command from which the command text and parameters will be copied. </param>
+        public virtual void PopulateFrom(IRelationalCommandTemplate commandTemplate)
         {
-            CommandText = command.CommandText;
-            Parameters = command.Parameters;
+            CommandText = commandTemplate.CommandText;
+            Parameters = commandTemplate.Parameters;
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -212,8 +212,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 DbCommandMethod commandMethod)
                 => throw new NotSupportedException();
 
-            public void PopulateFrom(IRelationalCommand command)
-                => _realRelationalCommand.PopulateFrom(command);
+            public void PopulateFrom(IRelationalCommandTemplate commandTemplate)
+                => _realRelationalCommand.PopulateFrom(commandTemplate);
 
             private int? PreExecution(IRelationalConnection connection)
             {

--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -296,7 +296,7 @@ namespace Microsoft.EntityFrameworkCore
                 CancellationToken cancellationToken = default)
                 => throw new NotImplementedException();
 
-            public void PopulateFrom(IRelationalCommand command)
+            public void PopulateFrom(IRelationalCommandTemplate commandTemplate)
                 => throw new NotImplementedException();
         }
     }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -284,7 +284,7 @@ namespace Microsoft.EntityFrameworkCore
                     DbCommandMethod commandMethod)
                     => throw new NotImplementedException();
 
-                public void PopulateFrom(IRelationalCommand command)
+                public void PopulateFrom(IRelationalCommandTemplate commandTemplate)
                     => throw new NotImplementedException();
             }
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -184,10 +184,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         return reader;
                     }
 
-                    public override void PopulateFrom(IRelationalCommand command)
+                    public override void PopulateFrom(IRelationalCommandTemplate commandTemplate)
                     {
-                        base.PopulateFrom(command);
-                        _values = ((BadDataRelationalCommand)command)._values;
+                        base.PopulateFrom(commandTemplate);
+                        _values = ((BadDataRelationalCommand)commandTemplate)._values;
                     }
 
                     private class BadDataRelationalDataReader : RelationalDataReader


### PR DESCRIPTION
Fixes #25225.

**Description**

As part of the query performance work in EF Core 6.0, a concurrency state bug was accidentally introduced where the same stateful object (RelationalCommand) may get reused concurrently, leading to issues.

**Customer Impact**

Running the same query concurrently as a split query on SQL Server may fail in unpredictable ways.

**How found**

User report.

**Test coverage**

Included in this PR.

**Regression?**
Yes, as result of a performance optimization introduced in EF Core 6.0.

**Risk**

Very low, the PR simply duplicates the stateful RelationalCommand for the non-primary split query case, a technique already used in other scenarios (e.g. single query).

~~There is also a remaining possible issue that I see: `RelationalShapedQueryCompilingExpressionVisitor.ShaperProcessingExpressionVisitor.PopulateSplitIncludeCollection(...)` (and `PopulateSplitIncludeCollectionAsync`) don't return their command template using `Connection.ReturnCommand(...)` like the other places where commands are rented.~~