### PR TITLE
Use new Hosted build pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,11 +58,11 @@ stages:
             enablePublishTestResults: true
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCorePublic-Pool
-                queue: BuildPool.Server.Amd64.VS2017.Open
+                name: NetCore1ESPool-Svc-Public
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                name: NetCoreInternal-Pool
-                queue: BuildPool.Server.Amd64.VS2017
+                name: NetCore1ESPool-Svc-Internal
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017
             variables:
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -185,11 +185,11 @@ stages:
             timeoutInMinutes: 180
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCorePublic-Pool
-                queue: BuildPool.Server.Amd64.VS2017.Open
+                name: NetCore1ESPool-Svc-Public
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                name: NetCoreInternal-Pool
-                queue: BuildPool.Server.Amd64.VS2017
+                name: NetCore1ESPool-Svc-Internal
+                demands: ImageOverride -equals Build.Server.Amd64.VS2017
             variables:
               - name: _HelixBuildConfig
                 value: $(_BuildConfig)


### PR DESCRIPTION
We are transitioning all servicing build to a new set of pools

- [x] I've read the guidelines for [contributing](CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [ ] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

