### PR TITLE
Fix to #19883 - Query: null semantics should keep track of columns that are guaranteed to be null and remove redundant IS NULL/ IS NOT NULL checks

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/NorthwindFunctionsQueryCosmosTest.cs
@@ -1088,14 +1088,22 @@ WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
         [ConditionalTheory(Skip = "Issue #17246")]
+        public override async Task IsNullOrEmpty_negated_in_predicate(bool async)
+        {
+            await base.IsNullOrEmpty_negated_in_predicate(async);
+
+            AssertSql(@"");
+        }
+
+        [ConditionalTheory(Skip = "Issue #17246")]
         public override Task IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(bool async)
         {
             return base.IsNullOrWhiteSpace_in_predicate_on_non_nullable_column(async);
         }
 
-        public override void IsNullOrEmpty_in_projection()
+        public override async Task IsNullOrEmpty_in_projection(bool async)
         {
-            base.IsNullOrEmpty_in_projection();
+            await base.IsNullOrEmpty_in_projection(async);
 
             AssertSql(
                 @"SELECT c[""CustomerID""], c[""Region""]
@@ -1103,9 +1111,9 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        public override void IsNullOrEmpty_negated_in_projection()
+        public override async Task IsNullOrEmpty_negated_in_projection(bool async)
         {
-            base.IsNullOrEmpty_negated_in_projection();
+            await base.IsNullOrEmpty_negated_in_projection(async);
 
             AssertSql(
                 @"SELECT c[""CustomerID""], c[""Region""]

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -1756,6 +1756,104 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(expected.Count, result.Count);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_simple(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => !(x.NullableStringA == null || x.NullableStringA != "Foo")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_negative(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => !(x.NullableStringA == null && x.NullableStringA != "Foo")));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_nested(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => x.NullableStringA == null
+                    || x.NullableStringB == null
+                    || x.NullableStringA != x.NullableStringB));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_intersection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => (x.NullableStringA == null
+                    && (x.StringA == "Foo" || x.NullableStringA == null || x.NullableStringB == null))
+                    || x.NullableStringA != x.NullableStringB));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => x.NullableStringA == null
+                    ? x.NullableStringA != x.NullableStringB
+                    : x.NullableStringA != x.NullableStringC));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_multiple(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => x.NullableStringA == null || x.NullableStringB == null
+                    ? x.NullableStringA == x.NullableStringB
+                    : x.NullableStringA != x.NullableStringB));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_negative(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => (x.NullableStringA == null || x.NullableStringB == null) && x.NullableBoolC == null
+                    ? x.NullableStringA == x.NullableStringB
+                    : x.NullableStringA != x.NullableStringB));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_with_setup(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => x.NullableBoolA == null
+                    || (x.NullableBoolB == null
+                        ? x.NullableBoolB != x.NullableBoolA
+                        : x.NullableBoolA != x.NullableBoolB)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_nested(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<NullSemanticsEntity1>().Where(x => x.NullableBoolA == null
+                    ? x.BoolA == x.BoolB
+                    : (x.NullableBoolC == null
+                        ? x.NullableBoolA != x.NullableBoolC
+                        : x.NullableBoolC != x.NullableBoolA)));
+        }
+
         private string NormalizeDelimitersInRawString(string sql)
             => Fixture.TestStore.NormalizeDelimitersInRawString(sql);
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -1681,28 +1681,34 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 60);
         }
 
-        [ConditionalFact]
-        public virtual void IsNullOrEmpty_in_projection()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task IsNullOrEmpty_in_projection(bool async)
         {
-            using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .Select(
-                    c => new { Id = c.CustomerID, Value = string.IsNullOrEmpty(c.Region) })
-                .ToList();
-
-            Assert.Equal(91, query.Count);
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Select(c => new { Id = c.CustomerID, Value = string.IsNullOrEmpty(c.Region) }),
+                elementSorter: e => e.Id);
         }
 
