### PR TITLE
Delete optional orphans when foreign key value is set to null

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -1257,28 +1257,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     if (value == null)
                     {
-                        if (EntityState != EntityState.Deleted
-                            && EntityState != EntityState.Detached)
-                        {
-                            _stateData.FlagProperty(propertyIndex, PropertyFlag.Null, isFlagged: true);
-
-                            if (setModified)
-                            {
-                                SetPropertyModified(
-                                    asProperty, changeState: true, isModified: true,
-                                    isConceptualNull: true);
-                            }
-
-                            if (!isCascadeDelete
-                                && StateManager.DeleteOrphansTiming == CascadeTiming.Immediate)
-                            {
-                                HandleConceptualNulls(
-                                    StateManager.SensitiveLoggingEnabled,
-                                    force: false,
-                                    isCascadeDelete: false);
-                            }
-                        }
-
+                        HandleNullForeignKey(asProperty, setModified, isCascadeDelete);
                         writeValue = false;
                     }
                     else
@@ -1373,6 +1352,40 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
 
                     StateManager.InternalEntityEntryNotifier.PropertyChanged(this, propertyBase, setModified);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        public void HandleNullForeignKey(
+            IProperty property,
+            bool setModified = false, 
+            bool isCascadeDelete = false)
+        {
+            if (EntityState != EntityState.Deleted
+                && EntityState != EntityState.Detached)
+            {
+                _stateData.FlagProperty(property.GetIndex(), PropertyFlag.Null, isFlagged: true);
+
+                if (setModified)
+                {
+                    SetPropertyModified(
+                        property, changeState: true, isModified: true,
+                        isConceptualNull: true);
+                }
+
+                if (!isCascadeDelete
+                    && StateManager.DeleteOrphansTiming == CascadeTiming.Immediate)
+                {
+                    HandleConceptualNulls(
+                        StateManager.SensitiveLoggingEnabled,
+                        force: false,
+                        isCascadeDelete: false);
                 }
             }
         }

--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -495,6 +495,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         }
                     }
 
+                    if (newValue == null
+                        && (foreignKey.DeleteBehavior == DeleteBehavior.Cascade
+                            || foreignKey.DeleteBehavior == DeleteBehavior.ClientCascade))
+                    {
+                        entry.HandleNullForeignKey(property);
+                    }
+
                     stateManager.UpdateDependentMap(entry, foreignKey);
                 }
 


### PR DESCRIPTION
Fixes #25360

This is a case where an optional relationship is configured with delete orphans behavior. Since the relationship is optional it means that the FK value can be explicitly set to null. (This is not possible for required relationships, which is the usual case for delete orphans.) In this case the navigation fixer was not triggering behavior in the state manager to process deleting orphans.

