### PR TITLE
Fix to #25834 - Query/Test: northwind tests don't have predefined entity asserters

### DIFF
--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
@@ -339,6 +339,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                     }
                 },
                 {
+                    typeof(NestedReferenceDerived), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (NestedReferenceDerived)e;
+                            var aa = (NestedReferenceDerived)a;
+
+                            Assert.Equal(ee.Id, aa.Id);
+                            Assert.Equal(ee.Name, aa.Name);
+                            Assert.Equal(ee.ParentReferenceId, aa.ParentReferenceId);
+                            Assert.Equal(ee.ParentCollectionId, aa.ParentCollectionId);
+                        }
+                    }
+                },
+                {
                     typeof(NonEntityBase), (e, a) =>
                     {
                         Assert.Equal(e == null, a == null);

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -4133,7 +4133,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery(
                 async,
-                ss => ss.Set<Order>().Where(o => o.OrderDate != null)
+                ss => ss.Set<Order>()
+                    .Where(o => o.OrderDate != null)
                     .Select(o => new Order { OrderDate = o.OrderDate.Value.AddMonths(1) }),
                 e => e.OrderDate);
         }

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
@@ -90,7 +91,150 @@ namespace Microsoft.EntityFrameworkCore.Query
             }.ToDictionary(e => e.Key, e => (object)e.Value);
 
         public IReadOnlyDictionary<Type, object> GetEntityAsserters()