-        [ConditionalFact]
-        public virtual void IsNullOrEmpty_negated_in_projection()
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task IsNullOrEmpty_negated_in_predicate(bool async)
         {
-            using var context = CreateContext();
-            var query = context.Set<Customer>()
-                .Select(
-                    c => new { Id = c.CustomerID, Value = !string.IsNullOrEmpty(c.Region) })
-                .ToList();
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => !string.IsNullOrEmpty(c.Region)),
+                entryCount: 31);
+        }
 
-            Assert.Equal(91, query.Count);
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task IsNullOrEmpty_negated_in_projection(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Select(c => new { Id = c.CustomerID, Value = !string.IsNullOrEmpty(c.Region) }),
+                elementSorter: e => e.Id);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindFunctionsQuerySqlServerTest.cs
@@ -1656,9 +1656,9 @@ FROM [Customers] AS [c]
 WHERE [c].[Region] IS NULL OR ([c].[Region] LIKE N'')");
         }
 
-        public override void IsNullOrEmpty_in_projection()
+        public override async Task IsNullOrEmpty_in_projection(bool async)
         {
-            base.IsNullOrEmpty_in_projection();
+            await base.IsNullOrEmpty_in_projection(async);
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
@@ -1668,13 +1668,23 @@ END AS [Value]
 FROM [Customers] AS [c]");
         }
 
