### PR TITLE
Add hook to get default type mapping in SqlExpressionFactory

### DIFF
--- a/src/EFCore.Relational/Query/SqlExpressionFactory.cs
+++ b/src/EFCore.Relational/Query/SqlExpressionFactory.cs
@@ -48,7 +48,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                     && sqlUnaryExpression.OperatorType == ExpressionType.Convert
                     && sqlUnaryExpression.Type == typeof(object)
                         ? sqlUnaryExpression.Operand
-                        : ApplyTypeMapping(sqlExpression, Dependencies.TypeMappingSource.FindMapping(sqlExpression.Type, Dependencies.Model));
+                        : ApplyTypeMapping(sqlExpression, GetDefaultTypeMapping(sqlExpression));
+
+        /// <summary>
+        ///     Gets the default type mapping for given <see cref="SqlExpression" />.
+        /// </summary>
+        /// <param name="sqlExpression"> A SQL Expression for which to get the default type mapping. </param>
+        /// <returns> The default type mapping for the given SQL expression. </returns>
+        public virtual RelationalTypeMapping? GetDefaultTypeMapping(SqlExpression sqlExpression)
+            => Dependencies.TypeMappingSource.FindMapping(sqlExpression.Type, Dependencies.Model);
 
         /// <inheritdoc />
         [return: NotNullIfNotNull("sqlExpression")]


### PR DESCRIPTION
So that it can be overridden in cases where the default type mapping depends on things other than the type.

For example, for the Npgsql timestamp changes I'm doing, I need to be able to select a different type mapping for DateTime constants based on the Kind of the value.