-            => null;
+            => new Dictionary<Type, Action<object, object>>
+            {
+                {
+                    typeof(Customer), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (Customer)e;
+                            var aa = (Customer)a;
+
+                            Assert.Equal(ee.CustomerID, aa.CustomerID);
+                            Assert.Equal(ee.Address, aa.Address);
+                            Assert.Equal(ee.CompanyName, aa.CompanyName);
+                            Assert.Equal(ee.ContactName, aa.ContactName);
+                            Assert.Equal(ee.ContactTitle, aa.ContactTitle);
+                            Assert.Equal(ee.Country, aa.Country);
+                            Assert.Equal(ee.Fax, aa.Fax);
+                            Assert.Equal(ee.Phone, aa.Phone);
+                            Assert.Equal(ee.PostalCode, aa.PostalCode);
+                        }
+                    }
+                },
+                {
+                    typeof(CustomerQuery), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (CustomerQuery)e;
+                            var aa = (CustomerQuery)a;
+
+                            Assert.Equal(ee.CompanyName, aa.CompanyName);
+                            Assert.Equal(ee.Address, aa.Address);
+                            Assert.Equal(ee.City, aa.City);
+                            Assert.Equal(ee.ContactName, aa.ContactName);
+                            Assert.Equal(ee.ContactTitle, aa.ContactTitle);
+                        }
+                    }
+                },
+                {
+                    typeof(Order), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (Order)e;
+                            var aa = (Order)a;
+
+                            Assert.Equal(ee.OrderID, aa.OrderID);
+                            Assert.Equal(ee.CustomerID, aa.CustomerID);
+                            Assert.Equal(ee.EmployeeID, aa.EmployeeID);
+                            Assert.Equal(ee.OrderDate, aa.OrderDate);
+                        }
+                    }
+                },
+                {
+                    typeof(OrderQuery), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (OrderQuery)e;
+                            var aa = (OrderQuery)a;
+
+                            Assert.Equal(ee.CustomerID, aa.CustomerID);
+                        }
+                    }
+                },
+                {
+                    typeof(Employee), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (Employee)e;
+                            var aa = (Employee)a;
+
+                            Assert.Equal(ee.EmployeeID, aa.EmployeeID);
+                            Assert.Equal(ee.Title, aa.Title);
+                            Assert.Equal(ee.City, aa.City);
+                            Assert.Equal(ee.Country, aa.Country);
+                            Assert.Equal(ee.FirstName, aa.FirstName);
+                        }
+                    }
+                },
+                {
+                    typeof(Product), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (Product)e;
+                            var aa = (Product)a;
+
+                            Assert.Equal(ee.ProductID, aa.ProductID);
+                            Assert.Equal(ee.ProductName, aa.ProductName);
+                            Assert.Equal(ee.SupplierID, aa.SupplierID);
+                            Assert.Equal(ee.UnitPrice, aa.UnitPrice);
+                            Assert.Equal(ee.UnitsInStock, aa.UnitsInStock);
+                        }
+                    }
+                },
+                {
+                    typeof(ProductQuery), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (ProductQuery)e;
+                            var aa = (ProductQuery)a;
+
+                            Assert.Equal(ee.ProductID, aa.ProductID);
+                            Assert.Equal(ee.CategoryName, aa.CategoryName);
+                            Assert.Equal(ee.ProductName, aa.ProductName);
+                        }
+                    }
+                },
+                {
+                    typeof(OrderDetail), (e, a) =>
+                    {
+                        Assert.Equal(e == null, a == null);
+
+                        if (a != null)
+                        {
+                            var ee = (OrderDetail)e;
+                            var aa = (OrderDetail)a;
+
+                            Assert.Equal(ee.OrderID, aa.OrderID);
+                            Assert.Equal(ee.ProductID, aa.ProductID);
+                            Assert.Equal(ee.Quantity, aa.Quantity);
+                            Assert.Equal(ee.UnitPrice, aa.UnitPrice);
+                            Assert.Equal(ee.Discount, aa.Discount);
+                        }
+                    }
+                },
+            }.ToDictionary(e => e.Key, e => (object)e.Value);
 
         protected override string StoreName { get; } = "Northwind";
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -2240,7 +2240,7 @@ namespace Microsoft.EntityFrameworkCore.Query
               elementSorter: e => e.c.CustomerID,
               elementAsserter: (e, a) =>
               {
-                  AssertInclude(e, a,
+                  AssertInclude(e.c, a.c,
                       new ExpectedInclude<Customer>(c => c.Orders),
                       new ExpectedInclude<Order>(o => o.OrderDetails, "Orders"));
                   AssertInclude(e.SingleOrder, a.SingleOrder, new ExpectedInclude<Order>(o => o.OrderDetails));

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -1698,6 +1698,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 ((Action<TElement, TElement>)asserter)(expected, actual);
                 ProcessIncludes(expected, actual, expectedIncludes);
             }
+            else
+            {
+                throw new InvalidOperationException($"Couldn't find entity asserter for entity type: '{typeof(TElement).Name}'.");
+            }
         }
 
         private void AssertIncludeCollection<TElement>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindSplitIncludeNoTrackingQuerySqlServerTest.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -17,6 +19,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalTheory(Skip = "Issue#21202")]
+        public override async Task Include_collection_skip_take_no_order_by(bool async)
+        {
+            await base.Include_collection_skip_take_no_order_by(async);
+        }
+
+        [ConditionalTheory(Skip = "Issue#21202")]
+        public override async Task Include_collection_skip_no_order_by(bool async)
+        {
+            await base.Include_collection_skip_no_order_by(async);
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindMiscellaneousQuerySqliteTest.cs
@@ -90,6 +90,7 @@ FROM ""Orders"" AS ""o""
 WHERE ""o"".""OrderDate"" IS NOT NULL");
         }
 
+        [ConditionalTheory(Skip = "issue #25851")]
         public override async Task Select_expression_datetime_add_month(bool async)
         {
             await base.Select_expression_datetime_add_month(async);
@@ -130,6 +131,7 @@ FROM ""Orders"" AS ""o""
 WHERE ""o"".""OrderDate"" IS NOT NULL");
         }
 
+        [ConditionalTheory(Skip = "issue #25851")]
         public override async Task Select_expression_datetime_add_ticks(bool async)
         {
             await base.Select_expression_datetime_add_ticks(async);


### PR DESCRIPTION
Also minor test fixes that were found as a result of fixing this.

Fixes #25834