### PR TITLE
Discover inverse navigations when entity added after being ignored

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyChangeTrackingConvention.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
             {
                 modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
 #pragma warning disable EF1001 // Internal EF Core API usage.
-                modelBuilder.HasAnnotation(CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation, true);
+                modelBuilder.HasAnnotation(CoreAnnotationNames.FullChangeTrackingNotificationsRequired, true);
 #pragma warning restore EF1001 // Internal EF Core API usage.
             }
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntrySubscriber.cs
@@ -113,8 +113,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             if (navigation.GetCollectionAccessor()
                 ?.GetOrCreate(entry.Entity, forMaterialization: false) is not INotifyCollectionChanged notifyingCollection)
             {
+                var collectionType = navigation.GetCollectionAccessor()
+                    ?.GetOrCreate(entry.Entity, forMaterialization: false).GetType().DisplayName(fullName: false);
                 throw new InvalidOperationException(
-                    CoreStrings.NonNotifyingCollection(navigation.Name, entityType.DisplayName(), changeTrackingStrategy));
+                    CoreStrings.NonNotifyingCollection(navigation.Name, entityType.DisplayName(), collectionType, changeTrackingStrategy));
             }
 
             return notifyingCollection;

--- a/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore/Design/Internal/CSharpRuntimeAnnotationCodeGenerator.cs
@@ -36,14 +36,23 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         /// <inheritdoc />
         public virtual void Generate(IModel model, CSharpRuntimeAnnotationCodeGeneratorParameters parameters)
         {
+            var annotations = parameters.Annotations;
             if (!parameters.IsRuntime)
             {
-                parameters.Annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                foreach (var annotation in annotations)
+                {
+                    if (CoreAnnotationNames.AllNames.Contains(annotation.Key)
+                        && annotation.Key != CoreAnnotationNames.ProductVersion
+                        && annotation.Key != CoreAnnotationNames.FullChangeTrackingNotificationsRequired)
+                    {
+                        annotations.Remove(annotation.Key);
+                    }
+                }
             }
             else
             {
-                parameters.Annotations.Remove(CoreAnnotationNames.ModelDependencies);
-                parameters.Annotations.Remove(CoreAnnotationNames.ReadOnlyModel);
+                annotations.Remove(CoreAnnotationNames.ModelDependencies);
+                annotations.Remove(CoreAnnotationNames.ReadOnlyModel);
             }
 
             GenerateSimpleAnnotations(parameters);
@@ -58,6 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
                 annotations.Remove(CoreAnnotationNames.NavigationAccessMode);
                 annotations.Remove(CoreAnnotationNames.DiscriminatorProperty);
+                annotations.Remove(CoreAnnotationNames.AmbiguousNavigations);
+                annotations.Remove(CoreAnnotationNames.NavigationCandidates);
             }
 
             GenerateSimpleAnnotations(parameters);

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -665,7 +665,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             Check.NotNull(model, nameof(model));
 
-            var requireFullNotifications = (bool?)model[CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation] == true;
+            var requireFullNotifications = (bool?)model[CoreAnnotationNames.FullChangeTrackingNotificationsRequired] == true;
             foreach (var entityType in model.GetEntityTypes())
             {
                 var errorMessage = EntityType.CheckChangeTrackingStrategy(

--- a/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/ModelCleanupConvention.cs
@@ -36,7 +36,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             RemoveEntityTypesUnreachableByNavigations(modelBuilder, context);
             RemoveNavigationlessForeignKeys(modelBuilder);
-            RemoveModelBuildingAnnotations(modelBuilder);
         }
 
         private void RemoveEntityTypesUnreachableByNavigations(
@@ -81,16 +80,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                         entityType.Builder.HasNoRelationship(foreignKey, fromDataAnnotation: true);
                     }
                 }