-        public override void IsNullOrEmpty_negated_in_projection()
+        public override async Task IsNullOrEmpty_negated_in_predicate(bool async)
         {
-            base.IsNullOrEmpty_negated_in_projection();
+            await base.IsNullOrEmpty_negated_in_predicate(async);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[Region] IS NOT NULL AND NOT ([c].[Region] LIKE N'')");
+        }
+
+        public override async Task IsNullOrEmpty_negated_in_projection(bool async)
+        {
+            await base.IsNullOrEmpty_negated_in_projection(async);
 
             AssertSql(
                 @"SELECT [c].[CustomerID] AS [Id], CASE
-    WHEN NOT ([c].[Region] IS NULL OR ([c].[Region] LIKE N'')) THEN CAST(1 AS bit)
+    WHEN [c].[Region] IS NOT NULL AND NOT ([c].[Region] LIKE N'') THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Value]
 FROM [Customers] AS [c]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -2120,6 +2120,149 @@ END = CASE
 END");
         }
 
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_simple(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_simple(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] IS NOT NULL AND ([e].[NullableStringA] = N'Foo')");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_negative(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_negative(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableStringA] IS NOT NULL OR (([e].[NullableStringA] = N'Foo') AND [e].[NullableStringA] IS NOT NULL)");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_nested(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_nested(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) OR ([e].[NullableStringA] <> [e].[NullableStringB])");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_intersection(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_intersection(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableStringA] IS NULL AND ((([e].[StringA] = N'Foo') OR [e].[NullableStringA] IS NULL) OR [e].[NullableStringB] IS NULL)) OR (([e].[NullableStringA] <> [e].[NullableStringB]) OR [e].[NullableStringB] IS NULL)");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional(async);
+
+            // issue #25977
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableStringA] IS NULL THEN CASE
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringC]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringC] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringC] IS NOT NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit)");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_multiple(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_multiple(async);
+
+            // issue #25977
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL THEN CASE
+        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit)");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_negative(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_negative(async);
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL) AND ([e].[NullableBoolC] IS NULL) THEN CASE
+        WHEN (([e].[NullableStringA] = [e].[NullableStringB]) AND ([e].[NullableStringA] IS NOT NULL AND [e].[NullableStringB] IS NOT NULL)) OR ([e].[NullableStringA] IS NULL AND [e].[NullableStringB] IS NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN (([e].[NullableStringA] <> [e].[NullableStringB]) OR ([e].[NullableStringA] IS NULL OR [e].[NullableStringB] IS NULL)) AND ([e].[NullableStringA] IS NOT NULL OR [e].[NullableStringB] IS NOT NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit)");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_with_setup(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_with_setup(async);
+
+            // issue #25977
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableBoolA] IS NULL) OR (CASE
+    WHEN [e].[NullableBoolB] IS NULL THEN CASE
+        WHEN ([e].[NullableBoolB] <> [e].[NullableBoolA]) OR ([e].[NullableBoolB] IS NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN ([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolB] IS NULL) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit))");
+        }
+
+        public override async Task Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_nested(bool async)
+        {
+            await base.Is_null_on_column_followed_by_OrElse_optimizes_nullability_conditional_nested(async);
+
+            // issue #25977
+            AssertSql(
+                @"SELECT [e].[Id], [e].[BoolA], [e].[BoolB], [e].[BoolC], [e].[IntA], [e].[IntB], [e].[IntC], [e].[NullableBoolA], [e].[NullableBoolB], [e].[NullableBoolC], [e].[NullableIntA], [e].[NullableIntB], [e].[NullableIntC], [e].[NullableStringA], [e].[NullableStringB], [e].[NullableStringC], [e].[StringA], [e].[StringB], [e].[StringC]
+FROM [Entities1] AS [e]
+WHERE CASE
+    WHEN [e].[NullableBoolA] IS NULL THEN CASE
+        WHEN [e].[BoolA] = [e].[BoolB] THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    WHEN [e].[NullableBoolC] IS NULL THEN CASE
+        WHEN (([e].[NullableBoolA] <> [e].[NullableBoolC]) OR (([e].[NullableBoolA] IS NULL) OR ([e].[NullableBoolC] IS NULL))) AND (([e].[NullableBoolA] IS NOT NULL) OR ([e].[NullableBoolC] IS NOT NULL)) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+    ELSE CASE
+        WHEN (([e].[NullableBoolC] <> [e].[NullableBoolA]) OR (([e].[NullableBoolC] IS NULL) OR ([e].[NullableBoolA] IS NULL))) AND (([e].[NullableBoolC] IS NOT NULL) OR ([e].[NullableBoolA] IS NOT NULL)) THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END
+END = CAST(1 AS bit)");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindFunctionsQuerySqliteTest.cs
@@ -617,6 +617,35 @@ FROM ""Customers"" AS ""c""
 WHERE regexp(""c"".""CustomerID"", 'ALFKI')");
         }
 
+        public override async Task IsNullOrEmpty_in_predicate(bool async)
+        {
+            await base.IsNullOrEmpty_in_predicate(async);
+
+            AssertSql(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ""c"".""Region"" IS NULL OR (""c"".""Region"" = '')");
+        }
+
+        public override async Task IsNullOrEmpty_in_projection(bool async)
+        {
+            await base.IsNullOrEmpty_in_projection(async);
+
+            AssertSql(
+                @"SELECT ""c"".""CustomerID"" AS ""Id"", ""c"".""Region"" IS NULL OR (""c"".""Region"" = '') AS ""Value""
+FROM ""Customers"" AS ""c""");
+        }
+
+        public override async Task IsNullOrEmpty_negated_in_predicate(bool async)
+        {
+            await base.IsNullOrEmpty_negated_in_predicate(async);
+
+            AssertSql(
+                @"SELECT ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+FROM ""Customers"" AS ""c""
+WHERE ""c"".""Region"" IS NOT NULL AND (""c"".""Region"" <> '')");
+        }
+
         public override Task Datetime_subtraction_TotalDays(bool async)
         {
             return AssertTranslationFailed(() => base.Datetime_subtraction_TotalDays(async));


### PR DESCRIPTION
Adding a list of columns guaranteed to be null in the given subtree. When processing right side of the || operator, we can convert those to non-nullable columns and therefore improve the generated sql.

Fixes #19883
Fixes #19410