### PR TITLE
Remove MethodCallCodeFragment constructor accepting a chained call

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -215,19 +215,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
                 // ttb => ttb.HasPeriodStart("Start").HasColumnName("ColumnStart")
                 temporalTableBuilderCalls.Add(
                     periodStartColumnName != null
-                    ? new MethodCallCodeFragment(
-                        _temporalTableHasPeriodStartMethodInfo,
-                        new[] { periodStartProperty.Name },
-                        new MethodCallCodeFragment(_temporalPropertyHasColumnNameMethodInfo, periodStartColumnName))
+                    ? new MethodCallCodeFragment(_temporalTableHasPeriodStartMethodInfo, periodStartProperty.Name)
+                        .Chain(new MethodCallCodeFragment(_temporalPropertyHasColumnNameMethodInfo, periodStartColumnName))
                     : new MethodCallCodeFragment(_temporalTableHasPeriodStartMethodInfo, periodStartProperty.Name));
 
                 // ttb => ttb.HasPeriodEnd("End").HasColumnName("ColumnEnd")
                 temporalTableBuilderCalls.Add(
                     periodEndColumnName != null
-                        ? new MethodCallCodeFragment(
-                            _temporalTableHasPeriodEndMethodInfo,
-                            new[] { periodEndProperty.Name },
-                            new MethodCallCodeFragment(_temporalPropertyHasColumnNameMethodInfo, periodEndColumnName))
+                        ? new MethodCallCodeFragment(_temporalTableHasPeriodEndMethodInfo, periodEndProperty.Name)
+                            .Chain(new MethodCallCodeFragment(_temporalPropertyHasColumnNameMethodInfo, periodEndColumnName))
                         : new MethodCallCodeFragment(_temporalTableHasPeriodEndMethodInfo, periodEndProperty.Name));
 
                 // ToTable(tb => tb.IsTemporal(ttb => { ... }))

--- a/src/EFCore/Design/MethodCallCodeFragment.cs
+++ b/src/EFCore/Design/MethodCallCodeFragment.cs
@@ -72,10 +72,18 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="methodInfo"> The method's <see cref="MethodInfo" />. </param>
         /// <param name="arguments"> The method call's arguments.  Can be <see cref="NestedClosureCodeFragment" />. </param>
         /// <param name="chainedCall"> The next method call to chain after this. </param>
+        [Obsolete("Use the constructor without a chained call, and then invoke Chain() on the result", error: true)]
         public MethodCallCodeFragment(
             MethodInfo methodInfo,
             object?[] arguments,
             MethodCallCodeFragment chainedCall)
+            : this(methodInfo, arguments)
+            => throw new NotSupportedException();
+
+        private MethodCallCodeFragment(
+            MethodInfo methodInfo,
+            MethodCallCodeFragment chainedCall,
+            object?[] arguments)
             : this(methodInfo, arguments)
         {
             Check.NotNull(chainedCall, nameof(chainedCall));
@@ -89,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="method"> The method's name. </param>
         /// <param name="arguments"> The method call's arguments.  Can be <see cref="NestedClosureCodeFragment" />. </param>
         /// <param name="chainedCall"> The next method call to chain after this. </param>
-        [Obsolete("Use the overload accepting a MethodInfo")]
+        [Obsolete("Use the overload accepting a MethodInfo, and then invoke Chain on the instance for the chained call")]
         public MethodCallCodeFragment(
             string method,
             object?[] arguments,
@@ -170,6 +178,6 @@ namespace Microsoft.EntityFrameworkCore.Design
 #pragma warning disable 618
                 ? new(_method!, _arguments.ToArray(), ChainedCall?.Chain(call) ?? call)
 #pragma warning restore 618
-                : new(MethodInfo, _arguments.ToArray(), ChainedCall?.Chain(call) ?? call);
+                : new(MethodInfo, ChainedCall?.Chain(call) ?? call, _arguments.ToArray());
     }
 }

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -334,8 +334,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void Fragment_MethodCallCodeFragment_works_when_chaining_on_chain()
         {
-            var method = new MethodCallCodeFragment(
-                    _testFuncMethodInfo, new[] { "One" }, new MethodCallCodeFragment(_testFuncMethodInfo, "Two"))
+            var method = new MethodCallCodeFragment(_testFuncMethodInfo, "One")
+                .Chain(new MethodCallCodeFragment(_testFuncMethodInfo, "Two"))
                 .Chain(_testFuncMethodInfo, "Three");
 
             var result = new CSharpHelper(TypeMappingSource).Fragment(method);
@@ -346,8 +346,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void Fragment_MethodCallCodeFragment_works_when_chaining_on_chain_with_call()
         {
-            var method = new MethodCallCodeFragment(_testFuncMethodInfo, new[] { "One" }, new MethodCallCodeFragment(_testFuncMethodInfo, "Two"))
-                .Chain(new MethodCallCodeFragment(_testFuncMethodInfo, new[] { "Three" }, new MethodCallCodeFragment(_testFuncMethodInfo, "Four")));
+            var method = new MethodCallCodeFragment(_testFuncMethodInfo, "One").Chain(new MethodCallCodeFragment(_testFuncMethodInfo, "Two"))
+                .Chain(new MethodCallCodeFragment(_testFuncMethodInfo, "Three").Chain(new MethodCallCodeFragment(_testFuncMethodInfo, "Four")));
 
             var result = new CSharpHelper(TypeMappingSource).Fragment(method);
 
@@ -379,7 +379,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         [ConditionalFact]
         public void Fragment_MethodCallCodeFragment_works_with_identifier_chained()
         {
-            var method = new MethodCallCodeFragment(_testFuncMethodInfo, new[] { "One"}, new MethodCallCodeFragment(_testFuncMethodInfo));
+            var method = new MethodCallCodeFragment(_testFuncMethodInfo, "One").Chain(new MethodCallCodeFragment(_testFuncMethodInfo));
 
             var result = new CSharpHelper(TypeMappingSource).Fragment(method, instanceIdentifier: "builder");
 


### PR DESCRIPTION
In 6.0 we added a MethodCallCodeFragment constructor when obsoleting the string-based APIs (for type-qualified calls) - this obsoletes it with error, since it's easy to accidentally call the other constructor which accepts `params object[] arguments`. I left it there with error so that anyone converting code would get a build error rather than resolving the wrong constructor.

Fixes #19780