-            }
-        }
-
-        private void RemoveModelBuildingAnnotations(IConventionModelBuilder modelBuilder)
-        {
-            modelBuilder.Metadata.RemoveAnnotation(CoreAnnotationNames.DerivedTypes);
-            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
-            {
-                entityType.RemoveAnnotation(CoreAnnotationNames.AmbiguousNavigations);
-                entityType.RemoveAnnotation(CoreAnnotationNames.NavigationCandidates);
             }
         }
 

--- a/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
+++ b/src/EFCore/Metadata/Conventions/RuntimeModelConvention.cs
@@ -195,7 +195,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             if (!runtime)
             {
-                annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
+                foreach (var annotation in annotations)
+                {
+                    if (CoreAnnotationNames.AllNames.Contains(annotation.Key)
+                        && annotation.Key != CoreAnnotationNames.ProductVersion
+                        && annotation.Key != CoreAnnotationNames.FullChangeTrackingNotificationsRequired)
+                    {
+                        annotations.Remove(annotation.Key);
+                    }
+                }
             }
             else
             {
@@ -242,6 +250,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 annotations.Remove(CoreAnnotationNames.PropertyAccessMode);
                 annotations.Remove(CoreAnnotationNames.NavigationAccessMode);
                 annotations.Remove(CoreAnnotationNames.DiscriminatorProperty);
+                annotations.Remove(CoreAnnotationNames.AmbiguousNavigations);
+                annotations.Remove(CoreAnnotationNames.NavigationCandidates);
 
                 if (annotations.TryGetValue(CoreAnnotationNames.QueryFilter, out var queryFilter))
                 {

--- a/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(
                 typeof(TEntity),
                 typeof(TCollection),
-                navigation.DeclaringEntityType.Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation] != null);
+                navigation.DeclaringEntityType.Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequired] != null);
 
             if (concreteType != null)
             {

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -247,6 +247,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public const string InverseNavigationCandidates = "RelationshipDiscoveryConvention:InverseNavigationCandidates";
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         public const string NavigationCandidates = "RelationshipDiscoveryConvention:NavigationCandidates";
 
         /// <summary>
@@ -287,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public const string FullChangeTrackingNotificationsRequiredAnnotation = "ModelValidator.FullChangeTrackingNotificationsRequired";
+        public const string FullChangeTrackingNotificationsRequired = "ModelValidator.FullChangeTrackingNotificationsRequired";
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -330,11 +338,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             PreUniquificationName,
             InverseNavigations,
             DerivedTypes,
+            InverseNavigationCandidates,
             NavigationCandidates,
             AmbiguousNavigations,
             AmbiguousField,
             DuplicateServiceProperties,
-            FullChangeTrackingNotificationsRequiredAnnotation
+            FullChangeTrackingNotificationsRequired
         };
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -3157,7 +3157,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (changeTrackingStrategy != null)
             {
                 var requireFullNotifications =
-                    (bool?)Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequiredAnnotation] == true;
+                    (bool?)Model[CoreAnnotationNames.FullChangeTrackingNotificationsRequired] == true;
                 var errorMessage = CheckChangeTrackingStrategy(this, changeTrackingStrategy.Value, requireFullNotifications);
                 if (errorMessage != null)
                 {

--- a/src/EFCore/Metadata/Internal/IMemberClassifier.cs
+++ b/src/EFCore/Metadata/Internal/IMemberClassifier.cs
@@ -53,6 +53,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        IReadOnlyCollection<Type> GetInverseCandidateTypes(IConventionEntityType entityType);
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
         IParameterBindingFactory? FindServicePropertyCandidateBindingFactory(PropertyInfo propertyInfo, IConventionModel model);
     }
 }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -3736,6 +3736,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                 existingTargetType.Name, existingTargetType.ClrType, configurationSource.Value, targetShouldBeOwned)
                             : ModelBuilder.Entity(existingTargetType.ClrType, configurationSource.Value, targetShouldBeOwned);
                 }
