### PR TITLE
Make sure navigations on property bag entity types don't use CLR properties.

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             IPropertyBase property)
             => Expression.Call(
                 parameter,
-                InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod(property.ClrType),
+                InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod((property as IProperty)?.ClrType ?? typeof(object)),
                 Expression.Constant(property.GetShadowIndex()));
 
         /// <summary>

--- a/src/EFCore/Metadata/IReadOnlyNavigation.cs
+++ b/src/EFCore/Metadata/IReadOnlyNavigation.cs
@@ -144,24 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 builder.Append(" (");
             }
 
-            if (this.GetIdentifyingMemberInfo() == null)
-            {
-                // Shadow navigation
-                if (IsCollection)
-                {
-                    builder.Append("IEnumerable<");
-                }
-                builder.Append(TargetEntityType.ClrType.ShortDisplayName());
-                if (IsCollection)
-                {
-                    builder.Append(">");
-                }
-                builder.Append(")");
-            }
-            else
-            {
-                builder.Append(ClrType.ShortDisplayName()).Append(")");
-            }
+            builder.Append(ClrType.ShortDisplayName()).Append(")");
 
             if (IsCollection)
             {

--- a/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyNavigationBase.cs
@@ -38,5 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         bool IsEagerLoaded
             => (bool?)this[CoreAnnotationNames.EagerLoaded] ?? false;
+
+        /// <inheritdoc />
+        // TODO: Remove when #3864 is implemented
+        bool IReadOnlyPropertyBase.IsShadowProperty() => this.GetIdentifyingMemberInfo() == null;
     }
 }

--- a/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
+++ b/src/EFCore/Metadata/IReadOnlyPropertyBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
@@ -60,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <returns>
         ///     <see langword="true" /> if the property is a shadow property, otherwise <see langword="false" />.
         /// </returns>
-        bool IsShadowProperty() => this.GetIdentifyingMemberInfo() == null;
+        bool IsShadowProperty() => PropertyInfo == null && FieldInfo == null;
 
         /// <summary>
         ///     Gets a value indicating whether this is an indexer property. An indexer property is one that is accessed through
@@ -70,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     <see langword="true" /> if the property is an indexer property, otherwise <see langword="false" />.
         /// </returns>
         bool IsIndexerProperty()
-            => this.GetIdentifyingMemberInfo() is PropertyInfo propertyInfo
+            => PropertyInfo is PropertyInfo propertyInfo
                 && propertyInfo == DeclaringType.FindIndexerPropertyInfo();
 
         /// <summary>

--- a/src/EFCore/Metadata/IReadOnlySkipNavigation.cs
+++ b/src/EFCore/Metadata/IReadOnlySkipNavigation.cs
@@ -89,24 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 builder.Append(" (");
             }
 
-            if (this.GetIdentifyingMemberInfo() == null)
-            {
-                // Shadow navigation
-                if (IsCollection)
-                {
-                    builder.Append("IEnumerable<");
-                }
-                builder.Append(TargetEntityType.ClrType.ShortDisplayName());
-                if (IsCollection)
-                {
-                    builder.Append(">");
-                }
-                builder.Append(")");
-            }
-            else
-            {
-                builder.Append(ClrType.ShortDisplayName()).Append(")");
-            }
+            builder.Append(ClrType.ShortDisplayName()).Append(")");
 
             if (IsCollection)
             {

--- a/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var memberInfo = GetMostDerivedMemberInfo();
-            var propertyType = memberInfo.GetMemberType();
+            var propertyType = navigation.IsIndexerProperty() ? navigation.ClrType : memberInfo.GetMemberType();
             var elementType = propertyType.TryGetElementType(typeof(IEnumerable<>));
 
             if (elementType == null)
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     : propertyInfo == null
                         ? fieldInfo
                         : fieldInfo.FieldType.IsAssignableFrom(propertyInfo.PropertyType)
-                            ? (MemberInfo)propertyInfo
+                            ? propertyInfo
                             : fieldInfo;
             }
         }

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -51,12 +51,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             this IReadOnlyEntityType entityType,
             string navigationName)
         {
-            var memberInfo = entityType.ClrType.GetMembersInHierarchy(navigationName).FirstOrDefault();
-
-            if (memberInfo == null)
+            MemberInfo? memberInfo;
+            if (entityType.IsPropertyBag)
             {
-                throw new InvalidOperationException(
-                    CoreStrings.NoClrNavigation(navigationName, entityType.DisplayName()));
+                memberInfo = entityType.FindIndexerPropertyInfo()!;
+            }
+            else
+            {
+                memberInfo = entityType.ClrType.GetMembersInHierarchy(navigationName).FirstOrDefault();
+
+                if (memberInfo == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NoClrNavigation(navigationName, entityType.DisplayName()));
+                }
             }
 
             return memberInfo;

