### PR TITLE
Always sort deletes before inserts for the same table to avoid deadlocks.

### DIFF
--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -333,13 +333,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 },
                 result =>
                 {
-                    Assert.Equal(14, result.Count);
-
-                    var createBankTableOperation = Assert.IsType<CreateTableOperation>(result[0]);
-                    Assert.Equal("Banks", createBankTableOperation.Name);
-                    Assert.Empty(createBankTableOperation.ForeignKeys);
-
-                    Assert.Equal(4, result.OfType<AddForeignKeyOperation>().Count());
+                    Assert.Equal(3, result.OfType<CreateTableOperation>().Count());
+                    Assert.Equal(7, result.OfType<CreateIndexOperation>().Count());
+                    Assert.Equal(7, result.OfType<CreateTableOperation>().SelectMany(t => t.ForeignKeys).Count()
+                        + result.OfType<AddForeignKeyOperation>().Count());
                 });
         }
 

--- a/test/EFCore.Tests/Utilities/MultigraphTest.cs
+++ b/test/EFCore.Tests/Utilities/MultigraphTest.cs
@@ -434,7 +434,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
             Assert.Equal(
                 CoreStrings.CircularDependency(message),
-                Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort(formatter)).Message);
+                Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort(null, formatter)).Message);
 
             Assert.Equal(3, cycleData.Count());
 
@@ -485,7 +485,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
             Assert.Equal(
                 CoreStrings.CircularDependency(message),
-                Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort(formatter)).Message);
+                Assert.Throws<InvalidOperationException>(() => graph.BatchingTopologicalSort(null, formatter)).Message);
 
             Assert.Equal(2, cycleData.Count);
 


### PR DESCRIPTION
This dependency isn't hard, so cycle breaking is introduced.
Make the implementations of `Multigraph` `TopologicalSort` and `BatchingTopologicalSort` more alike and faster

Fixes #14371