### PR TITLE
InMemory: Read nullable value for derived properties

### DIFF
--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryExpression.cs
@@ -93,13 +93,15 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
 
                     foreach (var property in derivedEntityType.GetDeclaredProperties())
                     {
+                        // We read nullable value from property of derived type since it could be null.
+                        var typeToRead = property.ClrType.MakeNullable();
                         var propertyExpression = Condition(
                             entityCheck,
-                            CreateReadValueExpression(property.ClrType, property.GetIndex(), property),
-                            Default(property.ClrType));
+                            CreateReadValueExpression(typeToRead, property.GetIndex(), property),
+                            Default(typeToRead));
 
                         selectorExpressions.Add(propertyExpression);
-                        var readExpression = CreateReadValueExpression(property.ClrType, selectorExpressions.Count - 1, property);
+                        var readExpression = CreateReadValueExpression(propertyExpression.Type, selectorExpressions.Count - 1, property);
                         propertyExpressionsMap[property] = readExpression;
                         _projectionMappingExpressions.Add(readExpression);
                     }

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -70,11 +70,5 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             Assert.Equal(InMemoryStrings.DistinctOnSubqueryNotSupported, message);
         }
-
-        [ConditionalTheory(Skip = "Issue #25735")]
-        public override Task Project_navigation_defined_on_derived_from_entity_with_inheritance_using_soft_cast(bool async)
-        {
-            return base.Project_navigation_defined_on_derived_from_entity_with_inheritance_using_soft_cast(async);
-        }
     }
 }


### PR DESCRIPTION
So that when that property is being read outside of entity materialization, we get null value rather than default of non-nullable type

Resolves #25735
