### PR TITLE
Fix to #24671 - Relational: No tests for TranslateContains path

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -312,7 +312,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 selectExpression.ClearOrdering();
             }
 
-            // TODO: See issue #24671
             if (source.ShaperExpression is ProjectionBindingExpression projectionBindingExpression)
             {
                 var projection = selectExpression.GetProjection(projectionBindingExpression);
@@ -323,7 +322,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     translation = _sqlExpressionFactory.In(translation, selectExpression, false);
 
-                    return new ShapedQueryExpression(
+                    return source.Update(
                         _sqlExpressionFactory.Select(translation),
                         Expression.Convert(
                             new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), typeof(bool?)),


### PR DESCRIPTION
All Contains calls are converted to Any with predicate (which allows to handle null semantics) so this code never gets but fixing this tiny bug, just in case. We were not setting the cardinality of the contains translation to single result, so the translation would have failed, if it wasn't converted to Any and therefore (correctly) being handled by it's translation code.

Fixes #24671