+                else if (!targetEntityType.IsNamed
+                    && !existingTargetType.HasSharedClrType
+                    && targetEntityType.Type != null
+                    && targetEntityType.Type.IsAssignableFrom(existingTargetType.ClrType))
+                {
+                    return existingNavigation.TargetEntityType.Builder;
+                }
             }
 
             if (navigation.MemberInfo == null

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1912,12 +1912,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
                 property, entityType, type);
 
         /// <summary>
-        ///     The collection type being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.
+        ///     The collection type '{2_collectionType}' being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.
         /// </summary>
-        public static string NonNotifyingCollection(object? navigation, object? entityType, object? changeTrackingStrategy)
+        public static string NonNotifyingCollection(object? navigation, object? entityType, object? collectionType, object? changeTrackingStrategy)
             => string.Format(
-                GetString("NonNotifyingCollection", "0_navigation", "1_entityType", nameof(changeTrackingStrategy)),
-                navigation, entityType, changeTrackingStrategy);
+                GetString("NonNotifyingCollection", "0_navigation", "1_entityType", "2_collectionType", nameof(changeTrackingStrategy)),
+                navigation, entityType, collectionType, changeTrackingStrategy);
 
         /// <summary>
         ///     The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{entityType}' is a shadow state entity type while '{baseEntityType}' is not.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1163,7 +1163,7 @@
     <value>Cannot add indexer property '{property}' since there is no indexer on '{entityType}' taking a single argument of type assignable from '{type}'.</value>
   </data>
   <data name="NonNotifyingCollection" xml:space="preserve">
-    <value>The collection type being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
+    <value>The collection type '{2_collectionType}' being used for navigation '{1_entityType}.{0_navigation}' does not implement 'INotifyCollectionChanged'. Any entity type configured to use the '{changeTrackingStrategy}' change tracking strategy must use collections that implement 'INotifyCollectionChanged'. Consider using 'ObservableCollection&lt;T&gt;' for this.</value>
   </data>
   <data name="NonShadowBaseType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{entityType}' is a shadow state entity type while '{baseEntityType}' is not.</value>

--- a/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
+++ b/test/EFCore.Cosmos.Tests/ModelBuilding/CosmosModelBuilderGenericTest.cs
@@ -271,12 +271,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
         public class CosmosGenericOneToMany : GenericOneToMany
         {
-            [ConditionalFact(Skip = "#25279")]
-            public override void Keyless_type_discovered_before_referenced_entity_type_does_not_leave_temp_id()
-            {
-                base.Keyless_type_discovered_before_referenced_entity_type_does_not_leave_temp_id();
-            }
-
             public override void Navigation_to_shared_type_is_not_discovered_by_convention()
             {
                 var modelBuilder = CreateModelBuilder();
@@ -319,6 +313,20 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.True(owned.HasSharedClrType);
                 Assert.Equal("ReferenceNavigationToSharedType.Navigation#Dictionary<string, object>",
                     owned.DisplayName());
+            }
+
+            [ConditionalFact]
+            public virtual void Inverse_discovered_after_entity_becomes_non_owned()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<QueryResult>();
+                modelBuilder.Entity<Value>();
+
+                var model = modelBuilder.FinalizeModel();
+
+                var queryResult = model.FindEntityType(typeof(QueryResult));
+                Assert.NotNull(queryResult.FindNavigation(nameof(QueryResult.Value)));
             }
 
             protected override TestModelBuilder CreateModelBuilder(Action<ModelConfigurationBuilder> configure = null)
