### PR TITLE
Fixing bugs around hidden period columns

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1602,6 +1602,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     builder.Append("END");
                 }
+
+                builder.Append(" HIDDEN");
             }
 
             builder.Append(operation.IsNullable ? " NULL" : " NOT NULL");
@@ -2674,6 +2676,30 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                             .Append(", ")
                             .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodEndColumnName))
                             .Append(")")
+                            .ToString()
+                    });
+
+                operations.Add(
+                    new SqlOperation
+                    {
+                        Sql = new StringBuilder()
+                            .Append("ALTER TABLE ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
+                            .Append(" ALTER COLUMN ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodStartColumnName))
+                            .Append(" ADD HIDDEN")
+                            .ToString()
+                    });
+
+                operations.Add(
+                    new SqlOperation
+                    {
+                        Sql = new StringBuilder()
+                            .Append("ALTER TABLE ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table, schema))
+                            .Append(" ALTER COLUMN ")
+                            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(periodEndColumnName))
+                            .Append(" ADD HIDDEN")
                             .ToString()
                     });
             }

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -718,11 +718,6 @@ LEFT JOIN [sys].[extended_properties] AS [e] ON [e].[major_id] = [o].[object_id]
 LEFT JOIN [sys].[computed_columns] AS [cc] ON [c].[object_id] = [cc].[object_id] AND [c].[column_id] = [cc].[column_id]
 LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_object_id] AND [c].[column_id] = [dc].[parent_column_id]";
 
-            if (SupportsTemporalTable())
-            {
-                commandText += " WHERE [c].[is_hidden] = 0";
-            }
-
             commandText += @"
 ORDER BY [table_schema], [table_name], [c].[column_id]";
 
@@ -953,25 +948,6 @@ JOIN [sys].[columns] AS [c] ON [ic].[object_id] = [c].[object_id] AND [ic].[colu
 WHERE [i].[is_hypothetical] = 0
 AND "
                 + tableFilter;
-
-            if (SupportsTemporalTable())
-            {
-                commandText += @"
-AND CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12)) NOT IN
-(
-   SELECT CAST([i].[object_id] AS nvarchar(12)) + '#' + CAST([i].[index_id] AS nvarchar(12))
-   FROM [sys].[indexes] i
-   JOIN [sys].[tables] AS [t] ON [i].[object_id] = [t].[object_id]
-   JOIN [sys].[index_columns] AS [ic] ON [i].[object_id] = [ic].[object_id] AND [i].[index_id] = [ic].[index_id]
-   JOIN [sys].[columns] AS [c] ON [ic].[object_id] = [c].[object_id] AND [ic].[column_id] = [c].[column_id]
-   WHERE "
-                    + tableFilter;
-
-                commandText += @"
-   AND [c].[is_hidden] = 1
-   AND [i].[is_hypothetical] = 0
-)";
-            }
 
             commandText += @"
 ORDER BY [table_schema], [table_name], [index_name], [ic].[key_ordinal]";

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/MigrationsSqlServerTest.cs
@@ -1933,8 +1933,8 @@ SELECT @@ROWCOUNT;");
 EXEC(N'CREATE TABLE [Customer] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customer] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + N'].[CustomerHistory]))');");
@@ -1985,8 +1985,8 @@ EXEC(N'CREATE TABLE [Customer] (
 EXEC(N'CREATE TABLE [Customer] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [End] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [Start] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [End] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [Start] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customer] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([Start], [End])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + N'].[CustomerHistory]))');");
@@ -2038,8 +2038,8 @@ EXEC(N'CREATE TABLE [Customer] (
 EXEC(N'CREATE TABLE [Customer] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customer] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + N'].[HistoryTable]))');");
@@ -2092,8 +2092,8 @@ EXEC(N'CREATE TABLE [Customer] (
                 @"CREATE TABLE [mySchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));");
@@ -2150,8 +2150,8 @@ EXEC(N'CREATE TABLE [Customer] (
                 @"CREATE TABLE [myDefaultSchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [myDefaultSchema].[CustomerHistory]));");
@@ -2208,8 +2208,8 @@ EXEC(N'CREATE TABLE [Customer] (
                 @"CREATE TABLE [mySchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));");