--- a/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalForeignKeyBuilder.cs
@@ -410,14 +410,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         }
                     }
 
-                    if (navigationProperty != null)
-                    {
-                        Metadata.SetDependentToPrincipal(navigationProperty, configurationSource);
-                    }
-                    else
-                    {
-                        Metadata.SetDependentToPrincipal(navigationToPrincipalName, configurationSource);
-                    }
+                    Metadata.SetDependentToPrincipal(navigationToPrincipal, configurationSource);
                 }
 
                 if (navigationToDependent != null)
@@ -438,14 +431,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         }
                     }
 
-                    if (navigationProperty != null)
-                    {
-                        Metadata.SetPrincipalToDependent(navigationProperty, configurationSource);
-                    }
-                    else
-                    {
-                        Metadata.SetPrincipalToDependent(navigationToDependentName, configurationSource);
-                    }
+                    Metadata.SetPrincipalToDependent(navigationToDependent, configurationSource);
                 }
 
                 builder = batch.Run(builder);
@@ -1362,10 +1348,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            if (Metadata.PrincipalToDependent?.IsShadowProperty() == false
+            var navigationMember = Metadata.PrincipalToDependent?.GetIdentifyingMemberInfo();
+            if (navigationMember != null
                 && !Navigation.IsCompatible(
-                    Metadata.PrincipalToDependent.Name,
-                    Metadata.PrincipalToDependent.GetIdentifyingMemberInfo()!,
+                    Metadata.PrincipalToDependent!.Name,
+                    navigationMember,
                     Metadata.PrincipalEntityType,
                     Metadata.DeclaringEntityType,
                     !unique,

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -703,11 +703,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 var identifyingMemberInfo = Metadata.GetIdentifyingMemberInfo();
 
-                newPropertyBuilder = identifyingMemberInfo == null
-                    ? entityTypeBuilder.Property(
-                        Metadata.ClrType, Metadata.Name, Metadata.GetTypeConfigurationSource(), configurationSource)
-                    : (identifyingMemberInfo as PropertyInfo)?.IsIndexerProperty() == true
-                        ? entityTypeBuilder.IndexerProperty(Metadata.ClrType, Metadata.Name, configurationSource)
+                newPropertyBuilder =  Metadata.IsIndexerProperty()
+                    ? entityTypeBuilder.IndexerProperty(Metadata.ClrType, Metadata.Name, configurationSource)
+                    : identifyingMemberInfo == null
+                        ? entityTypeBuilder.Property(
+                            Metadata.ClrType, Metadata.Name, Metadata.GetTypeConfigurationSource(), configurationSource)
                         : entityTypeBuilder.Property(identifyingMemberInfo, configurationSource!);
 
                 if (newPropertyBuilder is null)

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -42,7 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(foreignKey, nameof(foreignKey));
 
             ForeignKey = foreignKey;
-            ClrType = this.GetIdentifyingMemberInfo()?.GetMemberType() ?? typeof(object);
 
             _builder = new InternalNavigationBuilder(this, foreignKey.DeclaringEntityType.Model.Builder);
         }
@@ -53,7 +53,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     any release. You should only use it directly in your code with extreme caution and knowing that
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
-        public override Type ClrType { get; }
+        public override Type ClrType => this.GetIdentifyingMemberInfo()?.GetMemberType()
+            ?? (((IReadOnlyNavigation)this).IsCollection
+                ? typeof(IEnumerable<>).MakeGenericType(TargetEntityType.ClrType)
+                : TargetEntityType.ClrType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/NavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/NavigationExtensions.cs
@@ -18,8 +18,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static MemberIdentity CreateMemberIdentity(this IReadOnlyNavigation? navigation)
-            => navigation?.GetIdentifyingMemberInfo() == null
-                ? MemberIdentity.Create(navigation?.Name)
-                : MemberIdentity.Create(navigation.GetIdentifyingMemberInfo());
+        {
+            var memberInfo = navigation?.GetIdentifyingMemberInfo();
+            return memberInfo == null
+                           ? MemberIdentity.Create(navigation?.Name)
+                           : MemberIdentity.Create(memberInfo);
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -98,7 +98,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         // GetMemberInfo to get the property/field to use, which may be different.
         public static MemberInfo? GetIdentifyingMemberInfo(
             this IReadOnlyPropertyBase propertyBase)
-            => propertyBase.PropertyInfo ?? (MemberInfo?)propertyBase.FieldInfo;
+        {
+            var indexerPropertyInfo = propertyBase.DeclaringType.FindIndexerPropertyInfo();
+            return indexerPropertyInfo != null && propertyBase.PropertyInfo == indexerPropertyInfo
+                ? null
+                : (propertyBase.PropertyInfo ?? (MemberInfo?)propertyBase.FieldInfo);
+        }
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/SkipNavigation.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigation.cs
@@ -78,7 +78,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public override Type ClrType
-            => this.GetIdentifyingMemberInfo()!.GetMemberType();
+            => this.GetIdentifyingMemberInfo()?.GetMemberType()
+                ?? (IsCollection
+                    ? typeof(IEnumerable<>).MakeGenericType(TargetEntityType.ClrType)
+                    : TargetEntityType.ClrType);
 
         /// <summary>
         ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
+++ b/src/EFCore/Metadata/Internal/SkipNavigationExtensions.cs
@@ -18,8 +18,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     doing so can result in application failures when updating to a new Entity Framework Core release.
         /// </summary>
         public static MemberIdentity CreateMemberIdentity(this IReadOnlySkipNavigation? navigation)
-            => navigation?.GetIdentifyingMemberInfo() == null
-                ? MemberIdentity.Create(navigation?.Name)
-                : MemberIdentity.Create(navigation.GetIdentifyingMemberInfo());
+        {
+            var memberInfo = navigation?.GetIdentifyingMemberInfo();
+            return memberInfo == null
+                           ? MemberIdentity.Create(navigation?.Name)
+                           : MemberIdentity.Create(memberInfo);
+        }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1518,11 +1518,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                         {
                             Assert.Equal("LeftsId", p.Name);
                             Assert.False(p.IsShadowProperty());
+                            Assert.True(p.IsIndexerProperty());
                         },
                         p =>
                         {
                             Assert.Equal("RightsId", p.Name);
                             Assert.False(p.IsShadowProperty());
+                            Assert.True(p.IsIndexerProperty());
                         });
                     Assert.Collection(
                         joinEntity.FindDeclaredPrimaryKey().Properties,

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -31,72 +31,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public class ClrCollectionAccessorFactoryTest
     {
         [ConditionalFact]
-        public void Navigation_is_returned_if_it_implements_IClrCollectionAccessor()
-        {
-            var navigation = new FakeNavigation();
-
-            var fk = new FakeForeignKey { PrincipalToDependent = navigation };
-            navigation.ForeignKey = fk;
-            navigation.PropertyInfo = MyEntity.AsICollectionProperty;
-
-            Assert.Same(navigation, new ClrCollectionAccessorFactory().Create(navigation));
-        }
-
-        private class FakeNavigation : Annotatable, INavigation, IClrCollectionAccessor
-        {
-            public string Name { get; }
-            public IReadOnlyTypeBase DeclaringType { get; }
-            public Type ClrType { get; }
-            public PropertyInfo PropertyInfo { get; set; }
-            public FieldInfo FieldInfo { get; }
-            public IEntityType DeclaringEntityType { get; }
-            public IReadOnlyForeignKey ForeignKey { get; set; }
-
-            public bool Add(object entity, object value, bool forMaterialization)
-                => throw new NotImplementedException();
-
-            public bool Contains(object entity, object value)
-                => throw new NotImplementedException();
-
-            public bool Remove(object entity, object value)
-                => throw new NotImplementedException();
-
-            public object Create()
-                => throw new NotImplementedException();
-
-            public object GetOrCreate(object entity, bool forMaterialization)
-                => throw new NotImplementedException();
-
-            public IClrPropertyGetter GetGetter() => throw new NotImplementedException();
-
-            public IComparer<IUpdateEntry> GetCurrentValueComparer()
-                => throw new NotImplementedException();
-
-            public IClrCollectionAccessor GetCollectionAccessor()
-                => throw new NotImplementedException();
-
-            public PropertyAccessMode GetPropertyAccessMode()
-                => throw new NotImplementedException();
-
-            public Type CollectionType { get; }
-        }
-
-        public class FakeForeignKey : Annotatable, IReadOnlyForeignKey
-        {
-            public IReadOnlyEntityType DeclaringEntityType { get; }
-            public IReadOnlyList<IReadOnlyProperty> Properties { get; }
-            public IReadOnlyEntityType PrincipalEntityType { get; }
-            public IReadOnlyKey PrincipalKey { get; }
-            public IReadOnlyNavigation DependentToPrincipal { get; set; }
-            public IReadOnlyNavigation PrincipalToDependent { get; set; }
-            public bool IsUnique { get; }
-            public bool IsRequired { get; }
-            public bool IsRequiredDependent { get; }
-            public bool IsOwnership { get; }
-            public DeleteBehavior DeleteBehavior { get; }
-        }
-
-        [ConditionalFact]
         public void Delegate_accessor_is_returned_for_IEnumerable_navigation()
         {
             AccessorTest("AsIEnumerable", e => e.AsIEnumerable);
@@ -491,6 +425,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             private IEnumerable<MyOtherEntity> _fullPropNoFieldNotFound;
             private readonly IEnumerable<MyOtherEntity> _readOnlyPropNoFieldNotFound;
             private IEnumerable<MyOtherEntity> _writeOnlyPropNoFieldNotFound;
+
+            public MyEntity()
+                : this(false)
+            {
+            }
 
             public MyEntity(bool initialize)
             {

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -1911,7 +1911,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     c =>
                     {
                         c.HasData(
-                            new Beta { Id = -1 });
+                            new Beta { Id = -1, Name = " -1" });
                         var customers = new List<Beta> { new() { Id = -2 } };
                         c.HasData(customers);
                     });
@@ -1922,6 +1922,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var data = customer.GetSeedData();
                 Assert.Equal(2, data.Count());
                 Assert.Equal(-1, data.First()[nameof(Beta.Id)]);
+                Assert.Equal(" -1", data.First()[nameof(Beta.Name)]);
                 Assert.Equal(-2, data.Last()[nameof(Beta.Id)]);
 
                 var _ = finalModel.ToDebugString();

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -450,7 +450,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
         protected class Beta
         {
+            private string? _name;
             public int Id { get; set; }
+            public string? Name
+            {
+                get => "Beta: " + _name;
+                set => _name = value;
+            }
 
             public Alpha? FirstNav { get; set; }
             public Alpha? SecondNav { get; set; }


### PR DESCRIPTION
Make `GetIdentifyingMemberInfo()` return `null` for indexer properties since it doesn't uniquely identifies them
Replaced some usages of `GetIdentifyingMemberInfo()` with more appropriate code.

Fixes #25501
Fixes #25459