### PR TITLE
Query: Convert enum to underlying CLR type in type mapping when type …

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -485,6 +485,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
             parameter.ParameterName = name;
 
             value = ConvertUnderlyingEnumValueToEnum(value);
+
+            // We preserve convert nodes around enum to get actual enum value for type mapping
+            // But when enum is cast manually to something same as implicit cast
+            // And type mapping is not really enum then we need to convert the enum value to current Clr Type
+            if (value?.GetType().IsEnum == true
+                && ClrType.IsInteger())
+            {
+                value = Convert.ChangeType(value, ClrType);
+            }
+
             if (Converter != null)
             {
                 value = Converter.ConvertToProvider(value);


### PR DESCRIPTION
…mapping is not for enum

Resolves #21770
