### PR TITLE
Reuse some IExecutionStrategy instances.

### DIFF
--- a/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosClientWrapper.cs
@@ -19,7 +19,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -63,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
 
         private readonly ISingletonCosmosClientWrapper _singletonWrapper;
         private readonly string _databaseId;
-        private readonly IExecutionStrategyFactory _executionStrategyFactory;
+        private readonly IExecutionStrategy _executionStrategy;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _commandLogger;
         private readonly bool? _enableContentResponseOnWrite;
 
@@ -84,14 +83,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         public CosmosClientWrapper(
             ISingletonCosmosClientWrapper singletonWrapper,
             IDbContextOptions dbContextOptions,
-            IExecutionStrategyFactory executionStrategyFactory,
+            IExecutionStrategy executionStrategy,
             IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
         {
             var options = dbContextOptions.FindExtension<CosmosOptionsExtension>();
 
             _singletonWrapper = singletonWrapper;
             _databaseId = options!.DatabaseName;
-            _executionStrategyFactory = executionStrategyFactory;
+            _executionStrategy = executionStrategy;
             _commandLogger = commandLogger;
             _enableContentResponseOnWrite = options.EnableContentResponseOnWrite;
         }
@@ -106,12 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CreateDatabaseIfNotExists(ThroughputProperties? throughput)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute((throughput, this), CreateDatabaseIfNotExistsOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute((throughput, this), CreateDatabaseIfNotExistsOnce, null);
 
         private static bool CreateDatabaseIfNotExistsOnce(
             DbContext? context,
@@ -124,16 +118,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> CreateDatabaseIfNotExistsAsync(
+        public virtual Task<bool> CreateDatabaseIfNotExistsAsync(
             ThroughputProperties? throughput,
             CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                (throughput, this), CreateDatabaseIfNotExistsOnceAsync, null, cancellationToken).ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.ExecuteAsync(
+                (throughput, this), CreateDatabaseIfNotExistsOnceAsync, null, cancellationToken);
 
         private static async Task<bool> CreateDatabaseIfNotExistsOnceAsync(
             DbContext? _,
@@ -154,12 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool DeleteDatabase()
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute(this, DeleteDatabaseOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute(this, DeleteDatabaseOnce, null);
 
         private static bool DeleteDatabaseOnce(
             DbContext? context,
@@ -172,15 +156,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> DeleteDatabaseAsync(
+        public virtual Task<bool> DeleteDatabaseAsync(
             CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                this, DeleteDatabaseOnceAsync, null, cancellationToken).ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.ExecuteAsync(this, DeleteDatabaseOnceAsync, null, cancellationToken);
 
         private static async Task<bool> DeleteDatabaseOnceAsync(
             DbContext? _,
@@ -205,12 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual bool CreateContainerIfNotExists(ContainerProperties properties)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute((properties, this), CreateContainerIfNotExistsOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute((properties, this), CreateContainerIfNotExistsOnce, null);
 
         private static bool CreateContainerIfNotExistsOnce(
             DbContext context,
@@ -223,14 +196,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> CreateContainerIfNotExistsAsync(ContainerProperties properties, CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                (properties, this), CreateContainerIfNotExistsOnceAsync, null, cancellationToken).ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+        public virtual Task<bool> CreateContainerIfNotExistsAsync(ContainerProperties properties, CancellationToken cancellationToken = default)
+            => _executionStrategy.ExecuteAsync((properties, this), CreateContainerIfNotExistsOnceAsync, null, cancellationToken);
 
         private static async Task<bool> CreateContainerIfNotExistsOnceAsync(
             DbContext _,
@@ -268,12 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             string containerId,
             JToken document,
             IUpdateEntry entry)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute((containerId, document, entry, this), CreateItemOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute((containerId, document, entry, this), CreateItemOnce, null);
 
         private static bool CreateItemOnce(
             DbContext context,
@@ -286,18 +248,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> CreateItemAsync(
+        public virtual Task<bool> CreateItemAsync(
             string containerId,
             JToken document,
             IUpdateEntry updateEntry,
             CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                (containerId, document, updateEntry, this), CreateItemOnceAsync, null, cancellationToken).ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.ExecuteAsync((containerId, document, updateEntry, this), CreateItemOnceAsync, null, cancellationToken);
 
         private async static Task<bool> CreateItemOnceAsync(
             DbContext _,
@@ -347,13 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             string documentId,
             JObject document,
             IUpdateEntry entry)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute(
-                (collectionId, documentId, document, entry, this), ReplaceItemOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute((collectionId, documentId, document, entry, this), ReplaceItemOnce, null);
 
         private static bool ReplaceItemOnce(
             DbContext context,
@@ -366,20 +316,14 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> ReplaceItemAsync(
+        public virtual Task<bool> ReplaceItemAsync(
             string collectionId,
             string documentId,
             JObject document,
             IUpdateEntry updateEntry,
             CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                (collectionId, documentId, document, updateEntry, this), ReplaceItemOnceAsync, null, cancellationToken)
-                .ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.ExecuteAsync(
+                (collectionId, documentId, document, updateEntry, this), ReplaceItemOnceAsync, null, cancellationToken);
 
         private async static Task<bool> ReplaceItemOnceAsync(
             DbContext _,
@@ -429,12 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
             string containerId,
             string documentId,
             IUpdateEntry entry)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = executionStrategy.Execute((containerId, documentId, entry, this), DeleteItemOnce, null);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.Execute((containerId, documentId, entry, this), DeleteItemOnce, null);
 
         private static bool DeleteItemOnce(
             DbContext context,
@@ -447,18 +386,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<bool> DeleteItemAsync(
+        public virtual Task<bool> DeleteItemAsync(
             string containerId,
             string documentId,
             IUpdateEntry entry,
             CancellationToken cancellationToken = default)
-        {
-            var executionStrategy = _executionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
-                (containerId, documentId, entry, this), DeleteItemOnceAsync, null, cancellationToken).ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => _executionStrategy.ExecuteAsync((containerId, documentId, entry, this), DeleteItemOnceAsync, null, cancellationToken);
 
         private static async Task<bool> DeleteItemOnceAsync(
             DbContext? _,
@@ -625,9 +558,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             _commandLogger.ExecutingReadItem(containerId, partitionKey, resourceId);
 
-            var executionStrategy = _executionStrategyFactory.Create();
-            var response = executionStrategy.Execute((containerId, partitionKey, resourceId, this), CreateSingleItemQuery, null);
-            _executionStrategyFactory.Return(executionStrategy);
+            var response = _executionStrategy.Execute((containerId, partitionKey, resourceId, this), CreateSingleItemQuery, null);
 
             _commandLogger.ExecutedReadItem(
                 response.Diagnostics.GetClientElapsedTime(),
@@ -654,14 +585,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         {
             _commandLogger.ExecutingReadItem(containerId, partitionKey, resourceId);
 
-            var executionStrategy = _executionStrategyFactory.Create();
-            var response = await executionStrategy.ExecuteAsync(
+            var response = await _executionStrategy.ExecuteAsync(
                 (containerId, partitionKey, resourceId, this),
                 CreateSingleItemQueryAsync,
                 null,
                 cancellationToken)
                 .ConfigureAwait(false);
-            _executionStrategyFactory.Return(executionStrategy);
 
             _commandLogger.ExecutedReadItem(
                 response.Diagnostics.GetClientElapsedTime(),

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategy.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        protected override bool ShouldRetryOn(Exception? exception)
+        protected override bool ShouldRetryOn(Exception exception)
         {
             return exception switch
             {
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
                     ?? baseDelay;
         }
 
-        private static TimeSpan? GetDelayFromException(Exception? exception)
+        private static TimeSpan? GetDelayFromException(Exception exception)
         {
             switch (exception)
             {

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategyFactory.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategyFactory.cs
@@ -26,7 +26,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
     public class CosmosExecutionStrategyFactory : IExecutionStrategyFactory
     {
         private readonly Func<ExecutionStrategyDependencies, IExecutionStrategy> _createExecutionStrategy;
-        private IExecutionStrategy? _instance;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -68,26 +67,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IExecutionStrategy Create()
-        {
-            var instance = _instance;
-            if (instance != null)
-            {
-                _instance = null;
-                return instance;
-            }
-
-            return _createExecutionStrategy(Dependencies);
-        }
-
-        /// <summary>
-        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
-        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
-        ///     any release. You should only use it directly in your code with extreme caution and knowing that
-        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
-        /// </summary>
-        public virtual void Return(IExecutionStrategy executionStrategy)
-        {
-            _instance = executionStrategy;
-        }
+            => _createExecutionStrategy(Dependencies);
     }
 }

--- a/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategyFactory.cs
+++ b/src/EFCore.Cosmos/Storage/Internal/CosmosExecutionStrategyFactory.cs
@@ -26,6 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
     public class CosmosExecutionStrategyFactory : IExecutionStrategyFactory
     {
         private readonly Func<ExecutionStrategyDependencies, IExecutionStrategy> _createExecutionStrategy;
+        private IExecutionStrategy? _instance;
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -67,6 +68,26 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IExecutionStrategy Create()
-            => _createExecutionStrategy(Dependencies);
+        {
+            var instance = _instance;
+            if (instance != null)
+            {
+                _instance = null;
+                return instance;
+            }
+
+            return _createExecutionStrategy(Dependencies);
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual void Return(IExecutionStrategy executionStrategy)
+        {
+            _instance = executionStrategy;
+        }
     }
 }

--- a/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalDatabaseFacadeExtensions.cs
@@ -598,9 +598,9 @@ namespace Microsoft.EntityFrameworkCore
             this DatabaseFacade databaseFacade,
             DbTransaction? transaction,
             Guid transactionId)
-            => GetTransactionManager(databaseFacade) is not IRelationalTransactionManager relationalTransactionManager
-                ? throw new InvalidOperationException(RelationalStrings.RelationalNotInUse)
-                : relationalTransactionManager.UseTransaction(transaction, transactionId);
+            => GetTransactionManager(databaseFacade) is IRelationalTransactionManager relationalTransactionManager
+                ? relationalTransactionManager.UseTransaction(transaction, transactionId)
+                : throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
 
         /// <summary>
         ///     Sets the <see cref="DbTransaction" /> to be used by database operations on the <see cref="DbContext" />.
@@ -630,9 +630,9 @@ namespace Microsoft.EntityFrameworkCore
             DbTransaction? transaction,
             Guid transactionId,
             CancellationToken cancellationToken = default)
-            => GetTransactionManager(databaseFacade) is not IRelationalTransactionManager relationalTransactionManager
-                ? throw new InvalidOperationException(RelationalStrings.RelationalNotInUse)
-                : relationalTransactionManager.UseTransactionAsync(transaction, transactionId, cancellationToken);
+            => GetTransactionManager(databaseFacade) is IRelationalTransactionManager relationalTransactionManager
+                ? relationalTransactionManager.UseTransactionAsync(transaction, transactionId, cancellationToken)
+                : throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -197,8 +197,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            _relationalQueryContext.ExecutionStrategyFactory.Create()
-                                .Execute(this, (_, enumerator) => InitializeReader(enumerator), null);
+                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
+                            executionStrategy.Execute(this, (_, enumerator) => InitializeReader(enumerator), null);
+                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = _dataReader!.Read();
@@ -303,13 +304,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            await _relationalQueryContext.ExecutionStrategyFactory.Create()
-                                .ExecuteAsync(
+                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
+                            await executionStrategy.ExecuteAsync(
                                     this,
                                     (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
                                     null,
                                     _relationalQueryContext.CancellationToken)
                                 .ConfigureAwait(false);
+                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = await _dataReader!.ReadAsync(_relationalQueryContext.CancellationToken).ConfigureAwait(false);

--- a/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/FromSqlQueryingEnumerable.cs
@@ -197,9 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
-                            executionStrategy.Execute(this, (_, enumerator) => InitializeReader(enumerator), null);
-                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
+                            _relationalQueryContext.ExecutionStrategy.Execute(this, (_, enumerator) => InitializeReader(enumerator), null);
                         }
 
                         var hasNext = _dataReader!.Read();
@@ -304,14 +302,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
-                            await executionStrategy.ExecuteAsync(
+                            await _relationalQueryContext.ExecutionStrategy.ExecuteAsync(
                                     this,
                                     (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
                                     null,
                                     _relationalQueryContext.CancellationToken)
                                 .ConfigureAwait(false);
-                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = await _dataReader!.ReadAsync(_relationalQueryContext.CancellationToken).ConfigureAwait(false);

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -165,9 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
-                            executionStrategy.Execute(this, static (_, enumerator) => InitializeReader(enumerator), null);
-                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
+                            _relationalQueryContext.ExecutionStrategy.Execute(this, static (_, enumerator) => InitializeReader(enumerator), null);
                         }
 
                         var hasNext = _resultCoordinator!.HasNext ?? _dataReader!.Read();
@@ -304,14 +302,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
-                            await executionStrategy.ExecuteAsync(
+                            await _relationalQueryContext.ExecutionStrategy.ExecuteAsync(
                                     this,
                                     static (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
                                     null,
                                     _cancellationToken)
                                 .ConfigureAwait(false);
-                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = _resultCoordinator!.HasNext

--- a/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SingleQueryingEnumerable.cs
@@ -165,8 +165,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            _relationalQueryContext.ExecutionStrategyFactory.Create()
-                                .Execute(this, static (_, enumerator) => InitializeReader(enumerator), null);
+                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
+                            executionStrategy.Execute(this, static (_, enumerator) => InitializeReader(enumerator), null);
+                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = _resultCoordinator!.HasNext ?? _dataReader!.Read();
@@ -303,13 +304,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         if (_dataReader == null)
                         {
-                            await _relationalQueryContext.ExecutionStrategyFactory.Create()
-                                .ExecuteAsync(
+                            var executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
+                            await executionStrategy.ExecuteAsync(
                                     this,
                                     static (_, enumerator, cancellationToken) => InitializeReaderAsync(enumerator, cancellationToken),
                                     null,
                                     _cancellationToken)
                                 .ConfigureAwait(false);
+                            _relationalQueryContext.ExecutionStrategyFactory.Return(executionStrategy);
                         }
 
                         var hasNext = _resultCoordinator!.HasNext

--- a/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/SplitQueryingEnumerable.cs
@@ -245,6 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (_dataReader is not null)
                 {
+                    _relationalQueryContext.ExecutionStrategyFactory.Return(_executionStrategy!);
                     _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                     _dataReader.Dispose();
                     if (_resultCoordinator != null)
@@ -259,6 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _resultCoordinator = null;
                     }
 
+                    _executionStrategy = null;
                     _dataReader = null;
                     _dbDataReader = null;
                 }
@@ -393,6 +395,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             {
                 if (_dataReader != null)
                 {
+                    _relationalQueryContext.ExecutionStrategyFactory.Return(_executionStrategy!);
                     _relationalQueryContext.Connection.ReturnCommand(_relationalCommand!);
                     await _dataReader.DisposeAsync().ConfigureAwait(false);
                     if (_resultCoordinator != null)
@@ -408,6 +411,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _resultCoordinator.DataReaders.Clear();
                         _resultCoordinator = null;
                     }
+
+                    _executionStrategy = null;
                     _dataReader = null;
                     _dbDataReader = null;
                 }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -71,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 base.GenerateCacheKeyCore(query, async),
                 relationalOptions.UseRelationalNulls,
                 relationalOptions.QuerySplittingBehavior,
-                shouldBuffer: Dependencies.IsRetryingExecutionStrategy);
+                shouldBuffer: ExecutionStrategy.Current?.RetriesOnFailure ?? Dependencies.IsRetryingExecutionStrategy);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Storage/Internal/RelationalDatabaseFacadeDependencies.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalDatabaseFacadeDependencies.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public RelationalDatabaseFacadeDependencies(
             IDbContextTransactionManager transactionManager,
             IDatabaseCreator databaseCreator,
+            IExecutionStrategy executionStrategy,
             IExecutionStrategyFactory executionStrategyFactory,
             IEnumerable<IDatabaseProvider> databaseProviders,
             IRelationalCommandDiagnosticsLogger commandLogger,
@@ -34,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         {
             TransactionManager = transactionManager;
             DatabaseCreator = databaseCreator;
+            ExecutionStrategy = executionStrategy;
             ExecutionStrategyFactory = executionStrategyFactory;
             DatabaseProviders = databaseProviders;
             CommandLogger = commandLogger;
@@ -58,6 +60,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IDatabaseCreator DatabaseCreator { get; init; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IExecutionStrategy ExecutionStrategy { get; init; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalDatabaseCreatorDependencies.cs
@@ -69,20 +69,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             IMigrationsSqlGenerator migrationsSqlGenerator,
             IMigrationCommandExecutor migrationCommandExecutor,
             ISqlGenerationHelper sqlGenerationHelper,
+            IExecutionStrategy executionStrategy,
             IExecutionStrategyFactory executionStrategyFactory,
             ICurrentDbContext currentContext,
             IRelationalCommandDiagnosticsLogger commandLogger)
         {
-            Check.NotNull(model, nameof(model));
-            Check.NotNull(connection, nameof(connection));
-            Check.NotNull(modelDiffer, nameof(modelDiffer));
-            Check.NotNull(migrationsSqlGenerator, nameof(migrationsSqlGenerator));
-            Check.NotNull(migrationCommandExecutor, nameof(migrationCommandExecutor));
-            Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
-            Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
-            Check.NotNull(currentContext, nameof(currentContext));
-            Check.NotNull(commandLogger, nameof(commandLogger));
-
 #pragma warning disable CS0618 // Type or member is obsolete
             Model = model;
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -91,7 +82,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             MigrationsSqlGenerator = migrationsSqlGenerator;
             MigrationCommandExecutor = migrationCommandExecutor;
             SqlGenerationHelper = sqlGenerationHelper;
+            ExecutionStrategy = executionStrategy;
+#pragma warning disable CS0618 // Type or member is obsolete
             ExecutionStrategyFactory = executionStrategyFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             CurrentContext = currentContext;
             CommandLogger = commandLogger;
         }
@@ -128,12 +122,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ISqlGenerationHelper SqlGenerationHelper { get; init; }
 
         /// <summary>
-        ///     Gets the <see cref="IExecutionStrategyFactory" /> to be used.
+        ///     Gets the execution strategy.
         /// </summary>
+        public IExecutionStrategy ExecutionStrategy { get; }
+
+        /// <summary>
+        ///     Gets the execution strategy factory to be used.
+        /// </summary>
+        [Obsolete("Use ExecutionStrategy instead")]
         public IExecutionStrategyFactory ExecutionStrategyFactory { get; init; }
 
         /// <summary>
-        ///     The command logger.
+        ///     Gets the command logger.
         /// </summary>
         public IRelationalCommandDiagnosticsLogger CommandLogger { get; init; }
 

--- a/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
+++ b/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
@@ -23,7 +23,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public class RelationalExecutionStrategyFactory : IExecutionStrategyFactory
     {
         private readonly Func<ExecutionStrategyDependencies, IExecutionStrategy> _createExecutionStrategy;
-        private IExecutionStrategy? _instance;
 
         /// <summary>
         ///     Creates a new instance of this class with the given service dependencies.
@@ -56,24 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates an <see cref="IExecutionStrategy" /> for the current database provider.
         /// </summary>
         public virtual IExecutionStrategy Create()
-        {
-            var instance = _instance;
-            if (instance != null)
-            {
-                _instance = null;
-                return instance;
-            }
-
-            return _createExecutionStrategy(Dependencies);
-        }
-
-        /// <summary>
-        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
-        /// </summary>
-        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
-        public virtual void Return(IExecutionStrategy executionStrategy)
-        {
-            _instance = executionStrategy;
-        }
+            => _createExecutionStrategy(Dependencies);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
+++ b/src/EFCore.Relational/Storage/RelationalExecutionStrategyFactory.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public class RelationalExecutionStrategyFactory : IExecutionStrategyFactory
     {
         private readonly Func<ExecutionStrategyDependencies, IExecutionStrategy> _createExecutionStrategy;
+        private IExecutionStrategy? _instance;
 
         /// <summary>
         ///     Creates a new instance of this class with the given service dependencies.
@@ -55,6 +56,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates an <see cref="IExecutionStrategy" /> for the current database provider.
         /// </summary>
         public virtual IExecutionStrategy Create()
-            => _createExecutionStrategy(Dependencies);
+        {
+            var instance = _instance;
+            if (instance != null)
+            {
+                _instance = null;
+                return instance;
+            }
+
+            return _createExecutionStrategy(Dependencies);
+        }
+
+        /// <summary>
+        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
+        /// </summary>
+        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
+        public virtual void Return(IExecutionStrategy executionStrategy)
+        {
+            _instance = executionStrategy;
+        }
     }
 }

--- a/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
+++ b/src/EFCore.SqlServer/SqlServerRetryingExecutionStrategy.cs
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns>
         ///     <see langword="true" /> if the specified exception is considered as transient, otherwise <see langword="false" />.
         /// </returns>
-        protected override bool ShouldRetryOn(Exception? exception)
+        protected override bool ShouldRetryOn(Exception exception)
         {
             if (_additionalErrorNumbers != null
                 && exception is SqlException sqlException)
@@ -166,7 +166,7 @@ namespace Microsoft.EntityFrameworkCore
                 : baseDelay;
         }
 
-        private static bool IsMemoryOptimizedError(Exception? exception)
+        private static bool IsMemoryOptimizedError(Exception exception)
         {
             if (exception is SqlException sqlException)
             {

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -116,19 +116,23 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override bool HasTables()
-            => Dependencies.ExecutionStrategyFactory
-                .Create()
-                .Execute(
-                    _connection,
-                    connection => (int)CreateHasTablesCommand()
-                            .ExecuteScalar(
-                                new RelationalCommandParameterObject(
-                                    connection,
-                                    null,
-                                    null,
-                                    Dependencies.CurrentContext.Context,
-                                    Dependencies.CommandLogger, CommandSource.Migrations))!
-                        != 0);
+        {
+            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
+            var result = executionStrategy.Execute(
+                               _connection,
+                               connection => (int)CreateHasTablesCommand()
+                                       .ExecuteScalar(
+                                           new RelationalCommandParameterObject(
+                                               connection,
+                                               null,
+                                               null,
+                                               Dependencies.CurrentContext.Context,
+                                               Dependencies.CommandLogger, CommandSource.Migrations))!
+                                   != 0,
+                               null);
+            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
+            return result;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -136,20 +140,26 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override Task<bool> HasTablesAsync(CancellationToken cancellationToken = default)
-            => Dependencies.ExecutionStrategyFactory.Create().ExecuteAsync(
-                _connection,
-                async (connection, ct) => (int)(await CreateHasTablesCommand()
-                        .ExecuteScalarAsync(
-                            new RelationalCommandParameterObject(
-                                connection,
-                                null,
-                                null,
-                                Dependencies.CurrentContext.Context,
-                                Dependencies.CommandLogger, CommandSource.Migrations),
-                            cancellationToken: ct)
-                        .ConfigureAwait(false))!
-                    != 0, cancellationToken);
+        public override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = default)
+        {
+            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
+            var result = (int)(await executionStrategy.ExecuteAsync(
+                           _connection,
+                           (connection, ct) => CreateHasTablesCommand()
+                                   .ExecuteScalarAsync(
+                                       new RelationalCommandParameterObject(
+                                           connection,
+                                           null,
+                                           null,
+                                           Dependencies.CurrentContext.Context,
+                                           Dependencies.CommandLogger, CommandSource.Migrations),
+                                       cancellationToken: ct),
+                           null,
+                           cancellationToken).ConfigureAwait(false))!
+                               != 0;
+            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
+            return result;
+        }
 
         private IRelationalCommand CreateHasTablesCommand()
             => _rawSqlCommandBuilder
@@ -197,55 +207,62 @@ SELECT 1 ELSE SELECT 0");
             => Exists(retryOnNotExists: false);
 
         private bool Exists(bool retryOnNotExists)
-            => Dependencies.ExecutionStrategyFactory.Create().Execute(
-                DateTime.UtcNow + RetryTimeout, giveUp =>
-                {
-                    while (true)
-                    {
-                        var opened = false;
-                        try
-                        {
-                            using var _ = new TransactionScope(TransactionScopeOption.Suppress);
-                            _connection.Open(errorsExpected: true);
-                            opened = true;
+        {
+            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
+            var result = executionStrategy.Execute(
+                           DateTime.UtcNow + RetryTimeout, giveUp =>
+                           {
+                               while (true)
+                               {
+                                   var opened = false;
+                                   try
+                                   {
+                                       using var _ = new TransactionScope(TransactionScopeOption.Suppress);
+                                       _connection.Open(errorsExpected: true);
+                                       opened = true;
 
-                            _rawSqlCommandBuilder
-                                .Build("SELECT 1")
-                                .ExecuteNonQuery(
-                                    new RelationalCommandParameterObject(
-                                        _connection,
-                                        null,
-                                        null,
-                                        Dependencies.CurrentContext.Context,
-                                        Dependencies.CommandLogger, CommandSource.Migrations));
+                                       _rawSqlCommandBuilder
+                                           .Build("SELECT 1")
+                                           .ExecuteNonQuery(
+                                               new RelationalCommandParameterObject(
+                                                   _connection,
+                                                   null,
+                                                   null,
+                                                   Dependencies.CurrentContext.Context,
+                                                   Dependencies.CommandLogger, CommandSource.Migrations));
 
-                            return true;
-                        }
-                        catch (SqlException e)
-                        {
-                            if (!retryOnNotExists
-                                && IsDoesNotExist(e))
-                            {
-                                return false;
-                            }
+                                       return true;
+                                   }
+                                   catch (SqlException e)
+                                   {
+                                       if (!retryOnNotExists
+                                           && IsDoesNotExist(e))
+                                       {
+                                           return false;
+                                       }
 
-                            if (DateTime.UtcNow > giveUp
-                                || !RetryOnExistsFailure(e))
-                            {
-                                throw;
-                            }
+                                       if (DateTime.UtcNow > giveUp
+                                           || !RetryOnExistsFailure(e))
+                                       {
+                                           throw;
+                                       }
 
-                            Thread.Sleep(RetryDelay);
-                        }
-                        finally
-                        {
-                            if (opened)
-                            {
-                                _connection.Close();
-                            }
-                        }
-                    }
-                });
+                                       Thread.Sleep(RetryDelay);
+                                   }
+                                   finally
+                                   {
+                                       if (opened)
+                                       {
+                                           _connection.Close();
+                                       }
+                                   }
+                               }
+                           },
+                           null);
+
+            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
+            return result;
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -256,59 +273,65 @@ SELECT 1 ELSE SELECT 0");
         public override Task<bool> ExistsAsync(CancellationToken cancellationToken = default)
             => ExistsAsync(retryOnNotExists: false, cancellationToken: cancellationToken);
 
-        private Task<bool> ExistsAsync(bool retryOnNotExists, CancellationToken cancellationToken)
-            => Dependencies.ExecutionStrategyFactory.Create().ExecuteAsync(
-                DateTime.UtcNow + RetryTimeout, async (giveUp, ct) =>
-                {
-                    while (true)
-                    {
-                        var opened = false;
+        private async Task<bool> ExistsAsync(bool retryOnNotExists, CancellationToken cancellationToken)
+        {
+            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
+            var result = await executionStrategy.ExecuteAsync(
+                           DateTime.UtcNow + RetryTimeout, async (giveUp, ct) =>
+                           {
+                               while (true)
+                               {
+                                   var opened = false;
 
-                        try
-                        {
-                            using var _ = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
-                            await _connection.OpenAsync(ct, errorsExpected: true).ConfigureAwait(false);
-                            opened = true;
+                                   try
+                                   {
+                                       using var _ = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+                                       await _connection.OpenAsync(ct, errorsExpected: true).ConfigureAwait(false);
+                                       opened = true;
 
-                            await _rawSqlCommandBuilder
-                                .Build("SELECT 1")
-                                .ExecuteNonQueryAsync(
-                                    new RelationalCommandParameterObject(
-                                        _connection,
-                                        null,
-                                        null,
-                                        Dependencies.CurrentContext.Context,
-                                        Dependencies.CommandLogger, CommandSource.Migrations),
-                                    ct)
-                                .ConfigureAwait(false);
+                                       await _rawSqlCommandBuilder
+                                           .Build("SELECT 1")
+                                           .ExecuteNonQueryAsync(
+                                               new RelationalCommandParameterObject(
+                                                   _connection,
+                                                   null,
+                                                   null,
+                                                   Dependencies.CurrentContext.Context,
+                                                   Dependencies.CommandLogger, CommandSource.Migrations),
+                                               ct)
+                                           .ConfigureAwait(false);
 
-                            return true;
-                        }
-                        catch (SqlException e)
-                        {
-                            if (!retryOnNotExists
-                                && IsDoesNotExist(e))
-                            {
-                                return false;
-                            }
+                                       return true;
+                                   }
+                                   catch (SqlException e)
+                                   {
+                                       if (!retryOnNotExists
+                                           && IsDoesNotExist(e))
+                                       {
+                                           return false;
+                                       }
 
-                            if (DateTime.UtcNow > giveUp
-                                || !RetryOnExistsFailure(e))
-                            {
-                                throw;
-                            }
+                                       if (DateTime.UtcNow > giveUp
+                                           || !RetryOnExistsFailure(e))
+                                       {
+                                           throw;
+                                       }
 
-                            await Task.Delay(RetryDelay, ct).ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            if (opened)
-                            {
-                                await _connection.CloseAsync().ConfigureAwait(false);
-                            }
-                        }
-                    }
-                }, cancellationToken);
+                                       await Task.Delay(RetryDelay, ct).ConfigureAwait(false);
+                                   }
+                                   finally
+                                   {
+                                       if (opened)
+                                       {
+                                           await _connection.CloseAsync().ConfigureAwait(false);
+                                       }
+                                   }
+                               }
+                           }, null, cancellationToken).ConfigureAwait(false);
+
+            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
+            return result;
+        }
 
         // Login failed is thrown when database does not exist (See Issue #776)
         // Unable to attach database file is thrown when file does not exist (See Issue #2810)

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -1162,19 +1162,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual int SaveChanges(bool acceptAllChangesOnSuccess)
-        {
-            if (!Context.Database.AutoTransactionsEnabled)
-            {
-                return SaveChanges(this, acceptAllChangesOnSuccess);
-            }
-
-            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
-            var result = executionStrategy.Execute((StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
-                               static (_, t) => SaveChanges(t.StateManager, t.AcceptAllChangesOnSuccess),
-                               null);
-            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
-            return result;
-        }
+            => !Context.Database.AutoTransactionsEnabled
+                ? SaveChanges(this, acceptAllChangesOnSuccess)
+                : Dependencies.ExecutionStrategy.Execute((StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
+                static (_, t) => SaveChanges(t.StateManager, t.AcceptAllChangesOnSuccess),
+                null);
 
         private static int SaveChanges(StateManager stateManager, bool acceptAllChangesOnSuccess)
         {
@@ -1222,25 +1214,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public virtual async Task<int> SaveChangesAsync(
+        public virtual Task<int> SaveChangesAsync(
             bool acceptAllChangesOnSuccess,
             CancellationToken cancellationToken = default)
-        {
-            if (!Context.Database.AutoTransactionsEnabled)
-            {
-                return await SaveChangesAsync(this, acceptAllChangesOnSuccess, cancellationToken).ConfigureAwait(acceptAllChangesOnSuccess);
-            }
-
-            var executionStrategy = Dependencies.ExecutionStrategyFactory.Create();
-            var result = await executionStrategy.ExecuteAsync(
+            => !Context.Database.AutoTransactionsEnabled
+                ? SaveChangesAsync(this, acceptAllChangesOnSuccess, cancellationToken)
+                : Dependencies.ExecutionStrategy.ExecuteAsync(
                     (StateManager: this, AcceptAllChangesOnSuccess: acceptAllChangesOnSuccess),
                     static (_, t, cancellationToken) => SaveChangesAsync(t.StateManager, t.AcceptAllChangesOnSuccess, cancellationToken),
                     null,
                     cancellationToken);
-            Dependencies.ExecutionStrategyFactory.Return(executionStrategy);
-
-            return result;
-        }
 
         private static async Task<int> SaveChangesAsync(
             StateManager stateManager,

--- a/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -73,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             IEntityFinderSource entityFinderSource,
             IDbSetSource setSource,
             IEntityMaterializerSource entityMaterializerSource,
+            IExecutionStrategy executionStrategy,
             IExecutionStrategyFactory executionStrategyFactory,
             ICoreSingletonOptions coreSingletonOptions,
             ILoggingOptions loggingOptions,
@@ -90,7 +92,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             EntityFinderSource = entityFinderSource;
             SetSource = setSource;
             EntityMaterializerSource = entityMaterializerSource;
+            ExecutionStrategy = executionStrategy;
+#pragma warning disable CS0618 // Type or member is obsolete
             ExecutionStrategyFactory = executionStrategyFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             CoreSingletonOptions = coreSingletonOptions;
             LoggingOptions = loggingOptions;
             UpdateLogger = updateLogger;
@@ -186,6 +191,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
+        public IExecutionStrategy ExecutionStrategy { get; init; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        [Obsolete("Use ExecutionStrategy instead")]
         public IExecutionStrategyFactory ExecutionStrategyFactory { get; init; }
 
         /// <summary>

--- a/src/EFCore/Infrastructure/DatabaseFacade.cs
+++ b/src/EFCore/Infrastructure/DatabaseFacade.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     obtained from <see cref="DbContext.Database" /> and it is not designed to be directly constructed
         ///     in your application code.
         /// </summary>
-        /// <param name="context"> The context this database API belongs to .</param>
+        /// <param name="context"> The context this database API belongs to. </param>
         public DatabaseFacade(DbContext context)
         {
             Check.NotNull(context, nameof(context));

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -116,6 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IDbContextServices), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IValueGeneratorSelector), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IExecutionStrategyFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IExecutionStrategy), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IAsyncQueryProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryCompiler), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ICompiledQueryCacheKeyGenerator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -279,6 +280,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IValueGeneratorSelector, ValueGeneratorSelector>();
             TryAdd<IModelValidator, ModelValidator>();
             TryAdd<IExecutionStrategyFactory, ExecutionStrategyFactory>();
+            TryAdd(p => p.GetRequiredService<IExecutionStrategyFactory>().Create());
             TryAdd<ICompiledQueryCache, CompiledQueryCache>();
             TryAdd<IAsyncQueryProvider, EntityQueryProvider>();
             TryAdd<IQueryCompiler, QueryCompiler>();

--- a/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
@@ -69,7 +69,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Model = model;
             CurrentContext = currentContext;
-            IsRetryingExecutionStrategy = executionStrategyFactory.Create().RetriesOnFailure;
+            var executionStrategy = executionStrategyFactory.Create();
+            IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
+            executionStrategyFactory.Return(executionStrategy);
         }
 
         /// <summary>

--- a/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
@@ -61,17 +61,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public CompiledQueryCacheKeyGeneratorDependencies(
             IModel model,
             ICurrentDbContext currentContext,
-            IExecutionStrategyFactory executionStrategyFactory)
+            IExecutionStrategy executionStrategy)
         {
-            Check.NotNull(model, nameof(model));
-            Check.NotNull(currentContext, nameof(currentContext));
-            Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
-
             Model = model;
             CurrentContext = currentContext;
-            var executionStrategy = executionStrategyFactory.Create();
             IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
-            executionStrategyFactory.Return(executionStrategy);
         }
 
         /// <summary>

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -80,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Dependencies = dependencies;
             IsAsync = async;
             QueryTrackingBehavior = dependencies.QueryTrackingBehavior;
-            IsBuffering = dependencies.IsRetryingExecutionStrategy;
+            IsBuffering = ExecutionStrategy.Current?.RetriesOnFailure ?? dependencies.IsRetryingExecutionStrategy;
             Model = dependencies.Model;
             ContextOptions = dependencies.ContextOptions;
             ContextType = dependencies.ContextType;

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -64,30 +64,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             IQueryableMethodTranslatingExpressionVisitorFactory queryableMethodTranslatingExpressionVisitorFactory,
             IQueryTranslationPostprocessorFactory queryTranslationPostprocessorFactory,
             IShapedQueryCompilingExpressionVisitorFactory shapedQueryCompilingExpressionVisitorFactory,
-            IExecutionStrategyFactory executionStrategyFactory,
+            IExecutionStrategy executionStrategy,
             ICurrentDbContext currentContext,
             IDbContextOptions contextOptions,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
-            Check.NotNull(model, nameof(model));
-            Check.NotNull(queryTranslationPreprocessorFactory, nameof(queryTranslationPreprocessorFactory));
-            Check.NotNull(queryableMethodTranslatingExpressionVisitorFactory, nameof(queryableMethodTranslatingExpressionVisitorFactory));
-            Check.NotNull(queryTranslationPostprocessorFactory, nameof(queryTranslationPostprocessorFactory));
-            Check.NotNull(shapedQueryCompilingExpressionVisitorFactory, nameof(shapedQueryCompilingExpressionVisitorFactory));
-            Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
-            Check.NotNull(currentContext, nameof(currentContext));
-            Check.NotNull(contextOptions, nameof(contextOptions));
-            Check.NotNull(logger, nameof(logger));
-
             _currentContext = currentContext;
             Model = model;
             QueryTranslationPreprocessorFactory = queryTranslationPreprocessorFactory;
             QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
             QueryTranslationPostprocessorFactory = queryTranslationPostprocessorFactory;
             ShapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
-            var executionStrategy = executionStrategyFactory.Create();
             IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
-            executionStrategyFactory.Return(executionStrategy);
             ContextOptions = contextOptions;
             Logger = logger;
         }

--- a/src/EFCore/Query/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/QueryCompilationContextDependencies.cs
@@ -85,7 +85,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryableMethodTranslatingExpressionVisitorFactory = queryableMethodTranslatingExpressionVisitorFactory;
             QueryTranslationPostprocessorFactory = queryTranslationPostprocessorFactory;
             ShapedQueryCompilingExpressionVisitorFactory = shapedQueryCompilingExpressionVisitorFactory;
-            IsRetryingExecutionStrategy = executionStrategyFactory.Create().RetriesOnFailure;
+            var executionStrategy = executionStrategyFactory.Create();
+            IsRetryingExecutionStrategy = executionStrategy.RetriesOnFailure;
+            executionStrategyFactory.Return(executionStrategy);
             ContextOptions = contextOptions;
             Logger = logger;
         }

--- a/src/EFCore/Query/QueryContext.cs
+++ b/src/EFCore/Query/QueryContext.cs
@@ -80,8 +80,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             => Dependencies.QueryProvider;
 
         /// <summary>
+        ///     The execution strategy to use while executing the query.
+        /// </summary>
+        public virtual IExecutionStrategy ExecutionStrategy
+            => Dependencies.ExecutionStrategy;
+
+        /// <summary>
         ///     The execution strategy factory to use while executing the query.
         /// </summary>
+        [Obsolete("Use ExecutionStrategy instead")]
         public virtual IExecutionStrategyFactory ExecutionStrategyFactory
             => Dependencies.ExecutionStrategyFactory;
 

--- a/src/EFCore/Query/QueryContextDependencies.cs
+++ b/src/EFCore/Query/QueryContextDependencies.cs
@@ -60,19 +60,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         [EntityFrameworkInternal]
         public QueryContextDependencies(
             ICurrentDbContext currentContext,
+            IExecutionStrategy executionStrategy,
             IExecutionStrategyFactory executionStrategyFactory,
             IConcurrencyDetector concurrencyDetector,
             IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
             IDiagnosticsLogger<DbLoggerCategory.Query> queryLogger)
         {
-            Check.NotNull(currentContext, nameof(currentContext));
-            Check.NotNull(executionStrategyFactory, nameof(executionStrategyFactory));
-            Check.NotNull(concurrencyDetector, nameof(concurrencyDetector));
-            Check.NotNull(commandLogger, nameof(commandLogger));
-            Check.NotNull(queryLogger, nameof(queryLogger));
-
             CurrentContext = currentContext;
+            ExecutionStrategy = executionStrategy;
+#pragma warning disable CS0618 // Type or member is obsolete
             ExecutionStrategyFactory = executionStrategyFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
             ConcurrencyDetector = concurrencyDetector;
             CommandLogger = commandLogger;
             QueryLogger = queryLogger;
@@ -103,6 +101,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <summary>
         ///     The execution strategy.
         /// </summary>
+        public IExecutionStrategy ExecutionStrategy { get; init; }
+
+        /// <summary>
+        ///     The execution strategy factory.
+        /// </summary>
+        [Obsolete("Use ExecutionStrategy instead")]
         public IExecutionStrategyFactory ExecutionStrategyFactory { get; init; }
 
         /// <summary>

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Gets or sets the currently executing stategy. All nested calls will be handled by the outermost strategy.
+        ///     Gets or sets the currently executing strategy. All nested calls will be handled by the outermost strategy.
         /// </summary>
         public static ExecutionStrategy? Current
         {

--- a/src/EFCore/Storage/ExecutionStrategy.cs
+++ b/src/EFCore/Storage/ExecutionStrategy.cs
@@ -110,23 +110,39 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         protected virtual ExecutionStrategyDependencies Dependencies { get; }
 
-        private static readonly AsyncLocal<bool?> _suspended = new();
+        private static readonly AsyncLocal<ExecutionStrategy?> _current = new();
 
         /// <summary>
         ///     Indicates whether the strategy is suspended. The strategy is typically suspending while executing to avoid
         ///     recursive execution from nested operations.
         /// </summary>
+        [Obsolete("Use Current instead")]
         protected static bool Suspended
         {
-            get => _suspended.Value ?? false;
-            set => _suspended.Value = value;
+            get => Current != null;
+            set { }
+        }
+
+        /// <summary>
+        ///     Gets or sets the currently executing stategy. All nested calls will be handled by the outermost strategy.
+        /// </summary>
+        public static ExecutionStrategy? Current
+        {
+            get => _current.Value;
+            protected set => _current.Value = value;
         }
 
         /// <summary>
         ///     Indicates whether this <see cref="IExecutionStrategy" /> might retry the execution after a failure.
         /// </summary>
         public virtual bool RetriesOnFailure
-            => !Suspended && MaxRetryCount > 0;
+        {
+            get
+            {
+                var current = Current;
+                return (current == null || current == this) && MaxRetryCount > 0;
+            }
+        }
 
         /// <summary>
         ///     Executes the specified operation and returns the result.
@@ -149,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(operation, nameof(operation));
 
-            if (Suspended)
+            if (Current != null)
             {
                 return operation(Dependencies.CurrentContext.Context, state);
             }
@@ -172,14 +188,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
             {
                 try
                 {
-                    Suspended = true;
+                    Check.DebugAssert(Current == null, "Current != null");
+
+                    Current = this;
                     var result = operation(Dependencies.CurrentContext.Context, state);
-                    Suspended = false;
+                    Current = null;
                     return result;
                 }
                 catch (Exception ex)
                 {
-                    Suspended = false;
+                    Current = null;
 
                     EntityFrameworkEventSource.Log.ExecutionStrategyOperationFailure();
 
@@ -247,7 +265,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Check.NotNull(operation, nameof(operation));
 
-            if (Suspended)
+            if (Current != null)
             {
                 return await operation(Dependencies.CurrentContext.Context, state, cancellationToken).ConfigureAwait(false);
             }
@@ -275,15 +293,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
                 try
                 {
-                    Suspended = true;
+                    Check.DebugAssert(Current == null, "Current != null");
+
+                    Current = this;
                     var result = await operation(Dependencies.CurrentContext.Context, state, cancellationToken)
                         .ConfigureAwait(false);
-                    Suspended = false;
+                    Current = null;
                     return result;
                 }
                 catch (Exception ex)
                 {
-                    Suspended = false;
+                    Current = null;
 
                     EntityFrameworkEventSource.Log.ExecutionStrategyOperationFailure();
 
@@ -385,7 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns>
         ///     <see langword="true" /> if the specified exception could be thrown after a successful execution, otherwise <see langword="false" />.
         /// </returns>
-        protected internal virtual bool ShouldVerifySuccessOn(Exception? exception)
+        protected internal virtual bool ShouldVerifySuccessOn(Exception exception)
             => ShouldRetryOn(exception);
 
         /// <summary>
@@ -395,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns>
         ///     <see langword="true" /> if the specified exception is considered as transient, otherwise <see langword="false" />.
         /// </returns>
-        protected internal abstract bool ShouldRetryOn(Exception? exception);
+        protected internal abstract bool ShouldRetryOn(Exception exception);
 
         /// <summary>
         ///     Recursively gets InnerException from <paramref name="exception" /> as long as it is an
@@ -408,9 +428,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The result from <paramref name="exceptionHandler" />.
         /// </returns>
         public static TResult CallOnWrappedException<TResult>(
-            Exception? exception,
-            Func<Exception?, TResult> exceptionHandler)
+            Exception exception,
+            Func<Exception, TResult> exceptionHandler)
             => exception is DbUpdateException dbUpdateException
+                && dbUpdateException.InnerException != null
                 ? CallOnWrappedException(dbUpdateException.InnerException, exceptionHandler)
                 : exceptionHandler(exception);
     }

--- a/src/EFCore/Storage/IDatabaseFacadeDependencies.cs
+++ b/src/EFCore/Storage/IDatabaseFacadeDependencies.cs
@@ -36,6 +36,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         IDatabaseCreator DatabaseCreator { get; }
 
         /// <summary>
+        ///     The execution strategy.
+        /// </summary>
+        IExecutionStrategy ExecutionStrategy { get; }
+
+        /// <summary>
         ///     The execution strategy factory.
         /// </summary>
         IExecutionStrategyFactory ExecutionStrategyFactory { get; }

--- a/src/EFCore/Storage/IExecutionStrategy.cs
+++ b/src/EFCore/Storage/IExecutionStrategy.cs
@@ -4,11 +4,20 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
-    ///     A strategy that is used to execute a command or query against the database, possibly with logic to retry when a failure occurs.
+    ///     <para>
+    ///         A strategy that is used to execute a command or query against the database, possibly with logic to retry when a failure occurs.
+    ///     </para>
+    ///     <para>
+    ///         The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
+    ///         <see cref="DbContext" /> instance will use its own instance of this service.
+    ///         The implementation may depend on other services registered with any lifetime.
+    ///         The implementation does not need to be thread-safe.
+    ///     </para>
     /// </summary>
     public interface IExecutionStrategy
     {

--- a/src/EFCore/Storage/IExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/IExecutionStrategyFactory.cs
@@ -21,13 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Creates a new <see cref="IExecutionStrategy" />.
         /// </summary>
-        /// <returns>An instance of <see cref="IExecutionStrategy" />.</returns>
+        /// <returns> An instance of <see cref="IExecutionStrategy" />. </returns>
         IExecutionStrategy Create();
-
-        /// <summary>
-        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
-        /// </summary>
-        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
-        void Return(IExecutionStrategy executionStrategy);
     }
 }

--- a/src/EFCore/Storage/IExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/IExecutionStrategyFactory.cs
@@ -19,9 +19,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public interface IExecutionStrategyFactory
     {
         /// <summary>
-        ///     Creates a new  <see cref="IExecutionStrategy" />.
+        ///     Creates a new <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <returns>An instance of <see cref="IExecutionStrategy" />.</returns>
         IExecutionStrategy Create();
+
+        /// <summary>
+        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
+        /// </summary>
+        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
+        void Return(IExecutionStrategy executionStrategy);
     }
 }

--- a/src/EFCore/Storage/Internal/DatabaseFacadeDependencies.cs
+++ b/src/EFCore/Storage/Internal/DatabaseFacadeDependencies.cs
@@ -34,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public DatabaseFacadeDependencies(
             IDbContextTransactionManager transactionManager,
             IDatabaseCreator databaseCreator,
+            IExecutionStrategy executionStrategy,
             IExecutionStrategyFactory executionStrategyFactory,
             IEnumerable<IDatabaseProvider> databaseProviders,
             IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger,
@@ -42,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         {
             TransactionManager = transactionManager;
             DatabaseCreator = databaseCreator;
+            ExecutionStrategy = executionStrategy;
             ExecutionStrategyFactory = executionStrategyFactory;
             DatabaseProviders = databaseProviders;
             CommandLogger = commandLogger;
@@ -64,6 +66,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public virtual IDatabaseCreator DatabaseCreator { get; init; }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public virtual IExecutionStrategy ExecutionStrategy { get; init; }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
@@ -42,17 +42,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         protected virtual ExecutionStrategyDependencies Dependencies { get; }
 
         /// <summary>
-        ///     Creates a new  <see cref="IExecutionStrategy" />.
+        ///     Creates a new <see cref="IExecutionStrategy" />.
         /// </summary>
-        /// <returns>An instance of <see cref="IExecutionStrategy" />.</returns>
+        /// <returns> An instance of <see cref="IExecutionStrategy" />. </returns>
         public virtual IExecutionStrategy Create() => _instance;
-
-        /// <summary>
-        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
-        /// </summary>
-        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
-        public virtual void Return(IExecutionStrategy executionStrategy)
-        {
-        }
     }
 }

--- a/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
+++ b/src/EFCore/Storage/Internal/ExecutionStrategyFactory.cs
@@ -22,6 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class ExecutionStrategyFactory : IExecutionStrategyFactory
     {
+        private readonly NonRetryingExecutionStrategy _instance;
+
         /// <summary>
         ///     Creates a new instance of this class with the given service dependencies.
         /// </summary>
@@ -31,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             Check.NotNull(dependencies, nameof(dependencies));
 
             Dependencies = dependencies;
+            _instance = new NonRetryingExecutionStrategy(Dependencies);
         }
 
         /// <summary>
@@ -42,7 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     Creates a new  <see cref="IExecutionStrategy" />.
         /// </summary>
         /// <returns>An instance of <see cref="IExecutionStrategy" />.</returns>
-        public virtual IExecutionStrategy Create()
-            => new NonRetryingExecutionStrategy(Dependencies);
+        public virtual IExecutionStrategy Create() => _instance;
+
+        /// <summary>
+        ///     Returns the <see cref="IExecutionStrategy" /> instance to the pool
+        /// </summary>
+        /// <param name="executionStrategy"> The <see cref="IExecutionStrategy" /> instance. </param>
+        public virtual void Return(IExecutionStrategy executionStrategy)
+        {
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -815,7 +815,9 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             public IExecutionStrategyFactory ExecutionStrategyFactory
+#pragma warning disable CS0618 // Type or member is obsolete
                 => Dependencies.ExecutionStrategyFactory;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
Don't pass `null` to `ExecutionStrategy.ShouldRetryOn`.
Use the currently executing execution strategy to determine whether buffering is needed.

Fixes #21350
Fixes #23019
Fixes #21463