### PR TITLE
Query: Avoid incorrect cast when simplifying null check

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Extensions/TypeExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
-
 // ReSharper disable once CheckNamespace
 namespace System
 {

--- a/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -174,6 +174,24 @@ namespace Microsoft.EntityFrameworkCore
                 : query.ToList();
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Null_check_removal_in_ternary_maintain_appropriate_cast(bool async)
+        {
+            var contextFactory = await InitializeAsync<Context21770>();
+            using var context = contextFactory.CreateContext();
+
+            var query = from f in context.Food
+                        select new
+                        {
+                            Bar = f.Taste != null ? (Taste)f.Taste : (Taste?)null
+                        };
+
+            var bitterFood = async
+                ? await query.ToListAsync()
+                : query.ToList();
+        }
+
         protected class Context21770 : DbContext
         {
             public Context21770(DbContextOptions options)
@@ -194,6 +212,12 @@ namespace Microsoft.EntityFrameworkCore
                            new IceCream { IceCreamId = 2, Name = "Chocolate", Taste = (byte)Taste.Sweet },
                            new IceCream { IceCreamId = 3, Name = "Match", Taste = (byte)Taste.Bitter });
                    });
+
+                modelBuilder.Entity<Food>(
+                    entity =>
+                    {
+                        entity.HasData(new Food { Id = 1, Taste = null });
+                    });
             }
         }
 


### PR DESCRIPTION
Resolves #19425
