### PR TITLE
Query: Translate object.Equals correctly when object argument passed …

### DIFF
--- a/src/EFCore.Cosmos/Query/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Cosmos/Query/Internal/EqualsTranslator.cs
@@ -68,8 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Query.Internal
                 && right != null)
             {
                 return left.Type.UnwrapNullableType() == right.Type.UnwrapNullableType()
-                    || (right.Type == typeof(object) && right is SqlParameterExpression)
-                    || (left.Type == typeof(object) && left is SqlParameterExpression)
+                    || (right.Type == typeof(object) && (right is SqlParameterExpression || right is SqlConstantExpression))
+                    || (left.Type == typeof(object) && (left is SqlParameterExpression || left is SqlConstantExpression))
                         ? _sqlExpressionFactory.Equal(left, right)
                         : (SqlExpression)_sqlExpressionFactory.Constant(false);
             }

--- a/src/EFCore.Relational/Query/Internal/EqualsTranslator.cs
+++ b/src/EFCore.Relational/Query/Internal/EqualsTranslator.cs
@@ -68,8 +68,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && right != null)
             {
                 if (left.Type == right.Type
-                    || (right.Type == typeof(object) && right is SqlParameterExpression)
-                    || (left.Type == typeof(object) && left is SqlParameterExpression))
+                    || (right.Type == typeof(object) && (right is SqlParameterExpression || right is SqlConstantExpression))
+                    || (left.Type == typeof(object) && (left is SqlParameterExpression || left is SqlConstantExpression)))
                 {
                     return _sqlExpressionFactory.Equal(left, right);
                 }

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -9118,6 +9118,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_equals_method_on_nullable_with_object_overload(bool async)
+        {
+            return AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Rating.Equals(null)));
+        }
+
         protected GearsOfWarContext CreateContext()
             => Fixture.CreateContext();
 


### PR DESCRIPTION
…with constant

Resolves #22981
