### PR TITLE
[TINY] Fix to #26014 - Migrations/Temporal Tables: null value exception when executing Down migration to convert entity from temporal to normal

### DIFF
--- a/src/EFCore.Relational/Migrations/Operations/Builders/AlterOperationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/Operations/Builders/AlterOperationBuilder.cs
@@ -44,7 +44,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders
             object value)
         {
             Check.NotEmpty(name, nameof(name));
-            Check.NotNull(value, nameof(value));
 
             Operation.OldAnnotations.AddAnnotation(name, value);
 


### PR DESCRIPTION
Problem was that we were asserting that the value on OldAnnotation is not null. However, we should allow this - for some scenarios null value on annotation is correct.

Fixes #26014