@@ -2266,8 +2266,8 @@ EXEC(N'CREATE TABLE [Customer] (
                 @"CREATE TABLE [Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [historySchema].[HistoryTable]));");
@@ -3071,6 +3071,10 @@ ALTER TABLE [Customer] DROP COLUMN [PeriodStart];",
                 //
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([PeriodStart], [PeriodEnd])",
                 //
+                @"ALTER TABLE [Customer] ALTER COLUMN [PeriodStart] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [PeriodEnd] ADD HIDDEN",
+                //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[CustomerHistory]))')");
         }
@@ -3123,6 +3127,10 @@ EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + 
 
             AssertSql(
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([Start], [End])",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [Start] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [End] ADD HIDDEN",
                 //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[CustomerHistory]))')");
@@ -3179,6 +3187,10 @@ EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + 
 
             AssertSql(
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([Start], [End])",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [Start] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [End] ADD HIDDEN",
                 //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[HistoryTable]))')");
@@ -3237,6 +3249,10 @@ EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + 
                 //
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([Start], [End])",
                 //
+                @"ALTER TABLE [Customer] ALTER COLUMN [Start] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [End] ADD HIDDEN",
+                //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[CustomerHistory]))')");
         }
@@ -3294,6 +3310,10 @@ EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + 
                 @"ALTER TABLE [Customer] ADD [Start] datetime2 NOT NULL DEFAULT '0001-01-01T00:00:00.0000000';",
                 //
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([Start], [End])",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [Start] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [End] ADD HIDDEN",
                 //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[HistoryTable]))')");
@@ -3466,8 +3486,8 @@ EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + 
 EXEC(N'CREATE TABLE [Customer] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customer] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + N'].[CustomerHistory]))');
@@ -3549,6 +3569,10 @@ EXEC sp_addextendedproperty 'MS_Description', @description, 'SCHEMA', @defaultSc
                 @"CREATE INDEX [IX_Customer_Name] ON [Customer] ([Name]);",
                 //
                 @"ALTER TABLE [Customer] ADD PERIOD FOR SYSTEM_TIME ([Start], [End])",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [Start] ADD HIDDEN",
+                //
+                @"ALTER TABLE [Customer] ALTER COLUMN [End] ADD HIDDEN",
                 //
                 @"DECLARE @historyTableSchema sysname = SCHEMA_NAME()
 EXEC(N'ALTER TABLE [Customer] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + '].[HistoryTable]))')");
@@ -3725,8 +3749,8 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
                 @"CREATE TABLE [mySchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema2].[MyHistoryTable]));");
@@ -3784,8 +3808,8 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
                 @"CREATE TABLE [mySchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[CustomerHistory]));",
@@ -3793,8 +3817,8 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
                 @"CREATE TABLE [mySchema].[Orders] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Orders] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema].[OrderHistory]));");
@@ -3856,8 +3880,8 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
                 @"CREATE TABLE [mySchema].[Customers] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Customers] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema2].[CustomersHistoryTable]));",
@@ -3865,8 +3889,8 @@ ALTER TABLE [Customers] ALTER COLUMN [Name] nvarchar(450) NULL;",
                 @"CREATE TABLE [mySchema].[Orders] (
     [Id] int NOT NULL,
     [Name] nvarchar(max) NULL,
-    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END NOT NULL,
-    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START NOT NULL,
+    [SystemTimeEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    [SystemTimeStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
     CONSTRAINT [PK_Orders] PRIMARY KEY ([Id]),
     PERIOD FOR SYSTEM_TIME([SystemTimeStart], [SystemTimeEnd])
 ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [mySchema2].[OrdersHistoryTable]));");


### PR DESCRIPTION
Fixes #25841 - Create period columns as hidden
Fixes #25774 - EFCore.SqlServer - v6.00-preview - SqlServerDatabaseModelFactory doesn't read information about hidden temoral tables' columns
Fixes #25773 - EFCore.SqlServer - v6.00-preview - failed on creating model for WideWorldImporters sample database temporal tables

Problem was we used to skip over hidden columns when constructing database model. This made sense when temporal tables were not supported, but now we need that column information.
In migrations, we now generate period columns as HIDDEN. There is currently no way to change that, period column should not be marked as HIDDEN then migration needs to be manually updated.