### PR TITLE
Fix to #25842 - Cosmos: Translate string.Equals with StringComparison.Ordinal

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/StringMethodTranslator.cs
@@ -250,14 +250,19 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 || _stringComparisonWithComparisonTypeArgumentStatic.Equals(method))
             {
                 var comparisonTypeArgument = arguments[^1];
+
                 if (comparisonTypeArgument is SqlConstantExpression constantComparisonTypeArgument
                     && constantComparisonTypeArgument.Value is StringComparison comparisonTypeArgumentValue
-                    && comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase)
+                    && (comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase
+                        || comparisonTypeArgumentValue == StringComparison.Ordinal))
                 {
-
                     return _stringComparisonWithComparisonTypeArgumentInstance.Equals(method)
-                        ? TranslateSystemFunction("STRINGEQUALS", typeof(bool), instance!, arguments[0], _sqlExpressionFactory.Constant(true))
-                        : TranslateSystemFunction("STRINGEQUALS", typeof(bool), arguments[0], arguments[1], _sqlExpressionFactory.Constant(true));
+                        ? comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase
+                            ? TranslateSystemFunction("STRINGEQUALS", typeof(bool), instance!, arguments[0], _sqlExpressionFactory.Constant(true))
+                            : TranslateSystemFunction("STRINGEQUALS", typeof(bool), instance!, arguments[0])
+                        : comparisonTypeArgumentValue == StringComparison.OrdinalIgnoreCase
+                            ? TranslateSystemFunction("STRINGEQUALS", typeof(bool), arguments[0], arguments[1], _sqlExpressionFactory.Constant(true))
+                            : TranslateSystemFunction("STRINGEQUALS", typeof(bool), arguments[0], arguments[1]);
                 }
             }
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1365,6 +1365,36 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND STRINGEQUALS(c[""CustomerID""], ""alFkI"", true))");
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Case_sensitive_string_comparison_instance(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.Equals("ALFKI", StringComparison.Ordinal)),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND STRINGEQUALS(c[""CustomerID""], ""ALFKI""))");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Case_sensitive_string_comparison_static(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => string.Equals(c.CustomerID, "ALFKI", StringComparison.Ordinal)),
+            entryCount: 1);
+
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND STRINGEQUALS(c[""CustomerID""], ""ALFKI""))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #25842