@@ -468,12 +476,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
         public class CosmosGenericOwnedTypes : GenericOwnedTypes
         {
-            [ConditionalFact(Skip = "#25279")]
-            public override void Can_configure_owned_type_collection_with_one_call_afterwards()
-            {
-                base.Can_configure_owned_type_collection_with_one_call_afterwards();
-            }
-
             public override void Deriving_from_owned_type_throws()
             {
                 // On Cosmos the base type starts as owned

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -2028,6 +2028,18 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
         }
 
+        [ConditionalFact]
+        public virtual void InversePropertyAttribute_pointing_to_same_nav_on_base_with_one_ignored()
+        {
+            var modelBuilder = CreateModelBuilder();
+            modelBuilder.Entity<MultipleAnswersInverse>();
+            modelBuilder.Entity<MultipleAnswersRepeatingInverse>().Ignore(a => a.Answers);
+
+            var model = Validate(modelBuilder);
+
+            Assert.NotNull(model.FindEntityType(typeof(MultipleAnswersInverse)).FindNavigation(nameof(MultipleAnswersInverse.Answers)));
+        }
+
         private class PartialAnswerInverse
         {
             public int Id { get; set; }

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             ((FullNotificationEntity)entry.Entity).RelatedCollection = new List<ChangedOnlyNotificationEntity>();
 
             Assert.Equal(
-                CoreStrings.NonNotifyingCollection("RelatedCollection", "FullNotificationEntity", changeTrackingStrategy),
+                CoreStrings.NonNotifyingCollection("RelatedCollection", "FullNotificationEntity", "List<ChangedOnlyNotificationEntity>", changeTrackingStrategy),
                 Assert.Throws<InvalidOperationException>(
                     () => entry.SetEntityState(EntityState.Unchanged)).Message);
         }

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -935,6 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             var ownershipBuilder = entityTypeBuilder.HasOwnership(typeof(D), nameof(B.A), ConfigurationSource.Convention);
             var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
             ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+            ownedTypeBuilder.HasNoRelationship(ownershipBuilder.Metadata, ConfigurationSource.Convention);
 
             var baseOwnershipBuilder = entityTypeBuilder.HasOwnership(typeof(A), nameof(B.A), ConfigurationSource.Convention);
             var anotherEntityTypeBuilder = baseOwnershipBuilder.Metadata.DeclaringEntityType.Builder;

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4106,6 +4106,21 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     CoreStrings.NonConfiguredNavigationToSharedType("Navigation", nameof(ReferenceNavigationToSharedType)),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder.FinalizeModel()).Message);
             }
+
+            [ConditionalFact]
+            public virtual void Inverse_discovered_after_entity_unignored()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Ignore<Value>();
+                modelBuilder.Entity<QueryResult>();
+                modelBuilder.Entity<Value>();
+
+                var model = modelBuilder.FinalizeModel();
+
+                var queryResult = model.FindEntityType(typeof(QueryResult));
+                Assert.NotNull(queryResult.FindNavigation(nameof(QueryResult.Value)));
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -851,8 +851,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
 
                 Assert.Equal(2, modelBuilder.Model.FindEntityTypes(typeof(Order)).Count());
-                // SpecialOrder and Address are only used once, but once they are made shared they don't revert to non-shared
-                Assert.Equal(7, modelBuilder.Model.GetEntityTypes().Count(e => !e.HasSharedClrType));
 
                 var conventionModel = (IConventionModel)modelBuilder.Model;
                 Assert.Null(conventionModel.FindIgnoredConfigurationSource(typeof(Order)));

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -724,6 +724,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
         protected class QueryResult
         {
+            public int Id { get; set; }
             public int ValueFk { get; set; }
             public Value Value { get; set; }
         }
@@ -732,13 +733,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public int Id { get; set; }
             public int AlternateId { get; set; }
-        }
-
-        protected class QueryCoreResult
-        {
-            public int ValueFk { get; set; }
-            public int ValueId { get; set; }
-            public Value Value { get; set; }
         }
 
         protected class KeylessEntity


### PR DESCRIPTION
Discover inverse navigations when entity becomes non-owned
Don't remove leftover attributes in `ModelCleanupConvention`, instead ignore them in `RuntimeModelConvention`

Fixes #25279